### PR TITLE
feat(lisa): portfolio trajectory optimizer + gènes golden-boy + agent mécanique

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -621,10 +621,8 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       });
 
     if (error) {
-      // Ignorer si la migration 0051 n'est pas encore appliquée
-      if (!/lisa_mechanical_directives/.test(error.message) && !/does not exist/i.test(error.message)) {
-        this.logger.warn(`writeDirective DB error: ${error.message}`);
-      }
+      // Log all directive write errors with enough context to diagnose migration issues
+      this.logger.warn(`writeDirective DB error: ${error.message} — apply migrations 0051/0053 if missing columns`);
       return;
     }
 

--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -487,6 +487,19 @@ défini, sans markdown, sans explications hors JSON.
       }
     } else {
       mechLines.push(`- Aucun cycle mécanique enregistré — agent en attente de première directive.`);
+      // Fallback: compute exposure from open positions so Signal E can still trigger
+      const positions = req.openPositions ?? [];
+      if (positions.length > 0) {
+        const totalNotional = positions.reduce((s, p) => s + parseFloat(p.entryNotionalUsd), 0);
+        const cashUsd = req.availableCashUsd ? parseFloat(req.availableCashUsd) : 0;
+        const totalCapital = totalNotional + cashUsd;
+        const exposurePct = totalCapital > 0 ? (totalNotional / totalCapital) * 100 : null;
+        if (exposurePct != null) {
+          mechLines.push(
+            `- Exposition estimée (depuis positions ouvertes) : ${exposurePct.toFixed(1)}% capital · Cash : $${cashUsd.toFixed(0)} · ${positions.length} positions${exposurePct > 75 ? ' ⚠️ EXPOSITION ÉLEVÉE — Signal E actif' : ''}`,
+          );
+        }
+      }
     }
 
     return [


### PR DESCRIPTION
## Résumé

Évolution majeure de Lisa : de "scanner d'opportunités" à **portfolio trajectory optimizer**, couplé à un agent mécanique sans-LLM qui exécute les directives en autonomie (1 min/cycle).

## Changements

### Lisa v2 — Portfolio Trajectory Optimizer
- **Objectifs nets de coûts** : `return_target_daily/monthly/annual_pct` + `daily_cost_budget_usd` dans `lisa_session_configs` (migration 0050)
- **Boucle de contrôle adaptative** : statuts `EN_AVANCE / DANS_LE_PLAN / EN_RETARD / HORS_TRAJECTOIRE` calculés à chaque cycle
- **Bloc `# MISSION`** injecté dynamiquement dans le user message : objectifs, coûts 7j, historique, écart trajectoire
- **Format 3 blocs** `[DIAGNOSTIC]` / `[PLAN]` / `[CONDITIONS]` obligatoires dans `warnings[]`
- **UI** : 4 inputs config objectifs + parsing visuel des 3 blocs dans `proposal-card.tsx`

### Agent mécanique sans-LLM (cerveau/mains)
- `MechanicalTradingService` : cycles 1 min, applique directives Lisa sans appel Claude ($0/cycle)
- Pression d'ouverture pilotée par `trajectoryStatus` × `marketMomentum` (migration 0051)
- Mutex distribué anti-duplication multi-instances Fly (migration 0049)
- Snapshots de performance connectés aux cycles mécaniques et Lisa

### Gènes golden-boy + DSL `[AGENT]`
- **Bloc `06-golden-trader.ts`** (cacheable) : philosophie PTJ, Druckenmiller, Soros, Simons, Dalio, Livermore, Schwartz
- **9 règles signal→action** déterministes : cluster stops, win rate decay, VIX spike, choppiness, exposition élevée, DXY spike, outlier loss, win streak, cold start
- **DSL `[AGENT] {JSON}`** : Lisa émet des overrides fin-grain que l'agent mécanique lit et applique au cycle suivant
- **`tactical_overrides`** jsonb sur `lisa_mechanical_directives` (migration 0053)
- Overrides ne peuvent que **resserrer** les contraintes (jamais les relâcher)

### Briefing mécanique → Lisa
- **`lisa_mechanical_cycle_summary`** (migration 0052) : table écrite à chaque cycle mécanique (stops, P&L, win rate, VIX, DXY, exposition, drawdown)
- Lisa lit le dernier cycle avant chaque proposal → section `## Agent mécanique` dans le MISSION block
- **Fallback exposition** : si aucun cycle enregistré, exposition calculée depuis les positions ouvertes → Signal E toujours détectable

## Migrations à appliquer dans Supabase (prod)

```
0050_lisa_portfolio_mission.sql
0051_lisa_mechanical_directives.sql
0052_lisa_mechanical_cycle_summary.sql
0053_lisa_tactical_overrides.sql
```

## Test plan

- [ ] Appliquer migrations 0050-0053 dans Supabase SQL Editor (prod)
- [ ] Redéployer Fly depuis `main` après merge
- [ ] Vérifier 1 seul `autopilot_cycle_completed` par `cycle_minutes` (mutex actif)
- [ ] Saisir objectifs dans `/lisa` → sauver → vérifier `[DIAGNOSTIC]` cite les chiffres
- [ ] Forcer exposition > 75% → vérifier `[AGENT] {"pauseOpens": true, "pauseOpensReason": "exposure_high"}`
- [ ] Vérifier rendu 3 blocs visuels dans `proposal-card.tsx`
- [ ] Vérifier rétrocompatibilité : vieilles propositions sans préfixes → rendu classique

https://claude.ai/code/session_01MV6R715MGSqcPikYp65mjq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV6R715MGSqcPikYp65mjq)_