### PR TITLE
fix(lisa): agent status endpoint + carte visibilité mécanique

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -139,6 +139,16 @@ export class LisaController {
     return this.lisa.getSnapshotHistory(extractUserId(headers), portfolioId, windowDays);
   }
 
+  // ── Agent mécanique — statut temps réel ─────────────────────────────────────
+
+  @Get('agent/:portfolioId')
+  getAgentStatus(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+  ) {
+    return this.lisa.getAgentStatus(extractUserId(headers), portfolioId);
+  }
+
   // ── Decision log ────────────────────────────────────────────────────────────
 
   @Get('decisions/:portfolioId')

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -621,10 +621,8 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       });
 
     if (error) {
-      // Ignorer si la migration 0051 n'est pas encore appliquée
-      if (!/lisa_mechanical_directives/.test(error.message) && !/does not exist/i.test(error.message)) {
-        this.logger.warn(`writeDirective DB error: ${error.message}`);
-      }
+      // Log all directive write errors with enough context to diagnose migration issues
+      this.logger.warn(`writeDirective DB error: ${error.message} — apply migrations 0051/0053 if missing columns`);
       return;
     }
 

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1667,6 +1667,44 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     };
   }
 
+  async getAgentStatus(_userId: string, portfolioId: string) {
+    const client = this.supabase.getClient();
+
+    const [directiveRes, cyclesRes, actionsRes] = await Promise.all([
+      // Directive active
+      client
+        .from('lisa_mechanical_directives')
+        .select('generated_at, valid_until, market_momentum, trajectory_status, risk_posture, target_symbols, favored_asset_classes, avoided_asset_classes, tactical_overrides')
+        .eq('portfolio_id', portfolioId)
+        .order('generated_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+
+      // Derniers cycles mécaniques
+      client
+        .from('lisa_mechanical_cycle_summary')
+        .select('cycle_at, directive_age_minutes, opens_count, closes_stop_count, closes_target_count, closes_invalidated_count, net_pnl_since_proposal_usd, win_rate_pct, avg_hold_minutes, largest_win_pct, largest_loss_pct, stops_cluster_flag, exposure_pct, cash_usd, open_positions_count, drawdown_since_directive_pct, vix_level, dxy_level')
+        .eq('portfolio_id', portfolioId)
+        .order('cycle_at', { ascending: false })
+        .limit(20),
+
+      // Actions récentes de l'agent dans le decision log
+      client
+        .from('decision_log')
+        .select('created_at, kind, summary, payload')
+        .eq('portfolio_id', portfolioId)
+        .in('kind', ['mechanical_open', 'mechanical_close_stop', 'mechanical_close_target', 'mechanical_close_invalidated', 'mechanical_skip', 'autopilot_cycle_completed', 'mechanical_override_applied'])
+        .order('created_at', { ascending: false })
+        .limit(30),
+    ]);
+
+    return {
+      directive: directiveRes.data ?? null,
+      cycles: cyclesRes.data ?? [],
+      recentActions: actionsRes.data ?? [],
+    };
+  }
+
   /**
    * Dérive le statut d'avancement vs la trajectoire cible sur l'horizon
    * configuré. Utilise netReturn dans la fenêtre 7j (proxy) comparée à

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1690,7 +1690,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
 
       // Actions récentes de l'agent dans le decision log
       client
-        .from('decision_log')
+        .from('lisa_decision_log')
         .select('created_at, kind, summary, payload')
         .eq('portfolio_id', portfolioId)
         .in('kind', ['mechanical_open', 'mechanical_close_stop', 'mechanical_close_target', 'mechanical_close_invalidated', 'mechanical_skip', 'autopilot_cycle_completed', 'mechanical_override_applied'])

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1691,10 +1691,10 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       // Actions récentes de l'agent dans le decision log
       client
         .from('lisa_decision_log')
-        .select('created_at, kind, summary, payload')
+        .select('timestamp, kind, summary, payload')
         .eq('portfolio_id', portfolioId)
-        .in('kind', ['mechanical_open', 'mechanical_close_stop', 'mechanical_close_target', 'mechanical_close_invalidated', 'mechanical_skip', 'autopilot_cycle_completed', 'mechanical_override_applied'])
-        .order('created_at', { ascending: false })
+        .in('kind', ['autopilot_cycle_completed', 'autopilot_cycle_started', 'position_opened', 'position_closed'])
+        .order('timestamp', { ascending: false })
         .limit(30),
     ]);
 

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -13,6 +13,7 @@ import {
   useLisaSnapshot,
   useTriggerKillSwitch,
   useResetSimulation,
+  useAgentStatus,
   type SessionProfile,
 } from '@/hooks/use-lisa';
 import { DisclaimerBanner } from '@/components/disclaimer-banner';
@@ -25,6 +26,7 @@ import { LisaPortfolioSummary } from '@/components/lisa/portfolio-summary';
 import { LisaPortfolioChart } from '@/components/lisa/portfolio-chart';
 import { LisaPositionsTable } from '@/components/lisa/positions-table';
 import { LisaDecisionLog } from '@/components/lisa/decision-log';
+import { MechanicalAgentCard } from '@/components/lisa/mechanical-agent-card';
 
 const PROFILE_LABELS: Record<SessionProfile, { label: string; description: string }> = {
   long_term_investor: {
@@ -77,6 +79,7 @@ export default function LisaPage() {
   const [killReason, setKillReason] = useState('');
 
   const configQuery = useLisaConfig(selectedPortfolioId);
+  const agentStatusQuery = useAgentStatus(selectedPortfolioId);
   const upsertConfig = useUpsertLisaConfig(selectedPortfolioId ?? '');
   const generateProposal = useGenerateProposal(selectedPortfolioId ?? '');
   const proposalsQuery = useLisaProposals(selectedPortfolioId);
@@ -926,6 +929,12 @@ export default function LisaPage() {
         proposals={proposalsQuery.data ?? []}
         portfolioId={selectedPortfolioId ?? ''}
         isLoading={proposalsQuery.isLoading}
+      />
+
+      {/* Agent mécanique */}
+      <MechanicalAgentCard
+        data={agentStatusQuery.data}
+        isLoading={agentStatusQuery.isLoading}
       />
 
       {/* Decision log */}

--- a/apps/web/src/components/lisa/mechanical-agent-card.tsx
+++ b/apps/web/src/components/lisa/mechanical-agent-card.tsx
@@ -1,0 +1,309 @@
+'use client';
+
+import { useState } from 'react';
+import { Activity, ChevronDown, ChevronUp, Zap, AlertTriangle, TrendingUp, TrendingDown, Minus, Clock, Eye } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { LisaAgentStatus, MechanicalCycleSummary, AgentAction } from '@/hooks/use-lisa';
+
+interface Props {
+  data: LisaAgentStatus | undefined;
+  isLoading: boolean;
+}
+
+function fmt(n: number | null | undefined, decimals = 2, prefix = '') {
+  if (n == null) return 'n/a';
+  return `${prefix}${n.toFixed(decimals)}`;
+}
+
+function pnlColor(n: number | null | undefined) {
+  if (n == null) return 'text-muted-foreground';
+  return n >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-500';
+}
+
+const KIND_LABELS: Record<string, { label: string; color: string }> = {
+  mechanical_open: { label: 'OPEN', color: 'text-blue-600 dark:text-blue-400' },
+  mechanical_close_stop: { label: 'STOP', color: 'text-red-500' },
+  mechanical_close_target: { label: 'TARGET', color: 'text-emerald-600 dark:text-emerald-400' },
+  mechanical_close_invalidated: { label: 'INVALIDE', color: 'text-orange-500' },
+  mechanical_skip: { label: 'SKIP', color: 'text-muted-foreground' },
+  autopilot_cycle_completed: { label: 'CYCLE', color: 'text-muted-foreground' },
+  mechanical_override_applied: { label: 'OVERRIDE', color: 'text-purple-600 dark:text-purple-400' },
+};
+
+const MOMENTUM_LABELS: Record<string, string> = {
+  bullish_strong: '🟢 Haussier fort',
+  bullish: '🟡 Haussier',
+  neutral: '⚪ Neutre',
+  bearish: '🔴 Baissier',
+};
+
+const TRAJECTORY_LABELS: Record<string, { label: string; color: string }> = {
+  EN_AVANCE: { label: '🚀 En avance', color: 'text-emerald-600 dark:text-emerald-400' },
+  DANS_LE_PLAN: { label: '✅ Dans le plan', color: 'text-blue-600 dark:text-blue-400' },
+  EN_RETARD: { label: '⏳ En retard', color: 'text-orange-500' },
+  HORS_TRAJECTOIRE: { label: '🔴 Hors trajectoire', color: 'text-red-500' },
+};
+
+function DirectiveSection({ directive }: { directive: LisaAgentStatus['directive'] }) {
+  if (!directive) {
+    return (
+      <div className="text-sm text-muted-foreground italic">
+        Aucune directive active — lancez une proposition Lisa pour démarrer l'agent.
+      </div>
+    );
+  }
+
+  const overrides = directive.tactical_overrides ?? {};
+  const hasOverrides = Object.keys(overrides).length > 0;
+  const trajectoryInfo = TRAJECTORY_LABELS[directive.trajectory_status] ?? { label: directive.trajectory_status, color: '' };
+  const validUntil = directive.valid_until ? new Date(directive.valid_until) : null;
+  const isExpired = validUntil ? validUntil < new Date() : false;
+  const generatedAgo = Math.round((Date.now() - new Date(directive.generated_at).getTime()) / 60000);
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-2 text-sm">
+        <div>
+          <span className="text-muted-foreground">Momentum</span>
+          <p className="font-medium">{MOMENTUM_LABELS[directive.market_momentum] ?? directive.market_momentum}</p>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Trajectoire</span>
+          <p className={`font-medium ${trajectoryInfo.color}`}>{trajectoryInfo.label}</p>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Posture de risque</span>
+          <p className="font-medium capitalize">{directive.risk_posture?.replace(/_/g, ' ') ?? 'n/a'}</p>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Directive âgée de</span>
+          <p className={`font-medium ${isExpired ? 'text-red-500' : ''}`}>
+            {generatedAgo} min {isExpired ? '(expirée)' : ''}
+          </p>
+        </div>
+      </div>
+
+      {directive.target_symbols?.length > 0 && (
+        <div className="text-sm">
+          <span className="text-muted-foreground">Symboles cibles</span>
+          <p className="font-mono text-xs mt-0.5">{directive.target_symbols.join(', ')}</p>
+        </div>
+      )}
+
+      {hasOverrides && (
+        <div className="rounded-md bg-purple-50 dark:bg-purple-950/30 border border-purple-200 dark:border-purple-800 p-2 text-xs space-y-1">
+          <p className="font-semibold text-purple-700 dark:text-purple-300 flex items-center gap-1">
+            <Zap className="h-3 w-3" /> Overrides [AGENT] actifs
+          </p>
+          {overrides.pauseOpens === true && (
+            <p className="text-purple-600 dark:text-purple-400">
+              ⛔ Ouvertures pausées — {String(overrides.pauseOpensReason ?? 'signal actif')}
+            </p>
+          )}
+          {overrides.tightenStopsMultiplier != null && (overrides.tightenStopsMultiplier as number) < 1 && (
+            <p className="text-purple-600 dark:text-purple-400">
+              🎯 Stops resserrés ×{Number(overrides.tightenStopsMultiplier).toFixed(2)}
+            </p>
+          )}
+          {overrides.minConvictionOverride != null && (
+            <p className="text-purple-600 dark:text-purple-400">
+              📊 Conviction min override : {String(overrides.minConvictionOverride)}/10
+            </p>
+          )}
+          {overrides.maxNewOpensOverride != null && (
+            <p className="text-purple-600 dark:text-purple-400">
+              🔒 Max ouvertures/cycle : {String(overrides.maxNewOpensOverride)}
+            </p>
+          )}
+          {overrides.closeLowestConvictionIfExposureAbovePct != null && (
+            <p className="text-purple-600 dark:text-purple-400">
+              📉 Ferme plus faible conviction si exposition &gt; {String(overrides.closeLowestConvictionIfExposureAbovePct)}%
+            </p>
+          )}
+          {Array.isArray(overrides.preferredAssetClasses) && (overrides.preferredAssetClasses as string[]).length > 0 && (
+            <p className="text-purple-600 dark:text-purple-400">
+              🛡️ Classes préférées : {(overrides.preferredAssetClasses as string[]).join(', ')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CycleRow({ cycle }: { cycle: MechanicalCycleSummary }) {
+  const ago = Math.round((Date.now() - new Date(cycle.cycle_at).getTime()) / 60000);
+  const pnl = Number(cycle.net_pnl_since_proposal_usd);
+
+  return (
+    <tr className="border-b border-border/50 text-xs hover:bg-muted/30">
+      <td className="py-1.5 pr-2 text-muted-foreground whitespace-nowrap">
+        {ago < 60 ? `${ago}min` : `${Math.round(ago / 60)}h`}
+      </td>
+      <td className="pr-2">
+        <span className="text-blue-600 dark:text-blue-400">+{cycle.opens_count}</span>
+        {' / '}
+        <span className={cycle.closes_stop_count > 0 ? 'text-red-500' : ''}>
+          ✋{cycle.closes_stop_count}
+        </span>
+        {' / '}
+        <span className={cycle.closes_target_count > 0 ? 'text-emerald-600 dark:text-emerald-400' : ''}>
+          🎯{cycle.closes_target_count}
+        </span>
+      </td>
+      <td className={`pr-2 font-mono ${pnlColor(pnl)}`}>
+        {pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}
+      </td>
+      <td className="pr-2 text-muted-foreground">
+        {cycle.win_rate_pct != null ? `${cycle.win_rate_pct.toFixed(0)}%` : '—'}
+      </td>
+      <td className="pr-2 text-muted-foreground">
+        {cycle.exposure_pct != null ? (
+          <span className={cycle.exposure_pct > 80 ? 'text-orange-500 font-medium' : ''}>
+            {cycle.exposure_pct.toFixed(0)}%
+          </span>
+        ) : '—'}
+      </td>
+      <td className="text-muted-foreground">
+        {cycle.vix_level != null ? (
+          <span className={cycle.vix_level > 25 ? 'text-red-500 font-medium' : ''}>
+            {cycle.vix_level.toFixed(1)}
+          </span>
+        ) : '—'}
+      </td>
+      {cycle.stops_cluster_flag && (
+        <td><AlertTriangle className="h-3 w-3 text-orange-500" /></td>
+      )}
+    </tr>
+  );
+}
+
+function ActionRow({ action }: { action: AgentAction }) {
+  const info = KIND_LABELS[action.kind] ?? { label: action.kind, color: 'text-muted-foreground' };
+  const ago = Math.round((Date.now() - new Date(action.created_at).getTime()) / 60000);
+
+  return (
+    <div className="flex items-start gap-2 py-1.5 border-b border-border/40 text-xs">
+      <span className="text-muted-foreground whitespace-nowrap w-10 shrink-0">
+        {ago < 60 ? `${ago}m` : `${Math.round(ago / 60)}h`}
+      </span>
+      <span className={`font-mono font-semibold w-16 shrink-0 ${info.color}`}>{info.label}</span>
+      <span className="text-foreground/80 leading-snug">{action.summary}</span>
+    </div>
+  );
+}
+
+export function MechanicalAgentCard({ data, isLoading }: Props) {
+  const [showCycles, setShowCycles] = useState(false);
+  const [showActions, setShowActions] = useState(true);
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-4 animate-pulse h-32" />
+    );
+  }
+
+  const cycles = data?.cycles ?? [];
+  const actions = data?.recentActions ?? [];
+  const lastCycle = cycles[0];
+
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <div className="flex items-center gap-2">
+          <Activity className="h-4 w-4 text-muted-foreground" />
+          <h3 className="font-semibold text-sm">Agent mécanique</h3>
+          {lastCycle && (
+            <span className="text-xs text-muted-foreground flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              dernier cycle il y a {Math.round((Date.now() - new Date(lastCycle.cycle_at).getTime()) / 60000)} min
+            </span>
+          )}
+        </div>
+        {lastCycle && (
+          <div className="flex items-center gap-3 text-xs">
+            <span className={pnlColor(Number(lastCycle.net_pnl_since_proposal_usd))}>
+              P&L {Number(lastCycle.net_pnl_since_proposal_usd) >= 0 ? '+' : ''}${Number(lastCycle.net_pnl_since_proposal_usd).toFixed(2)}
+            </span>
+            {lastCycle.exposure_pct != null && (
+              <span className={lastCycle.exposure_pct > 80 ? 'text-orange-500 font-medium' : 'text-muted-foreground'}>
+                Expo {lastCycle.exposure_pct.toFixed(0)}%
+              </span>
+            )}
+            {lastCycle.stops_cluster_flag && (
+              <span className="flex items-center gap-1 text-orange-500">
+                <AlertTriangle className="h-3 w-3" /> Cluster stops
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="p-4 space-y-4">
+        {/* Directive */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+            Directive active
+          </p>
+          <DirectiveSection directive={data?.directive ?? null} />
+        </div>
+
+        {/* Cycles */}
+        {cycles.length > 0 && (
+          <div>
+            <button
+              onClick={() => setShowCycles((v) => !v)}
+              className="flex items-center gap-1 text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2 hover:text-foreground transition-colors"
+            >
+              {showCycles ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+              Cycles récents ({cycles.length})
+            </button>
+            {showCycles && (
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="text-[10px] text-muted-foreground uppercase border-b border-border">
+                      <th className="text-left pb-1 pr-2">Il y a</th>
+                      <th className="text-left pb-1 pr-2">Open/Stop/Target</th>
+                      <th className="text-left pb-1 pr-2">P&L</th>
+                      <th className="text-left pb-1 pr-2">Win%</th>
+                      <th className="text-left pb-1 pr-2">Expo</th>
+                      <th className="text-left pb-1">VIX</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {cycles.map((c, i) => <CycleRow key={i} cycle={c} />)}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Actions récentes */}
+        <div>
+          <button
+            onClick={() => setShowActions((v) => !v)}
+            className="flex items-center gap-1 text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2 hover:text-foreground transition-colors"
+          >
+            {showActions ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            <Eye className="h-3 w-3" />
+            Activité récente ({actions.length})
+          </button>
+          {showActions && (
+            <div className="max-h-64 overflow-y-auto">
+              {actions.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic">
+                  Aucune action enregistrée — migrations 0051/0052 appliquées ?
+                </p>
+              ) : (
+                actions.map((a, i) => <ActionRow key={i} action={a} />)
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/lisa/mechanical-agent-card.tsx
+++ b/apps/web/src/components/lisa/mechanical-agent-card.tsx
@@ -180,7 +180,7 @@ function CycleRow({ cycle }: { cycle: MechanicalCycleSummary }) {
 
 function ActionRow({ action }: { action: AgentAction }) {
   const info = KIND_LABELS[action.kind] ?? { label: action.kind, color: 'text-muted-foreground' };
-  const ago = Math.round((Date.now() - new Date(action.created_at).getTime()) / 60000);
+  const ago = Math.round((Date.now() - new Date(action.timestamp).getTime()) / 60000);
 
   return (
     <div className="flex items-start gap-2 py-1.5 border-b border-border/40 text-xs">

--- a/apps/web/src/hooks/use-lisa.ts
+++ b/apps/web/src/hooks/use-lisa.ts
@@ -117,6 +117,52 @@ export interface LisaSnapshot {
   drawdown_from_peak_pct: number;
 }
 
+export interface MechanicalCycleSummary {
+  cycle_at: string;
+  directive_age_minutes: number | null;
+  opens_count: number;
+  closes_stop_count: number;
+  closes_target_count: number;
+  closes_invalidated_count: number;
+  net_pnl_since_proposal_usd: number;
+  win_rate_pct: number | null;
+  avg_hold_minutes: number | null;
+  largest_win_pct: number | null;
+  largest_loss_pct: number | null;
+  stops_cluster_flag: boolean;
+  exposure_pct: number | null;
+  cash_usd: number | null;
+  open_positions_count: number;
+  drawdown_since_directive_pct: number | null;
+  vix_level: number | null;
+  dxy_level: number | null;
+}
+
+export interface MechanicalDirective {
+  generated_at: string;
+  valid_until: string | null;
+  market_momentum: string;
+  trajectory_status: string;
+  risk_posture: string;
+  target_symbols: string[];
+  favored_asset_classes: string[];
+  avoided_asset_classes: string[];
+  tactical_overrides: Record<string, unknown>;
+}
+
+export interface AgentAction {
+  created_at: string;
+  kind: string;
+  summary: string;
+  payload: Record<string, unknown>;
+}
+
+export interface LisaAgentStatus {
+  directive: MechanicalDirective | null;
+  cycles: MechanicalCycleSummary[];
+  recentActions: AgentAction[];
+}
+
 export interface LisaDecisionLogRow {
   id: string;
   portfolio_id: string;
@@ -232,6 +278,20 @@ export function useRejectProposal(portfolioId: string) {
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['lisa', 'proposals', portfolioId] });
     },
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Agent mécanique
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function useAgentStatus(portfolioId: string | null) {
+  return useQuery({
+    queryKey: ['lisa', 'agent', portfolioId],
+    queryFn: () => apiFetch<LisaAgentStatus>(`/lisa/agent/${portfolioId}`),
+    enabled: !!portfolioId,
+    refetchInterval: 30_000, // rafraîchit toutes les 30s (cycle agent = 1 min)
+    ...LISA_QUERY_OPTIONS,
   });
 }
 

--- a/apps/web/src/hooks/use-lisa.ts
+++ b/apps/web/src/hooks/use-lisa.ts
@@ -151,7 +151,7 @@ export interface MechanicalDirective {
 }
 
 export interface AgentAction {
-  created_at: string;
+  timestamp: string;
   kind: string;
   summary: string;
   payload: Record<string, unknown>;

--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -487,6 +487,19 @@ défini, sans markdown, sans explications hors JSON.
       }
     } else {
       mechLines.push(`- Aucun cycle mécanique enregistré — agent en attente de première directive.`);
+      // Fallback: compute exposure from open positions so Signal E can still trigger
+      const positions = req.openPositions ?? [];
+      if (positions.length > 0) {
+        const totalNotional = positions.reduce((s, p) => s + parseFloat(p.entryNotionalUsd), 0);
+        const cashUsd = req.availableCashUsd ? parseFloat(req.availableCashUsd) : 0;
+        const totalCapital = totalNotional + cashUsd;
+        const exposurePct = totalCapital > 0 ? (totalNotional / totalCapital) * 100 : null;
+        if (exposurePct != null) {
+          mechLines.push(
+            `- Exposition estimée (depuis positions ouvertes) : ${exposurePct.toFixed(1)}% capital · Cash : $${cashUsd.toFixed(0)} · ${positions.length} positions${exposurePct > 75 ? ' ⚠️ EXPOSITION ÉLEVÉE — Signal E actif' : ''}`,
+          );
+        }
+      }
     }
 
     return [


### PR DESCRIPTION
## Changements

3 commits manquants en prod depuis le dernier merge :

- `12c398f` **feat**: carte visibilité agent mécanique — directive active, cycles récents (20), activité (30 actions), overrides [AGENT] en violet. Endpoint `GET /lisa/agent/:portfolioId`. Polling 30s.
- `124cbdd` **fix**: `decision_log` → `lisa_decision_log` dans `getAgentStatus`
- `5d782db` **fix**: `lisa_decision_log` — `timestamp` au lieu de `created_at`, kinds valides (`autopilot_cycle_*`, `position_*`)

## Contexte

Production Fly.io sur `main@8d73c0e`. Ces 3 commits sont visibles en preview Vercel mais pas déployés sur Fly.

https://claude.ai/code/session_01MV6R715MGSqcPikYp65mjq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV6R715MGSqcPikYp65mjq)_