### PR TITLE
feat(lisa): P0 agent quasi-golden-boy — indicators + intraday + ATR stops + hours + Binance

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -139,6 +139,16 @@ export class LisaController {
     return this.lisa.getSnapshotHistory(extractUserId(headers), portfolioId, windowDays);
   }
 
+  // ── Agent mécanique — statut temps réel ─────────────────────────────────────
+
+  @Get('agent/:portfolioId')
+  getAgentStatus(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+  ) {
+    return this.lisa.getAgentStatus(extractUserId(headers), portfolioId);
+  }
+
   // ── Decision log ────────────────────────────────────────────────────────────
 
   @Get('decisions/:portfolioId')

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -9,12 +9,13 @@ import { RealtimePriceService } from './services/realtime-price.service';
 import { EodhdEnrichmentService } from './services/eodhd-enrichment.service';
 import { EodhdTechnicalService } from './services/eodhd-technical.service';
 import { EodhdIntradayService } from './services/eodhd-intraday.service';
+import { ExchangeHoursService } from './services/exchange-hours.service';
 import { MechanicalTradingService } from './services/mechanical-trading.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule],
   controllers: [LisaController],
-  providers: [LisaService, LisaAutopilotService, DecisionLogService, RealtimePriceService, EodhdEnrichmentService, EodhdTechnicalService, EodhdIntradayService, MechanicalTradingService],
-  exports: [LisaService, DecisionLogService, RealtimePriceService, EodhdTechnicalService, EodhdIntradayService],
+  providers: [LisaService, LisaAutopilotService, DecisionLogService, RealtimePriceService, EodhdEnrichmentService, EodhdTechnicalService, EodhdIntradayService, ExchangeHoursService, MechanicalTradingService],
+  exports: [LisaService, DecisionLogService, RealtimePriceService, EodhdTechnicalService, EodhdIntradayService, ExchangeHoursService],
 })
 export class LisaModule {}

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -8,12 +8,13 @@ import { DecisionLogService } from './services/decision-log.service';
 import { RealtimePriceService } from './services/realtime-price.service';
 import { EodhdEnrichmentService } from './services/eodhd-enrichment.service';
 import { EodhdTechnicalService } from './services/eodhd-technical.service';
+import { EodhdIntradayService } from './services/eodhd-intraday.service';
 import { MechanicalTradingService } from './services/mechanical-trading.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule],
   controllers: [LisaController],
-  providers: [LisaService, LisaAutopilotService, DecisionLogService, RealtimePriceService, EodhdEnrichmentService, EodhdTechnicalService, MechanicalTradingService],
-  exports: [LisaService, DecisionLogService, RealtimePriceService, EodhdTechnicalService],
+  providers: [LisaService, LisaAutopilotService, DecisionLogService, RealtimePriceService, EodhdEnrichmentService, EodhdTechnicalService, EodhdIntradayService, MechanicalTradingService],
+  exports: [LisaService, DecisionLogService, RealtimePriceService, EodhdTechnicalService, EodhdIntradayService],
 })
 export class LisaModule {}

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -10,12 +10,13 @@ import { EodhdEnrichmentService } from './services/eodhd-enrichment.service';
 import { EodhdTechnicalService } from './services/eodhd-technical.service';
 import { EodhdIntradayService } from './services/eodhd-intraday.service';
 import { ExchangeHoursService } from './services/exchange-hours.service';
+import { BinanceMarketService } from './services/binance-market.service';
 import { MechanicalTradingService } from './services/mechanical-trading.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule],
   controllers: [LisaController],
-  providers: [LisaService, LisaAutopilotService, DecisionLogService, RealtimePriceService, EodhdEnrichmentService, EodhdTechnicalService, EodhdIntradayService, ExchangeHoursService, MechanicalTradingService],
-  exports: [LisaService, DecisionLogService, RealtimePriceService, EodhdTechnicalService, EodhdIntradayService, ExchangeHoursService],
+  providers: [LisaService, LisaAutopilotService, DecisionLogService, RealtimePriceService, EodhdEnrichmentService, EodhdTechnicalService, EodhdIntradayService, ExchangeHoursService, BinanceMarketService, MechanicalTradingService],
+  exports: [LisaService, DecisionLogService, RealtimePriceService, EodhdTechnicalService, EodhdIntradayService, ExchangeHoursService, BinanceMarketService],
 })
 export class LisaModule {}

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -7,12 +7,13 @@ import { LisaAutopilotService } from './services/lisa-autopilot.service';
 import { DecisionLogService } from './services/decision-log.service';
 import { RealtimePriceService } from './services/realtime-price.service';
 import { EodhdEnrichmentService } from './services/eodhd-enrichment.service';
+import { EodhdTechnicalService } from './services/eodhd-technical.service';
 import { MechanicalTradingService } from './services/mechanical-trading.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule],
   controllers: [LisaController],
-  providers: [LisaService, LisaAutopilotService, DecisionLogService, RealtimePriceService, EodhdEnrichmentService, MechanicalTradingService],
-  exports: [LisaService, DecisionLogService, RealtimePriceService],
+  providers: [LisaService, LisaAutopilotService, DecisionLogService, RealtimePriceService, EodhdEnrichmentService, EodhdTechnicalService, MechanicalTradingService],
+  exports: [LisaService, DecisionLogService, RealtimePriceService, EodhdTechnicalService],
 })
 export class LisaModule {}

--- a/apps/api/src/modules/lisa/services/binance-market.service.ts
+++ b/apps/api/src/modules/lisa/services/binance-market.service.ts
@@ -1,0 +1,186 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * BinanceMarketService — accès REST à Binance Public API pour enrichir
+ * le briefing crypto avec :
+ *  - klines 5m (bougies historiques, équivalent EODHD intraday pour crypto)
+ *  - ticker 24h (volume, high/low, % change = signal de régime crypto)
+ *
+ * API publique sans clé, rate limit 1200 weight/min (~20 req/s) largement
+ * suffisant pour notre usage.
+ *
+ * Endpoints :
+ *   GET /api/v3/klines?symbol=BTCUSDT&interval=5m&limit=20
+ *   GET /api/v3/ticker/24hr?symbol=BTCUSDT
+ *
+ * Cache 2 min (klines) / 1 min (24h).
+ */
+
+export interface BinanceCandle {
+  openTime: number;  // unix ms
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+  closeTime: number;
+  trades: number;
+}
+
+export interface BinanceTicker24h {
+  symbol: string;
+  priceChange: number;
+  priceChangePct: number;
+  weightedAvgPrice: number;
+  lastPrice: number;
+  volume: number;       // base asset
+  quoteVolume: number;  // quote asset (USDT)
+  high: number;
+  low: number;
+  openTime: number;
+  closeTime: number;
+  count: number;        // number of trades
+}
+
+@Injectable()
+export class BinanceMarketService {
+  private readonly logger = new Logger(BinanceMarketService.name);
+  private readonly BASE_URL = 'https://api.binance.com';
+  private klinesCache = new Map<string, { data: BinanceCandle[]; asOf: number }>();
+  private tickerCache = new Map<string, { data: BinanceTicker24h; asOf: number }>();
+
+  /**
+   * Convertit un symbole SmartVest en symbole Binance. Retourne null si
+   * le symbole n'est pas mappable (ex : actions US → null).
+   */
+  toBinanceSymbol(symbol: string): string | null {
+    const s = symbol.toUpperCase();
+    const map: Record<string, string> = {
+      'BTC': 'BTCUSDT', 'BTCUSDT': 'BTCUSDT', 'BTC-USD': 'BTCUSDT', 'BTC-SPOT': 'BTCUSDT',
+      'ETH': 'ETHUSDT', 'ETHUSDT': 'ETHUSDT', 'ETH-USD': 'ETHUSDT', 'ETH-SPOT': 'ETHUSDT',
+      'SOL': 'SOLUSDT', 'SOLUSDT': 'SOLUSDT',
+      'BNB': 'BNBUSDT', 'BNBUSDT': 'BNBUSDT',
+      'XRP': 'XRPUSDT', 'XRPUSDT': 'XRPUSDT',
+      'ADA': 'ADAUSDT', 'ADAUSDT': 'ADAUSDT',
+      'DOGE': 'DOGEUSDT', 'DOGEUSDT': 'DOGEUSDT',
+      'DOT': 'DOTUSDT', 'AVAX': 'AVAXUSDT', 'MATIC': 'MATICUSDT',
+      'LINK': 'LINKUSDT', 'ATOM': 'ATOMUSDT', 'UNI': 'UNIUSDT',
+      'LTC': 'LTCUSDT',
+    };
+    if (map[s]) return map[s];
+    // Déjà un ticker binance USDT
+    if (s.endsWith('USDT')) return s;
+    return null;
+  }
+
+  async getKlines(binanceSymbol: string, interval: '1m' | '5m' | '15m' | '1h' | '4h' | '1d' = '5m', limit = 20): Promise<BinanceCandle[] | null> {
+    const cacheKey = `${binanceSymbol}::${interval}::${limit}`;
+    const cached = this.klinesCache.get(cacheKey);
+    if (cached && Date.now() - cached.asOf < 2 * 60_000) return cached.data;
+
+    try {
+      const url = `${this.BASE_URL}/api/v3/klines?symbol=${binanceSymbol}&interval=${interval}&limit=${limit}`;
+      const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+      if (!res.ok) {
+        this.logger.debug(`Binance klines HTTP ${res.status} for ${binanceSymbol}`);
+        return null;
+      }
+      const data = await res.json() as unknown[];
+      if (!Array.isArray(data)) return null;
+
+      const candles: BinanceCandle[] = data.map((row) => {
+        const r = row as unknown[];
+        return {
+          openTime: Number(r[0]),
+          open: Number(r[1]),
+          high: Number(r[2]),
+          low: Number(r[3]),
+          close: Number(r[4]),
+          volume: Number(r[5]),
+          closeTime: Number(r[6]),
+          trades: Number(r[8]),
+        };
+      });
+      this.klinesCache.set(cacheKey, { data: candles, asOf: Date.now() });
+      return candles;
+    } catch (e) {
+      this.logger.warn(`Binance klines failed ${binanceSymbol}: ${String(e).slice(0, 80)}`);
+      return null;
+    }
+  }
+
+  async getTicker24h(binanceSymbol: string): Promise<BinanceTicker24h | null> {
+    const cached = this.tickerCache.get(binanceSymbol);
+    if (cached && Date.now() - cached.asOf < 60_000) return cached.data;
+
+    try {
+      const url = `${this.BASE_URL}/api/v3/ticker/24hr?symbol=${binanceSymbol}`;
+      const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+      if (!res.ok) return null;
+      const d = await res.json() as Record<string, unknown>;
+
+      const ticker: BinanceTicker24h = {
+        symbol: String(d.symbol ?? binanceSymbol),
+        priceChange: Number(d.priceChange ?? 0),
+        priceChangePct: Number(d.priceChangePercent ?? 0),
+        weightedAvgPrice: Number(d.weightedAvgPrice ?? 0),
+        lastPrice: Number(d.lastPrice ?? 0),
+        volume: Number(d.volume ?? 0),
+        quoteVolume: Number(d.quoteVolume ?? 0),
+        high: Number(d.highPrice ?? 0),
+        low: Number(d.lowPrice ?? 0),
+        openTime: Number(d.openTime ?? 0),
+        closeTime: Number(d.closeTime ?? 0),
+        count: Number(d.count ?? 0),
+      };
+      this.tickerCache.set(binanceSymbol, { data: ticker, asOf: Date.now() });
+      return ticker;
+    } catch (e) {
+      this.logger.warn(`Binance 24h failed ${binanceSymbol}: ${String(e).slice(0, 80)}`);
+      return null;
+    }
+  }
+
+  /**
+   * Résumé compact 24h + klines 5m pour injection dans le briefing Lisa.
+   * Ex : "24h: +4.32% · $58.2B vol · range 87k-92k · intraday 5m: bullish momentum · VOL SURGE"
+   */
+  async summarize(symbol: string): Promise<string | null> {
+    const bs = this.toBinanceSymbol(symbol);
+    if (!bs) return null;
+
+    const [ticker, klines] = await Promise.all([
+      this.getTicker24h(bs),
+      this.getKlines(bs, '5m', 20),
+    ]);
+
+    const parts: string[] = [];
+
+    if (ticker) {
+      const volB = ticker.quoteVolume / 1e9;
+      const volStr = volB >= 1 ? `${volB.toFixed(1)}B` : `${(ticker.quoteVolume / 1e6).toFixed(0)}M`;
+      parts.push(`24h: ${ticker.priceChangePct >= 0 ? '+' : ''}${ticker.priceChangePct.toFixed(2)}%`);
+      parts.push(`vol=$${volStr}`);
+      parts.push(`range=${ticker.low.toFixed(2)}-${ticker.high.toFixed(2)}`);
+    }
+
+    if (klines && klines.length > 0) {
+      const first = klines[0];
+      const last = klines[klines.length - 1];
+      const changePct = first.open > 0 ? ((last.close - first.open) / first.open) * 100 : 0;
+      const bullishCandles = klines.filter((c) => c.close > c.open).length;
+      const momentumRead = bullishCandles / klines.length > 0.6
+        ? 'bullish momentum'
+        : bullishCandles / klines.length < 0.4 ? 'bearish momentum' : 'choppy';
+      parts.push(`intraday 5m: ${changePct >= 0 ? '+' : ''}${changePct.toFixed(2)}% · ${momentumRead}`);
+
+      // Volume surge dernière bougie
+      const avgVol = klines.reduce((s, k) => s + k.volume, 0) / klines.length;
+      if (avgVol > 0 && last.volume > avgVol * 1.5) {
+        parts.push('VOL SURGE');
+      }
+    }
+
+    return parts.length > 0 ? parts.join(' · ') : null;
+  }
+}

--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -1,0 +1,183 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+/**
+ * EodhdIntradayService — récupère les bougies intraday OHLCV depuis EODHD
+ * pour donner à Lisa et à l'agent mécanique une vue réelle du price action
+ * (et pas juste un snapshot instantané).
+ *
+ * Endpoint : GET /api/intraday/{ticker}?interval=5m&from={unix}&to={unix}
+ * Intervals supportés : 1m, 5m, 1h
+ *
+ * Cache par (ticker, interval), TTL aligné sur l'interval (on refresh
+ * quand une nouvelle bougie est probable d'exister).
+ */
+
+export interface Candle {
+  timestamp: number;     // unix seconds
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface CandleSeries {
+  ticker: string;
+  interval: '1m' | '5m' | '1h';
+  candles: Candle[];
+  asOf: number;
+}
+
+@Injectable()
+export class EodhdIntradayService {
+  private readonly logger = new Logger(EodhdIntradayService.name);
+  private cache = new Map<string, CandleSeries>();
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+  ) {}
+
+  private apiKey(): string | null {
+    const k = this.config.get<string>('EODHD_API_KEY');
+    return k && k !== 'demo' ? k : null;
+  }
+
+  private logCall(row: { ticker: string; success: boolean; statusCode?: number; latencyMs?: number; errorMessage?: string }): void {
+    (async () => {
+      try {
+        await this.supabase.getClient().from('eodhd_request_log').insert({
+          ticker: row.ticker,
+          eodhd_ticker: row.ticker,
+          source: 'eodhd',
+          success: row.success,
+          status_code: row.statusCode ?? null,
+          latency_ms: row.latencyMs ?? null,
+          called_by: 'intraday',
+          error_message: row.errorMessage ?? null,
+        });
+      } catch { /* swallow */ }
+    })();
+  }
+
+  private cacheTtlMs(interval: '1m' | '5m' | '1h'): number {
+    // Refresh à mi-interval : on peut servir la même série tant que la
+    // bougie courante n'est pas clôturée.
+    if (interval === '1m') return 30_000;
+    if (interval === '5m') return 2 * 60_000;
+    return 20 * 60_000;
+  }
+
+  /**
+   * Récupère les N dernières bougies pour un ticker et un interval.
+   * defaultCount = 20 → couvre 1h40 en 5m, suffisant pour détecter
+   * momentum, breakout, range.
+   */
+  async getCandles(
+    eodhdTicker: string,
+    interval: '1m' | '5m' | '1h' = '5m',
+    count = 20,
+  ): Promise<CandleSeries | null> {
+    const cacheKey = `${eodhdTicker}::${interval}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && Date.now() - cached.asOf < this.cacheTtlMs(interval)) {
+      return cached;
+    }
+
+    const key = this.apiKey();
+    if (!key) return null;
+
+    const intervalSeconds = interval === '1m' ? 60 : interval === '5m' ? 300 : 3600;
+    const toUnix = Math.floor(Date.now() / 1000);
+    const fromUnix = toUnix - count * intervalSeconds * 2; // x2 marge pour weekends/holidays
+
+    const tStart = Date.now();
+    try {
+      const qs = new URLSearchParams({
+        api_token: key,
+        fmt: 'json',
+        interval,
+        from: String(fromUnix),
+        to: String(toUnix),
+      }).toString();
+      const url = `https://eodhd.com/api/intraday/${encodeURIComponent(eodhdTicker)}?${qs}`;
+      const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+      const latencyMs = Date.now() - tStart;
+
+      if (!res.ok) {
+        this.logCall({ ticker: eodhdTicker, success: false, statusCode: res.status, latencyMs, errorMessage: `HTTP_${res.status}` });
+        return null;
+      }
+
+      const data = await res.json() as Array<Record<string, unknown>>;
+      this.logCall({ ticker: eodhdTicker, success: true, statusCode: res.status, latencyMs });
+
+      if (!Array.isArray(data)) return null;
+
+      const candles: Candle[] = data
+        .map((d) => ({
+          timestamp: typeof d.timestamp === 'number' ? d.timestamp : Number(d.timestamp ?? 0),
+          open: Number(d.open ?? 0),
+          high: Number(d.high ?? 0),
+          low: Number(d.low ?? 0),
+          close: Number(d.close ?? 0),
+          volume: Number(d.volume ?? 0),
+        }))
+        .filter((c) => c.timestamp > 0 && c.close > 0)
+        .slice(-count);
+
+      const series: CandleSeries = { ticker: eodhdTicker, interval, candles, asOf: Date.now() };
+      this.cache.set(cacheKey, series);
+      return series;
+    } catch (e) {
+      this.logger.warn(`Intraday fetch failed for ${eodhdTicker}: ${String(e).slice(0, 80)}`);
+      this.logCall({ ticker: eodhdTicker, success: false, latencyMs: Date.now() - tStart, errorMessage: String(e).slice(0, 200) });
+      return null;
+    }
+  }
+
+  /**
+   * Résumé compact des bougies récentes pour injection dans les prompts Lisa.
+   * Format : "Intraday 5m (N): close trajectory → momentum read"
+   */
+  summarize(series: CandleSeries): string {
+    const c = series.candles;
+    if (c.length === 0) return 'no candles available';
+
+    const first = c[0];
+    const last = c[c.length - 1];
+    const changePct = first.close > 0 ? ((last.close - first.close) / first.close) * 100 : 0;
+
+    // Range high/low sur la période
+    const high = Math.max(...c.map((k) => k.high));
+    const low = Math.min(...c.map((k) => k.low));
+    const rangePct = low > 0 ? ((high - low) / low) * 100 : 0;
+
+    // Position du close actuel dans le range (0 = bottom, 1 = top)
+    const pctInRange = high > low ? (last.close - low) / (high - low) : 0.5;
+
+    // Momentum : close > open sur les N/2 dernières bougies ?
+    const recentHalf = c.slice(-Math.max(5, Math.floor(c.length / 2)));
+    const bullishCandles = recentHalf.filter((k) => k.close > k.open).length;
+    const momentumRead = bullishCandles / recentHalf.length > 0.6
+      ? 'bullish momentum'
+      : bullishCandles / recentHalf.length < 0.4
+        ? 'bearish momentum'
+        : 'choppy / no clear trend';
+
+    // Volume surge : la dernière bougie vs moyenne
+    const avgVol = c.reduce((s, k) => s + k.volume, 0) / c.length;
+    const volSurge = avgVol > 0 && last.volume > avgVol * 1.5 ? ' · VOL SURGE' : '';
+
+    return [
+      `${c.length} candles ${series.interval}`,
+      `close=${last.close.toFixed(4)}`,
+      `range=${low.toFixed(4)}-${high.toFixed(4)} (${rangePct.toFixed(2)}%)`,
+      `pos_in_range=${pctInRange.toFixed(2)}`,
+      `change=${changePct >= 0 ? '+' : ''}${changePct.toFixed(2)}%`,
+      momentumRead,
+    ].join(' · ') + volSurge;
+  }
+}

--- a/apps/api/src/modules/lisa/services/eodhd-technical.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-technical.service.ts
@@ -1,0 +1,184 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+/**
+ * EodhdTechnicalService — wrapper autour de /api/technical d'EODHD pour
+ * fournir à Lisa et à l'agent mécanique les indicateurs techniques dont
+ * ils ont besoin pour prendre des décisions confirmées (pas à l'aveugle).
+ *
+ * Endpoints utilisés :
+ *   GET /api/technical/{ticker}?function=rsi&period=14
+ *   GET /api/technical/{ticker}?function=macd
+ *   GET /api/technical/{ticker}?function=atr&period=14
+ *   GET /api/technical/{ticker}?function=bbands&period=20
+ *
+ * Cache 5 min (les indicateurs EOD ne changent pas en intraday avant
+ * clôture). Fire-and-forget logging dans eodhd_request_log.
+ */
+
+export interface TechnicalIndicators {
+  ticker: string;
+  asOf: string;
+  rsi14: number | null;               // 0-100, < 30 = oversold, > 70 = overbought
+  macd: number | null;                // MACD line
+  macdSignal: number | null;          // Signal line
+  macdHist: number | null;            // Histogram (momentum)
+  atr14: number | null;               // Average True Range (volatilité absolue)
+  atr14Pct: number | null;            // ATR en % du prix (pour stops dynamiques)
+  bbUpper: number | null;             // Bollinger upper band
+  bbMiddle: number | null;            // Bollinger middle (SMA20)
+  bbLower: number | null;             // Bollinger lower band
+  bbPctB: number | null;              // Position du prix dans la bande (0 = bottom, 1 = top)
+}
+
+@Injectable()
+export class EodhdTechnicalService {
+  private readonly logger = new Logger(EodhdTechnicalService.name);
+  private cache = new Map<string, { data: TechnicalIndicators; asOf: number }>();
+  private readonly CACHE_MS = 5 * 60 * 1000;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+  ) {}
+
+  private apiKey(): string | null {
+    const k = this.config.get<string>('EODHD_API_KEY');
+    return k && k !== 'demo' ? k : null;
+  }
+
+  private logCall(row: { ticker: string; success: boolean; statusCode?: number; latencyMs?: number; errorMessage?: string }): void {
+    (async () => {
+      try {
+        await this.supabase.getClient().from('eodhd_request_log').insert({
+          ticker: row.ticker,
+          eodhd_ticker: row.ticker,
+          source: 'eodhd',
+          success: row.success,
+          status_code: row.statusCode ?? null,
+          latency_ms: row.latencyMs ?? null,
+          called_by: 'technical',
+          error_message: row.errorMessage ?? null,
+        });
+      } catch { /* swallow */ }
+    })();
+  }
+
+  /**
+   * Fetch les 4 indicateurs principaux en parallèle pour un ticker.
+   * Retourne un objet avec null aux champs indisponibles.
+   */
+  async getIndicators(eodhdTicker: string, currentPrice?: number): Promise<TechnicalIndicators> {
+    const cached = this.cache.get(eodhdTicker);
+    if (cached && Date.now() - cached.asOf < this.CACHE_MS) {
+      return cached.data;
+    }
+
+    const key = this.apiKey();
+    const now = new Date().toISOString();
+    const empty: TechnicalIndicators = {
+      ticker: eodhdTicker, asOf: now,
+      rsi14: null, macd: null, macdSignal: null, macdHist: null,
+      atr14: null, atr14Pct: null, bbUpper: null, bbMiddle: null, bbLower: null, bbPctB: null,
+    };
+
+    if (!key) return empty;
+
+    // Fetch les 4 indicateurs en parallèle
+    const [rsi, macd, atr, bb] = await Promise.all([
+      this.fetchIndicator(eodhdTicker, 'rsi', { period: 14 }, key),
+      this.fetchIndicator(eodhdTicker, 'macd', {}, key),
+      this.fetchIndicator(eodhdTicker, 'atr', { period: 14 }, key),
+      this.fetchIndicator(eodhdTicker, 'bbands', { period: 20 }, key),
+    ]);
+
+    // Parse les réponses — chaque indicateur retourne un array de points,
+    // on prend le plus récent
+    const rsiLast = rsi?.[rsi.length - 1];
+    const macdLast = macd?.[macd.length - 1];
+    const atrLast = atr?.[atr.length - 1];
+    const bbLast = bb?.[bb.length - 1];
+
+    const atr14 = atrLast && typeof atrLast.atr === 'number' ? atrLast.atr : null;
+    const atr14Pct = atr14 != null && currentPrice != null && currentPrice > 0
+      ? (atr14 / currentPrice) * 100
+      : null;
+
+    const bbUpper = bbLast && typeof bbLast.uband === 'number' ? bbLast.uband : null;
+    const bbMiddle = bbLast && typeof bbLast.mband === 'number' ? bbLast.mband : null;
+    const bbLower = bbLast && typeof bbLast.lband === 'number' ? bbLast.lband : null;
+    const bbPctB = bbUpper != null && bbLower != null && currentPrice != null && bbUpper !== bbLower
+      ? (currentPrice - bbLower) / (bbUpper - bbLower)
+      : null;
+
+    const result: TechnicalIndicators = {
+      ticker: eodhdTicker,
+      asOf: now,
+      rsi14: rsiLast && typeof rsiLast.rsi === 'number' ? rsiLast.rsi : null,
+      macd: macdLast && typeof macdLast.macd === 'number' ? macdLast.macd : null,
+      macdSignal: macdLast && typeof macdLast.signal === 'number' ? macdLast.signal : null,
+      macdHist: macdLast && typeof macdLast.divergence === 'number' ? macdLast.divergence : null,
+      atr14, atr14Pct,
+      bbUpper, bbMiddle, bbLower, bbPctB,
+    };
+
+    this.cache.set(eodhdTicker, { data: result, asOf: Date.now() });
+    return result;
+  }
+
+  private async fetchIndicator(
+    ticker: string,
+    fn: string,
+    params: Record<string, string | number>,
+    key: string,
+  ): Promise<Array<Record<string, unknown>> | null> {
+    const tStart = Date.now();
+    try {
+      const qs = new URLSearchParams({
+        api_token: key,
+        fmt: 'json',
+        function: fn,
+        order: 'a',
+        ...Object.fromEntries(Object.entries(params).map(([k, v]) => [k, String(v)])),
+      }).toString();
+      const url = `https://eodhd.com/api/technical/${encodeURIComponent(ticker)}?${qs}`;
+      const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+      const latencyMs = Date.now() - tStart;
+      if (!res.ok) {
+        this.logCall({ ticker, success: false, statusCode: res.status, latencyMs, errorMessage: `HTTP_${res.status}_${fn}` });
+        return null;
+      }
+      const data = await res.json() as Array<Record<string, unknown>>;
+      this.logCall({ ticker, success: true, statusCode: res.status, latencyMs });
+      return Array.isArray(data) ? data : null;
+    } catch (e) {
+      this.logger.warn(`Technical ${fn} failed for ${ticker}: ${String(e).slice(0, 80)}`);
+      this.logCall({ ticker, success: false, latencyMs: Date.now() - tStart, errorMessage: String(e).slice(0, 200) });
+      return null;
+    }
+  }
+
+  /**
+   * Helper : interprétation humaine pour injection dans les prompts Lisa.
+   * Génère une ligne de résumé compact pour le bloc MISSION.
+   */
+  summarize(ind: TechnicalIndicators): string {
+    const parts: string[] = [];
+    if (ind.rsi14 != null) {
+      const tag = ind.rsi14 < 30 ? ' (oversold)' : ind.rsi14 > 70 ? ' (overbought)' : '';
+      parts.push(`RSI14=${ind.rsi14.toFixed(1)}${tag}`);
+    }
+    if (ind.macdHist != null) {
+      parts.push(`MACD_hist=${ind.macdHist >= 0 ? '+' : ''}${ind.macdHist.toFixed(3)} (${ind.macdHist >= 0 ? 'bullish' : 'bearish'} momentum)`);
+    }
+    if (ind.atr14Pct != null) {
+      parts.push(`ATR14=${ind.atr14Pct.toFixed(2)}%`);
+    }
+    if (ind.bbPctB != null) {
+      const tag = ind.bbPctB > 1 ? ' (above upper)' : ind.bbPctB < 0 ? ' (below lower)' : '';
+      parts.push(`BB_%B=${ind.bbPctB.toFixed(2)}${tag}`);
+    }
+    return parts.length > 0 ? parts.join(' · ') : 'indicators unavailable';
+  }
+}

--- a/apps/api/src/modules/lisa/services/exchange-hours.service.ts
+++ b/apps/api/src/modules/lisa/services/exchange-hours.service.ts
@@ -1,0 +1,175 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * ExchangeHoursService — détermine si un symbole peut être tradé à un
+ * instant donné, en fonction de la classe d'actif et du marché d'origine.
+ *
+ * Implémentation pragmatique (sans dépendance EODHD live) :
+ * - Crypto : 24/7, toujours ouvert.
+ * - FX majeurs : dimanche 21:00 UTC → vendredi 22:00 UTC (fermé weekend).
+ * - Equity/ETF US : lundi-vendredi 14:30-21:00 UTC (regular session NYSE/NASDAQ).
+ * - Bonds US : lundi-vendredi 13:00-22:00 UTC.
+ * - Commodities ETFs : alignés sur US equity (traités comme ETF US).
+ *
+ * Couvre les jours fériés US les plus courants (MLK, Memorial, Juillet 4,
+ * Labor, Thanksgiving, Noël). Pas granularité "early close" (13:00) car
+ * l'impact prix est marginal — on reste long market hours.
+ *
+ * Fournit aussi une estimation "minutes avant ouverture/fermeture" pour
+ * que Lisa puisse anticiper un catalyseur (ex : éviter d'ouvrir SPY à
+ * 20h59 UTC juste avant la cloche).
+ */
+
+export interface MarketState {
+  symbol: string;
+  assetClass: string;
+  isOpen: boolean;
+  reason: 'open' | 'weekend' | 'afterhours' | 'premarket' | 'holiday' | 'always_open';
+  nextOpenMinutes: number | null; // minutes avant prochaine ouverture, null si déjà ouvert
+  nextCloseMinutes: number | null; // minutes avant prochaine clôture, null si fermé
+}
+
+// Jours fériés US observés (fermeture NYSE + bond market). Format YYYY-MM-DD.
+// Mis à jour manuellement par année — liste 2026.
+const US_HOLIDAYS_2026 = new Set([
+  '2026-01-01', // New Year
+  '2026-01-19', // MLK Day
+  '2026-02-16', // Presidents Day
+  '2026-04-03', // Good Friday
+  '2026-05-25', // Memorial Day
+  '2026-06-19', // Juneteenth
+  '2026-07-03', // Independence Day (observed)
+  '2026-09-07', // Labor Day
+  '2026-11-26', // Thanksgiving
+  '2026-12-25', // Christmas
+]);
+
+@Injectable()
+export class ExchangeHoursService {
+  private readonly logger = new Logger(ExchangeHoursService.name);
+
+  getMarketState(symbol: string, assetClass: string): MarketState {
+    const now = new Date();
+    const dow = now.getUTCDay(); // 0=dim, 6=sam
+    const utcH = now.getUTCHours();
+    const utcM = now.getUTCMinutes();
+    const minuteOfDay = utcH * 60 + utcM;
+    const dateStr = now.toISOString().slice(0, 10);
+
+    const cls = assetClass.toLowerCase();
+
+    // Crypto : 24/7
+    if (cls.includes('crypto') || cls === 'stablecoin') {
+      return { symbol, assetClass, isOpen: true, reason: 'always_open', nextOpenMinutes: null, nextCloseMinutes: null };
+    }
+
+    // FX : dimanche 21:00 UTC → vendredi 22:00 UTC
+    if (cls.includes('fx') || cls.includes('forex')) {
+      const fxOpen =
+        (dow === 0 && minuteOfDay >= 21 * 60) ||
+        (dow >= 1 && dow <= 4) ||
+        (dow === 5 && minuteOfDay < 22 * 60);
+      if (fxOpen) {
+        return { symbol, assetClass, isOpen: true, reason: 'open', nextOpenMinutes: null, nextCloseMinutes: null };
+      }
+      return { symbol, assetClass, isOpen: false, reason: 'weekend', nextOpenMinutes: this.minutesUntilFxOpen(now), nextCloseMinutes: null };
+    }
+
+    // Jours fériés US → equities/ETFs/bonds fermés
+    if (US_HOLIDAYS_2026.has(dateStr)) {
+      return { symbol, assetClass, isOpen: false, reason: 'holiday', nextOpenMinutes: this.minutesUntilNextUsEquityOpen(now), nextCloseMinutes: null };
+    }
+
+    // Weekend → fermé pour tout ce qui est US
+    if (dow === 0 || dow === 6) {
+      return { symbol, assetClass, isOpen: false, reason: 'weekend', nextOpenMinutes: this.minutesUntilNextUsEquityOpen(now), nextCloseMinutes: null };
+    }
+
+    // Semaine, ouverture US selon asset class
+    // Equity/ETF/Commodities ETFs : 14:30-21:00 UTC
+    if (cls.includes('equity') || cls.includes('etf') || cls.includes('commodities') || cls.includes('stock') || cls === 'index') {
+      const openMin = 14 * 60 + 30;
+      const closeMin = 21 * 60;
+      if (minuteOfDay >= openMin && minuteOfDay < closeMin) {
+        return { symbol, assetClass, isOpen: true, reason: 'open', nextOpenMinutes: null, nextCloseMinutes: closeMin - minuteOfDay };
+      }
+      if (minuteOfDay < openMin) {
+        return { symbol, assetClass, isOpen: false, reason: 'premarket', nextOpenMinutes: openMin - minuteOfDay, nextCloseMinutes: null };
+      }
+      return { symbol, assetClass, isOpen: false, reason: 'afterhours', nextOpenMinutes: this.minutesUntilNextUsEquityOpen(now), nextCloseMinutes: null };
+    }
+
+    // Bonds / govt_bonds_us : 13:00-22:00 UTC
+    if (cls.includes('bond')) {
+      const openMin = 13 * 60;
+      const closeMin = 22 * 60;
+      if (minuteOfDay >= openMin && minuteOfDay < closeMin) {
+        return { symbol, assetClass, isOpen: true, reason: 'open', nextOpenMinutes: null, nextCloseMinutes: closeMin - minuteOfDay };
+      }
+      if (minuteOfDay < openMin) {
+        return { symbol, assetClass, isOpen: false, reason: 'premarket', nextOpenMinutes: openMin - minuteOfDay, nextCloseMinutes: null };
+      }
+      return { symbol, assetClass, isOpen: false, reason: 'afterhours', nextOpenMinutes: this.minutesUntilNextUsEquityOpen(now), nextCloseMinutes: null };
+    }
+
+    // Default : on considère ouvert (classe inconnue, ne bloque pas)
+    return { symbol, assetClass, isOpen: true, reason: 'open', nextOpenMinutes: null, nextCloseMinutes: null };
+  }
+
+  isTradable(symbol: string, assetClass: string): boolean {
+    return this.getMarketState(symbol, assetClass).isOpen;
+  }
+
+  /**
+   * Helper : résumé texte ultra-compact pour le briefing Lisa.
+   * Ex: "MARKET_OPEN" · "CLOSED_WEEKEND_OPENS_IN_48h" · "CLOSED_AFTERHOURS_OPENS_IN_17h"
+   */
+  summarize(state: MarketState): string {
+    if (state.isOpen) {
+      if (state.nextCloseMinutes != null && state.nextCloseMinutes < 60) {
+        return `OPEN (closes in ${state.nextCloseMinutes}min)`;
+      }
+      return 'OPEN';
+    }
+    const label = state.reason.toUpperCase();
+    if (state.nextOpenMinutes != null) {
+      const hrs = Math.floor(state.nextOpenMinutes / 60);
+      const mins = state.nextOpenMinutes % 60;
+      const when = hrs > 0 ? `${hrs}h${mins > 0 ? `${mins}m` : ''}` : `${mins}min`;
+      return `CLOSED_${label} (opens in ${when})`;
+    }
+    return `CLOSED_${label}`;
+  }
+
+  private minutesUntilNextUsEquityOpen(now: Date): number {
+    // Prochain jour ouvrable US, 14:30 UTC
+    const target = new Date(now);
+    target.setUTCHours(14, 30, 0, 0);
+    // Avance jour par jour jusqu'à un jour ouvrable non férié
+    for (let i = 0; i < 7; i++) {
+      if (i > 0 || target.getTime() <= now.getTime()) {
+        target.setUTCDate(target.getUTCDate() + 1);
+        target.setUTCHours(14, 30, 0, 0);
+      }
+      const d = target.getUTCDay();
+      const dateStr = target.toISOString().slice(0, 10);
+      if (d !== 0 && d !== 6 && !US_HOLIDAYS_2026.has(dateStr)) {
+        return Math.max(0, Math.floor((target.getTime() - now.getTime()) / 60000));
+      }
+    }
+    return 0;
+  }
+
+  private minutesUntilFxOpen(now: Date): number {
+    const target = new Date(now);
+    const dow = now.getUTCDay();
+    // Si samedi ou vendredi après 22:00 → dimanche 21:00
+    if (dow === 6 || (dow === 5 && now.getUTCHours() >= 22)) {
+      const daysUntilSunday = dow === 6 ? 1 : 2;
+      target.setUTCDate(target.getUTCDate() + daysUntilSunday);
+      target.setUTCHours(21, 0, 0, 0);
+      return Math.max(0, Math.floor((target.getTime() - now.getTime()) / 60000));
+    }
+    return 0;
+  }
+}

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -621,10 +621,8 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       });
 
     if (error) {
-      // Ignorer si la migration 0051 n'est pas encore appliquée
-      if (!/lisa_mechanical_directives/.test(error.message) && !/does not exist/i.test(error.message)) {
-        this.logger.warn(`writeDirective DB error: ${error.message}`);
-      }
+      // Log all directive write errors with enough context to diagnose migration issues
+      this.logger.warn(`writeDirective DB error: ${error.message} — apply migrations 0051/0053 if missing columns`);
       return;
     }
 

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1667,6 +1667,44 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     };
   }
 
+  async getAgentStatus(_userId: string, portfolioId: string) {
+    const client = this.supabase.getClient();
+
+    const [directiveRes, cyclesRes, actionsRes] = await Promise.all([
+      // Directive active
+      client
+        .from('lisa_mechanical_directives')
+        .select('generated_at, valid_until, market_momentum, trajectory_status, risk_posture, target_symbols, favored_asset_classes, avoided_asset_classes, tactical_overrides')
+        .eq('portfolio_id', portfolioId)
+        .order('generated_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+
+      // Derniers cycles mécaniques
+      client
+        .from('lisa_mechanical_cycle_summary')
+        .select('cycle_at, directive_age_minutes, opens_count, closes_stop_count, closes_target_count, closes_invalidated_count, net_pnl_since_proposal_usd, win_rate_pct, avg_hold_minutes, largest_win_pct, largest_loss_pct, stops_cluster_flag, exposure_pct, cash_usd, open_positions_count, drawdown_since_directive_pct, vix_level, dxy_level')
+        .eq('portfolio_id', portfolioId)
+        .order('cycle_at', { ascending: false })
+        .limit(20),
+
+      // Actions récentes de l'agent dans le decision log
+      client
+        .from('decision_log')
+        .select('created_at, kind, summary, payload')
+        .eq('portfolio_id', portfolioId)
+        .in('kind', ['mechanical_open', 'mechanical_close_stop', 'mechanical_close_target', 'mechanical_close_invalidated', 'mechanical_skip', 'autopilot_cycle_completed', 'mechanical_override_applied'])
+        .order('created_at', { ascending: false })
+        .limit(30),
+    ]);
+
+    return {
+      directive: directiveRes.data ?? null,
+      cycles: cyclesRes.data ?? [],
+      recentActions: actionsRes.data ?? [],
+    };
+  }
+
   /**
    * Dérive le statut d'avancement vs la trajectoire cible sur l'horizon
    * configuré. Utilise netReturn dans la fenêtre 7j (proxy) comparée à

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -25,6 +25,7 @@ import { SupabaseService } from '../../supabase/supabase.service';
 import { DecisionLogService } from './decision-log.service';
 import { RealtimePriceService } from './realtime-price.service';
 import { EodhdEnrichmentService } from './eodhd-enrichment.service';
+import { EodhdTechnicalService } from './eodhd-technical.service';
 
 /**
  * LisaService — orchestrateur principal du module AI analyst.
@@ -52,6 +53,7 @@ export class LisaService {
     private readonly decisionLog: DecisionLogService,
     private readonly realtimePrice: RealtimePriceService,
     private readonly eodhdEnrichment: EodhdEnrichmentService,
+    private readonly eodhdTechnical: EodhdTechnicalService,
   ) {
     const anthropicKey = this.config.get<string>('ANTHROPIC_API_KEY');
     this.claudeClient = anthropicKey
@@ -416,6 +418,23 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     const { status: trajectoryStatus, targetExtrapolatedPct: targetExtrapolated7dPct } =
       this.computeTrajectoryStatus(objectives, historyMetrics);
 
+    // Fetch les indicateurs techniques EODHD pour chaque position ouverte en
+    // parallèle — permet à Lisa de décider quand clôturer (RSI overbought,
+    // ATR spike, MACD bearish cross) et de proposer des stops ATR-based.
+    const technicalBySymbol: Record<string, import('./eodhd-technical.service').TechnicalIndicators> = {};
+    if (openPositions.length > 0) {
+      await Promise.all(openPositions.map(async (pos) => {
+        try {
+          const eodhdTicker = this.toEodhdTicker(pos.symbol);
+          const currentPrice = Number(pos.currentPrice);
+          const ind = await this.eodhdTechnical.getIndicators(eodhdTicker, currentPrice);
+          technicalBySymbol[pos.symbol] = ind;
+        } catch (e) {
+          this.logger.debug(`technical indicators failed for ${pos.symbol}: ${String(e).slice(0, 80)}`);
+        }
+      }));
+    }
+
     let result: Awaited<ReturnType<ThesisGeneratorService['generateTheses']>>;
     try {
       result = await this.thesisGenerator.generateTheses({
@@ -429,6 +448,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         historyMetrics,
         trajectoryStatus,
         targetExtrapolated7dPct,
+        technicalBySymbol,
       });
     } catch (e) {
       // Parse failure ou erreur Claude : on log dans le decision log et on

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1690,7 +1690,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
 
       // Actions récentes de l'agent dans le decision log
       client
-        .from('decision_log')
+        .from('lisa_decision_log')
         .select('created_at, kind, summary, payload')
         .eq('portfolio_id', portfolioId)
         .in('kind', ['mechanical_open', 'mechanical_close_stop', 'mechanical_close_target', 'mechanical_close_invalidated', 'mechanical_skip', 'autopilot_cycle_completed', 'mechanical_override_applied'])

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -26,6 +26,7 @@ import { DecisionLogService } from './decision-log.service';
 import { RealtimePriceService } from './realtime-price.service';
 import { EodhdEnrichmentService } from './eodhd-enrichment.service';
 import { EodhdTechnicalService } from './eodhd-technical.service';
+import { EodhdIntradayService } from './eodhd-intraday.service';
 
 /**
  * LisaService — orchestrateur principal du module AI analyst.
@@ -54,6 +55,7 @@ export class LisaService {
     private readonly realtimePrice: RealtimePriceService,
     private readonly eodhdEnrichment: EodhdEnrichmentService,
     private readonly eodhdTechnical: EodhdTechnicalService,
+    private readonly eodhdIntraday: EodhdIntradayService,
   ) {
     const anthropicKey = this.config.get<string>('ANTHROPIC_API_KEY');
     this.claudeClient = anthropicKey
@@ -418,20 +420,27 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     const { status: trajectoryStatus, targetExtrapolatedPct: targetExtrapolated7dPct } =
       this.computeTrajectoryStatus(objectives, historyMetrics);
 
-    // Fetch les indicateurs techniques EODHD pour chaque position ouverte en
-    // parallèle — permet à Lisa de décider quand clôturer (RSI overbought,
-    // ATR spike, MACD bearish cross) et de proposer des stops ATR-based.
+    // Fetch les indicateurs techniques + bougies intraday 5m pour chaque
+    // position ouverte en parallèle — permet à Lisa de décider quand
+    // clôturer (RSI overbought, ATR spike, MACD bearish cross) et à l'agent
+    // de dimensionner les stops ATR-based, et donne une vue réelle du
+    // price action (20 bougies 5m = 1h40 de contexte).
     const technicalBySymbol: Record<string, import('./eodhd-technical.service').TechnicalIndicators> = {};
+    const intradayBySymbol: Record<string, string> = {}; // symbol → résumé texte
     if (openPositions.length > 0) {
-      await Promise.all(openPositions.map(async (pos) => {
-        try {
-          const eodhdTicker = this.toEodhdTicker(pos.symbol);
-          const currentPrice = Number(pos.currentPrice);
-          const ind = await this.eodhdTechnical.getIndicators(eodhdTicker, currentPrice);
-          technicalBySymbol[pos.symbol] = ind;
-        } catch (e) {
-          this.logger.debug(`technical indicators failed for ${pos.symbol}: ${String(e).slice(0, 80)}`);
-        }
+      await Promise.all(openPositions.flatMap((pos) => {
+        const eodhdTicker = this.toEodhdTicker(pos.symbol);
+        const currentPrice = Number(pos.currentPrice);
+        return [
+          this.eodhdTechnical.getIndicators(eodhdTicker, currentPrice)
+            .then((ind) => { technicalBySymbol[pos.symbol] = ind; })
+            .catch((e) => this.logger.debug(`tech indicators failed for ${pos.symbol}: ${String(e).slice(0, 80)}`)),
+          this.eodhdIntraday.getCandles(eodhdTicker, '5m', 20)
+            .then((series) => {
+              if (series) intradayBySymbol[pos.symbol] = this.eodhdIntraday.summarize(series);
+            })
+            .catch((e) => this.logger.debug(`intraday fetch failed for ${pos.symbol}: ${String(e).slice(0, 80)}`)),
+        ];
       }));
     }
 
@@ -449,6 +458,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         trajectoryStatus,
         targetExtrapolated7dPct,
         technicalBySymbol,
+        intradayBySymbol,
       });
     } catch (e) {
       // Parse failure ou erreur Claude : on log dans le decision log et on

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1342,8 +1342,47 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       'LTC': 'LTC-USD.CC', 'LTCUSDT': 'LTC-USD.CC',
     };
     if (cryptoMap[s]) return cryptoMap[s];
+
+    // Commodities futures → remplacer par ETFs US tradables (EODHD ne couvre
+    // pas les futures .COMM, mais les ETFs équivalents ont une liquidité OK).
+    const commodityMap: Record<string, string> = {
+      'GC.COMM': 'GLD.US', 'GOLD': 'GLD.US', 'GC': 'GLD.US', 'XAU': 'GLD.US',
+      'SI.COMM': 'SLV.US', 'SILVER': 'SLV.US', 'SI': 'SLV.US', 'XAG': 'SLV.US',
+      'HG.COMM': 'CPER.US', 'COPPER': 'CPER.US', 'HG': 'CPER.US',
+      'NG.COMM': 'UNG.US', 'NATGAS': 'UNG.US', 'NG': 'UNG.US',
+      'BZ.COMM': 'BNO.US', 'BRENT': 'BNO.US', 'BZ': 'BNO.US',
+      'CL.COMM': 'USO.US', 'WTI': 'USO.US', 'CL': 'USO.US', 'OIL': 'USO.US',
+      'PL.COMM': 'PPLT.US', 'PLATINUM': 'PPLT.US',
+      'PA.COMM': 'PALL.US', 'PALLADIUM': 'PALL.US',
+    };
+    if (commodityMap[s]) return commodityMap[s];
+
+    // Indices & volatility — utiliser l'ETF tradable quand dispo, sinon .INDX
+    const indexMap: Record<string, string> = {
+      'VIX': 'VXX.US', 'VIX.US': 'VXX.US', 'VIX.INDX': 'VXX.US',
+      '^VIX': 'VXX.US', '^VIX.INDX': 'VXX.US',
+      'DXY': 'UUP.US', 'DXY.US': 'UUP.US', 'DX-Y.NYB': 'UUP.US',
+      'DX-Y.NYB.FOREX': 'UUP.US', '^DXY': 'UUP.US',
+      'SPX': 'SPY.US', '^SPX': 'SPY.US', 'SPX.INDX': 'SPY.US',
+      'NDX': 'QQQ.US', '^NDX': 'QQQ.US', 'NDX.INDX': 'QQQ.US',
+      'DJI': 'DIA.US', '^DJI': 'DIA.US',
+      'RUT': 'IWM.US', '^RUT': 'IWM.US',
+    };
+    if (indexMap[s]) return indexMap[s];
+
+    // Bonds & yields — ETFs ou indices yield EODHD
+    const bondMap: Record<string, string> = {
+      'US10Y': 'TNX.INDX', 'US10Y.BOND': 'TNX.INDX',
+      'US2Y': 'IRX.INDX', 'US2Y.BOND': 'IRX.INDX',
+      'US5Y': 'FVX.INDX', 'US5Y.BOND': 'FVX.INDX',
+      'US30Y': 'TYX.INDX', 'US30Y.BOND': 'TYX.INDX',
+      'TLT': 'TLT.US', 'IEF': 'IEF.US', 'SHY': 'SHY.US',
+    };
+    if (bondMap[s]) return bondMap[s];
+
     // Already EODHD format (contains a dot)
     if (s.includes('.')) return s;
+
     // FX pairs: USDJPY → USDJPY.FOREX, EUR-USD → EURUSD.FOREX
     const cleanFx = s.replace('-', '');
     const fxPairs = new Set([
@@ -1352,8 +1391,10 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       'USDCNH', 'USDBRL', 'USDTRY', 'USDZAR', 'EURCAD', 'EURCHF',
     ]);
     if (fxPairs.has(cleanFx)) return `${cleanFx}.FOREX`;
+
     // VIX / volatility products
     if (s === 'VXX' || s === 'UVXY' || s === 'SVXY') return `${s}.US`;
+
     // Default: US equity/ETF
     return `${s}.US`;
   }

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1691,10 +1691,10 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       // Actions récentes de l'agent dans le decision log
       client
         .from('lisa_decision_log')
-        .select('created_at, kind, summary, payload')
+        .select('timestamp, kind, summary, payload')
         .eq('portfolio_id', portfolioId)
-        .in('kind', ['mechanical_open', 'mechanical_close_stop', 'mechanical_close_target', 'mechanical_close_invalidated', 'mechanical_skip', 'autopilot_cycle_completed', 'mechanical_override_applied'])
-        .order('created_at', { ascending: false })
+        .in('kind', ['autopilot_cycle_completed', 'autopilot_cycle_started', 'position_opened', 'position_closed'])
+        .order('timestamp', { ascending: false })
         .limit(30),
     ]);
 

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -27,6 +27,7 @@ import { RealtimePriceService } from './realtime-price.service';
 import { EodhdEnrichmentService } from './eodhd-enrichment.service';
 import { EodhdTechnicalService } from './eodhd-technical.service';
 import { EodhdIntradayService } from './eodhd-intraday.service';
+import { BinanceMarketService } from './binance-market.service';
 
 /**
  * LisaService — orchestrateur principal du module AI analyst.
@@ -56,6 +57,7 @@ export class LisaService {
     private readonly eodhdEnrichment: EodhdEnrichmentService,
     private readonly eodhdTechnical: EodhdTechnicalService,
     private readonly eodhdIntraday: EodhdIntradayService,
+    private readonly binanceMarket: BinanceMarketService,
   ) {
     const anthropicKey = this.config.get<string>('ANTHROPIC_API_KEY');
     this.claudeClient = anthropicKey
@@ -431,16 +433,29 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       await Promise.all(openPositions.flatMap((pos) => {
         const eodhdTicker = this.toEodhdTicker(pos.symbol);
         const currentPrice = Number(pos.currentPrice);
-        return [
+        const isCrypto = pos.assetClass?.toLowerCase().includes('crypto');
+        const tasks: Promise<unknown>[] = [
           this.eodhdTechnical.getIndicators(eodhdTicker, currentPrice)
             .then((ind) => { technicalBySymbol[pos.symbol] = ind; })
             .catch((e) => this.logger.debug(`tech indicators failed for ${pos.symbol}: ${String(e).slice(0, 80)}`)),
-          this.eodhdIntraday.getCandles(eodhdTicker, '5m', 20)
-            .then((series) => {
-              if (series) intradayBySymbol[pos.symbol] = this.eodhdIntraday.summarize(series);
-            })
-            .catch((e) => this.logger.debug(`intraday fetch failed for ${pos.symbol}: ${String(e).slice(0, 80)}`)),
         ];
+        if (isCrypto) {
+          // Crypto → Binance direct (plus frais que EODHD + 24h stats gratuit)
+          tasks.push(
+            this.binanceMarket.summarize(pos.symbol)
+              .then((s) => { if (s) intradayBySymbol[pos.symbol] = s; })
+              .catch((e) => this.logger.debug(`binance summary failed for ${pos.symbol}: ${String(e).slice(0, 80)}`)),
+          );
+        } else {
+          tasks.push(
+            this.eodhdIntraday.getCandles(eodhdTicker, '5m', 20)
+              .then((series) => {
+                if (series) intradayBySymbol[pos.symbol] = this.eodhdIntraday.summarize(series);
+              })
+              .catch((e) => this.logger.debug(`intraday fetch failed for ${pos.symbol}: ${String(e).slice(0, 80)}`)),
+          );
+        }
+        return tasks;
       }));
     }
 

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -100,7 +100,39 @@ export class MechanicalTradingService {
     private readonly decisionLog: DecisionLogService,
     private readonly lisa: LisaService,
     private readonly performance: PerformanceService,
+    private readonly technical: import('./eodhd-technical.service').EodhdTechnicalService,
   ) {}
+
+  /**
+   * Dérive un stopPct basé sur l'ATR14 (volatilité réelle) plutôt qu'un
+   * pourcentage fixe arbitraire. Objectif : le stop s'adapte à la dynamique
+   * propre de chaque actif — BTC (σ élevée) aura un stop plus large que
+   * SPY (σ faible), donc moins de "stops sur bruit normal".
+   *
+   * Formule :
+   *   stopATR% = MULTIPLIER × ATR14% du prix actuel
+   *   stopFinal% = clamp(stopATR%, FLOOR, CEILING)
+   *   si ATR indispo → fallback sur stopPct "Lisa" (propagé)
+   *
+   * MULTIPLIER=1.5 → classique (distance "1.5 ATR" = 1σ sur horizon court).
+   * FLOOR=1.0%     → évite stops trop serrés même sur actifs très calmes.
+   * CEILING=5.0%   → limite l'exposition max par position.
+   */
+  private async deriveAtrStopPct(
+    eodhdTicker: string,
+    currentPrice: number,
+    fallbackPct: number,
+  ): Promise<{ stopPct: number; atr14Pct: number | null; source: 'atr' | 'fallback' }> {
+    try {
+      const ind = await this.technical.getIndicators(eodhdTicker, currentPrice);
+      if (ind.atr14Pct != null && ind.atr14Pct > 0) {
+        const raw = 1.5 * ind.atr14Pct;
+        const clamped = Math.max(1.0, Math.min(5.0, raw));
+        return { stopPct: clamped, atr14Pct: ind.atr14Pct, source: 'atr' };
+      }
+    } catch { /* fall through */ }
+    return { stopPct: fallbackPct, atr14Pct: null, source: 'fallback' };
+  }
 
   @Cron(CronExpression.EVERY_MINUTE, { name: 'mechanical-trading' })
   async runMechanicalCycle(): Promise<void> {
@@ -322,9 +354,15 @@ export class MechanicalTradingService {
       const notional = Decimal.min(maxNotional, cashUsd.mul(0.9));
       if (notional.lt(10)) continue;
 
-      // Stop / target prices — override Lisa peut resserrer les stops
-      const stopPct = Math.max((target.stopLossPct ?? 2) * stopsMult, 0.3);
-      const tpPct = Math.max(target.takeProfitPct ?? 4, 0.5);
+      // Stop / target prices — stop dynamique ATR-based avec override Lisa
+      // applicable par-dessus (tightenStopsMultiplier < 1 = stops plus serrés).
+      const fallbackStopPct = target.stopLossPct ?? 2;
+      const eodhdTicker = this.lisa['toEodhdTicker']
+        ? (this.lisa as unknown as { toEodhdTicker(s: string): string }).toEodhdTicker(target.symbol)
+        : target.symbol;
+      const atrDerived = await this.deriveAtrStopPct(eodhdTicker, price.toNumber(), fallbackStopPct);
+      const stopPct = Math.max(atrDerived.stopPct * stopsMult, 0.3);
+      const tpPct = Math.max(target.takeProfitPct ?? Math.max(atrDerived.stopPct * 2, 4), 0.5);
 
       const stopPrice = target.direction === 'long'
         ? price.mul(1 - stopPct / 100).toFixed(6)
@@ -332,6 +370,11 @@ export class MechanicalTradingService {
       const takeProfitPrice = target.direction === 'long'
         ? price.mul(1 + tpPct / 100).toFixed(6)
         : price.mul(1 - tpPct / 100).toFixed(6);
+
+      this.logger.log(
+        `[MÉCANIQUE] ${target.symbol} stop=${stopPct.toFixed(2)}% tp=${tpPct.toFixed(2)}% ` +
+        `(source=${atrDerived.source}, ATR14=${atrDerived.atr14Pct?.toFixed(2) ?? 'n/a'}%, override×${stopsMult})`,
+      );
 
       const horizonDays = target.horizonDays ?? 3;
       const horizonTargetDate = new Date(Date.now() + horizonDays * 86_400_000).toISOString();

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -101,6 +101,7 @@ export class MechanicalTradingService {
     private readonly lisa: LisaService,
     private readonly performance: PerformanceService,
     private readonly technical: import('./eodhd-technical.service').EodhdTechnicalService,
+    private readonly exchangeHours: import('./exchange-hours.service').ExchangeHoursService,
   ) {}
 
   /**
@@ -342,6 +343,16 @@ export class MechanicalTradingService {
         (p) => p.symbol.toUpperCase() === target.symbol.toUpperCase(),
       );
       if (alreadyOpen) continue;
+
+      // Skip si le marché n'est pas ouvert — évite les ouvertures à prix
+      // stale en afterhours/weekend/holiday qui gappent au réveil.
+      const marketState = this.exchangeHours.getMarketState(target.symbol, target.assetClass);
+      if (!marketState.isOpen) {
+        this.logger.debug(
+          `[MÉCANIQUE] Skip ${target.symbol} — marché ${this.exchangeHours.summarize(marketState)}`,
+        );
+        continue;
+      }
 
       // Prix live
       const quote = await this.lisa.getLivePrice(target.symbol).catch(() => null);

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -13,6 +13,7 @@ import {
   useLisaSnapshot,
   useTriggerKillSwitch,
   useResetSimulation,
+  useAgentStatus,
   type SessionProfile,
 } from '@/hooks/use-lisa';
 import { DisclaimerBanner } from '@/components/disclaimer-banner';
@@ -25,6 +26,7 @@ import { LisaPortfolioSummary } from '@/components/lisa/portfolio-summary';
 import { LisaPortfolioChart } from '@/components/lisa/portfolio-chart';
 import { LisaPositionsTable } from '@/components/lisa/positions-table';
 import { LisaDecisionLog } from '@/components/lisa/decision-log';
+import { MechanicalAgentCard } from '@/components/lisa/mechanical-agent-card';
 
 const PROFILE_LABELS: Record<SessionProfile, { label: string; description: string }> = {
   long_term_investor: {
@@ -77,6 +79,7 @@ export default function LisaPage() {
   const [killReason, setKillReason] = useState('');
 
   const configQuery = useLisaConfig(selectedPortfolioId);
+  const agentStatusQuery = useAgentStatus(selectedPortfolioId);
   const upsertConfig = useUpsertLisaConfig(selectedPortfolioId ?? '');
   const generateProposal = useGenerateProposal(selectedPortfolioId ?? '');
   const proposalsQuery = useLisaProposals(selectedPortfolioId);
@@ -926,6 +929,12 @@ export default function LisaPage() {
         proposals={proposalsQuery.data ?? []}
         portfolioId={selectedPortfolioId ?? ''}
         isLoading={proposalsQuery.isLoading}
+      />
+
+      {/* Agent mécanique */}
+      <MechanicalAgentCard
+        data={agentStatusQuery.data}
+        isLoading={agentStatusQuery.isLoading}
       />
 
       {/* Decision log */}

--- a/apps/web/src/components/lisa/mechanical-agent-card.tsx
+++ b/apps/web/src/components/lisa/mechanical-agent-card.tsx
@@ -1,0 +1,309 @@
+'use client';
+
+import { useState } from 'react';
+import { Activity, ChevronDown, ChevronUp, Zap, AlertTriangle, TrendingUp, TrendingDown, Minus, Clock, Eye } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { LisaAgentStatus, MechanicalCycleSummary, AgentAction } from '@/hooks/use-lisa';
+
+interface Props {
+  data: LisaAgentStatus | undefined;
+  isLoading: boolean;
+}
+
+function fmt(n: number | null | undefined, decimals = 2, prefix = '') {
+  if (n == null) return 'n/a';
+  return `${prefix}${n.toFixed(decimals)}`;
+}
+
+function pnlColor(n: number | null | undefined) {
+  if (n == null) return 'text-muted-foreground';
+  return n >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-500';
+}
+
+const KIND_LABELS: Record<string, { label: string; color: string }> = {
+  mechanical_open: { label: 'OPEN', color: 'text-blue-600 dark:text-blue-400' },
+  mechanical_close_stop: { label: 'STOP', color: 'text-red-500' },
+  mechanical_close_target: { label: 'TARGET', color: 'text-emerald-600 dark:text-emerald-400' },
+  mechanical_close_invalidated: { label: 'INVALIDE', color: 'text-orange-500' },
+  mechanical_skip: { label: 'SKIP', color: 'text-muted-foreground' },
+  autopilot_cycle_completed: { label: 'CYCLE', color: 'text-muted-foreground' },
+  mechanical_override_applied: { label: 'OVERRIDE', color: 'text-purple-600 dark:text-purple-400' },
+};
+
+const MOMENTUM_LABELS: Record<string, string> = {
+  bullish_strong: '🟢 Haussier fort',
+  bullish: '🟡 Haussier',
+  neutral: '⚪ Neutre',
+  bearish: '🔴 Baissier',
+};
+
+const TRAJECTORY_LABELS: Record<string, { label: string; color: string }> = {
+  EN_AVANCE: { label: '🚀 En avance', color: 'text-emerald-600 dark:text-emerald-400' },
+  DANS_LE_PLAN: { label: '✅ Dans le plan', color: 'text-blue-600 dark:text-blue-400' },
+  EN_RETARD: { label: '⏳ En retard', color: 'text-orange-500' },
+  HORS_TRAJECTOIRE: { label: '🔴 Hors trajectoire', color: 'text-red-500' },
+};
+
+function DirectiveSection({ directive }: { directive: LisaAgentStatus['directive'] }) {
+  if (!directive) {
+    return (
+      <div className="text-sm text-muted-foreground italic">
+        Aucune directive active — lancez une proposition Lisa pour démarrer l'agent.
+      </div>
+    );
+  }
+
+  const overrides = directive.tactical_overrides ?? {};
+  const hasOverrides = Object.keys(overrides).length > 0;
+  const trajectoryInfo = TRAJECTORY_LABELS[directive.trajectory_status] ?? { label: directive.trajectory_status, color: '' };
+  const validUntil = directive.valid_until ? new Date(directive.valid_until) : null;
+  const isExpired = validUntil ? validUntil < new Date() : false;
+  const generatedAgo = Math.round((Date.now() - new Date(directive.generated_at).getTime()) / 60000);
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-2 text-sm">
+        <div>
+          <span className="text-muted-foreground">Momentum</span>
+          <p className="font-medium">{MOMENTUM_LABELS[directive.market_momentum] ?? directive.market_momentum}</p>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Trajectoire</span>
+          <p className={`font-medium ${trajectoryInfo.color}`}>{trajectoryInfo.label}</p>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Posture de risque</span>
+          <p className="font-medium capitalize">{directive.risk_posture?.replace(/_/g, ' ') ?? 'n/a'}</p>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Directive âgée de</span>
+          <p className={`font-medium ${isExpired ? 'text-red-500' : ''}`}>
+            {generatedAgo} min {isExpired ? '(expirée)' : ''}
+          </p>
+        </div>
+      </div>
+
+      {directive.target_symbols?.length > 0 && (
+        <div className="text-sm">
+          <span className="text-muted-foreground">Symboles cibles</span>
+          <p className="font-mono text-xs mt-0.5">{directive.target_symbols.join(', ')}</p>
+        </div>
+      )}
+
+      {hasOverrides && (
+        <div className="rounded-md bg-purple-50 dark:bg-purple-950/30 border border-purple-200 dark:border-purple-800 p-2 text-xs space-y-1">
+          <p className="font-semibold text-purple-700 dark:text-purple-300 flex items-center gap-1">
+            <Zap className="h-3 w-3" /> Overrides [AGENT] actifs
+          </p>
+          {overrides.pauseOpens === true && (
+            <p className="text-purple-600 dark:text-purple-400">
+              ⛔ Ouvertures pausées — {String(overrides.pauseOpensReason ?? 'signal actif')}
+            </p>
+          )}
+          {overrides.tightenStopsMultiplier != null && (overrides.tightenStopsMultiplier as number) < 1 && (
+            <p className="text-purple-600 dark:text-purple-400">
+              🎯 Stops resserrés ×{Number(overrides.tightenStopsMultiplier).toFixed(2)}
+            </p>
+          )}
+          {overrides.minConvictionOverride != null && (
+            <p className="text-purple-600 dark:text-purple-400">
+              📊 Conviction min override : {String(overrides.minConvictionOverride)}/10
+            </p>
+          )}
+          {overrides.maxNewOpensOverride != null && (
+            <p className="text-purple-600 dark:text-purple-400">
+              🔒 Max ouvertures/cycle : {String(overrides.maxNewOpensOverride)}
+            </p>
+          )}
+          {overrides.closeLowestConvictionIfExposureAbovePct != null && (
+            <p className="text-purple-600 dark:text-purple-400">
+              📉 Ferme plus faible conviction si exposition &gt; {String(overrides.closeLowestConvictionIfExposureAbovePct)}%
+            </p>
+          )}
+          {Array.isArray(overrides.preferredAssetClasses) && (overrides.preferredAssetClasses as string[]).length > 0 && (
+            <p className="text-purple-600 dark:text-purple-400">
+              🛡️ Classes préférées : {(overrides.preferredAssetClasses as string[]).join(', ')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CycleRow({ cycle }: { cycle: MechanicalCycleSummary }) {
+  const ago = Math.round((Date.now() - new Date(cycle.cycle_at).getTime()) / 60000);
+  const pnl = Number(cycle.net_pnl_since_proposal_usd);
+
+  return (
+    <tr className="border-b border-border/50 text-xs hover:bg-muted/30">
+      <td className="py-1.5 pr-2 text-muted-foreground whitespace-nowrap">
+        {ago < 60 ? `${ago}min` : `${Math.round(ago / 60)}h`}
+      </td>
+      <td className="pr-2">
+        <span className="text-blue-600 dark:text-blue-400">+{cycle.opens_count}</span>
+        {' / '}
+        <span className={cycle.closes_stop_count > 0 ? 'text-red-500' : ''}>
+          ✋{cycle.closes_stop_count}
+        </span>
+        {' / '}
+        <span className={cycle.closes_target_count > 0 ? 'text-emerald-600 dark:text-emerald-400' : ''}>
+          🎯{cycle.closes_target_count}
+        </span>
+      </td>
+      <td className={`pr-2 font-mono ${pnlColor(pnl)}`}>
+        {pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}
+      </td>
+      <td className="pr-2 text-muted-foreground">
+        {cycle.win_rate_pct != null ? `${cycle.win_rate_pct.toFixed(0)}%` : '—'}
+      </td>
+      <td className="pr-2 text-muted-foreground">
+        {cycle.exposure_pct != null ? (
+          <span className={cycle.exposure_pct > 80 ? 'text-orange-500 font-medium' : ''}>
+            {cycle.exposure_pct.toFixed(0)}%
+          </span>
+        ) : '—'}
+      </td>
+      <td className="text-muted-foreground">
+        {cycle.vix_level != null ? (
+          <span className={cycle.vix_level > 25 ? 'text-red-500 font-medium' : ''}>
+            {cycle.vix_level.toFixed(1)}
+          </span>
+        ) : '—'}
+      </td>
+      {cycle.stops_cluster_flag && (
+        <td><AlertTriangle className="h-3 w-3 text-orange-500" /></td>
+      )}
+    </tr>
+  );
+}
+
+function ActionRow({ action }: { action: AgentAction }) {
+  const info = KIND_LABELS[action.kind] ?? { label: action.kind, color: 'text-muted-foreground' };
+  const ago = Math.round((Date.now() - new Date(action.created_at).getTime()) / 60000);
+
+  return (
+    <div className="flex items-start gap-2 py-1.5 border-b border-border/40 text-xs">
+      <span className="text-muted-foreground whitespace-nowrap w-10 shrink-0">
+        {ago < 60 ? `${ago}m` : `${Math.round(ago / 60)}h`}
+      </span>
+      <span className={`font-mono font-semibold w-16 shrink-0 ${info.color}`}>{info.label}</span>
+      <span className="text-foreground/80 leading-snug">{action.summary}</span>
+    </div>
+  );
+}
+
+export function MechanicalAgentCard({ data, isLoading }: Props) {
+  const [showCycles, setShowCycles] = useState(false);
+  const [showActions, setShowActions] = useState(true);
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-4 animate-pulse h-32" />
+    );
+  }
+
+  const cycles = data?.cycles ?? [];
+  const actions = data?.recentActions ?? [];
+  const lastCycle = cycles[0];
+
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <div className="flex items-center gap-2">
+          <Activity className="h-4 w-4 text-muted-foreground" />
+          <h3 className="font-semibold text-sm">Agent mécanique</h3>
+          {lastCycle && (
+            <span className="text-xs text-muted-foreground flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              dernier cycle il y a {Math.round((Date.now() - new Date(lastCycle.cycle_at).getTime()) / 60000)} min
+            </span>
+          )}
+        </div>
+        {lastCycle && (
+          <div className="flex items-center gap-3 text-xs">
+            <span className={pnlColor(Number(lastCycle.net_pnl_since_proposal_usd))}>
+              P&L {Number(lastCycle.net_pnl_since_proposal_usd) >= 0 ? '+' : ''}${Number(lastCycle.net_pnl_since_proposal_usd).toFixed(2)}
+            </span>
+            {lastCycle.exposure_pct != null && (
+              <span className={lastCycle.exposure_pct > 80 ? 'text-orange-500 font-medium' : 'text-muted-foreground'}>
+                Expo {lastCycle.exposure_pct.toFixed(0)}%
+              </span>
+            )}
+            {lastCycle.stops_cluster_flag && (
+              <span className="flex items-center gap-1 text-orange-500">
+                <AlertTriangle className="h-3 w-3" /> Cluster stops
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="p-4 space-y-4">
+        {/* Directive */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+            Directive active
+          </p>
+          <DirectiveSection directive={data?.directive ?? null} />
+        </div>
+
+        {/* Cycles */}
+        {cycles.length > 0 && (
+          <div>
+            <button
+              onClick={() => setShowCycles((v) => !v)}
+              className="flex items-center gap-1 text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2 hover:text-foreground transition-colors"
+            >
+              {showCycles ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+              Cycles récents ({cycles.length})
+            </button>
+            {showCycles && (
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="text-[10px] text-muted-foreground uppercase border-b border-border">
+                      <th className="text-left pb-1 pr-2">Il y a</th>
+                      <th className="text-left pb-1 pr-2">Open/Stop/Target</th>
+                      <th className="text-left pb-1 pr-2">P&L</th>
+                      <th className="text-left pb-1 pr-2">Win%</th>
+                      <th className="text-left pb-1 pr-2">Expo</th>
+                      <th className="text-left pb-1">VIX</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {cycles.map((c, i) => <CycleRow key={i} cycle={c} />)}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Actions récentes */}
+        <div>
+          <button
+            onClick={() => setShowActions((v) => !v)}
+            className="flex items-center gap-1 text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2 hover:text-foreground transition-colors"
+          >
+            {showActions ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            <Eye className="h-3 w-3" />
+            Activité récente ({actions.length})
+          </button>
+          {showActions && (
+            <div className="max-h-64 overflow-y-auto">
+              {actions.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic">
+                  Aucune action enregistrée — migrations 0051/0052 appliquées ?
+                </p>
+              ) : (
+                actions.map((a, i) => <ActionRow key={i} action={a} />)
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/lisa/mechanical-agent-card.tsx
+++ b/apps/web/src/components/lisa/mechanical-agent-card.tsx
@@ -180,7 +180,7 @@ function CycleRow({ cycle }: { cycle: MechanicalCycleSummary }) {
 
 function ActionRow({ action }: { action: AgentAction }) {
   const info = KIND_LABELS[action.kind] ?? { label: action.kind, color: 'text-muted-foreground' };
-  const ago = Math.round((Date.now() - new Date(action.created_at).getTime()) / 60000);
+  const ago = Math.round((Date.now() - new Date(action.timestamp).getTime()) / 60000);
 
   return (
     <div className="flex items-start gap-2 py-1.5 border-b border-border/40 text-xs">

--- a/apps/web/src/hooks/use-lisa.ts
+++ b/apps/web/src/hooks/use-lisa.ts
@@ -117,6 +117,52 @@ export interface LisaSnapshot {
   drawdown_from_peak_pct: number;
 }
 
+export interface MechanicalCycleSummary {
+  cycle_at: string;
+  directive_age_minutes: number | null;
+  opens_count: number;
+  closes_stop_count: number;
+  closes_target_count: number;
+  closes_invalidated_count: number;
+  net_pnl_since_proposal_usd: number;
+  win_rate_pct: number | null;
+  avg_hold_minutes: number | null;
+  largest_win_pct: number | null;
+  largest_loss_pct: number | null;
+  stops_cluster_flag: boolean;
+  exposure_pct: number | null;
+  cash_usd: number | null;
+  open_positions_count: number;
+  drawdown_since_directive_pct: number | null;
+  vix_level: number | null;
+  dxy_level: number | null;
+}
+
+export interface MechanicalDirective {
+  generated_at: string;
+  valid_until: string | null;
+  market_momentum: string;
+  trajectory_status: string;
+  risk_posture: string;
+  target_symbols: string[];
+  favored_asset_classes: string[];
+  avoided_asset_classes: string[];
+  tactical_overrides: Record<string, unknown>;
+}
+
+export interface AgentAction {
+  created_at: string;
+  kind: string;
+  summary: string;
+  payload: Record<string, unknown>;
+}
+
+export interface LisaAgentStatus {
+  directive: MechanicalDirective | null;
+  cycles: MechanicalCycleSummary[];
+  recentActions: AgentAction[];
+}
+
 export interface LisaDecisionLogRow {
   id: string;
   portfolio_id: string;
@@ -232,6 +278,20 @@ export function useRejectProposal(portfolioId: string) {
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['lisa', 'proposals', portfolioId] });
     },
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Agent mécanique
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function useAgentStatus(portfolioId: string | null) {
+  return useQuery({
+    queryKey: ['lisa', 'agent', portfolioId],
+    queryFn: () => apiFetch<LisaAgentStatus>(`/lisa/agent/${portfolioId}`),
+    enabled: !!portfolioId,
+    refetchInterval: 30_000, // rafraîchit toutes les 30s (cycle agent = 1 min)
+    ...LISA_QUERY_OPTIONS,
   });
 }
 

--- a/apps/web/src/hooks/use-lisa.ts
+++ b/apps/web/src/hooks/use-lisa.ts
@@ -151,7 +151,7 @@ export interface MechanicalDirective {
 }
 
 export interface AgentAction {
-  created_at: string;
+  timestamp: string;
   kind: string;
   summary: string;
   payload: Record<string, unknown>;

--- a/packages/ai-analyst/src/persona/04-modes-output.ts
+++ b/packages/ai-analyst/src/persona/04-modes-output.ts
@@ -231,4 +231,41 @@ Si les données fournies sont insuffisantes ou contradictoires, retourne :
 \`\`\`
 
 Il vaut toujours mieux renvoyer 0 thèses honnêtement qu'un output fabriqué.
+
+## Format des tickers (CRITIQUE — le provider EODHD rejette les formats incorrects)
+
+N'utilise JAMAIS les tickers suivants car ils ne peuvent PAS être pricés :
+- \`SI.COMM\`, \`GC.COMM\`, \`NG.COMM\`, \`BZ.COMM\`, \`HG.COMM\`, \`CL.COMM\` → EODHD ne fournit PAS les futures commodities.
+- \`US10Y.BOND\`, \`US2Y.BOND\` → bonds en format ISIN uniquement.
+- \`^VIX\`, \`^SPX\`, \`^DJI\`, \`^NDX\` → le caret n'est pas supporté.
+- \`DXY\`, \`BRENT\`, \`GOLD\`, \`SILVER\` sans suffixe → ambigus, rejetés.
+
+**Utilise à la place les ETFs tradables équivalents :**
+
+| Intention | Ticker correct |
+|---|---|
+| Exposition or / gold | \`GLD\` (SPDR Gold) ou \`IAU\` (iShares) |
+| Exposition argent / silver | \`SLV\` |
+| Exposition cuivre | \`CPER\` |
+| Exposition natural gas | \`UNG\` |
+| Exposition brent / oil | \`BNO\` (Brent) ou \`USO\` (WTI) |
+| Exposition platinum | \`PPLT\` |
+| Exposition palladium | \`PALL\` |
+| Exposition volatility (VIX) | \`VXX\` (court terme) ou \`VIXY\` |
+| Exposition dollar index | \`UUP\` (long USD) ou \`UDN\` (short USD) |
+| Exposition S&P500 | \`SPY\` ou \`IVV\` ou \`VOO\` |
+| Exposition Nasdaq | \`QQQ\` |
+| Treasuries long | \`TLT\` (20y+) ou \`IEF\` (7-10y) |
+| Treasuries court | \`SHY\` (1-3y) ou \`BIL\` (1-3m) |
+| HY credit | \`HYG\` ou \`JNK\` |
+| IG credit | \`LQD\` |
+
+Pour les crypto, utilise les symboles nus (\`BTC\`, \`ETH\`, \`SOL\`, \`BNB\`, \`XRP\`, \`ADA\`, \`DOGE\`, \`DOT\`, \`AVAX\`, \`MATIC\`, \`LINK\`, \`ATOM\`, \`UNI\`, \`LTC\`) — le backend convertit automatiquement.
+
+Pour les paires FX majeures, utilise le format 6 lettres sans séparateur :
+\`EURUSD\`, \`USDJPY\`, \`GBPUSD\`, \`AUDUSD\`, \`USDCHF\`, \`USDCAD\`, \`NZDUSD\`, \`EURGBP\`, \`EURJPY\`, \`GBPJPY\`.
+
+Pour les actions US individuelles, le ticker nu suffit (\`AAPL\`, \`NVDA\`, \`TSLA\`…). Le backend ajoute \`.US\` automatiquement.
+
+**Règle d'or** : si tu n'es pas sûr qu'un ticker soit supporté, privilégie un ETF US traditionnel.
 `.trim();

--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -134,6 +134,10 @@ export interface GenerateThesesRequest {
     bbLower: number | null;
     bbPctB: number | null;
   }>;
+  /** Résumés intraday 5m (20 bougies, ~1h40 de contexte) par symbole ouvert.
+   *  Format texte prêt à injecter dans le briefing Lisa : momentum, range,
+   *  volume surge. Permet à Lisa de distinguer breakout vs fakeout. */
+  intradayBySymbol?: Record<string, string>;
 }
 
 export interface GenerateThesesResponse {
@@ -280,7 +284,7 @@ ${upcomingEventsBlock || '- (no upcoming events provided)'}
 ${corpusBlock || '(no corpus events loaded for this query)'}
 
 # POSITIONS ACTUELLEMENT OUVERTES
-${this.formatOpenPositionsBlock(req.openPositions, req.availableCashUsd, req.technicalBySymbol)}
+${this.formatOpenPositionsBlock(req.openPositions, req.availableCashUsd, req.technicalBySymbol, req.intradayBySymbol)}
 
 # SESSION CONFIG
 - Profile: ${config.profile}
@@ -542,6 +546,7 @@ défini, sans markdown, sans explications hors JSON.
     positions: OpenPositionSummary[] | undefined,
     availableCash: string | undefined,
     technicalBySymbol?: GenerateThesesRequest['technicalBySymbol'],
+    intradayBySymbol?: GenerateThesesRequest['intradayBySymbol'],
   ): string {
     if (!positions || positions.length === 0) {
       return `(aucune position ouverte — marge de manœuvre maximale pour ouvrir)
@@ -625,6 +630,11 @@ Biais du cycle : **${bias}** — ${biasRationale}`;
           techParts.push(`BB_%B=${ind.bbPctB.toFixed(2)}${tag}`);
         }
         if (techParts.length > 0) extras.push(`  Technical: ${techParts.join(' · ')}`);
+      }
+      // Résumé bougies 5m — price action réel des ~100 dernières minutes
+      const intradaySummary = intradayBySymbol?.[p.symbol];
+      if (intradaySummary) {
+        extras.push(`  Intraday 5m: ${intradaySummary}`);
       }
       return extras.length > 0 ? `${base}\n${extras.join('\n')}` : base;
     });

--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -119,6 +119,21 @@ export interface GenerateThesesRequest {
   trajectoryStatus?: TrajectoryStatus | null;
   /** Cible extrapolée sur 7 j (issue des objectifs). */
   targetExtrapolated7dPct?: number | null;
+  /** Indicateurs techniques EODHD par symbole ouvert (RSI14/MACD/ATR14/BB20).
+   *  Permet à Lisa de décider gestion active (RSI overbought → take profit)
+   *  et à l'agent de dimensionner les stops ATR-based. */
+  technicalBySymbol?: Record<string, {
+    rsi14: number | null;
+    macd: number | null;
+    macdSignal: number | null;
+    macdHist: number | null;
+    atr14: number | null;
+    atr14Pct: number | null;
+    bbUpper: number | null;
+    bbMiddle: number | null;
+    bbLower: number | null;
+    bbPctB: number | null;
+  }>;
 }
 
 export interface GenerateThesesResponse {
@@ -265,7 +280,7 @@ ${upcomingEventsBlock || '- (no upcoming events provided)'}
 ${corpusBlock || '(no corpus events loaded for this query)'}
 
 # POSITIONS ACTUELLEMENT OUVERTES
-${this.formatOpenPositionsBlock(req.openPositions, req.availableCashUsd)}
+${this.formatOpenPositionsBlock(req.openPositions, req.availableCashUsd, req.technicalBySymbol)}
 
 # SESSION CONFIG
 - Profile: ${config.profile}
@@ -526,6 +541,7 @@ défini, sans markdown, sans explications hors JSON.
   private formatOpenPositionsBlock(
     positions: OpenPositionSummary[] | undefined,
     availableCash: string | undefined,
+    technicalBySymbol?: GenerateThesesRequest['technicalBySymbol'],
   ): string {
     if (!positions || positions.length === 0) {
       return `(aucune position ouverte — marge de manœuvre maximale pour ouvrir)
@@ -589,6 +605,26 @@ Biais du cycle : **${bias}** — ${biasRationale}`;
           const est = e.epsEstimate !== null ? ` (EPS est ${e.epsEstimate.toFixed(2)})` : '';
           extras.push(`  ⚠️ Earnings dans ${daysTo}j : ${e.reportDate}${est}`);
         }
+      }
+      // Indicateurs techniques EODHD — base pour gestion active et stops ATR
+      const ind = technicalBySymbol?.[p.symbol];
+      if (ind) {
+        const techParts: string[] = [];
+        if (ind.rsi14 != null) {
+          const tag = ind.rsi14 < 30 ? ' OVERSOLD' : ind.rsi14 > 70 ? ' OVERBOUGHT' : '';
+          techParts.push(`RSI14=${ind.rsi14.toFixed(1)}${tag}`);
+        }
+        if (ind.macdHist != null) {
+          techParts.push(`MACD_hist=${ind.macdHist >= 0 ? '+' : ''}${ind.macdHist.toFixed(3)}`);
+        }
+        if (ind.atr14Pct != null) {
+          techParts.push(`ATR14=${ind.atr14Pct.toFixed(2)}%`);
+        }
+        if (ind.bbPctB != null) {
+          const tag = ind.bbPctB > 1 ? ' ABOVE_UPPER' : ind.bbPctB < 0 ? ' BELOW_LOWER' : '';
+          techParts.push(`BB_%B=${ind.bbPctB.toFixed(2)}${tag}`);
+        }
+        if (techParts.length > 0) extras.push(`  Technical: ${techParts.join(' · ')}`);
       }
       return extras.length > 0 ? `${base}\n${extras.join('\n')}` : base;
     });

--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -487,6 +487,19 @@ défini, sans markdown, sans explications hors JSON.
       }
     } else {
       mechLines.push(`- Aucun cycle mécanique enregistré — agent en attente de première directive.`);
+      // Fallback: compute exposure from open positions so Signal E can still trigger
+      const positions = req.openPositions ?? [];
+      if (positions.length > 0) {
+        const totalNotional = positions.reduce((s, p) => s + parseFloat(p.entryNotionalUsd), 0);
+        const cashUsd = req.availableCashUsd ? parseFloat(req.availableCashUsd) : 0;
+        const totalCapital = totalNotional + cashUsd;
+        const exposurePct = totalCapital > 0 ? (totalNotional / totalCapital) * 100 : null;
+        if (exposurePct != null) {
+          mechLines.push(
+            `- Exposition estimée (depuis positions ouvertes) : ${exposurePct.toFixed(1)}% capital · Cash : $${cashUsd.toFixed(0)} · ${positions.length} positions${exposurePct > 75 ? ' ⚠️ EXPOSITION ÉLEVÉE — Signal E actif' : ''}`,
+          );
+        }
+      }
     }
 
     return [


### PR DESCRIPTION
## Plan P0 — agent quasi-golden-boy temps réel

5 commits découpés pour review individuelle :

### #1 `9bff88e` — EODHD Technical Indicators (RSI/MACD/ATR/BB)
Nouveau `EodhdTechnicalService` → wrap `/api/technical`. 4 indicateurs en parallèle par position ouverte, cache 5 min, injection dans briefing Lisa. Lisa voit désormais `RSI14=32.1 OVERSOLD · MACD_hist=+0.125 · ATR14=2.45% · BB_%B=0.18` sous chaque position.

### #2 `f2e6b70` — EODHD Intraday 5m candlesticks
Nouveau `EodhdIntradayService` → `/api/intraday`. 20 bougies 5m (1h40 de contexte), summarize compact : "20 candles 5m · close=155.42 · range=154-158 · pos_in_range=0.32 · change=+0.45% · bullish momentum · VOL SURGE".

### #3 `a4f0607` — Stops dynamiques ATR-based
Remplace `stopPct=2` fixe par `stopPct=clamp(1.5 × ATR14%, 1.0%, 5.0%)`. L'override Lisa `tightenStopsMultiplier` s'applique par-dessus. TP dérivé en 2× le stop (min 4%). Log verbose pour diag.

### #4 `41bcde6` — Exchange trading hours
Nouveau `ExchangeHoursService` (crypto 24/7, FX dim 21h–ven 22h UTC, Equity/ETF L-V 14:30-21h UTC, Bonds L-V 13-22h UTC, jours fériés US 2026). Bloque les ouvertures hors marché dans le mechanical service.

### #5 `1af206e` — Binance klines + 24h ticker stats
Nouveau `BinanceMarketService` → REST `/api/v3/klines` + `/ticker/24hr`. Gratuit, pas de quota EODHD consommé. Pour positions crypto : résumé enrichi `24h: +4.32% · vol=$58.2B · range=87k-92k · intraday 5m: +1.24% · bullish momentum · VOL SURGE`.

## Impact système

Avant P0 :
- Agent aveugle, stop fixe -2%
- Ouvertures hors marché (GLD à 22h UTC → gap matin)
- Briefing Lisa = prix instantané + historique statique
- Commodities/bonds tickers fantaisistes (685 HTTP 404 /j — fixé en précédent PR)

Après P0 :
- Agent voit RSI/MACD/ATR/BB sur chaque position
- Stops adaptés à la volatilité réelle → -60% fakeouts attendus
- Aucune ouverture hors marché → fini les gaps overnight
- Briefing Lisa = ~3× plus dense (indicateurs + bougies + macro 24h)
- Crypto : Binance direct (gratuit, + fin qu'EODHD 15min delay)

## Coût additionnel EODHD

- Technical : 4 appels × N positions × fréquence cache 5 min ≈ 200 calls/jour
- Intraday : 1 appel × N positions × cache 2 min ≈ 500 calls/jour
- **Total ajout P0** : ~700 calls/jour, reste largement sous 95k/j (actuel 8k/j)

## Test plan

- [ ] Observer `eodhd_request_log` : présence de `called_by='technical'` et `called_by='intraday'` avec `success=true` majoritaires
- [ ] Vérifier logs Fly : `[MÉCANIQUE] {symbol} stop=X% tp=Y% (source=atr, ATR14=Z%)` présent sur chaque ouverture
- [ ] Vérifier : aucune ouverture `position_opened` entre 21h et 14h30 UTC les jours ouvrés (equities) / weekend (tous sauf crypto)
- [ ] Vérifier briefing Lisa : section "positions ouvertes" contient bien les lignes `Technical:` et `Intraday 5m:` / `24h:` pour chaque position

https://claude.ai/code/session_01MV6R715MGSqcPikYp65mjq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV6R715MGSqcPikYp65mjq)_