### PR TITLE
fix(lisa): crash NestJS DI au boot (Object index 4 MechanicalTradingService)

### DIFF
--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -21,6 +21,8 @@ import { SupabaseService } from '../../supabase/supabase.service';
 import { PerformanceService } from '../../performance/performance.service';
 import { DecisionLogService } from './decision-log.service';
 import { LisaService } from './lisa.service';
+import { EodhdTechnicalService } from './eodhd-technical.service';
+import { ExchangeHoursService } from './exchange-hours.service';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types internes
@@ -100,8 +102,8 @@ export class MechanicalTradingService {
     private readonly decisionLog: DecisionLogService,
     private readonly lisa: LisaService,
     private readonly performance: PerformanceService,
-    private readonly technical: import('./eodhd-technical.service').EodhdTechnicalService,
-    private readonly exchangeHours: import('./exchange-hours.service').ExchangeHoursService,
+    private readonly technical: EodhdTechnicalService,
+    private readonly exchangeHours: ExchangeHoursService,
   ) {}
 
   /**


### PR DESCRIPTION
## Problème

Depuis le merge P0 + P1, `fly deploy` échoue. La machine Fly crash 10× au boot puis s'arrête :

```
Error: Nest can't resolve dependencies of the MechanicalTradingService
  (SupabaseService, DecisionLogService, LisaService, PerformanceService, ?, Object).
Please make sure that the argument Object at index [4] is available in the LisaModule context.
```

## Cause racine

Dans les commits P0 #3 et #4, j'ai ajouté deux dépendances au constructeur de `MechanicalTradingService` en utilisant la syntaxe TypeScript `import('...').X` **directement comme type de paramètre** :

```ts
constructor(
  private readonly supabase: SupabaseService,        // index 0 ✅
  private readonly decisionLog: DecisionLogService,  // index 1 ✅
  private readonly lisa: LisaService,                // index 2 ✅
  private readonly performance: PerformanceService,  // index 3 ✅
  private readonly technical: import('./eodhd-technical.service').EodhdTechnicalService,    // index 4 ❌
  private readonly exchangeHours: import('./exchange-hours.service').ExchangeHoursService,   // index 5 ❌
) {}
```

NestJS utilise `Reflect.getMetadata('design:paramtypes')` pour résoudre les dépendances. Avec `import('...').X` comme type de paramètre, TypeScript émet `Object` comme type runtime au lieu de la classe réelle → NestJS voit `Object` à l'index 4, ne trouve pas de provider correspondant, crashe.

Les autres occurrences `import('./eodhd-technical.service').TechnicalIndicators` dans le corps des méthodes (`let ind: ... = null`) sont OK : elles sont type-only et ne passent pas par la DI.

## Fix

Un seul fichier modifié : `apps/api/src/modules/lisa/services/mechanical-trading.service.ts`

1. Ajouter 2 imports ES6 classiques en tête
2. Utiliser les classes importées directement dans le constructeur

Les providers `EodhdTechnicalService` et `ExchangeHoursService` sont déjà correctement enregistrés dans `LisaModule` (aucun changement nécessaire).

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` → clean
- [x] `grep -rn "private readonly.*: import(" apps/api/src` → 0 résultat
- [ ] `fly deploy` depuis la racine → logs doivent afficher `Nest application successfully started` sans erreur DI
- [ ] `curl https://smartvest.fly.dev/health` → `{ "status": "ok" }`

https://claude.ai/code/session_01MV6R715MGSqcPikYp65mjq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV6R715MGSqcPikYp65mjq)_