### PR TITLE
feat(risk): kill-switch autopilot si dataQuality degraded (us10y+vix …

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -64,7 +64,8 @@
       "^@smartvest/portfolio-engine$": "<rootDir>/../../../packages/portfolio-engine/src/index.ts",
       "^@smartvest/cost-engine$": "<rootDir>/../../../packages/cost-engine/src/index.ts",
       "^@smartvest/audit$": "<rootDir>/../../../packages/audit/src/index.ts",
-      "^@smartvest/brokers$": "<rootDir>/../../../packages/brokers/src/index.ts"
+      "^@smartvest/brokers$": "<rootDir>/../../../packages/brokers/src/index.ts",
+      "^@smartvest/ai-analyst$": "<rootDir>/../../../packages/ai-analyst/src/index.ts"
     }
   }
 }

--- a/apps/api/src/modules/lisa/services/__tests__/data-quality-degraded.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/data-quality-degraded.spec.ts
@@ -1,0 +1,72 @@
+import { computeDataQualityDegraded } from '@smartvest/ai-analyst';
+
+/**
+ * PATCH 1 (PR#1 P0) — kill-switch dataQuality.
+ *
+ * La règle :
+ *   degraded = (us10y ∈ fallback ET vix ∈ fallback) OU |fallback| ≥ 3
+ *
+ * us10y + vix simultanément en fallback = base macro inutilisable
+ * (taux + volatilité = piliers de la classification de régime).
+ * 3+ feeds en fallback = dégradation systémique du provider.
+ */
+describe('computeDataQualityDegraded', () => {
+  it('returns true when us10y AND vix are both in fallback', () => {
+    expect(computeDataQualityDegraded(['us10y', 'vix'])).toBe(true);
+  });
+
+  it('returns true when us10y AND vix in fallback even with other lives', () => {
+    // Présence d'autres feeds en fallback ne change rien : us10y + vix suffit
+    expect(computeDataQualityDegraded(['us10y', 'vix', 'gold'])).toBe(true);
+  });
+
+  it('returns true when 3+ feeds are in fallback (without us10y/vix combo)', () => {
+    expect(computeDataQualityDegraded(['gold', 'silver', 'brent'])).toBe(true);
+  });
+
+  it('returns true when 4 feeds are in fallback', () => {
+    expect(computeDataQualityDegraded(['gold', 'silver', 'brent', 'creditHyOas'])).toBe(true);
+  });
+
+  it('returns false when only 1 critical feed in fallback (us10y alone)', () => {
+    expect(computeDataQualityDegraded(['us10y'])).toBe(false);
+  });
+
+  it('returns false when only vix in fallback', () => {
+    expect(computeDataQualityDegraded(['vix'])).toBe(false);
+  });
+
+  it('returns false when 2 non-critical feeds in fallback', () => {
+    expect(computeDataQualityDegraded(['gold', 'silver'])).toBe(false);
+  });
+
+  it('returns false when fallback is empty', () => {
+    expect(computeDataQualityDegraded([])).toBe(false);
+  });
+
+  it('returns true when 3 feeds, one being us10y but not vix', () => {
+    // 3+ feeds → degraded indépendamment du contenu
+    expect(computeDataQualityDegraded(['us10y', 'gold', 'silver'])).toBe(true);
+  });
+
+  it('returns false when only 2 feeds and neither is us10y+vix combo', () => {
+    expect(computeDataQualityDegraded(['us10y', 'gold'])).toBe(false);
+    expect(computeDataQualityDegraded(['vix', 'silver'])).toBe(false);
+  });
+});
+
+/**
+ * Integration test du guard dans lisa-autopilot.runPortfolioCycleInner :
+ * vérifie que `decisionLog.append({ payload.reason: 'data_quality_degraded' })`
+ * est appelé et que `lisa.generateProposal` n'est PAS appelé quand
+ * `snapshot.dataQuality.degraded === true && !allowDegradedMacro`.
+ *
+ * TODO (PR séparée) : nécessite un test harness Supabase chain mock complet
+ * (.select().eq().in().order().limit().maybeSingle().gte() — 30+ méthodes).
+ * Le pattern existant dans funding/transfers.service.spec.ts couvre ~5 méthodes.
+ *
+ * Pour l'instant, la logique critique (computeDataQualityDegraded ci-dessus) est
+ * 100 % testée. Le câblage autopilot est validé manuellement post-deploy via
+ * le decision_log : tout cycle skippé doit avoir kind='autopilot_cycle_completed'
+ * + payload.reason='data_quality_degraded'.
+ */

--- a/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
@@ -247,6 +247,9 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
           cfg.portfolio_id as string,
           (cfg.autopilot_cycle_minutes as number) ?? 60,
           autoApprove && !expired,
+          // PATCH 1 — kill-switch dataQuality. Si false (default), le cycle
+          // sera skippé quand le snapshot macro est dégradé. Cf. PR#1 P0.
+          cfg.allow_degraded_macro === true,
         );
       } catch (e) {
         this.logger.error(
@@ -277,6 +280,7 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
     portfolioId: string,
     cycleMinutes: number,
     autoApprove: boolean = false,
+    allowDegradedMacro: boolean = false,
   ): Promise<void> {
     // Mutex in-memory : skip si un cycle est déjà en cours pour ce portfolio
     if (this.runningCycles.has(portfolioId)) {
@@ -297,7 +301,7 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
     this.runningCycles.add(portfolioId);
     this.cycleStartedAt.set(portfolioId, Date.now());
     try {
-      await this.runPortfolioCycleInner(userId, portfolioId, cycleMinutes, autoApprove);
+      await this.runPortfolioCycleInner(userId, portfolioId, cycleMinutes, autoApprove, allowDegradedMacro);
     } finally {
       this.runningCycles.delete(portfolioId);
       this.cycleStartedAt.delete(portfolioId);
@@ -309,6 +313,7 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
     portfolioId: string,
     cycleMinutes: number,
     autoApprove: boolean = false,
+    allowDegradedMacro: boolean = false,
   ): Promise<void> {
     // 1. Rate limit baseline = MAX(dernier cycle_started OU completed,
     //    dernière proposal). Source de vérité = lisa_proposals.created_at
@@ -434,6 +439,36 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
         summary: 'Cycle completed (new proposals paused — critical drawdown)',
         rationale: riskResult.violations.map((v) => v.message).join(' | '),
         payload: { riskStatus: riskResult.status },
+        triggeredBy: 'autopilot_cron',
+      }).catch((e) => this.logger.warn(`log append failed: ${String(e)}`));
+      return;
+    }
+
+    // PATCH 1 — Kill-switch dataQuality (PR#1 P0).
+    // Si le snapshot macro est dégradé (us10y+vix en fallback OU 3+ feeds
+    // en fallback), on skip le cycle pour ne pas gaspiller un appel Claude
+    // (~$0.17 Opus) sur des inputs non fiables. L'utilisateur peut bypass
+    // via config.allow_degraded_macro = true.
+    const guardSnapshot = await this.lisa.fetchMarketSnapshot().catch((e) => {
+      this.logger.warn(`[dataQuality guard] fetchMarketSnapshot failed: ${String(e).slice(0, 120)}`);
+      return null;
+    });
+    if (guardSnapshot?.dataQuality?.degraded === true && !allowDegradedMacro) {
+      const fallbackList = guardSnapshot.dataQuality.fallback ?? [];
+      this.logger.warn(
+        `[dataQuality guard] cycle skipped — fallback feeds: ${fallbackList.join(', ')}`,
+      );
+      await this.decisionLog.append({
+        portfolioId,
+        kind: 'autopilot_cycle_completed',
+        summary: `Cycle skipped (data quality degraded — ${fallbackList.length} feeds en fallback)`,
+        rationale: `Macro snapshot non fiable : ${fallbackList.join(', ')}. Cycle Lisa épargné pour éviter un raisonnement sur inputs hardcoded. Active config.allow_degraded_macro pour outrepasser.`,
+        payload: {
+          reason: 'data_quality_degraded',
+          fallbackFeeds: fallbackList,
+          live: guardSnapshot.dataQuality.live,
+          proxy: guardSnapshot.dataQuality.proxy,
+        },
         triggeredBy: 'autopilot_cron',
       }).catch((e) => this.logger.warn(`log append failed: ${String(e)}`));
       return;

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -9,6 +9,7 @@ import {
   RiskEnforcer,
   RiskMonitorService,
   ThesisGeneratorService,
+  computeDataQualityDegraded,
   type AllocationProposal,
   type HistoryMetrics,
   type LisaSessionConfig,
@@ -190,6 +191,8 @@ export class LisaService {
       autopilot_expires_at: pick('autopilot_expires_at', 'autopilotExpiresAt', existing?.autopilot_expires_at ?? null),
       autopilot_aggressive: pick('autopilot_aggressive', 'autopilotAggressive', existing?.autopilot_aggressive ?? false),
       autopilot_market_hours_only: pick('autopilot_market_hours_only', 'autopilotMarketHoursOnly', existing?.autopilot_market_hours_only ?? false),
+      // PATCH 1 — kill-switch dataQuality (PR#1 P0) — default false.
+      allow_degraded_macro: pick('allow_degraded_macro', 'allowDegradedMacro', existing?.allow_degraded_macro ?? false),
       // Lisa v2 — objectifs & budget (tous nullables)
       return_target_daily_pct: pick('return_target_daily_pct', 'returnTargetDailyPct', existing?.return_target_daily_pct ?? null),
       return_target_monthly_pct: pick('return_target_monthly_pct', 'returnTargetMonthlyPct', existing?.return_target_monthly_pct ?? null),
@@ -256,6 +259,20 @@ export class LisaService {
       error = retry.error;
     }
 
+    // PATCH 1 — fallback si migration 0070_allow_degraded_macro pas encore appliquée
+    if (error && /allow_degraded_macro/i.test(error.message)) {
+      this.logger.warn('Colonne allow_degraded_macro absente — retry sans ce champ');
+      const { allow_degraded_macro: _omit, ...mergedFallback } = merged;
+      void _omit;
+      const retry = await this.supabase.getClient()
+        .from('lisa_session_configs')
+        .upsert(mergedFallback, { onConflict: 'portfolio_id' })
+        .select()
+        .single();
+      data = retry.data;
+      error = retry.error;
+    }
+
     if (error) throw new BadRequestException(error.message);
     return data;
   }
@@ -307,6 +324,8 @@ export class LisaService {
       enableCrypto: (config.enable_crypto as boolean) ?? true,
       enableDerivatives: (config.enable_derivatives as boolean) ?? false,
       enableLeverage: (config.enable_leverage as boolean) ?? false,
+      // PATCH 1 — kill-switch dataQuality (PR#1 P0).
+      allowDegradedMacro: (config.allow_degraded_macro as boolean) ?? false,
     };
 
     const marketSnapshot = await this.fetchMarketSnapshot();
@@ -2028,7 +2047,10 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
    * Le tracking dataQuality (live/proxy/fallback) permet à Lisa de savoir
    * que le snapshot est partiel et d'être conservatrice sur son diagnostic.
    */
-  private async fetchMarketSnapshot(): Promise<MarketSnapshot> {
+  /** Public — utilisé par le kill-switch dataQuality côté autopilot (PATCH 1).
+   *  Le caller doit vérifier `result.dataQuality?.degraded` avant de lancer
+   *  un cycle Lisa coûteux si `allowDegradedMacro = false`. */
+  async fetchMarketSnapshot(): Promise<MarketSnapshot> {
     const eodhKey = this.config.get<string>('EODHD_API_KEY');
 
     // Static fallback (3e niveau, dernier recours)
@@ -2041,7 +2063,22 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       recentNews: [], upcomingEvents: [],
     };
 
-    if (!eodhKey || eodhKey === 'demo') return fallback;
+    if (!eodhKey || eodhKey === 'demo') {
+      // Pas de clé EODHD → tous les indicateurs sont en fallback hardcoded.
+      // On retourne dataQuality.degraded = true pour que l'autopilot skip.
+      const allIndicators = ['vix', 'dxy', 'us10y', 'us2y', 'brent', 'gold',
+        'silver', 'btc', 'eth', 'spy', 'qqq', 'eurusd', 'usdjpy',
+        'creditHyOas', 'creditIgOas'];
+      return {
+        ...fallback,
+        dataQuality: {
+          live: [],
+          proxy: [],
+          fallback: allIndicators,
+          degraded: computeDataQualityDegraded(allIndicators),
+        },
+      };
+    }
 
     const dataQuality = { live: [] as string[], proxy: [] as string[], fallback: [] as string[] };
 
@@ -2183,6 +2220,12 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       dataQuality.fallback.push('creditIgOas');
     }
 
+    // PATCH 1 — calcul du flag dégradé pour le kill-switch autopilot.
+    const dataQualityWithDegraded = {
+      ...dataQuality,
+      degraded: computeDataQualityDegraded(dataQuality.fallback),
+    };
+
     // SPY ≈ SP500/10, QQQ ≈ NASDAQ/40
     return {
       timestamp: new Date().toISOString(),
@@ -2200,7 +2243,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       usdJpy: usdjpy ?? fallback.usdJpy,
       creditHyOasBps,
       creditIgOasBps,
-      dataQuality,
+      dataQuality: dataQualityWithDegraded,
       recentNews: [],
       upcomingEvents: [],
     };

--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -54,11 +54,17 @@ export interface MarketSnapshot {
   /** Qualité des données du snapshot. Permet à Lisa de savoir quels
    *  indicateurs sont en LIVE vs PROXY (estimé via ETF) vs FALLBACK
    *  (valeur hardcoded - DANGER). Si fallback dominant, Lisa doit être
-   *  conservatrice sur son diagnostic régime. */
+   *  conservatrice sur son diagnostic régime.
+   *
+   *  `degraded` est un signal binaire calculé à partir des 3 listes
+   *  (cf. `computeDataQualityDegraded`). Si true, l'autopilot saute le
+   *  cycle (sauf si `LisaSessionConfig.allowDegradedMacro = true`).
+   */
   dataQuality?: {
     live: string[];      // indicateurs avec vraie valeur EODHD
     proxy: string[];     // indicateurs estimés via ETF (VXX→VIX, UUP→DXY)
     fallback: string[];  // indicateurs sur valeur hardcoded (DANGER)
+    degraded: boolean;   // true si lecture macro non fiable (cf. règle ci-dessus)
   };
   /** News / événements récents 24-72h */
   recentNews: Array<{
@@ -111,6 +117,29 @@ export interface MarketSnapshot {
    *  bucket, par conviction, par symbole. Calibre la confiance de Lisa
    *  sur des données empiriques de SON portfolio, pas des intuitions. */
   performanceAnalytics?: string;
+}
+
+/**
+ * Calcule si la qualité des données macro est trop dégradée pour que Lisa
+ * raisonne fiablement.
+ *
+ * Règle (cf. PATCH 1 risk-01-dataquality-killswitch) :
+ *   degraded = (us10y ∈ fallback ET vix ∈ fallback) OU |fallback| ≥ 3
+ *
+ * Justification :
+ *   - us10y + vix tous les deux indisponibles = base macro inutilisable
+ *     (taux + volatilité = piliers de toute classification de régime)
+ *   - 3+ feeds en fallback = dégradation systémique du provider data
+ *
+ * Fonction pure → testable en isolation (cf. computeDataQualityDegraded.spec.ts).
+ */
+export function computeDataQualityDegraded(
+  fallback: readonly string[],
+): boolean {
+  const set = new Set(fallback);
+  if (set.has('us10y') && set.has('vix')) return true;
+  if (fallback.length >= 3) return true;
+  return false;
 }
 
 /**

--- a/packages/ai-analyst/src/types/index.ts
+++ b/packages/ai-analyst/src/types/index.ts
@@ -468,5 +468,11 @@ export const LisaSessionConfig = z.object({
   enableCrypto: z.boolean().default(true),
   enableDerivatives: z.boolean().default(false),
   enableLeverage: z.boolean().default(false),
+  /** Si true, autorise les cycles autopilot même quand le macro snapshot
+   *  est dégradé (us10y + vix en fallback OU 3+ feeds en fallback).
+   *  Default false : kill-switch actif, le cycle est skippé silencieusement
+   *  avec audit `cycle_skipped_data_quality_degraded`. Cf. PATCH 1
+   *  risk-01-dataquality-killswitch. */
+  allowDegradedMacro: z.boolean().optional().default(false),
 });
 export type LisaSessionConfig = z.infer<typeof LisaSessionConfig>;

--- a/supabase/migrations/0070_allow_degraded_macro.sql
+++ b/supabase/migrations/0070_allow_degraded_macro.sql
@@ -1,0 +1,22 @@
+-- 0070_allow_degraded_macro.sql
+--
+-- PATCH 1 (PR#1 P0) — kill-switch dataQuality côté autopilot.
+--
+-- Ajoute une colonne booléenne `allow_degraded_macro` à `lisa_session_configs`.
+-- Default false : le cycle autopilot est skippé silencieusement quand le
+-- snapshot macro est dégradé (us10y + vix en fallback OU 3+ feeds en
+-- fallback) pour éviter un appel Claude Opus (~$0.17) sur inputs non fiables.
+--
+-- L'utilisateur peut outrepasser explicitement via UI (à venir) en mettant
+-- ce flag à true — typiquement utile en mode personnel quand on veut Lisa
+-- même avec data dégradée pour observer son comportement.
+--
+-- Audit décisionnel : chaque skip écrit un événement
+-- `autopilot_cycle_completed` avec `payload.reason = 'data_quality_degraded'`
+-- dans `lisa_decision_log` (cf. lisa-autopilot.service.ts).
+
+ALTER TABLE public.lisa_session_configs
+  ADD COLUMN IF NOT EXISTS allow_degraded_macro boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.lisa_session_configs.allow_degraded_macro IS
+  'Si true, autorise les cycles autopilot Lisa même si macro snapshot dégradé. Default false (kill-switch actif).';


### PR DESCRIPTION
…fallback)

PATCH 1 (PR#1 P0 BLOQUANT) — empêche Lisa de tourner sur des inputs macro non fiables.

Règle (cf. computeDataQualityDegraded) :
  degraded = (us10y ∈ fallback ET vix ∈ fallback) OU |fallback| ≥ 3

Justification : us10y + vix simultanément en fallback = base macro inutilisable (taux + volatilité = piliers de la classification de régime). 3+ feeds en fallback = dégradation systémique du provider.

Comportement
------------
- fetchMarketSnapshot retourne `dataQuality.degraded: boolean` calculé.
- runPortfolioCycleInner check le flag avant generateProposal.
- Si degraded && !allowDegradedMacro → skip + audit decisionLog `payload.reason: data_quality_degraded`.
- Économie ~$0.17 (Opus) par cycle skippé sur inputs invalides.

Bypass utilisateur
------------------
Nouveau champ `lisa_session_configs.allow_degraded_macro` (default false). Mettre à true pour autoriser cycles Lisa même avec data dégradée (typiquement mode personnel, observation comportement).

Migration : 0070_allow_degraded_macro.sql

Tests Jest
----------
apps/api/src/modules/lisa/services/__tests__/data-quality-degraded.spec.ts
- 10 tests sur la fonction pure computeDataQualityDegraded ✅
- Couvre tous les cas frontière : us10y+vix combo, 3+ feeds, 1 critique, empty fallback, mix avec autres feeds.

NB framework : repo utilise Jest (pas Vitest). Mapper @smartvest/ai-analyst ajouté à apps/api/package.json:moduleNameMapper.

Test integration autopilot guard reporté à PR séparée — nécessite test harness Supabase chain mock complet (30+ méthodes vs ~5 mockées actuellement dans funding/transfers.service.spec.ts).

Validation manuelle post-deploy
-------------------------------
Quand un cycle est skippé, observer dans /lisa decision_log :
  kind = 'autopilot_cycle_completed'
  summary = 'Cycle skipped (data quality degraded — N feeds en fallback)'
  payload.reason = 'data_quality_degraded'
  payload.fallbackFeeds = [...]

Fichiers
--------
- packages/ai-analyst/src/thesis/thesis-generator.service.ts (type MarketSnapshot.dataQuality.degraded + helper exporté)
- packages/ai-analyst/src/types/index.ts (LisaSessionConfig.allowDegradedMacro)
- apps/api/src/modules/lisa/services/lisa.service.ts (fetchMarketSnapshot public + degraded calc + R/W allow_degraded_macro)
- apps/api/src/modules/lisa/services/lisa-autopilot.service.ts (guard avant generateProposal + propagation allowDegradedMacro)
- supabase/migrations/0070_allow_degraded_macro.sql
- apps/api/package.json (jest moduleNameMapper)
- apps/api/src/modules/lisa/services/__tests__/data-quality-degraded.spec.ts

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb