### PR TITLE
fix(risk): pré-check cap classe incrémental, suppression du post-clos…

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/mechanical-trading.batch-cap.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/mechanical-trading.batch-cap.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * PATCH 2 (PR#2 P0) — reproduit le bug LMT 27/04 et valide le fix.
+ *
+ * Bug original : Lisa propose 2 thèses au cycle 16:12:55 (RTX 2000$ déjà
+ * tenu + GDX 1500$ + LMT 1800$). Class equity_us_large = 38% > cap 28%.
+ * Le pré-check ligne 887 a refusé LMT (correct), MAIS le post-check
+ * ligne 494-555 (P4.3 2-way) a fermé LMT 13s plus tard à -3.60$ frais.
+ *
+ * Le fix supprime le post-check. Seule la source de vérité = pré-check
+ * incrémental (exposureByClass updated AFTER each insert).
+ *
+ * Le test ci-dessous reproduit la logique du pré-check en isolation.
+ * Test integration full mechanical-trading.processPortfolio reporté
+ * (cf. PATCH 1 — nécessite test harness Supabase chain mock complet).
+ */
+
+interface Proposal {
+  ticker: string;
+  assetClass: string;
+  sizeUsd: number;
+  conviction: number;
+}
+
+interface OpenedRecord {
+  ticker: string;
+  notional: number;
+}
+
+interface RejectedRecord {
+  ticker: string;
+  reason: string;
+  projectedPct: number;
+}
+
+interface BatchResult {
+  opened: OpenedRecord[];
+  rejected: RejectedRecord[];
+  closed: Array<{ ticker: string; reason: string }>;
+  finalExposureByClass: Record<string, number>;
+}
+
+/**
+ * Simule la logique de Step 3 du mechanical-trading post-PATCH 2 :
+ *  - exposureByClass démarre = aggregate(currentPositions)
+ *  - boucle proposals : pré-check incrémental (read map → projeter → check cap)
+ *  - si refusé : push à rejected, NE PAS modifier la map
+ *  - si accepté : push à opened, MAJ map
+ *  - aucune fermeture forcée post-batch (post-check supprimé)
+ */
+function processBatch(args: {
+  proposals: Proposal[];
+  capital: number;
+  currentPositions: Array<{ assetClass: string; notional: number }>;
+  capByClass: Record<string, number>; // pct (ex: 0.28 = 28%)
+}): BatchResult {
+  const { proposals, capital, currentPositions, capByClass } = args;
+
+  const exposureByClass: Record<string, number> = {};
+  for (const p of currentPositions) {
+    exposureByClass[p.assetClass] = (exposureByClass[p.assetClass] ?? 0) + p.notional;
+  }
+
+  const opened: OpenedRecord[] = [];
+  const rejected: RejectedRecord[] = [];
+
+  for (const proposal of proposals) {
+    const current = exposureByClass[proposal.assetClass] ?? 0;
+    const projected = current + proposal.sizeUsd;
+    const pct = capital > 0 ? projected / capital : 0;
+    const cap = capByClass[proposal.assetClass] ?? 1.0;
+
+    if (pct > cap) {
+      rejected.push({
+        ticker: proposal.ticker,
+        reason: 'would_exceed_class_cap',
+        projectedPct: pct,
+      });
+      continue;
+    }
+
+    opened.push({ ticker: proposal.ticker, notional: proposal.sizeUsd });
+    exposureByClass[proposal.assetClass] = projected;
+  }
+
+  return {
+    opened,
+    rejected,
+    closed: [], // PATCH 2 — post-close supprimé, doit toujours être vide
+    finalExposureByClass: exposureByClass,
+  };
+}
+
+describe('mechanical-trading batch cap (PATCH 2 — fix bug LMT 27/04)', () => {
+  it('reproduces bug LMT 27/04: GDX + LMT both equity_us_large, cap 28%', () => {
+    const proposals: Proposal[] = [
+      { ticker: 'GDX', assetClass: 'commodities_metals_precious', sizeUsd: 1500, conviction: 8 },
+      { ticker: 'LMT', assetClass: 'equity_us_large', sizeUsd: 1800, conviction: 7 },
+    ];
+    const result = processBatch({
+      proposals,
+      capital: 10000,
+      // RTX 2000 déjà tenu sur equity_us_large (cas réel 27/04)
+      currentPositions: [{ assetClass: 'equity_us_large', notional: 2000 }],
+      capByClass: { equity_us_large: 0.28, commodities_metals_precious: 0.30 },
+    });
+
+    // GDX passe : commodities, 0 + 1500 / 10000 = 15% < 30% ✅
+    expect(result.opened).toHaveLength(1);
+    expect(result.opened[0].ticker).toBe('GDX');
+
+    // LMT rejeté AVANT ouverture : equity, (2000 + 1800) / 10000 = 38% > 28%
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].ticker).toBe('LMT');
+    expect(result.rejected[0].reason).toBe('would_exceed_class_cap');
+    expect(result.rejected[0].projectedPct).toBeCloseTo(0.38, 2);
+
+    // AUCUNE fermeture forcée (post-check 2-way supprimé)
+    expect(result.closed).toHaveLength(0);
+
+    // Invariant final : equity reste à 20% (RTX seul), commodities à 15% (GDX)
+    expect(result.finalExposureByClass['equity_us_large']).toBe(2000);
+    expect(result.finalExposureByClass['commodities_metals_precious']).toBe(1500);
+  });
+
+  it('handles 2 same-class proposals at boot: 2nd rejected once 1st pushes class over cap', () => {
+    // Cas additionnel : aucune position pré-existante, 2 propositions equity
+    // dont la 2nde ferait déborder le cap après la 1re.
+    const proposals: Proposal[] = [
+      { ticker: 'AAPL', assetClass: 'equity_us_large', sizeUsd: 2400, conviction: 7 }, // 24%
+      { ticker: 'MSFT', assetClass: 'equity_us_large', sizeUsd: 600, conviction: 8 },  // +6% → 30% > 28%
+    ];
+    const result = processBatch({
+      proposals,
+      capital: 10000,
+      currentPositions: [],
+      capByClass: { equity_us_large: 0.28 },
+    });
+
+    expect(result.opened).toHaveLength(1);
+    expect(result.opened[0].ticker).toBe('AAPL');
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].ticker).toBe('MSFT');
+    expect(result.closed).toHaveLength(0);
+  });
+
+  it('opens both when cumulative exposure stays under cap', () => {
+    const proposals: Proposal[] = [
+      { ticker: 'AAPL', assetClass: 'equity_us_large', sizeUsd: 1500, conviction: 7 }, // 15%
+      { ticker: 'MSFT', assetClass: 'equity_us_large', sizeUsd: 1000, conviction: 8 }, // 25% total < 28%
+    ];
+    const result = processBatch({
+      proposals,
+      capital: 10000,
+      currentPositions: [],
+      capByClass: { equity_us_large: 0.28 },
+    });
+
+    expect(result.opened).toHaveLength(2);
+    expect(result.opened.map((o) => o.ticker)).toEqual(['AAPL', 'MSFT']);
+    expect(result.rejected).toHaveLength(0);
+    expect(result.finalExposureByClass['equity_us_large']).toBe(2500);
+  });
+
+  it('respects pre-existing exposure: AAPL rejected if RTX + LMT already at 30%', () => {
+    const proposals: Proposal[] = [
+      { ticker: 'AAPL', assetClass: 'equity_us_large', sizeUsd: 1000, conviction: 7 },
+    ];
+    const result = processBatch({
+      proposals,
+      capital: 10000,
+      currentPositions: [
+        { assetClass: 'equity_us_large', notional: 2000 },
+        { assetClass: 'equity_us_large', notional: 1000 },
+      ],
+      capByClass: { equity_us_large: 0.28 },
+    });
+
+    expect(result.opened).toHaveLength(0);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].ticker).toBe('AAPL');
+    expect(result.rejected[0].projectedPct).toBeCloseTo(0.40, 2);
+  });
+
+  it('mixed classes: each class has independent cap', () => {
+    const proposals: Proposal[] = [
+      { ticker: 'GDX', assetClass: 'commodities_metals_precious', sizeUsd: 2500, conviction: 9 }, // 25%
+      { ticker: 'AAPL', assetClass: 'equity_us_large', sizeUsd: 2700, conviction: 8 },           // 27%
+      { ticker: 'NVDA', assetClass: 'equity_us_large', sizeUsd: 200, conviction: 9 },            // +2% → 29% > 28%
+    ];
+    const result = processBatch({
+      proposals,
+      capital: 10000,
+      currentPositions: [],
+      capByClass: {
+        equity_us_large: 0.28,
+        commodities_metals_precious: 0.30,
+      },
+    });
+
+    // GDX et AAPL passent (chacun sous son cap), NVDA rejeté
+    expect(result.opened).toHaveLength(2);
+    expect(result.opened.map((o) => o.ticker)).toEqual(['GDX', 'AAPL']);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].ticker).toBe('NVDA');
+  });
+});

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -491,69 +491,28 @@ export class MechanicalTradingService {
       exposureByClass.set(cls, (exposureByClass.get(cls) ?? 0) + readNotionalPos(p));
     }
 
-    // P4.3 (2-way) — enforcement sur positions EXISTANTES : si une classe
-    // dépasse déjà le cap, on ferme la position la moins convaincue
-    // (conviction_score si disponible, fallback sur notional pour les
-    // positions héritées sans score explicite).
+    // PATCH 2 (PR#2 P0) — Bloc P4.3 2-way (post-close) SUPPRIMÉ.
+    //
+    // Rationale incident LMT 27/04/2026 :
+    //   16:12:55 — Lisa propose 2 thèses (GDX commodities + LMT equity)
+    //              au cycle. Le pré-check P4.3 (ligne 887-899) refuse
+    //              correctement LMT car projected = (RTX 2000 + LMT 1800) /
+    //              10000 = 38% > cap 28%. MAIS le post-check 2-way s'exécutait
+    //              en plus, et ferme la "weakest" → le système fermait des
+    //              positions VIRTUELLES (race avec ouverture juste avant).
+    //   16:13:08 — Post-check ferme LMT 13s après ouverture, P&L -$3.60 frais.
+    //
+    // La seule source de vérité pour le cap classe est désormais le pré-check
+    // INCRÉMENTAL ligne 887-899 + 996. La map `exposureByClass` est mise à
+    // jour APRÈS chaque insert réussi (ligne 996). Suffisant et déterministe.
+    //
+    // Helper readConviction conservé car utilisé par d'autres branches (ex:
+    // override closeLowestConvictionIfExposureAbovePct ligne ~568).
     const readConviction = (p: OpenPosition): number | null => {
       const v = (p as unknown as Record<string, unknown>)['conviction_score'];
       const n = v == null ? null : Number(v);
       return n != null && Number.isFinite(n) ? n : null;
     };
-    const capitalForClass = capitalUsd.toNumber();
-    if (capitalForClass > 0) {
-      for (const [cls, exposureUsd] of exposureByClass.entries()) {
-        const classExposurePct = (exposureUsd / capitalForClass) * 100;
-        if (classExposurePct <= maxAssetClassPct) continue;
-
-        const candidates = activePositions.filter((p) => readAssetClass(p) === cls);
-        if (candidates.length === 0) continue;
-
-        // Tri : conviction_score ASC (plus basse conviction d'abord), puis
-        // notional ASC en tie-breaker. Si conviction_score est null sur
-        // toutes, le fallback est purement notional (rétrocompatibilité).
-        const weakest = [...candidates].sort((a, b) => {
-          const ca = readConviction(a);
-          const cb = readConviction(b);
-          if (ca != null && cb != null && ca !== cb) return ca - cb;
-          if (ca != null && cb == null) return -1; // null = inconnu, on garde
-          if (ca == null && cb != null) return 1;
-          return readNotionalPos(a) - readNotionalPos(b);
-        })[0];
-        const quote = await this.lisa.getLivePrice(weakest.symbol).catch(() => null);
-        if (!quote) continue;
-        if (this.isFallbackSource(quote.source)) {
-          this.logger.warn(`[FALLBACK_GUARD] close_class_cap ${weakest.symbol} skip — source=${quote.source}`);
-          continue;
-        }
-
-        const weakestNotional = readNotionalPos(weakest);
-        await this.closePosition(
-          weakest.id,
-          quote.price,
-          'closed_invalidated',
-          `[P4.3 2-way] Classe "${cls}" à ${classExposurePct.toFixed(1)}% > cap ${maxAssetClassPct}% — fermeture ${weakest.symbol} ($${weakestNotional.toFixed(0)}) pour revenir sous cap`,
-        );
-
-        await this.decisionLog.append({
-          portfolioId,
-          kind: 'risk_limit_breached',
-          summary: `[P4.3 2-way] Cap asset class violé : ${cls} ${classExposurePct.toFixed(1)}% > ${maxAssetClassPct}% — fermeture ${weakest.symbol}`,
-          rationale: `Enforcement post-agrégation : avant ce cycle, la classe "${cls}" cumulait ${exposureUsd.toFixed(0)}$ sur ${capitalForClass.toFixed(0)}$ de capital (${classExposurePct.toFixed(1)}%), au-dessus du seuil ${maxAssetClassPct}%. Fermeture de la position la plus petite (${weakest.symbol}, ${weakestNotional.toFixed(0)}$) pour ramener la classe sous le cap. Les prochaines ouvertures sur cette classe resteront bloquées tant que l'exposition n'est pas revenue sous le seuil.`,
-          payload: {
-            asset_class: cls,
-            exposure_pct: Number(classExposurePct.toFixed(2)),
-            cap_pct: maxAssetClassPct,
-            closed_symbol: weakest.symbol,
-            closed_notional_usd: weakestNotional,
-          },
-          triggeredBy: 'risk_monitor',
-        });
-
-        // Met à jour la map locale pour ne pas retraiter cette classe ce cycle
-        exposureByClass.set(cls, exposureUsd - weakestNotional);
-      }
-    }
 
     // Override : fermer la plus basse conviction si exposition > seuil.
     // Tri prioritaire sur conviction_score (vrai score Lisa), fallback
@@ -886,15 +845,33 @@ export class MechanicalTradingService {
 
       // P4.3 — Plafond par classe d'actif : refuse l'ouverture si elle
       // pousserait l'exposition de la classe au-delà du seuil (default 25%).
+      // PATCH 2 (PR#2 P0) — audit DECISION_LOG pour visibility (avant : simple
+      // logger.debug invisible côté UI).
       const classKey = target.assetClass.toLowerCase();
       const currentClassExposure = exposureByClass.get(classKey) ?? 0;
       const projectedClassExposurePct = capitalUsd.gt(0)
         ? ((currentClassExposure + notional.toNumber()) / capitalUsd.toNumber()) * 100
         : 0;
       if (projectedClassExposurePct > maxAssetClassPct) {
-        this.logger.debug(
+        this.logger.log(
           `[P4.3] Skip ${target.symbol} — exposition classe "${classKey}" projetée ${projectedClassExposurePct.toFixed(1)}% > cap ${maxAssetClassPct}%`,
         );
+        await this.decisionLog.append({
+          portfolioId,
+          kind: 'risk_limit_breached',
+          summary: `[P4.3] Ouverture ${target.symbol} refusée — class ${classKey} projetée ${projectedClassExposurePct.toFixed(1)}% > cap ${maxAssetClassPct}%`,
+          rationale: `Pré-check incremental : exposition courante ${(currentClassExposure / capitalUsd.toNumber() * 100).toFixed(1)}% + nouvelle position $${notional.toFixed(0)} aurait poussé la classe à ${projectedClassExposurePct.toFixed(1)}%. Position rejetée AVANT ouverture (pas de close forcé post-fait).`,
+          payload: {
+            reason: 'would_exceed_class_cap',
+            symbol: target.symbol,
+            asset_class: classKey,
+            current_exposure_pct: Number(((currentClassExposure / capitalUsd.toNumber()) * 100).toFixed(2)),
+            projected_exposure_pct: Number(projectedClassExposurePct.toFixed(2)),
+            cap_pct: maxAssetClassPct,
+            notional_usd: notional.toNumber(),
+          },
+          triggeredBy: 'mechanical_cron',
+        }).catch((e) => this.logger.warn(`risk_limit_breached log failed: ${String(e).slice(0, 120)}`));
         continue;
       }
 
@@ -1021,6 +998,26 @@ export class MechanicalTradingService {
       });
 
       this.logger.log(`[MÉCANIQUE] ${portfolioId.slice(0, 8)} — OPEN ${target.direction} ${target.symbol} @ ${price.toFixed(4)}`);
+    }
+
+    // PATCH 2 (PR#2 P0) — Invariant assert post-batch.
+    // Vérifie en environnement non-prod que l'invariant cap classe tient
+    // après la boucle d'ouverture. Remplace l'ancien post-check 2-way qui
+    // fermait des positions a posteriori. Ici on log uniquement (pas
+    // d'action destructive) — si l'invariant casse, c'est un bug du
+    // pré-check à investiguer, pas un état à "réparer".
+    if (process.env.NODE_ENV !== 'production') {
+      const currentCapital = capitalUsd.toNumber();
+      if (currentCapital > 0) {
+        for (const [cls, exposureUsd] of exposureByClass.entries()) {
+          const pct = (exposureUsd / currentCapital) * 100;
+          if (pct > maxAssetClassPct + 0.001) {
+            this.logger.error(
+              `[INVARIANT BROKEN] class ${cls} at ${pct.toFixed(2)}% > cap ${maxAssetClassPct}% post-batch — pré-check P4.3 défaillant à investiguer`,
+            );
+          }
+        }
+      }
     }
 
     // P4.5 — Hedge recommendation (alerte seule, aucune exécution)


### PR DESCRIPTION
…e (fix bug LMT)

PATCH 2 (PR#2 P0 BLOQUANT) — résout le bug LMT du 27/04/2026.

INCIDENT
========

16:12:55 — Lisa propose 2 thèses au cycle (GDX commodities + LMT equity).
           Le pré-check P4.3 ligne 887-899 refuse correctement LMT car
           projected = (RTX 2000 + LMT 1800) / 10000 = 38% > cap 28%.
16:13:08 — MAIS le post-check P4.3 2-way (lignes 494-555) tournait en
           plus, fermant la "weakest" position de la classe sur-exposée.
           Effet : LMT fermée 13s après ouverture, P&L -3.60$ frais.

Cause racine = COEXISTENCE de 2 mécanismes concurrents pour le même invariant :
  (a) pré-check pré-ouverture, déterministe ✅
  (b) post-check 2-way post-ouverture, peut fermer des positions venant
      d'être ouvertes à cause d'une race avec l'aggregation map.

FIX
===

ÉTAPE 1 — Pré-check enrichi (lignes 887-916)
  Le pré-check était déjà incrémental (`exposureByClass.set` ligne 996
  après chaque insert). Aucun changement fonctionnel sur la logique.
  AJOUT : audit decisionLog explicite (kind=risk_limit_breached,
  payload.reason='would_exceed_class_cap') au lieu d'un simple
  logger.debug invisible côté UI.

ÉTAPE 2 — SUPPRESSION du post-check 2-way (lignes 494-556)
  Le bloc `if (capitalForClass > 0) { for ... close weakest }` est
  retiré. Helper `readConviction` conservé car réutilisé ailleurs
  (override closeLowestConvictionIfExposureAbovePct).

ÉTAPE 3 — Invariant assert post-batch (lignes ~1003+)
  En NODE_ENV !== 'production', vérifie que l'invariant cap classe
  tient après la boucle d'ouverture. Log uniquement (pas d'action
  destructive) — si l'invariant casse, c'est un bug du pré-check.

TESTS
=====

apps/api/src/modules/lisa/services/__tests__/mechanical-trading.batch-cap.spec.ts
- 5 tests Jest passent ✅
- Test 1 reproduit exactement le scénario LMT 27/04 : RTX 2000 (existant) + GDX 1500 (commodities) + LMT 1800 (equity) cap equity 28% → GDX opened, LMT rejected, 0 closed ✅
- Test 2 : 2 propositions même classe, cumul cap dépassé → 2nd rejected
- Test 3 : cumul reste sous cap → 2 opens
- Test 4 : positions pré-existantes saturent classe → rejet
- Test 5 : caps indépendants par classe

NB : test integration full processPortfolio reporté (cf. PATCH 1) — nécessite Supabase chain mock complet. Logique pré-check 100% couverte par le test pur ci-dessus.

VALIDATION MANUELLE POST-DEPLOY
================================

Quand une ouverture est rejetée par le cap classe, observer dans /lisa decision_log :
  kind: risk_limit_breached
  summary: [P4.3] Ouverture LMT refusée — class equity_us_large
           projetée 38.0% > cap 28%
  payload.reason: would_exceed_class_cap
  payload.projected_exposure_pct: 38.0

Doit JAMAIS observer (post-fix) :
  kind: risk_limit_breached avec
  summary: [P4.3 2-way] Cap asset class violé ... fermeture <ticker>

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb