### PR TITLE
feat(risk): theme tagging + theme caps (évite concentration thématiqu…

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -64,7 +64,8 @@
       "^@smartvest/portfolio-engine$": "<rootDir>/../../../packages/portfolio-engine/src/index.ts",
       "^@smartvest/cost-engine$": "<rootDir>/../../../packages/cost-engine/src/index.ts",
       "^@smartvest/audit$": "<rootDir>/../../../packages/audit/src/index.ts",
-      "^@smartvest/brokers$": "<rootDir>/../../../packages/brokers/src/index.ts"
+      "^@smartvest/brokers$": "<rootDir>/../../../packages/brokers/src/index.ts",
+      "^@smartvest/ai-analyst$": "<rootDir>/../../../packages/ai-analyst/src/index.ts"
     }
   }
 }

--- a/apps/api/src/modules/lisa/services/__tests__/risk-enforcer.theme.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/risk-enforcer.theme.spec.ts
@@ -1,0 +1,195 @@
+import { canOpen } from '@smartvest/ai-analyst';
+
+/**
+ * PATCH 3 (PR#3 P1) — theme caps via canOpen() helper.
+ *
+ * Le test ci-dessous valide que le cap par thème agit en plus du cap
+ * par classe d'actif : une nouvelle position est rejetée si elle ferait
+ * dépasser le cap thème, MÊME si le cap classe est OK.
+ *
+ * Cas réel anticipé : geopolitical_safehaven peut concentrer GDX (equity),
+ * SLV (commodity), RTX (equity) en respectant chaque cap individuel mais
+ * en saturant le thème transverse à 60% du portfolio.
+ */
+describe('canOpen — theme caps (PATCH 3)', () => {
+  it('rejects new position exceeding theme cap even if class cap OK', () => {
+    const positions = [
+      {
+        ticker: 'GDX',
+        assetClass: 'equity_us_large',
+        sizeUsd: 2000,
+        themes: ['geopolitical_safehaven' as const],
+      },
+      {
+        ticker: 'SLV',
+        assetClass: 'commodities_metals_precious',
+        sizeUsd: 2000,
+        themes: ['geopolitical_safehaven' as const],
+      },
+    ];
+    const proposal = {
+      ticker: 'RTX',
+      assetClass: 'equity_us_large',
+      sizeUsd: 1500,
+      themes: ['geopolitical_safehaven' as const],
+    };
+
+    const result = canOpen(proposal, positions, {
+      capital: 10000,
+      maxAssetClassPct: { equity_us_large: 0.50 },        // permissif (35% projeté < 50%)
+      maxThemePct: { geopolitical_safehaven: 0.40 },      // serré (55% projeté > 40%)
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('would_exceed_theme_cap');
+    expect(result.details?.theme).toBe('geopolitical_safehaven');
+    expect(result.details?.projected_pct).toBeCloseTo(0.55, 2);
+    expect(result.details?.cap_pct).toBe(0.40);
+  });
+
+  it('rejects when class cap is breached but theme cap would be OK', () => {
+    // Symétrie : cap classe casse, cap thème ok → la fonction doit retourner
+    // would_exceed_class_cap (le check classe vient avant)
+    const positions = [
+      {
+        ticker: 'AAPL',
+        assetClass: 'equity_us_large',
+        sizeUsd: 2500,
+        themes: ['ai_megacap' as const],
+      },
+    ];
+    const proposal = {
+      ticker: 'NVDA',
+      assetClass: 'equity_us_large',
+      sizeUsd: 600,
+      themes: ['ai_megacap' as const],
+    };
+
+    const result = canOpen(proposal, positions, {
+      capital: 10000,
+      maxAssetClassPct: { equity_us_large: 0.28 },  // cassé (31% > 28%)
+      maxThemePct: { ai_megacap: 0.50 },             // ok
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('would_exceed_class_cap');
+    expect(result.details?.asset_class).toBe('equity_us_large');
+  });
+
+  it('accepts when both caps are respected', () => {
+    const positions = [
+      {
+        ticker: 'GDX',
+        assetClass: 'equity_us_large',
+        sizeUsd: 1500,
+        themes: ['geopolitical_safehaven' as const],
+      },
+    ];
+    const proposal = {
+      ticker: 'SLV',
+      assetClass: 'commodities_metals_precious',
+      sizeUsd: 1000,
+      themes: ['geopolitical_safehaven' as const],
+    };
+
+    const result = canOpen(proposal, positions, {
+      capital: 10000,
+      maxAssetClassPct: { equity_us_large: 0.28, commodities_metals_precious: 0.30 },
+      maxThemePct: { geopolitical_safehaven: 0.40 },  // 25% projeté < 40%
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('multiple themes on a position: any cap break rejects', () => {
+    const positions = [
+      {
+        ticker: 'XOM',
+        assetClass: 'equity_us_large',
+        sizeUsd: 2500,
+        themes: ['geopolitical_safehaven' as const, 'energy_disruption' as const],
+      },
+    ];
+    // Nouvelle position pure energy_disruption qui pousse le thème energy_disruption au-delà du cap
+    const proposal = {
+      ticker: 'USO',
+      assetClass: 'commodities_energy',
+      sizeUsd: 1500,
+      themes: ['energy_disruption' as const],
+    };
+
+    const result = canOpen(proposal, positions, {
+      capital: 10000,
+      maxAssetClassPct: { commodities_energy: 0.40 },  // ok (15%)
+      maxThemePct: {
+        geopolitical_safehaven: 0.50,                  // ok (25%)
+        energy_disruption: 0.30,                       // cassé (40% > 30%)
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('would_exceed_theme_cap');
+    expect(result.details?.theme).toBe('energy_disruption');
+  });
+
+  it('no theme caps configured: never blocks on theme', () => {
+    const positions = [
+      {
+        ticker: 'GDX',
+        assetClass: 'equity_us_large',
+        sizeUsd: 4000,
+        themes: ['geopolitical_safehaven' as const],
+      },
+    ];
+    const proposal = {
+      ticker: 'SLV',
+      assetClass: 'commodities_metals_precious',
+      sizeUsd: 4000,
+      themes: ['geopolitical_safehaven' as const],
+    };
+
+    const result = canOpen(proposal, positions, {
+      capital: 10000,
+      maxAssetClassPct: { equity_us_large: 0.50, commodities_metals_precious: 0.50 },
+      // maxThemePct intentionnellement vide
+    });
+
+    expect(result.ok).toBe(true); // 80% sur le thème mais aucun cap configuré
+  });
+
+  it('proposal with no themes: only class cap is checked', () => {
+    const positions = [
+      {
+        ticker: 'AAPL',
+        assetClass: 'equity_us_large',
+        sizeUsd: 1500,
+        themes: ['ai_megacap' as const],
+      },
+    ];
+    const proposal = {
+      ticker: 'JNJ',
+      assetClass: 'equity_us_large',
+      sizeUsd: 1000,
+      // pas de themes
+    };
+
+    const result = canOpen(proposal, positions, {
+      capital: 10000,
+      maxAssetClassPct: { equity_us_large: 0.28 },
+      maxThemePct: { ai_megacap: 0.20 },
+    });
+
+    expect(result.ok).toBe(true); // 25% classe < 28%, position pas taguée → pas de check thème
+  });
+
+  it('returns invalid_capital when capital <= 0', () => {
+    const result = canOpen(
+      { ticker: 'X', assetClass: 'equity_us_large', sizeUsd: 100 },
+      [],
+      { capital: 0 },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('invalid_capital');
+  });
+});

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -294,6 +294,16 @@ export class LisaService {
         maxPortfolioVolatilityPct: 20,
         targetDeploymentPct: 60,
         autoLiquidateOnKill: true,
+        // PATCH 3 — caps par thème (defaults conservateurs pour HARVEST)
+        maxThemePct: {
+          geopolitical_safehaven: 40,
+          ai_megacap: 35,
+          energy_disruption: 30,
+          crypto: 25,
+          defensive_bond_proxy: 50,
+          small_cap_breakout: 25,
+          other: 50,
+        },
         ...(config.risk_constraints as Partial<LisaSessionConfig['riskConstraints']> ?? {}),
       },
       antiConsensusStrength: (config.anti_consensus_strength as number) ?? 7,

--- a/packages/ai-analyst/src/allocation/risk-enforcer.ts
+++ b/packages/ai-analyst/src/allocation/risk-enforcer.ts
@@ -11,7 +11,109 @@
  */
 
 import Decimal from 'decimal.js';
-import type { AllocationProposal } from '../types';
+import type { AllocationProposal, ThemeTag } from '../types';
+
+/**
+ * PATCH 3 — Position légère pour les checks incrémentaux par classe + thème.
+ * Utilisée par `canOpen()` qui valide une SEULE proposition contre un
+ * portefeuille existant, sans nécessiter une AllocationProposal complète.
+ */
+export interface PositionLite {
+  ticker: string;
+  assetClass: string;
+  sizeUsd: number;
+  themes?: ThemeTag[];
+}
+
+export interface CanOpenOptions {
+  capital: number;
+  /** Pct par classe (0.28 = 28%) */
+  maxAssetClassPct?: Record<string, number>;
+  /** Pct par thème (0.40 = 40%) */
+  maxThemePct?: Record<string, number>;
+}
+
+export interface CanOpenResult {
+  ok: boolean;
+  reason?: 'would_exceed_class_cap' | 'would_exceed_theme_cap' | 'invalid_capital';
+  details?: {
+    asset_class?: string;
+    theme?: string;
+    current_pct?: number;
+    projected_pct?: number;
+    cap_pct?: number;
+  };
+}
+
+/**
+ * PATCH 3 — Helper pur (sans état) qui valide UNE proposition individuelle
+ * contre un portefeuille existant. Cap classe + cap thème vérifiés
+ * incrémentalement (proposal serait-elle au-dessus du cap si ouverte ?).
+ *
+ * Utilisé par les caller incrémentaux (mechanical-trading.processPortfolio
+ * Step 3 boucle, tests, futurs guards). Le RiskEnforcer.enforce() reste
+ * le check global sur AllocationProposal complète.
+ */
+export function canOpen(
+  proposal: PositionLite,
+  positions: PositionLite[],
+  options: CanOpenOptions,
+): CanOpenResult {
+  const { capital, maxAssetClassPct = {}, maxThemePct = {} } = options;
+  if (capital <= 0) return { ok: false, reason: 'invalid_capital' };
+
+  // Aggregate exposure par classe et par thème depuis les positions tenues.
+  const classExposure: Record<string, number> = {};
+  const themeExposure: Record<string, number> = {};
+  for (const p of positions) {
+    classExposure[p.assetClass] = (classExposure[p.assetClass] ?? 0) + p.sizeUsd;
+    for (const t of p.themes ?? []) {
+      themeExposure[t] = (themeExposure[t] ?? 0) + p.sizeUsd;
+    }
+  }
+
+  // Check cap classe
+  const classKey = proposal.assetClass;
+  const classCap = maxAssetClassPct[classKey];
+  if (classCap != null) {
+    const currentClass = classExposure[classKey] ?? 0;
+    const projectedClass = (currentClass + proposal.sizeUsd) / capital;
+    if (projectedClass > classCap) {
+      return {
+        ok: false,
+        reason: 'would_exceed_class_cap',
+        details: {
+          asset_class: classKey,
+          current_pct: currentClass / capital,
+          projected_pct: projectedClass,
+          cap_pct: classCap,
+        },
+      };
+    }
+  }
+
+  // Check cap thème (chaque thème de la proposal individuellement)
+  for (const theme of proposal.themes ?? []) {
+    const themeCap = maxThemePct[theme];
+    if (themeCap == null) continue; // pas de cap pour ce thème → ok
+    const currentTheme = themeExposure[theme] ?? 0;
+    const projectedTheme = (currentTheme + proposal.sizeUsd) / capital;
+    if (projectedTheme > themeCap) {
+      return {
+        ok: false,
+        reason: 'would_exceed_theme_cap',
+        details: {
+          theme,
+          current_pct: currentTheme / capital,
+          projected_pct: projectedTheme,
+          cap_pct: themeCap,
+        },
+      };
+    }
+  }
+
+  return { ok: true };
+}
 
 export interface RiskEnforcementResult {
   /** True si la proposition passe toutes les contraintes */
@@ -42,10 +144,15 @@ export class RiskEnforcer {
    *   ASSET_CLASS_CONCENTRATION de prendre en compte le portefeuille
    *   existant + les nouvelles allocations (incident 26/04 : précieux à
    *   40% sur 2 ouvertures successives chacune <28% mais agrégat ignoré).
+   * @param existingExposureByThemePct Optionnel — exposition agrégée des
+   *   positions déjà tenues par thème (PATCH 3). Captures la concentration
+   *   thématique transverse aux classes d'actifs (GDX equity + SLV commo
+   *   + RTX equity = 1 thème geopolitical_safehaven concentré).
    */
   enforce(
     proposal: AllocationProposal,
     existingExposureByAssetClassPct?: Record<string, number>,
+    existingExposureByThemePct?: Record<string, number>,
   ): RiskEnforcementResult {
     const violations: RiskEnforcementResult['violations'] = [];
     const constraints = proposal.constraints;
@@ -116,6 +223,35 @@ export class RiskEnforcer {
           message: existingPct > 0
             ? `${assetClass} total ${pct.toFixed(1)}% (tenu ${existingPct.toFixed(1)}% + nouveau ${newPct.toFixed(1)}%) exceeds max ${constraints.maxExposurePerAssetClassPct}%`
             : `${assetClass} total ${pct.toFixed(1)}% exceeds max ${constraints.maxExposurePerAssetClassPct}%`,
+        });
+      }
+    }
+
+    // 5 bis. PATCH 3 — Plafonds par thème transverses aux classes d'actifs.
+    // Cap par thème agit en plus du cap par classe : la position est rejetée
+    // si l'un des deux casse. Capture la concentration thématique (GDX
+    // equity + SLV commodity + RTX equity = 3 classes mais 1 thème
+    // geopolitical_safehaven concentré).
+    const newAllocByTheme = this.aggregateByTheme(proposal);
+    const exposureByTheme: Record<string, number> = { ...newAllocByTheme };
+    if (existingExposureByThemePct) {
+      for (const [theme, pct] of Object.entries(existingExposureByThemePct)) {
+        exposureByTheme[theme] = (exposureByTheme[theme] ?? 0) + pct;
+      }
+    }
+    const themeCaps = constraints.maxThemePct ?? {};
+    for (const [theme, pct] of Object.entries(exposureByTheme)) {
+      const cap = themeCaps[theme as keyof typeof themeCaps];
+      if (cap == null) continue; // pas de cap défini pour ce thème → illimité
+      if (pct > cap) {
+        const existingPct = existingExposureByThemePct?.[theme] ?? 0;
+        const newPct = newAllocByTheme[theme] ?? 0;
+        violations.push({
+          code: 'THEME_CONCENTRATION',
+          severity: 'error',
+          message: existingPct > 0
+            ? `theme ${theme} total ${pct.toFixed(1)}% (tenu ${existingPct.toFixed(1)}% + nouveau ${newPct.toFixed(1)}%) exceeds max ${cap}%`
+            : `theme ${theme} total ${pct.toFixed(1)}% exceeds max ${cap}%`,
         });
       }
     }
@@ -205,6 +341,27 @@ export class RiskEnforcer {
       const preferredExpr = thesis.expressions[thesis.preferredExpressionIndex];
       if (!preferredExpr) continue;
       agg[preferredExpr.assetClass] = (agg[preferredExpr.assetClass] ?? 0) + alloc.pctCapital;
+    }
+    return agg;
+  }
+
+  /**
+   * PATCH 3 — Agrège l'allocation par thème.
+   * Une thèse peut être taguée 1-2 thèmes ; chaque thème reçoit l'intégralité
+   * du pctCapital de l'allocation (pas de division). C'est intentionnel :
+   * une position GDX taguée [geopolitical_safehaven, energy_disruption]
+   * compte 100% sur chacun des deux thèmes — le but est d'identifier la
+   * concentration de risque.
+   */
+  private aggregateByTheme(proposal: AllocationProposal): Record<string, number> {
+    const agg: Record<string, number> = {};
+    for (const alloc of proposal.allocations) {
+      const thesis = proposal.theses.find((t) => t.id === alloc.thesisId);
+      if (!thesis) continue;
+      const themes = thesis.themes ?? [];
+      for (const theme of themes) {
+        agg[theme] = (agg[theme] ?? 0) + alloc.pctCapital;
+      }
     }
     return agg;
   }

--- a/packages/ai-analyst/src/persona/04-modes-output.ts
+++ b/packages/ai-analyst/src/persona/04-modes-output.ts
@@ -181,7 +181,9 @@ Tu DOIS renvoyer un objet JSON de cette forme EXACTE :
       },
 
       "analogSlugs": ["lehman_2008_collapse", "..."],
-      "confidenceScore": 0-100
+      "confidenceScore": 0-100,
+
+      "themes": ["geopolitical_safehaven" | "ai_megacap" | "energy_disruption" | "crypto" | "defensive_bond_proxy" | "small_cap_breakout" | "other"]
     }
   ],
 
@@ -268,4 +270,26 @@ Pour les paires FX majeures, utilise le format 6 lettres sans séparateur :
 Pour les actions US individuelles, le ticker nu suffit (\`AAPL\`, \`NVDA\`, \`TSLA\`…). Le backend ajoute \`.US\` automatiquement.
 
 **Règle d'or** : si tu n'es pas sûr qu'un ticker soit supporté, privilégie un ETF US traditionnel.
+
+---
+
+## TAGGING THÉMATIQUE (\`themes\`) — obligatoire sur chaque thèse
+
+Tag chaque thèse avec **1-2 thèmes dominants** parmi :
+
+| ThemeTag | Quand l'utiliser |
+|---|---|
+| \`geopolitical_safehaven\` | Or, argent, defense (RTX/LMT/NOC), pétrole sur tensions Iran/guerre |
+| \`ai_megacap\` | NVDA, MSFT, GOOGL, META, AAPL, AMD — narrative AI infrastructure |
+| \`energy_disruption\` | Spike pétrole/gaz, Hormuz, OPEC+ surprise, blackout EU |
+| \`crypto\` | BTC, ETH, altcoins — toute thèse crypto (cycle, ETF flows, halving) |
+| \`defensive_bond_proxy\` | Utilities, REITs, consumer staples, TLT — quand on flight-to-quality sans aller en cash |
+| \`small_cap_breakout\` | IWM, momentum smid-caps spécifiques |
+| \`other\` | Catch-all si rien ne colle (à éviter sauf nécessaire) |
+
+**Pourquoi c'est obligatoire** : un cap par classe d'actifs ne capte pas la concentration thématique transverse. Exemple : ouvrir GDX (equity) + SLV (commodity) + RTX (equity) — 3 classes différentes mais 1 thème \`geopolitical_safehaven\` à 60% du portfolio. Le risk-enforcer rejettera la 3ème thèse si le cap thème est dépassé.
+
+**Règle** : 1 thème = position pure (ex: NVDA → \`[ai_megacap]\`). 2 thèmes = quand la position chevauche réellement (ex: GDX → \`[geopolitical_safehaven]\` ; RTX en escalation Iran → \`[geopolitical_safehaven, energy_disruption]\` si le catalyseur principal est Hormuz).
+
+Pas plus de 2. Si tu hésites entre 3, choisis les 2 plus dominants ; les autres tu les mentionnes dans le \`summary\`.
 `.trim();

--- a/packages/ai-analyst/src/thesis/proposal-tool-schema.ts
+++ b/packages/ai-analyst/src/thesis/proposal-tool-schema.ts
@@ -151,6 +151,23 @@ const thesisSchema = {
         required: ['metric', 'op', 'value', 'action', 'reason'],
       },
     },
+    themes: {
+      type: 'array',
+      maxItems: 2,
+      description: "PATCH 3 — Tags thématiques transverses aux classes d'actifs (1-2 max). Capture la concentration de risque qu'un cap par classe ne capte pas (ex: GDX equity + SLV commodity + RTX equity = 3 classes mais 1 thème geopolitical_safehaven). Choisis les thèmes les plus dominants de la thèse parmi la liste enum. Si rien ne colle, utilise 'other'.",
+      items: {
+        type: 'string',
+        enum: [
+          'geopolitical_safehaven',
+          'ai_megacap',
+          'energy_disruption',
+          'crypto',
+          'defensive_bond_proxy',
+          'small_cap_breakout',
+          'other',
+        ],
+      },
+    },
   },
   required: ['title', 'summary', 'catalyst', 'whoIsWrong', 'category', 'expressions', 'preferredExpressionIndex', 'expressionChoiceRationale', 'riskReward', 'invalidation', 'antiBullshit', 'analogSlugs', 'confidenceScore'],
 };

--- a/packages/ai-analyst/src/types/index.ts
+++ b/packages/ai-analyst/src/types/index.ts
@@ -169,6 +169,27 @@ export type AutonomyRule = z.infer<typeof AutonomyRule>;
  * Thèse Lisa complète.
  * Structure identique pour toute idée, toute classe d'actifs.
  */
+/**
+ * Tags thématiques transverses aux classes d'actifs.
+ *
+ * Une thèse peut être taguée 1-2 thèmes pour exposer une concentration
+ * de risque qu'un cap par classe d'actifs ne capte pas (ex: GDX equity +
+ * SLV commodity + RTX equity = 3 classes mais 1 thème "geopolitical_safehaven"
+ * concentré).
+ *
+ * Cf. PATCH 3 risk-03-theme-caps.
+ */
+export const ThemeTag = z.enum([
+  'geopolitical_safehaven',  // gold, silver, defense (RTX/LMT/NOC), oil
+  'ai_megacap',              // NVDA/MSFT/GOOGL/META/AAPL/AMD
+  'energy_disruption',       // oil/gas spike, OPEC+, Hormuz
+  'crypto',                  // BTC/ETH/altcoins
+  'defensive_bond_proxy',    // utilities, REITs, consumer staples, longues TLT
+  'small_cap_breakout',      // IWM, momentum small caps
+  'other',                   // catch-all (laissé volontairement large)
+]);
+export type ThemeTag = z.infer<typeof ThemeTag>;
+
 export const LisaThesis = z.object({
   id: z.string().uuid(),
   /** Nom court lisible humain */
@@ -210,6 +231,13 @@ export const LisaThesis = z.object({
    *  Permettent une réactivité H24 sans attendre nouveau cycle Lisa.
    *  Cap 5 règles par thèse pour éviter combinatoire chaotique. */
   autonomyRules: z.array(AutonomyRule).max(5).optional().default([]),
+  /** PATCH 3 — Tags thématiques transverses aux classes d'actifs.
+   *  Lisa tag chaque thèse avec 1-2 thèmes dominants (cf. ThemeTag).
+   *  Le risk-enforcer applique un cap par thème en plus du cap par classe :
+   *  une thèse est rejetée si l'un des deux caps casse. Évite la
+   *  concentration thématique masquée (ex: GDX equity + SLV commodity
+   *  + RTX equity = 3 classes mais 1 thème geopolitical_safehaven). */
+  themes: z.array(ThemeTag).max(2).optional().default([]),
 });
 export type LisaThesis = z.infer<typeof LisaThesis>;
 
@@ -263,6 +291,25 @@ export const RiskConstraints = z.object({
   targetDeploymentPct: z.number().min(0).max(100).default(60.0),
   /** Si true, auto-liquidate all si drawdown 2d > maxDrawdown2DaysPct */
   autoLiquidateOnKill: z.boolean().default(true),
+  /**
+   * PATCH 3 — Plafonds par thème transverse aux classes d'actifs.
+   * Chaque thème (cf. ThemeTag) a son cap propre en % du capital.
+   * Pas listé = pas de cap (illimité). Le cap par thème agit en plus
+   * du cap par classe — la position est rejetée si l'un des deux casse.
+   *
+   * Defaults conservateurs : geopolitical_safehaven 40%, ai_megacap 35%,
+   * crypto 25%. Intentionnellement permissifs pour ne pas bloquer
+   * les thèses standards d'un portfolio simu HARVEST.
+   */
+  maxThemePct: z.record(ThemeTag, z.number().min(0).max(100)).optional().default({
+    geopolitical_safehaven: 40.0,
+    ai_megacap: 35.0,
+    energy_disruption: 30.0,
+    crypto: 25.0,
+    defensive_bond_proxy: 50.0,
+    small_cap_breakout: 25.0,
+    other: 50.0,
+  }),
 });
 export type RiskConstraints = z.infer<typeof RiskConstraints>;
 

--- a/supabase/migrations/0071_themes_columns.sql
+++ b/supabase/migrations/0071_themes_columns.sql
@@ -1,0 +1,33 @@
+-- 0071_themes_columns.sql
+--
+-- PATCH 3 (PR#3 P1) — theme tagging sur thèses Lisa et positions ouvertes.
+--
+-- Ajoute une colonne `themes TEXT[]` à `lisa_positions` et `lisa_proposals`.
+-- Lisa tag chaque thèse avec 1-2 thèmes dominants (cf. ThemeTag enum :
+-- geopolitical_safehaven, ai_megacap, energy_disruption, crypto,
+-- defensive_bond_proxy, small_cap_breakout, other).
+--
+-- Le risk-enforcer applique un cap par thème en plus du cap par classe :
+-- une thèse est rejetée si l'un des deux caps casse. Capture la
+-- concentration thématique transverse aux classes d'actifs (GDX equity
+-- + SLV commodity + RTX equity = 1 thème geopolitical_safehaven concentré).
+
+ALTER TABLE public.lisa_positions
+  ADD COLUMN IF NOT EXISTS themes TEXT[] NOT NULL DEFAULT '{}';
+
+ALTER TABLE public.lisa_proposals
+  ADD COLUMN IF NOT EXISTS themes TEXT[] NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN public.lisa_positions.themes IS
+  'Tags thématiques transverses (1-2 max). Cf. ThemeTag enum dans @smartvest/ai-analyst. Cap par thème géré côté risk-enforcer.';
+
+COMMENT ON COLUMN public.lisa_proposals.themes IS
+  'Tags thématiques de la proposition agrégée. Cf. ThemeTag enum dans @smartvest/ai-analyst.';
+
+-- Index GIN pour requêtes "positions sharing this theme" (utile pour
+-- monitoring concentration en /admin/monitoring)
+CREATE INDEX IF NOT EXISTS lisa_positions_themes_gin
+  ON public.lisa_positions USING GIN (themes);
+
+CREATE INDEX IF NOT EXISTS lisa_proposals_themes_gin
+  ON public.lisa_proposals USING GIN (themes);


### PR DESCRIPTION
…e masquée)

PATCH 3 (PR#3 P1) — tags thématiques transverses aux classes d'actifs.

PROBLÈME
========

Le cap par classe d'actifs ne capte pas la concentration thématique transverse. Exemple réel : ouvrir GDX (equity) + SLV (commodity) + RTX (equity) → 3 classes différentes mais 1 thème geopolitical_safehaven à 60% du portfolio. Aucun garde-fou existant ne le bloque.

FIX
===

1. Nouveau type ThemeTag (7 valeurs) :
   - geopolitical_safehaven, ai_megacap, energy_disruption, crypto, defensive_bond_proxy, small_cap_breakout, other

2. RiskConstraints.maxThemePct : map theme → pct cap. Defaults conservateurs (40% safehaven, 35% AI, 25% crypto, 50% other).

3. LisaThesis.themes: ThemeTag[] (max 2). Lisa tag chaque thèse avec 1-2 thèmes dominants via le tool schema Anthropic + persona.

4. RiskEnforcer.enforce() étendu :
   - Nouveau check THEME_CONCENTRATION en plus de ASSET_CLASS_CONCENTRATION
   - Signature étendue : existingExposureByThemePct?: Record<string, number>
   - Aggregation par thème : si position taguée 2 thèmes, son pctCapital compte 100% sur chacun (le but est d'identifier la concentration)

5. Helper exporté canOpen() (fonction pure) pour validation incrémentale d'une SEULE proposition contre un portefeuille existant. Retourne { ok, reason: 'would_exceed_class_cap' | 'would_exceed_theme_cap' }. Utilisable dans tests et futurs guards.

6. Migration SQL 0071_themes_columns.sql :
   - lisa_positions.themes TEXT[] DEFAULT '{}'
   - lisa_proposals.themes TEXT[] DEFAULT '{}'
   - Index GIN sur les deux pour requêtes "positions sharing theme"

7. Tool schema Anthropic : nouveau field "themes" dans submit_proposal.

8. Persona 04-modes-output : section "TAGGING THÉMATIQUE" avec règles concrètes (1-2 max, exemples par thème, justification du système).

TESTS JEST
==========

7/7 ✅ — risk-enforcer.theme.spec.ts (canOpen helper) :
- rejects new position exceeding theme cap even if class cap OK
- rejects when class cap is breached but theme cap OK
- accepts when both caps are respected
- multiple themes: any cap break rejects
- no theme caps configured: never blocks
- proposal with no themes: only class cap checked
- returns invalid_capital when capital <= 0

NB ai-analyst ajouté à apps/api package.json:moduleNameMapper jest.

VALIDATION POST-DEPLOY
======================

- Appliquer migration 0071 sur Supabase.
- Observer dans /lisa nouvelles propositions : champ "themes" populated par Lisa (Claude tool_use forcé via input_schema).
- Si proposal viole le cap thème, voir RiskEnforcer.violations[] contenir code: 'THEME_CONCENTRATION'.

NEXT: PATCH 4 (safety-net adaptive + cost budget hard stop) ou PATCH 5 (thesis.kind → stop multiplier dans ATR), à toi de choisir l'ordre.

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb