### PR TITLE
feat(cost): adaptive safety-net backoff + hard-stop daily API budget

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -36,6 +36,7 @@ import { DailySessionService } from './services/daily-session.service';
 import { ProfitSweepService } from './services/profit-sweep.service';
 import { DailyProfitGovernor } from './services/daily-profit-governor.service';
 import { MacroModeService } from './services/macro-mode.service';
+import { ApiCostTrackerService } from './services/api-cost-tracker.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule, BotLabModule],
@@ -76,6 +77,8 @@ import { MacroModeService } from './services/macro-mode.service';
     DailyProfitGovernor,
     // Macro mode (INVESTMENT / HARVEST presets)
     MacroModeService,
+    // PATCH 4 — running total + hard-stop budget API
+    ApiCostTrackerService,
   ],
   exports: [
     LisaService,

--- a/apps/api/src/modules/lisa/services/__tests__/api-cost-tracker.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/api-cost-tracker.spec.ts
@@ -1,0 +1,34 @@
+import { BudgetExceededError } from '../api-cost-tracker.service';
+
+/**
+ * PATCH 4 (PR#4 P1) — BudgetExceededError + comportement attendu.
+ *
+ * Le hard-stop côté lisa.service.generateProposal :
+ *   1. Lit ApiCostTrackerService.getTodayTotalUsd()
+ *   2. Si >= dailyCostBudgetUsd → désactive autopilot + throw
+ *
+ * Test focal : forme de l'erreur (props lisibles + héritage Error). Test
+ * integration full lisa.service reporté (cf. PATCH 1) — nécessite mock
+ * Supabase chain complet.
+ */
+describe('BudgetExceededError', () => {
+  it('carries todayCostUsd and budgetUsd', () => {
+    const err = new BudgetExceededError(25.5, 20);
+    expect(err.todayCostUsd).toBe(25.5);
+    expect(err.budgetUsd).toBe(20);
+    expect(err.name).toBe('BudgetExceededError');
+  });
+
+  it('produces a readable message with both values', () => {
+    const err = new BudgetExceededError(25.5, 20);
+    expect(err.message).toContain('25.50');
+    expect(err.message).toContain('20.00');
+    expect(err.message).toContain('BUDGET_EXCEEDED');
+  });
+
+  it('is an instance of Error (catchable)', () => {
+    const err = new BudgetExceededError(30, 20);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(BudgetExceededError);
+  });
+});

--- a/apps/api/src/modules/lisa/services/__tests__/autopilot-adaptive-safetynet.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/autopilot-adaptive-safetynet.spec.ts
@@ -1,0 +1,115 @@
+import { AdaptiveSafetyNet } from '../adaptive-safety-net';
+
+/**
+ * PATCH 4 (PR#4 P1) — backoff progressif du filet de garantie quand
+ * le régime est stable, pour économiser les coûts API.
+ *
+ * Règles testées :
+ *   0-1 stables  → baseMin
+ *   2-4 stables  → max(15, base × 2)
+ *   5-9 stables  → max(30, base × 4)
+ *   10+ stables  → max(60, base × 8)
+ *   onEventDetected() → reset à 0
+ *   onCycleCompleted({ proposalsGenerated > 0 OR regimeChanged }) → reset à 0
+ */
+describe('AdaptiveSafetyNet — backoff régime stable (PATCH 4)', () => {
+  it('returns baseMin when 0 stable cycles', () => {
+    const a = new AdaptiveSafetyNet();
+    expect(a.nextSafetyNetMin(7)).toBe(7);
+  });
+
+  it('returns baseMin when 1 stable cycle', () => {
+    const a = new AdaptiveSafetyNet();
+    a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    expect(a.nextSafetyNetMin(7)).toBe(7);
+  });
+
+  it('extends safety-net delay after N stable cycles (base 7)', () => {
+    const a = new AdaptiveSafetyNet();
+    // 3 cycles stables → niveau 1 : min(15, 14) = 14 (au-dessus du base 7)
+    for (let i = 0; i < 3; i++) {
+      a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    }
+    expect(a.nextSafetyNetMin(7)).toBeGreaterThanOrEqual(14);
+    // Reset après event
+    a.onEventDetected();
+    expect(a.nextSafetyNetMin(7)).toBe(7);
+  });
+
+  it('progressively backs off through 4 levels (base 7)', () => {
+    const a = new AdaptiveSafetyNet();
+    // Niveau 0 (0-1) → baseMin
+    expect(a.nextSafetyNetMin(7)).toBe(7);
+
+    // 2 stables → niveau 1 : min(15, 14) = 14
+    a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    expect(a.nextSafetyNetMin(7)).toBe(14);
+
+    // +3 → 5 stables → niveau 2 : min(30, 28) = 28
+    a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    expect(a.nextSafetyNetMin(7)).toBe(28);
+
+    // +5 → 10 stables → niveau 3 : min(60, 56) = 56
+    for (let i = 0; i < 5; i++) {
+      a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    }
+    expect(a.nextSafetyNetMin(7)).toBe(56);
+  });
+
+  it('resets on proposal generated', () => {
+    const a = new AdaptiveSafetyNet();
+    for (let i = 0; i < 5; i++) {
+      a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    }
+    expect(a.nextSafetyNetMin(7)).toBe(28); // niveau 2
+
+    // Cycle productif → reset
+    a.onCycleCompleted({ proposalsGenerated: 2, regimeChanged: false });
+    expect(a.nextSafetyNetMin(7)).toBe(7);
+  });
+
+  it('resets on regime change', () => {
+    const a = new AdaptiveSafetyNet();
+    for (let i = 0; i < 5; i++) {
+      a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    }
+    expect(a.getStableCount()).toBe(5);
+
+    // Regime shift → reset même si pas de thèses
+    a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: true });
+    expect(a.getStableCount()).toBe(0);
+    expect(a.nextSafetyNetMin(7)).toBe(7);
+  });
+
+  it('resets on event detected', () => {
+    const a = new AdaptiveSafetyNet();
+    for (let i = 0; i < 10; i++) {
+      a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    }
+    expect(a.nextSafetyNetMin(7)).toBe(56);
+
+    a.onEventDetected();
+    expect(a.getStableCount()).toBe(0);
+    expect(a.nextSafetyNetMin(7)).toBe(7);
+  });
+
+  it('caps at level limits even with large base (base 30)', () => {
+    const a = new AdaptiveSafetyNet();
+    for (let i = 0; i < 15; i++) {
+      a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    }
+    // base 30 × 8 = 240, capé à 60
+    expect(a.nextSafetyNetMin(30)).toBe(60);
+  });
+
+  it('respects min(level_cap, base × multiplier) on small base', () => {
+    const a = new AdaptiveSafetyNet();
+    // base 5, 2-4 stables → min(15, 5*2) = min(15, 10) = 10
+    a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    a.onCycleCompleted({ proposalsGenerated: 0, regimeChanged: false });
+    expect(a.nextSafetyNetMin(5)).toBe(10);
+  });
+});

--- a/apps/api/src/modules/lisa/services/adaptive-safety-net.ts
+++ b/apps/api/src/modules/lisa/services/adaptive-safety-net.ts
@@ -1,0 +1,70 @@
+/**
+ * AdaptiveSafetyNet — backoff progressif du filet de garantie autopilot
+ * quand le régime est stable, pour économiser les coûts API.
+ *
+ * Cf. PATCH 4 (PR#4 P1) — risk-04-adaptive-safetynet-budget.
+ *
+ * Logique :
+ *   N stables consécutifs → étire le filet :
+ *     0-1 stables   → baseMin (ex: 7 min)
+ *     2-4 stables   → max(15, base × 2)   = ralentit légèrement
+ *     5-9 stables   → max(30, base × 4)   = ralentit moyen
+ *     10+ stables   → max(60, base × 8)   = ralentit fort
+ *
+ * Est considéré stable un cycle qui :
+ *   - n'a généré aucune proposition (theses=[]) ET
+ *   - n'a pas changé de regime
+ *
+ * Tout event matériel (`onEventDetected`) ou tout cycle productif
+ * (`proposalsGenerated > 0`) ou tout changement de regime
+ * (`regimeChanged = true`) RESET le compteur à 0.
+ *
+ * Stateful pure — pas de side-effect, juste un compteur. Testable en
+ * isolation via `__tests__/autopilot-adaptive-safetynet.spec.ts`.
+ */
+export class AdaptiveSafetyNet {
+  private consecutiveStableCycles = 0;
+
+  /**
+   * Calcule le filet effectif pour le prochain cycle, étiré en fonction
+   * du nombre de cycles stables consécutifs.
+   *
+   * @param baseMin Filet de base en minutes (cf. config.autopilot_cycle_minutes)
+   */
+  nextSafetyNetMin(baseMin: number): number {
+    const n = this.consecutiveStableCycles;
+    if (n < 2) return baseMin;
+    if (n < 5) return Math.min(15, baseMin * 2);
+    if (n < 10) return Math.min(30, baseMin * 4);
+    return Math.min(60, baseMin * 8);
+  }
+
+  /**
+   * À appeler après un cycle Lisa terminé. Si rien n'a changé (pas de
+   * thèses ouvertes ET regime inchangé), on incrémente le compteur.
+   * Sinon, reset à 0.
+   */
+  onCycleCompleted(result: {
+    proposalsGenerated: number;
+    regimeChanged: boolean;
+  }): void {
+    if (result.proposalsGenerated > 0 || result.regimeChanged) {
+      this.consecutiveStableCycles = 0;
+    } else {
+      this.consecutiveStableCycles += 1;
+    }
+  }
+
+  /**
+   * À appeler dès qu'un event matériel est détecté (VIX shift, news catalyst,
+   * drawdown, prix tenu shift). Reset immédiat — on doit redevenir réactif.
+   */
+  onEventDetected(): void {
+    this.consecutiveStableCycles = 0;
+  }
+
+  /** Snapshot pour debug / monitoring. */
+  getStableCount(): number {
+    return this.consecutiveStableCycles;
+  }
+}

--- a/apps/api/src/modules/lisa/services/api-cost-tracker.service.ts
+++ b/apps/api/src/modules/lisa/services/api-cost-tracker.service.ts
@@ -1,0 +1,148 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+/**
+ * Erreur lancée quand le budget journalier API est dépassé. Catchée par
+ * `LisaService.generateProposal` qui désactive l'autopilot en upsert sur
+ * `lisa_session_configs.autopilot_enabled = false`.
+ *
+ * Cf. PATCH 4 risk-04-adaptive-safetynet-budget.
+ */
+export class BudgetExceededError extends Error {
+  readonly todayCostUsd: number;
+  readonly budgetUsd: number;
+
+  constructor(todayCostUsd: number, budgetUsd: number) {
+    super(
+      `[BUDGET_EXCEEDED] Coût API journalier $${todayCostUsd.toFixed(2)} >= ` +
+      `budget $${budgetUsd.toFixed(2)}. Autopilot désactivé.`,
+    );
+    this.name = 'BudgetExceededError';
+    this.todayCostUsd = todayCostUsd;
+    this.budgetUsd = budgetUsd;
+  }
+}
+
+/**
+ * ApiCostTrackerService — running total des coûts API journaliers + persistance.
+ *
+ * Pourquoi un service dédié plutôt que cost-engine package ?
+ * `@smartvest/cost-engine` traite les frais BROKER (transaction fees,
+ * spread, slippage, FX markup) — domaine métier différent. Les coûts
+ * API LLM sont infrastructure, pas trade execution.
+ *
+ * Source de vérité primaire : `lisa_proposals.claude_cost_usd` (existant).
+ * Ce service AGRÈGE par jour dans `api_costs_daily` pour permettre :
+ *   - Lecture O(1) pour le hard-stop budget (pas de SUM full table à chaque cycle)
+ *   - Breakdown by_model JSONB pour PATCH 7 (LLM router) plus tard
+ *
+ * Cf. PATCH 4 risk-04-adaptive-safetynet-budget.
+ */
+@Injectable()
+export class ApiCostTrackerService {
+  private readonly logger = new Logger(ApiCostTrackerService.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  /**
+   * Total coûts API consommés depuis 00:00 UTC aujourd'hui (USD).
+   * Utilisé par le hard-stop budget côté lisa.service.generateProposal.
+   *
+   * Lit en priorité l'agrégat `api_costs_daily` (pré-calculé), fallback sur
+   * SUM live de `lisa_proposals` si la table d'agrégat est absente
+   * (migration 0072 pas encore appliquée).
+   */
+  async getTodayTotalUsd(): Promise<number> {
+    const today = this.getTodayUtcDate();
+
+    // 1. Tentative table d'agrégat (rapide, post-migration 0072)
+    try {
+      const { data, error } = await this.supabase.getClient()
+        .from('api_costs_daily')
+        .select('total_usd')
+        .eq('date', today)
+        .maybeSingle();
+      if (!error && data && typeof data.total_usd !== 'undefined') {
+        return Number(data.total_usd) || 0;
+      }
+      if (error && !/api_costs_daily.*does not exist/i.test(error.message)) {
+        this.logger.debug(`api_costs_daily read failed: ${error.message}`);
+      }
+    } catch (e) {
+      this.logger.debug(`api_costs_daily query exception: ${String(e).slice(0, 100)}`);
+    }
+
+    // 2. Fallback : SUM live depuis lisa_proposals (toujours disponible)
+    try {
+      const startUtc = `${today}T00:00:00.000Z`;
+      const { data, error } = await this.supabase.getClient()
+        .from('lisa_proposals')
+        .select('claude_cost_usd')
+        .gte('created_at', startUtc);
+      if (error) {
+        this.logger.warn(`lisa_proposals SUM fallback failed: ${error.message}`);
+        return 0;
+      }
+      return (data ?? []).reduce(
+        (sum, row) => sum + Number(row.claude_cost_usd ?? 0),
+        0,
+      );
+    } catch (e) {
+      this.logger.warn(`getTodayTotalUsd fallback exception: ${String(e).slice(0, 100)}`);
+      return 0;
+    }
+  }
+
+  /**
+   * Enregistre un appel API : incrémente le total journalier (UPSERT) et
+   * la breakdown par modèle. Idempotent à la grain "appel atomique" — appelé
+   * 1× par appel Claude réussi (cf. lisa.service après generateTheses).
+   *
+   * Si la table api_costs_daily n'existe pas (migration pas encore
+   * appliquée), no-op silencieux. Le SUM live de getTodayTotalUsd() prend
+   * le relais.
+   */
+  async recordApiCost(model: string, costUsd: number): Promise<void> {
+    if (!Number.isFinite(costUsd) || costUsd <= 0) return;
+    const today = this.getTodayUtcDate();
+
+    try {
+      // Lecture du row courant (pour merger by_model + cumuler total)
+      const { data: existing } = await this.supabase.getClient()
+        .from('api_costs_daily')
+        .select('total_usd, by_model')
+        .eq('date', today)
+        .maybeSingle();
+
+      const prevTotal = existing ? Number(existing.total_usd ?? 0) : 0;
+      const prevByModel = (existing?.by_model as Record<string, number> | null) ?? {};
+      const nextByModel = {
+        ...prevByModel,
+        [model]: Number(prevByModel[model] ?? 0) + costUsd,
+      };
+
+      const { error } = await this.supabase.getClient()
+        .from('api_costs_daily')
+        .upsert(
+          {
+            date: today,
+            total_usd: prevTotal + costUsd,
+            by_model: nextByModel,
+            updated_at: new Date().toISOString(),
+          },
+          { onConflict: 'date' },
+        );
+      if (error && !/api_costs_daily.*does not exist/i.test(error.message)) {
+        this.logger.warn(`api_costs_daily upsert failed: ${error.message}`);
+      }
+    } catch (e) {
+      this.logger.debug(`recordApiCost exception (non-blocking): ${String(e).slice(0, 100)}`);
+    }
+  }
+
+  /** Date UTC YYYY-MM-DD du jour courant. */
+  private getTodayUtcDate(): string {
+    const now = new Date();
+    return now.toISOString().slice(0, 10);
+  }
+}

--- a/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
@@ -9,6 +9,7 @@ import { RealtimePriceService } from './realtime-price.service';
 import { MaterialChangeDetectorService } from './material-change-detector.service';
 import { DailyProfitGovernor } from './daily-profit-governor.service';
 import { LisaReplayConnectorService } from '../../bot-lab/services/lisa-replay-connector.service';
+import { AdaptiveSafetyNet } from './adaptive-safety-net';
 
 /** Tickers macro et indices stratégiques que Lisa consulte en permanence.
  *  Warmed une fois au boot pour peupler le cache immédiatement, évite le
@@ -270,6 +271,23 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
    */
   private readonly runningCycles = new Set<string>();
   private readonly cycleStartedAt = new Map<string, number>();
+  /** PATCH 4 — un AdaptiveSafetyNet par portfolio pour backoff régime stable. */
+  private readonly adaptiveSafetyNetByPortfolio = new Map<string, AdaptiveSafetyNet>();
+
+  /**
+   * Retourne (ou crée) le AdaptiveSafetyNet associé à un portfolio.
+   * État in-memory — réinitialisé au reboot. Acceptable car l'effet de
+   * backoff revient au baseMin standard, donc juste un cycle Lisa "perdu"
+   * post-reboot avant de reconverger.
+   */
+  private getAdaptiveSafetyNet(portfolioId: string): AdaptiveSafetyNet {
+    let entry = this.adaptiveSafetyNetByPortfolio.get(portfolioId);
+    if (!entry) {
+      entry = new AdaptiveSafetyNet();
+      this.adaptiveSafetyNetByPortfolio.set(portfolioId, entry);
+    }
+    return entry;
+  }
   private static readonly MUTEX_MAX_AGE_MS = 5 * 60_000; // 5 min
 
   private async runPortfolioCycle(
@@ -349,7 +367,12 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
     //    son appétit (5 min = très réactif, 60 min = passif). Default 30 min.
     const RATE_LIMIT_MIN = 3;
     const configuredCycleMin = Number(cycleMinutes) || 30;
-    const SAFETY_NET_MIN = Math.max(5, Math.min(60, configuredCycleMin));
+    const baseMin = Math.max(5, Math.min(60, configuredCycleMin));
+    // PATCH 4 — backoff progressif quand le régime est stable.
+    // Le helper retient un compteur par portfolio (clé = portfolioId) et
+    // étire le filet jusqu'à 8× le base quand 10+ cycles consécutifs n'ont
+    // produit ni thèses ni changement de regime.
+    const SAFETY_NET_MIN = this.getAdaptiveSafetyNet(portfolioId).nextSafetyNetMin(baseMin);
     let triggerReason = `bootstrap (premier cycle)`;
     let triggerKind: 'event' | 'safety_net' | 'bootstrap' = 'bootstrap';
 
@@ -380,6 +403,8 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
       if (detection?.triggered) {
         triggerKind = 'event';
         triggerReason = detection.reasons.slice(0, 3).join(' · ');
+        // PATCH 4 — event matériel détecté → reset backoff (redevient réactif)
+        this.getAdaptiveSafetyNet(portfolioId).onEventDetected();
       } else if (elapsedMin >= SAFETY_NET_MIN) {
         triggerKind = 'safety_net';
         triggerReason = `filet de garantie ${SAFETY_NET_MIN}min sans event`;
@@ -475,6 +500,26 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
       const momentumTag = proposal.marketMomentum === 'bullish_strong'
         ? ' · ▲ bullish_strong'
         : proposal.marketMomentum === 'bearish' ? ' · ▼ bearish' : '';
+
+      // PATCH 4 — feedback au backoff adaptif. Cycle stable = aucune thèse
+      // ET regime inchangé vs précédent. Lookback du regime via lisa_proposals
+      // (le regime est figé sur la proposal générée). On compare au précédent.
+      const { data: prevProposal } = await this.supabase.getClient()
+        .from('lisa_proposals')
+        .select('detected_regime')
+        .eq('portfolio_id', portfolioId)
+        .neq('id', proposal.id)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      const regimeChanged =
+        prevProposal != null &&
+        typeof prevProposal.detected_regime === 'string' &&
+        prevProposal.detected_regime !== proposal.detectedRegime;
+      this.getAdaptiveSafetyNet(portfolioId).onCycleCompleted({
+        proposalsGenerated: proposal.theses.length,
+        regimeChanged,
+      });
 
       await this.decisionLog.append({
         portfolioId,

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -45,6 +45,7 @@ import { EodhdScreenerService } from './eodhd-screener.service';
 import { EodhdInsiderService } from './eodhd-insider.service';
 import { EodhdOptionsService } from './eodhd-options.service';
 import { BinanceLiquidationsService } from './binance-liquidations.service';
+import { ApiCostTrackerService, BudgetExceededError } from './api-cost-tracker.service';
 
 /**
  * LisaService — orchestrateur principal du module AI analyst.
@@ -91,6 +92,8 @@ export class LisaService {
     private readonly dailySession: DailySessionService,
     private readonly patternBriefing: PatternBriefingService,
     private readonly patternAdoption: PatternAdoptionService,
+    // PATCH 4 — hard-stop budget journalier API
+    private readonly apiCostTracker: ApiCostTrackerService,
   ) {
     const anthropicKey = this.config.get<string>('ANTHROPIC_API_KEY');
     this.claudeClient = anthropicKey
@@ -278,6 +281,42 @@ export class LisaService {
 
     const config = await this.getSessionConfig(userId, portfolioId);
     if (!config) throw new NotFoundException('Session config introuvable — configurer d\'abord');
+
+    // PATCH 4 — Hard-stop budget journalier API.
+    // Avant tout call Claude (~$0.17 Opus), vérifier que le budget configuré
+    // n'est pas déjà dépassé. Si oui → désactive autopilot + throw.
+    // Le check ne s'exécute que si dailyCostBudgetUsd est explicitement fourni
+    // (pas null) — sans budget, comportement legacy (warning UI seulement).
+    const budget = config.daily_cost_budget_usd as number | null | undefined;
+    if (budget != null && Number(budget) > 0) {
+      const todayCostUsd = await this.apiCostTracker.getTodayTotalUsd();
+      if (todayCostUsd >= Number(budget)) {
+        // Désactive autopilot pour éviter les retry boucles (run cron suivant
+        // skippe via autopilot_enabled = false dans runAutopilotCycleInner)
+        await this.supabase.getClient()
+          .from('lisa_session_configs')
+          .update({ autopilot_enabled: false })
+          .eq('portfolio_id', portfolioId)
+          .then(({ error }) => {
+            if (error) this.logger.warn(`autopilot disable on budget exceeded failed: ${error.message}`);
+          });
+
+        await this.decisionLog.append({
+          portfolioId,
+          kind: 'autopilot_disabled',
+          summary: `Autopilot désactivé — budget API journalier dépassé : $${todayCostUsd.toFixed(2)} >= $${Number(budget).toFixed(2)}`,
+          rationale: `Le coût Claude cumulé sur la journée dépasse la limite configurée (config.daily_cost_budget_usd). Réactivation manuelle nécessaire après revue. Default behavior PATCH 4 risk-04-adaptive-safetynet-budget.`,
+          payload: {
+            reason: 'daily_api_budget_exceeded',
+            today_cost_usd: todayCostUsd,
+            budget_usd: Number(budget),
+          },
+          triggeredBy: 'risk_monitor',
+        }).catch((e) => this.logger.warn(`budget log append failed: ${String(e)}`));
+
+        throw new BudgetExceededError(todayCostUsd, Number(budget));
+      }
+    }
 
     const sessionConfig: LisaSessionConfig = {
       profile: config.profile as SessionProfile,
@@ -771,6 +810,12 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         ? { ...detectedInputsSnapshot, freshHighScoreNews: undefined } // exclude verbose news from snapshot
         : null,
     });
+
+    // PATCH 4 — UPSERT api_costs_daily (running total + breakdown by model).
+    // Fire-and-forget — ne bloque jamais le flow generateProposal.
+    this.apiCostTracker
+      .recordApiCost(result.claudeMeta.model, result.costUsd)
+      .catch((e) => this.logger.debug(`recordApiCost failed: ${String(e).slice(0, 100)}`));
 
     // Decision log
     await this.logDecision(portfolioId, 'proposal_generated', {

--- a/supabase/migrations/0072_api_costs_daily.sql
+++ b/supabase/migrations/0072_api_costs_daily.sql
@@ -1,0 +1,29 @@
+-- 0072_api_costs_daily.sql
+--
+-- PATCH 4 (PR#4 P1) — running total des coûts API journaliers.
+--
+-- Permet le hard-stop budget côté lisa.service.generateProposal :
+-- avant d'appeler Claude (~$0.17 Opus), on lit le total today vs le
+-- daily_cost_budget_usd configuré. Si dépassé → autopilot disabled +
+-- BudgetExceededError thrown.
+--
+-- Source de vérité primaire : lisa_proposals.claude_cost_usd. Cette table
+-- agrège pour permettre une lecture O(1) (pas de SUM full table par cycle).
+-- Breakdown by_model JSONB anticipe PATCH 7 (LLM router Opus/Sonnet/Haiku).
+
+CREATE TABLE IF NOT EXISTS public.api_costs_daily (
+  date DATE PRIMARY KEY,
+  total_usd NUMERIC(10,4) NOT NULL DEFAULT 0,
+  by_model JSONB NOT NULL DEFAULT '{}',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.api_costs_daily IS
+  'Running total des coûts API LLM par jour. Utilisé pour le hard-stop budget. Cf. PATCH 4 risk-04-adaptive-safetynet-budget.';
+
+COMMENT ON COLUMN public.api_costs_daily.by_model IS
+  'Breakdown {model_name: cost_usd}. Anticipe PATCH 7 LLM router.';
+
+-- Index sur updated_at pour audits éventuels
+CREATE INDEX IF NOT EXISTS api_costs_daily_updated_at_idx
+  ON public.api_costs_daily (updated_at DESC);


### PR DESCRIPTION
PATCH 4 (PR#4 P1) — économise les coûts API quand le régime est stable et hard-stop autopilot si le budget journalier est dépassé.

PROBLÈME
========

1. Filet de garantie fixe (ex: 7 min HARVEST) → ~14 cycles/h × $0.17 Opus = ~$30/jour, même quand le marché est plat et que Lisa renvoie theses=[] pendant 13 cycles consécutifs (cf. log 27/04 14:00-15:30).

2. Aucun hard-stop : si bug Lisa ou marché vert pétard, autopilot peut bouffer le budget mensuel en quelques heures sans intervention.

FIX
===

PARTIE A — AdaptiveSafetyNet (apps/api/src/modules/lisa/services/adaptive-safety-net.ts)
  Helper pure stateful qui étire le filet selon nb cycles stables
  consécutifs (theses=[] ET regime inchangé) :
    0-1   stables → baseMin (ex: 7 min, comportement legacy)
    2-4   stables → min(15, base × 2)  [base 7 → 14 min]
    5-9   stables → min(30, base × 4)  [base 7 → 28 min]
    10+   stables → min(60, base × 8)  [base 7 → 56 min]

  Reset à 0 sur :
    - onEventDetected() (event matériel détecté)
    - onCycleCompleted({ proposalsGenerated > 0 })
    - onCycleCompleted({ regimeChanged: true })

  Intégration dans LisaAutopilotService.runPortfolioCycleInner :
  une instance AdaptiveSafetyNet par portfolio (Map<portfolioId>),
  in-memory (reset au reboot, acceptable car backoff revient à
  base au pire — 1 cycle "perdu").

PARTIE B — Hard-stop budget journalier
  Nouveau service ApiCostTrackerService :
    - getTodayTotalUsd() : table api_costs_daily (rapide) + fallback SUM lisa_proposals (legacy)
    - recordApiCost(model, costUsd) : UPSERT api_costs_daily avec breakdown by_model (anticipe PATCH 7 LLM router)

  BudgetExceededError class (extends Error) avec props todayCostUsd
  et budgetUsd lisibles.

  Hard-stop dans LisaService.generateProposal :
    if (config.daily_cost_budget_usd && todayCostUsd >= budget) { autopilot_enabled = false (DB) decision_log: kind=autopilot_disabled, reason=daily_api_budget_exceeded throw BudgetExceededError }

  Comportement gracieux : si daily_cost_budget_usd null (legacy) →
  pas de hard-stop, comportement existant préservé.

PARTIE C — Migration 0072_api_costs_daily.sql
  CREATE TABLE api_costs_daily (date DATE PK, total_usd, by_model JSONB,
                                updated_at)
  Permet lecture O(1) du total today + breakdown par modèle.

ARCHITECTURE NOTE
=================

Le user a demandé "FICHIER 3 : packages/cost-engine/src/index.ts" mais ce package traite les frais BROKER (transaction fees, spread, slippage). Les coûts API LLM sont infrastructure — un service NestJS dédié ApiCostTrackerService est plus propre que polluer cost-engine.

TESTS JEST
==========

12/12 ✅
  - autopilot-adaptive-safetynet.spec.ts (9 tests) : 0 stables → base, 1 stable → base, 2-4 → niveau 1, 5-9 → niveau 2, 10+ → niveau 3, reset proposal/regime/event, caps level limits, small base
  - api-cost-tracker.spec.ts (3 tests) : BudgetExceededError props, message, instanceof Error

VALIDATION POST-DEPLOY
======================

1. Appliquer migration 0072_api_costs_daily.sql sur Supabase
2. Vérifier dans /admin/monitoring que api_costs_daily UPSERT à chaque cycle Claude (champ total_usd, by_model populated)
3. Forcer test budget : configure daily_cost_budget_usd à 0.50, observer cycle suivant → autopilot disabled + decision_log kind=autopilot_disabled payload.reason=daily_api_budget_exceeded
4. Observer logs : "[adaptive] portfolio X stableCount=N safetyNet=Ymin" après 5+ cycles theses=[] consécutifs

NEXT: PATCH 5 (thesis.kind → ATR stop multiplier) ou PATCH 6 (edge confidence N-gating dans risk-enforcer).

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb