### PR TITLE
feat(risk): stop ATR multiplier par thesis.kind + sizing inv. proport…

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/atr-stop-by-kind.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/atr-stop-by-kind.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * PATCH 5 — Stop ATR par type de thèse + sizing compensatoire.
+ *
+ * Tests purs sur `computeAtrStopByKind` (helper sans I/O exporté depuis
+ * @smartvest/ai-analyst). Vérifie :
+ *   - mean_reversion donne 2× plus de respiration que momentum
+ *   - clamp [1%, 7%] respecté aux bornes
+ *   - sizing compensatoire conserve risk$ par trade constant
+ *   - default 'momentum' si kind undefined (rétrocompat avant prod data)
+ */
+
+import {
+  ATR_STOP_MULTIPLIER_BY_KIND,
+  computeAtrStopByKind,
+  ThesisKind,
+} from '@smartvest/ai-analyst';
+
+describe('computeAtrStopByKind — multipliers par thesis.kind', () => {
+  it('gives mean_reversion ~2x more room than momentum on the same ATR', () => {
+    const atr14Pct = 2.0; // 2% ATR
+
+    const momStop = computeAtrStopByKind(atr14Pct, 'momentum');
+    const mrStop = computeAtrStopByKind(atr14Pct, 'mean_reversion');
+
+    expect(momStop.stopPct).toBeCloseTo(2.0, 5); // 1.0 × 2 = 2%
+    expect(mrStop.stopPct).toBeCloseTo(4.0, 5); // 2.0 × 2 = 4%
+    expect(mrStop.stopPct / momStop.stopPct).toBeCloseTo(2.0, 5);
+  });
+
+  it('exposes the kind multiplier on the result for audit/debug', () => {
+    expect(computeAtrStopByKind(2.0, 'momentum').kindMultiplier).toBe(1.0);
+    expect(computeAtrStopByKind(2.0, 'mean_reversion').kindMultiplier).toBe(2.0);
+    expect(computeAtrStopByKind(2.0, 'breakout').kindMultiplier).toBe(1.2);
+    expect(computeAtrStopByKind(2.0, 'event').kindMultiplier).toBe(1.5);
+    expect(computeAtrStopByKind(2.0, 'macro_hedge').kindMultiplier).toBe(2.2);
+  });
+
+  it('matches the ATR_STOP_MULTIPLIER_BY_KIND lookup table', () => {
+    const kinds: ThesisKind[] = [
+      'momentum',
+      'mean_reversion',
+      'breakout',
+      'event',
+      'macro_hedge',
+    ];
+    for (const k of kinds) {
+      const r = computeAtrStopByKind(3.0, k);
+      // ATR 3% × mult, clamp [1, 7]. Tous les produits restent dans le clamp ici
+      // sauf macro_hedge (6.6, dans bounds).
+      const expected = Math.max(1.0, Math.min(7.0, ATR_STOP_MULTIPLIER_BY_KIND[k] * 3.0));
+      expect(r.stopPct).toBeCloseTo(expected, 5);
+    }
+  });
+
+  it('defaults to 1.5x (legacy) when kind is undefined', () => {
+    const r = computeAtrStopByKind(2.0, undefined);
+    expect(r.kindMultiplier).toBe(1.5);
+    expect(r.stopPct).toBeCloseTo(3.0, 5); // 1.5 × 2 = 3%
+  });
+});
+
+describe('computeAtrStopByKind — clamp [1%, 7%]', () => {
+  it('clamps to floor 1% on tiny ATR (mean_reversion 0.3% ATR → 0.6%, floored to 1%)', () => {
+    const r = computeAtrStopByKind(0.3, 'mean_reversion');
+    expect(r.stopPct).toBe(1.0);
+  });
+
+  it('clamps to ceiling 7% on large ATR (macro_hedge 4% ATR × 2.2 = 8.8%, capped 7%)', () => {
+    const r = computeAtrStopByKind(4.0, 'macro_hedge');
+    expect(r.stopPct).toBe(7.0);
+  });
+
+  it('extends the historical 5% ceiling to 7% (mean_reversion 3.5% ATR × 2 = 7%)', () => {
+    const r = computeAtrStopByKind(3.5, 'mean_reversion');
+    expect(r.stopPct).toBe(7.0);
+    // Sanity : > 5% (l'ancien clamp aurait coupé à 5%)
+    expect(r.stopPct).toBeGreaterThan(5.0);
+  });
+
+  it('clamps momentum extreme high ATR to 7% as well (momentum 8% ATR × 1 = 8%, capped 7%)', () => {
+    const r = computeAtrStopByKind(8.0, 'momentum');
+    expect(r.stopPct).toBe(7.0);
+  });
+});
+
+describe('computeAtrStopByKind — sizing compensatoire', () => {
+  it('returns null sizing when capital is not provided', () => {
+    const r = computeAtrStopByKind(2.0, 'momentum');
+    expect(r.recommendedSizeUsd).toBeNull();
+  });
+
+  it('returns null sizing when capital is 0 or negative', () => {
+    expect(computeAtrStopByKind(2.0, 'momentum', 0).recommendedSizeUsd).toBeNull();
+    expect(computeAtrStopByKind(2.0, 'momentum', -100).recommendedSizeUsd).toBeNull();
+  });
+
+  it('keeps risk$ per trade CONSTANT across kinds (mean_reversion gets smaller size)', () => {
+    const capital = 100_000;
+    const atr14Pct = 2.0;
+    const riskPct = 0.5; // 0.5% du capital par trade = $500 cible
+
+    const mom = computeAtrStopByKind(atr14Pct, 'momentum', capital, riskPct);
+    const mr = computeAtrStopByKind(atr14Pct, 'mean_reversion', capital, riskPct);
+
+    // Stop momentum 2%, taille 25k → risk = 25k × 2% = $500
+    // Stop mean_rev 4%, taille 12.5k → risk = 12.5k × 4% = $500
+    expect(mom.recommendedSizeUsd).toBeCloseTo(25_000, 1);
+    expect(mr.recommendedSizeUsd).toBeCloseTo(12_500, 1);
+
+    const riskMom = mom.recommendedSizeUsd! * (mom.stopPct / 100);
+    const riskMr = mr.recommendedSizeUsd! * (mr.stopPct / 100);
+    expect(riskMom).toBeCloseTo(500, 1);
+    expect(riskMr).toBeCloseTo(500, 1);
+    expect(riskMom).toBeCloseTo(riskMr, 1); // invariant : même risk$
+  });
+
+  it('respects custom riskPerTradePct (1% double la taille recommandée)', () => {
+    const capital = 100_000;
+    const r05 = computeAtrStopByKind(2.0, 'momentum', capital, 0.5);
+    const r10 = computeAtrStopByKind(2.0, 'momentum', capital, 1.0);
+    expect(r10.recommendedSizeUsd! / r05.recommendedSizeUsd!).toBeCloseTo(2.0, 5);
+  });
+
+  it('uses default 0.5% riskPerTradePct when not provided', () => {
+    const r = computeAtrStopByKind(2.0, 'momentum', 100_000);
+    // capital × (0.5 / 2.0) = 100k × 0.25 = 25k
+    expect(r.recommendedSizeUsd).toBeCloseTo(25_000, 1);
+  });
+});

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -933,6 +933,8 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         horizonDays,
         venue: expr.preferredVenue,
         thesisId: thesis.id,
+        // PATCH 5 — propage thesisKind au mécanique pour multiplicateur ATR
+        ...(thesis.kind ? { thesisKind: thesis.kind } : {}),
         ...(isOptionLong
           ? {
               optionStructure: {

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -17,6 +17,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import Decimal from 'decimal.js';
 import { randomUUID } from 'node:crypto';
+import { computeAtrStopByKind, type ThesisKind } from '@smartvest/ai-analyst';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { PerformanceService } from '../../performance/performance.service';
 import { DecisionLogService } from './decision-log.service';
@@ -47,6 +48,10 @@ interface TargetSymbol {
   horizonDays: number;
   venue?: string;
   thesisId?: string;
+  /** PATCH 5 — type de thèse pour calibrer la posture de risque
+   *  (multiplier ATR du stop). Cf. ThesisKind dans @smartvest/ai-analyst.
+   *  Default 'momentum' (1.0× ATR) si absent. */
+  thesisKind?: ThesisKind;
   /** Si présent, ouvrir une option (long call/put) au lieu d'une position
    *  equity classique. Routé vers OptionBrokerService.openOption() :
    *   - direction 'long' → call (parie sur la hausse du sous-jacent)
@@ -211,29 +216,57 @@ export class MechanicalTradingService {
    * propre de chaque actif — BTC (σ élevée) aura un stop plus large que
    * SPY (σ faible), donc moins de "stops sur bruit normal".
    *
-   * Formule :
-   *   stopATR% = MULTIPLIER × ATR14% du prix actuel
-   *   stopFinal% = clamp(stopATR%, FLOOR, CEILING)
+   * PATCH 5 — Multiplicateur modulé par `thesisKind` :
+   *   momentum=1.0 (serré), mean_reversion=2.0 (respire), breakout=1.2,
+   *   event=1.5, macro_hedge=2.2. Default 1.5 si kind absent (rétrocompat).
+   *   Ceiling étendu 5% → 7% pour mean_reversion / macro_hedge avec ATR > 3%.
+   *
+   * Formule (cf. computeAtrStopByKind dans @smartvest/ai-analyst) :
+   *   stopATR% = MULTIPLIER[kind] × ATR14% du prix actuel
+   *   stopFinal% = clamp(stopATR%, FLOOR=1.0%, CEILING=7.0%)
    *   si ATR indispo → fallback sur stopPct "Lisa" (propagé)
    *
-   * MULTIPLIER=1.5 → classique (distance "1.5 ATR" = 1σ sur horizon court).
-   * FLOOR=1.0%     → évite stops trop serrés même sur actifs très calmes.
-   * CEILING=5.0%   → limite l'exposition max par position.
+   * Le caller peut aussi récupérer recommendedSizeUsd pour appliquer un
+   * sizing compensatoire (size inversement proportionnelle au stop pour
+   * que le risk$ par trade reste constant). Aujourd'hui retourné mais
+   * NON-appliqué automatiquement (le sizing Lisa prévaut). À câbler dans
+   * un PR ultérieur quand on aura le riskPerTradePct configurable user.
    */
   private async deriveAtrStopPct(
     eodhdTicker: string,
     currentPrice: number,
     fallbackPct: number,
-  ): Promise<{ stopPct: number; atr14Pct: number | null; source: 'atr' | 'fallback' }> {
+    thesisKind?: ThesisKind,
+    capitalUsd?: number,
+  ): Promise<{
+    stopPct: number;
+    atr14Pct: number | null;
+    source: 'atr' | 'fallback';
+    kindMultiplier: number;
+    recommendedSizeUsd: number | null;
+  }> {
     try {
       const ind = await this.technical.getIndicators(eodhdTicker, currentPrice);
       if (ind.atr14Pct != null && ind.atr14Pct > 0) {
-        const raw = 1.5 * ind.atr14Pct;
-        const clamped = Math.max(1.0, Math.min(5.0, raw));
-        return { stopPct: clamped, atr14Pct: ind.atr14Pct, source: 'atr' };
+        const result = computeAtrStopByKind(ind.atr14Pct, thesisKind, capitalUsd);
+        return {
+          stopPct: result.stopPct,
+          atr14Pct: ind.atr14Pct,
+          source: 'atr',
+          kindMultiplier: result.kindMultiplier,
+          recommendedSizeUsd: result.recommendedSizeUsd,
+        };
       }
     } catch { /* fall through */ }
-    return { stopPct: fallbackPct, atr14Pct: null, source: 'fallback' };
+    return {
+      stopPct: fallbackPct,
+      atr14Pct: null,
+      source: 'fallback',
+      kindMultiplier: thesisKind
+        ? (computeAtrStopByKind(0, thesisKind).kindMultiplier)
+        : 1.5,
+      recommendedSizeUsd: null,
+    };
   }
 
   @Cron(CronExpression.EVERY_MINUTE, { name: 'mechanical-trading' })
@@ -886,7 +919,16 @@ export class MechanicalTradingService {
       const eodhdTicker = this.lisa['toEodhdTicker']
         ? (this.lisa as unknown as { toEodhdTicker(s: string): string }).toEodhdTicker(target.symbol)
         : target.symbol;
-      const atrDerived = await this.deriveAtrStopPct(eodhdTicker, price.toNumber(), fallbackStopPct);
+      // PATCH 5 — passer thesisKind à deriveAtrStopPct pour multiplier ATR
+      // adapté (momentum 1×, mean_reversion 2×, breakout 1.2×, event 1.5×,
+      // macro_hedge 2.2×). Default 'momentum' si Lisa n'a pas tagué.
+      const atrDerived = await this.deriveAtrStopPct(
+        eodhdTicker,
+        price.toNumber(),
+        fallbackStopPct,
+        target.thesisKind,
+        capitalUsd.toNumber(),
+      );
       const stopPct = Math.max(atrDerived.stopPct * stopsMult, 0.3);
       const tpPct = Math.max(target.takeProfitPct ?? Math.max(atrDerived.stopPct * 2, 4), 0.5);
 
@@ -899,7 +941,8 @@ export class MechanicalTradingService {
 
       this.logger.log(
         `[MÉCANIQUE] ${target.symbol} stop=${stopPct.toFixed(2)}% tp=${tpPct.toFixed(2)}% ` +
-        `(source=${atrDerived.source}, ATR14=${atrDerived.atr14Pct?.toFixed(2) ?? 'n/a'}%, override×${stopsMult})`,
+        `(source=${atrDerived.source}, ATR14=${atrDerived.atr14Pct?.toFixed(2) ?? 'n/a'}%, ` +
+        `kind=${target.thesisKind ?? 'default'} ×${atrDerived.kindMultiplier}, override×${stopsMult})`,
       );
 
       const horizonDays = target.horizonDays ?? 3;

--- a/packages/ai-analyst/src/persona/04-modes-output.ts
+++ b/packages/ai-analyst/src/persona/04-modes-output.ts
@@ -134,6 +134,7 @@ Tu DOIS renvoyer un objet JSON de cette forme EXACTE :
       "catalyst": "description du catalyseur",
       "whoIsWrong": "qui est mal positionné",
       "category": "hidden_gem | turnaround | flow_timing | watchlist | contrarian | mean_reversion | event_driven",
+      "kind": "momentum | mean_reversion | breakout | event | macro_hedge",
 
       "expressions": [
         {
@@ -205,6 +206,40 @@ Tu DOIS renvoyer un objet JSON de cette forme EXACTE :
 }
 \`\`\`
 
+### TYPE DE THÈSE (\`kind\`) — calibre la posture de risque
+
+Le champ \`kind\` est ORTHOGONAL à \`category\`. \`category\` décrit la SOURCE
+de l'edge (où vient l'opportunité). \`kind\` décrit la POSTURE DE RISQUE
+nécessaire pour la jouer correctement (combien de respiration le stop doit
+tolérer pour que la thèse ait le temps de se réaliser).
+
+Le stop est calibré dynamiquement : \`stopPct = mult[kind] × ATR14\` clampé
+\`[1%, 7%]\`. Le sizing s'ajuste en proportion inverse du stop pour conserver
+le même risque dollar par trade.
+
+| \`kind\` | Multiplicateur | Quand l'utiliser |
+|---|---|---|
+| \`momentum\` | 1.0 (stop serré) | Cassure de range haussière, suite de hauts plus hauts, breakout volume |
+| \`mean_reversion\` | 2.0 (stop large) | RSI extrême, écart vs MA, retour à la moyenne, oversold violent |
+| \`breakout\` | 1.2 | Cassure de niveau clé avec confirmation volume, follow-through attendu |
+| \`event\` | 1.5 | Earnings, FDA, Fed, M&A — catalyseur daté binaire |
+| \`macro_hedge\` | 2.2 (le plus large) | Hedge long-duration (gold, vol, USD), thèse macro multi-mois |
+
+**Few-shot examples** :
+
+- **RTX RSI 24, oversold, target retour à MA50** → \`kind: "mean_reversion"\`
+  (PAS \`momentum\` — un mean-reversion a besoin de respiration ; un stop
+  serré te sortirait sur le bruit à l'entrée d'un creux).
+- **NVDA cassure $850 sur volume 2× moyenne** → \`kind: "breakout"\`
+- **TSLA après earnings beat, momentum 5 jours up** → \`kind: "momentum"\`
+- **AAPL long avant earnings vendredi, IV élevée** → \`kind: "event"\`
+- **GLD long pour hedge stagflation 6-12 mois** → \`kind: "macro_hedge"\`
+
+Si tu hésites, \`momentum\` est le défaut le plus serré — préfère-le quand
+tu joues un signal court terme avec un niveau d'invalidation proche.
+\`mean_reversion\` n'est légitime que si la thèse REPOSE sur un retour de
+prix/ratio à un niveau plus normal après un excès mesurable.
+
 ### Règles strictes du format
 
 1. **Pas de markdown dans les strings** (pas de \`**bold**\`, pas de \`#\` headers)
@@ -216,6 +251,7 @@ Tu DOIS renvoyer un objet JSON de cette forme EXACTE :
 7. **3 à 7 thèses max** — respect strict
 8. **Allocations somme <= 100%** (le reste = cash reserve)
 9. **Tous les analogSlugs doivent exister** dans \`historical_events_corpus\`
+10. **\`kind\` cohérent avec la thèse** — voir section "TYPE DE THÈSE" ci-dessus
 
 ### En cas d'incapacité à générer
 

--- a/packages/ai-analyst/src/thesis/proposal-tool-schema.ts
+++ b/packages/ai-analyst/src/thesis/proposal-tool-schema.ts
@@ -168,6 +168,11 @@ const thesisSchema = {
         ],
       },
     },
+    kind: {
+      type: 'string',
+      enum: ['momentum', 'mean_reversion', 'breakout', 'event', 'macro_hedge'],
+      description: "PATCH 5 — Type de thèse pour calibrer la posture de risque (multiplicateur ATR du stop). Orthogonal à 'category'. momentum=1.0× ATR (stop serré, sortie sur cassure de momentum), mean_reversion=2.0× (stop large, drawdown initial attendu), breakout=1.2× (stop sous niveau cassé, faux breakouts), event=1.5× (volatilité event), macro_hedge=2.2× (couverture long-terme). Si tu hésites, choisir 'momentum' (default conservateur).",
+    },
   },
   required: ['title', 'summary', 'catalyst', 'whoIsWrong', 'category', 'expressions', 'preferredExpressionIndex', 'expressionChoiceRationale', 'riskReward', 'invalidation', 'antiBullshit', 'analogSlugs', 'confidenceScore'],
 };

--- a/packages/ai-analyst/src/types/index.ts
+++ b/packages/ai-analyst/src/types/index.ts
@@ -68,6 +68,94 @@ export const ThesisCategory = z.enum([
 export type ThesisCategory = z.infer<typeof ThesisCategory>;
 
 /**
+ * PATCH 5 — Type de thèse pour calibrer la POSTURE DE RISQUE.
+ *
+ * Orthogonal à `ThesisCategory` (qui décrit la SOURCE de l'edge).
+ * `ThesisKind` décrit la dynamique d'invalidation attendue, ce qui
+ * détermine combien de respiration le stop-loss doit donner.
+ *
+ *  - `momentum` : ride une tendance ; stop serré (1.0× ATR), sortie sur
+ *    cassure de momentum. Mean-reversion = invalidation immédiate.
+ *  - `mean_reversion` : exploite un retour à la moyenne ; stop large
+ *    (2.0× ATR) car le drawdown initial est attendu (oversold qui
+ *    s'enfonce 1-2% avant rebound).
+ *  - `breakout` : entrée sur cassure ; stop sous le niveau cassé
+ *    (1.2× ATR), un tout petit peu de respiration pour faux breakouts.
+ *  - `event` : pari sur catalyseur spécifique (earnings, FOMC, FDA) ;
+ *    stop intermédiaire 1.5× ATR pour absorber la volatilité event.
+ *  - `macro_hedge` : couverture macro long-terme ; stop très large
+ *    (2.2× ATR) car la thèse joue sur des mois, pas des heures.
+ *
+ * Cf. PATCH 5 risk-05-stop-by-thesis-kind.
+ */
+export const ThesisKind = z.enum([
+  'momentum',
+  'mean_reversion',
+  'breakout',
+  'event',
+  'macro_hedge',
+]);
+export type ThesisKind = z.infer<typeof ThesisKind>;
+
+/**
+ * PATCH 5 — Multiplicateurs ATR par type de thèse.
+ *
+ * Default 1.5 si `kind` absent (rétrocompat). Le multiplicateur final
+ * est appliqué à `ATR14%` puis clampé `[1.0, 7.0]%` (vs 5% historique
+ * — ceiling étendu pour mean_reversion / macro_hedge).
+ */
+export const ATR_STOP_MULTIPLIER_BY_KIND: Record<ThesisKind, number> = {
+  momentum: 1.0,
+  mean_reversion: 2.0,
+  breakout: 1.2,
+  event: 1.5,
+  macro_hedge: 2.2,
+};
+
+export interface AtrStopByKindResult {
+  /** Stop en % du prix d'entrée (clampé [1, 7]). */
+  stopPct: number;
+  /** Multiplicateur effectivement appliqué (debug / audit). */
+  kindMultiplier: number;
+  /** Recommandation de sizing pour conserver risk constant par trade.
+   *  riskPerTradeUsd ≈ capital × riskPerTradePct = sizeUsd × stopPct.
+   *  Champ optionnel — null si capital non fourni au caller. */
+  recommendedSizeUsd: number | null;
+}
+
+/**
+ * PATCH 5 — Calcule un stop ATR-based modulé par le type de thèse.
+ * Helper pur (sans I/O), testable en isolation.
+ *
+ * @param atr14Pct ATR14 en % du prix actuel (ex: 2.5 pour 2.5%)
+ * @param kind Type de thèse (default 'momentum' = 1.0× ATR)
+ * @param capitalUsd Capital total — si fourni, calcule le sizing compensatoire
+ * @param riskPerTradePct Pct du capital à risquer par trade (default 0.5%)
+ */
+export function computeAtrStopByKind(
+  atr14Pct: number,
+  kind: ThesisKind | undefined,
+  capitalUsd?: number,
+  riskPerTradePct: number = 0.5,
+): AtrStopByKindResult {
+  const mult = kind ? ATR_STOP_MULTIPLIER_BY_KIND[kind] : 1.5;
+  const raw = mult * atr14Pct;
+  // PATCH 5 : ceiling 5% → 7% pour laisser respirer mean_reversion +
+  // macro_hedge (avec ATR 4% × 2.2 = 8.8% pré-clamp).
+  const stopPct = Math.max(1.0, Math.min(7.0, raw));
+
+  let recommendedSizeUsd: number | null = null;
+  if (capitalUsd != null && capitalUsd > 0 && stopPct > 0) {
+    // riskPerTradeUsd = sizeUsd × (stopPct / 100)
+    // → sizeUsd = (capital × riskPerTradePct%) / (stopPct / 100)
+    //          = capital × (riskPerTradePct / stopPct)
+    recommendedSizeUsd = capitalUsd * (riskPerTradePct / stopPct);
+  }
+
+  return { stopPct, kindMultiplier: mult, recommendedSizeUsd };
+}
+
+/**
  * Expression = façon concrète de jouer une thèse.
  * Plusieurs expressions possibles pour la même thèse (equity vs derivative vs credit).
  */
@@ -238,6 +326,11 @@ export const LisaThesis = z.object({
    *  concentration thématique masquée (ex: GDX equity + SLV commodity
    *  + RTX equity = 3 classes mais 1 thème geopolitical_safehaven). */
   themes: z.array(ThemeTag).max(2).optional().default([]),
+  /** PATCH 5 — Type de thèse pour calibrer la posture de risque (stop ATR
+   *  multiplier + sizing compensatoire). Cf. ThesisKind. Orthogonal à
+   *  `category` (source de l'edge) — `kind` décrit comment la thèse se
+   *  comporte face au drawdown initial. */
+  kind: ThesisKind.optional().default('momentum'),
 });
 export type LisaThesis = z.infer<typeof LisaThesis>;
 


### PR DESCRIPTION
…ionnel

Pourquoi: le stop ATR-based était agnostique au type de thèse (1.5×ATR clamp 1-5%). Une mean-reversion a besoin de respiration (oversold qui s'enfonce 1-2% avant rebound), un momentum doit sortir vite sur cassure. Stop unique pour les deux = soit trop serré (whipsaw mean-rev), soit trop large (perte évitable momentum).

Changements:
- ThesisKind enum (momentum, mean_reversion, breakout, event, macro_hedge) orthogonal à ThesisCategory (source de l'edge vs posture de risque).
- ATR_STOP_MULTIPLIER_BY_KIND: 1.0 / 2.0 / 1.2 / 1.5 / 2.2 ; ceiling 5%→7%.
- computeAtrStopByKind() helper pur exporté depuis @smartvest/ai-analyst, retourne { stopPct, kindMultiplier, recommendedSizeUsd } avec sizing inversement proportionnel au stop pour conserver risk\$/trade constant (stop 2× plus large → taille 2× plus petite, même $$ à risque).
- mechanical-trading.service.deriveAtrStopPct propage kind + capital.
- lisa.service.ts propage thesis.kind sur TargetSymbol.
- Persona 04-modes-output: kind dans schema JSON + section "TYPE DE THÈSE" avec few-shots (ex: RTX RSI 24 oversold → mean_reversion, pas momentum).
- Test apps/api/src/modules/lisa/services/__tests__/atr-stop-by-kind.spec.ts (13 tests passent, couvre multipliers, clamp [1,7]%, sizing constant-risk\$).