### PR TITLE
fix(positions): map snake_case→camelCase + force take-profit (P0 incident 27/04)

### DIFF
--- a/apps/api/src/modules/lisa/helpers/__tests__/position-mapper.spec.ts
+++ b/apps/api/src/modules/lisa/helpers/__tests__/position-mapper.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests pour position.mapper.ts — fix incident 27/04/2026.
+ *
+ * Vérifie que :
+ *  - tous les champs snake_case du row Supabase reçoivent un alias camelCase
+ *  - les champs nullable (stop_loss_price, take_profit_price, ...) deviennent
+ *    `null` (pas `undefined`) en camelCase pour qu'un check `?.toString()`
+ *    fonctionne sans crash
+ *  - les champs originaux snake_case sont préservés (pour les call sites
+ *    qui lisent encore via `as Record<>['field']`)
+ *  - reproduction du scénario crash BTC : un row réaliste passe le
+ *    `pos.assetClass.toLowerCase()` sans throw
+ */
+import { mapPositionRow, mapPositionRows } from '../position.mapper';
+
+describe('mapPositionRow', () => {
+  const btcRow = {
+    id: 'pos-btc-uuid',
+    portfolio_id: 'p-uuid',
+    user_id: 'u-uuid',
+    proposal_id: 'prop-uuid',
+    thesis_id: 'th-uuid',
+    symbol: 'BTC',
+    asset_class: 'crypto_bitcoin',
+    direction: 'long',
+    venue: 'Binance',
+    quantity: '0.0286',
+    entry_price: '76875.69',
+    entry_timestamp: '2026-04-27T17:38:00Z',
+    entry_notional_usd: '2200.00',
+    status: 'open',
+    stop_loss_price: '73031.90',
+    take_profit_price: '78797.58',
+    horizon_target_date: '2026-05-04',
+    estimated_entry_cost_usd: '4.40',
+    autonomy_rules: [],
+    conviction_score: 7,
+    created_at: '2026-04-27T17:38:00Z',
+    updated_at: '2026-04-27T17:38:00Z',
+  };
+
+  it('aliases asset_class → assetClass', () => {
+    const mapped = mapPositionRow(btcRow);
+    expect(mapped.assetClass).toBe('crypto_bitcoin');
+    expect(mapped.asset_class).toBe('crypto_bitcoin'); // snake_case preserved
+  });
+
+  it('aliases entry_price → entryPrice', () => {
+    const mapped = mapPositionRow(btcRow);
+    expect(mapped.entryPrice).toBe('76875.69');
+    expect(mapped.entry_price).toBe('76875.69');
+  });
+
+  it('aliases entry_notional_usd → entryNotionalUsd', () => {
+    const mapped = mapPositionRow(btcRow);
+    expect(mapped.entryNotionalUsd).toBe('2200.00');
+  });
+
+  it('aliases stop_loss_price → stopLossPrice (set value)', () => {
+    const mapped = mapPositionRow(btcRow);
+    expect(mapped.stopLossPrice).toBe('73031.90');
+  });
+
+  it('aliases take_profit_price → takeProfitPrice (set value)', () => {
+    const mapped = mapPositionRow(btcRow);
+    expect(mapped.takeProfitPrice).toBe('78797.58');
+  });
+
+  it('returns null (NOT undefined) when stop_loss_price is null in DB', () => {
+    const noStop = { ...btcRow, stop_loss_price: null };
+    const mapped = mapPositionRow(noStop);
+    expect(mapped.stopLossPrice).toBeNull();
+    expect(mapped.stopLossPrice).not.toBeUndefined();
+  });
+
+  it('returns null (NOT undefined) when take_profit_price is null in DB', () => {
+    // Repro du bug du 27/04 : BTC + RTX en prod avaient TP=NULL
+    const noTp = { ...btcRow, take_profit_price: null };
+    const mapped = mapPositionRow(noTp);
+    expect(mapped.takeProfitPrice).toBeNull();
+  });
+
+  it('preserves all original snake_case fields (no destructive overwrite)', () => {
+    const mapped = mapPositionRow(btcRow);
+    // Tous les champs originaux du row doivent être présents
+    for (const key of Object.keys(btcRow)) {
+      expect(mapped).toHaveProperty(key);
+    }
+  });
+
+  it('repro crash BTC : pos.assetClass.toLowerCase() ne crashe PAS sur row mappé', () => {
+    // C'est le bug ligne 1886 mechanical-trading.service.ts. Avant le mapper,
+    // pos.assetClass était undefined → .toLowerCase() throw TypeError.
+    const mapped = mapPositionRow(btcRow);
+    expect(() => mapped.assetClass.toLowerCase()).not.toThrow();
+    expect(mapped.assetClass.toLowerCase()).toBe('crypto_bitcoin');
+    expect(mapped.assetClass.toLowerCase().includes('crypto')).toBe(true);
+  });
+
+  it('repro silent stop skip : pos.stopLossPrice + takeProfitPrice présents sur row valide', () => {
+    // C'est le bug ligne 1446 mechanical-trading.service.ts.
+    // Avant : `if (!pos.stopLossPrice && !pos.takeProfitPrice) return;`
+    // → toujours true → return early → stops jamais évalués.
+    const mapped = mapPositionRow(btcRow);
+    const skipsStopCheck = !mapped.stopLossPrice && !mapped.takeProfitPrice;
+    expect(skipsStopCheck).toBe(false); // checkStopTarget ne doit PAS skip
+  });
+});
+
+describe('mapPositionRows', () => {
+  it('handles empty array', () => {
+    expect(mapPositionRows([])).toEqual([]);
+  });
+
+  it('handles null input', () => {
+    expect(mapPositionRows(null)).toEqual([]);
+  });
+
+  it('handles undefined input', () => {
+    expect(mapPositionRows(undefined)).toEqual([]);
+  });
+
+  it('maps multiple rows preserving order', () => {
+    const rows = [
+      { id: 'a', symbol: 'BTC', asset_class: 'crypto_bitcoin', entry_price: '1', stop_loss_price: '0.9', take_profit_price: null, entry_notional_usd: '100', entry_timestamp: '2026-04-27T17:38:00Z', horizon_target_date: null },
+      { id: 'b', symbol: 'RTX', asset_class: 'equity_us_large', entry_price: '172.92', stop_loss_price: '166.00', take_profit_price: null, entry_notional_usd: '2500', entry_timestamp: '2026-04-27T19:14:00Z', horizon_target_date: null },
+    ];
+    const mapped = mapPositionRows(rows);
+    expect(mapped).toHaveLength(2);
+    expect(mapped[0].symbol).toBe('BTC');
+    expect(mapped[0].assetClass).toBe('crypto_bitcoin');
+    expect(mapped[1].symbol).toBe('RTX');
+    expect(mapped[1].stopLossPrice).toBe('166.00');
+    expect(mapped[1].takeProfitPrice).toBeNull(); // bug obs en prod 27/04
+  });
+});

--- a/apps/api/src/modules/lisa/helpers/position.mapper.ts
+++ b/apps/api/src/modules/lisa/helpers/position.mapper.ts
@@ -1,0 +1,66 @@
+/**
+ * Position row mapper — Supabase snake_case → domain camelCase.
+ *
+ * INCIDENT 27/04/2026 (BTC + RTX positions silencieusement non protégées) :
+ * `mechanical-trading.service.ts` chargeait des positions via
+ * `.from('lisa_positions').select('*')` puis castait directement en
+ * `OpenPosition[]`. Les colonnes DB sont en snake_case (entry_price,
+ * asset_class, stop_loss_price, take_profit_price, ...) mais le contrat
+ * `OpenPosition` les déclare en camelCase. Conséquence :
+ *
+ *  - `pos.stopLossPrice` et `pos.takeProfitPrice` toujours `undefined` →
+ *    `checkStopTarget` early-return ligne 1446 → stops jamais évalués.
+ *  - `pos.assetClass.toLowerCase()` ligne 1886 crashe sur BTC car undefined →
+ *    autonomy rules cassées par cycle.
+ *  - `pos.entryPrice` undefined → `new Decimal(undefined)` throw silencieux
+ *    dans plusieurs branches.
+ *
+ * Ce helper est la SOURCE UNIQUE pour transformer un row brut
+ * `lisa_positions` en objet domaine. À utiliser à CHAQUE site qui fait un
+ * `.from('lisa_positions').select('*')` et l'utilise ensuite avec un
+ * accès camelCase.
+ *
+ * Note : `PaperBrokerService.mapRow` fait déjà ce travail correctement
+ * pour les call sites qui passent par `paperBroker.getPositions()`. Ce
+ * helper duplique partiellement la logique pour les call sites directs ;
+ * unification possible plus tard (refactor de `OpenPosition` <-> `PaperPosition`).
+ */
+export interface PositionCamelCaseFields {
+  assetClass: string;
+  entryPrice: string;
+  entryTimestamp: string;
+  entryNotionalUsd: string;
+  stopLossPrice: string | null;
+  takeProfitPrice: string | null;
+  horizonTargetDate: string | null;
+}
+
+/**
+ * Ajoute les alias camelCase à un row Supabase tout en préservant les
+ * champs snake_case originaux (les call sites mixtes continuent à
+ * fonctionner — cf. lisa.service.ts:815, 1321 qui lisent toujours en
+ * snake_case via `as Record<>`).
+ *
+ * Les nouveaux champs sont **alias**, pas des doublons sémantiques —
+ * `row.entryPrice === row.entry_price` après mapping.
+ */
+export function mapPositionRow<T extends Record<string, unknown>>(
+  row: T,
+): T & PositionCamelCaseFields {
+  return {
+    ...row,
+    assetClass: row.asset_class as string,
+    entryPrice: row.entry_price as string,
+    entryTimestamp: row.entry_timestamp as string,
+    entryNotionalUsd: row.entry_notional_usd as string,
+    stopLossPrice: (row.stop_loss_price as string | null) ?? null,
+    takeProfitPrice: (row.take_profit_price as string | null) ?? null,
+    horizonTargetDate: (row.horizon_target_date as string | null) ?? null,
+  };
+}
+
+export function mapPositionRows<T extends Record<string, unknown>>(
+  rows: T[] | null | undefined,
+): (T & PositionCamelCaseFields)[] {
+  return (rows ?? []).map(mapPositionRow);
+}

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1427,6 +1427,27 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
           ? livePx.mul(new Decimal(1).minus(new Decimal(stopPct))).toFixed(8)
           : livePx.mul(new Decimal(1).plus(new Decimal(stopPct))).toFixed(8);
 
+        // 🛡️ Take-profit OBLIGATOIRE — incident 27/04/2026 : BTC + RTX
+        // ouvertes via paperBroker avaient `takeProfitPrice: null` en dur,
+        // ce qui inscrivait NULL en DB. Le mécanique skippait ensuite tout
+        // check TP (cf. checkStopTarget). On force ici un TP basé sur :
+        //   - daily_harvest_config.takeProfitAbsolutePct si DAILY_HARVEST actif
+        //   - sinon defaults : 2.5% hyper_active, 4% standard
+        const harvestCfg = sessionCfg?.daily_harvest_config as
+          | { takeProfitAbsolutePct?: number }
+          | null
+          | undefined;
+        const isHyper = sessionCfg?.profile === 'hyper_active';
+        const tpPct = (
+          (typeof harvestCfg?.takeProfitAbsolutePct === 'number' && harvestCfg.takeProfitAbsolutePct > 0)
+            ? harvestCfg.takeProfitAbsolutePct
+            : (isHyper ? 2.5 : 4.0)
+        ) / 100;
+        const isLongDir = direction === 'long' || direction === 'long_call' || direction === 'long_put';
+        const takeProfitPrice = isLongDir
+          ? livePx.mul(new Decimal(1).plus(new Decimal(tpPct))).toFixed(8)
+          : livePx.mul(new Decimal(1).minus(new Decimal(tpPct))).toFixed(8);
+
         const binanceResult = isCrypto
           ? await this.tryBinanceExecution(expression.symbol as string, alloc.amountUsd, quote.price)
           : null;
@@ -1439,7 +1460,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
           capitalAllocationUsd: alloc.amountUsd,
           livePrice: quote.price,
           stopLossPrice,
-          takeProfitPrice: null,
+          takeProfitPrice,
           horizonDays: riskReward.horizonDays ?? 30,
         });
         opened.push(pos);

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -18,6 +18,7 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import Decimal from 'decimal.js';
 import { randomUUID } from 'node:crypto';
 import { computeAtrStopByKind, type ThesisKind } from '@smartvest/ai-analyst';
+import { mapPositionRows } from '../helpers/position.mapper';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { PerformanceService } from '../../performance/performance.service';
 import { DecisionLogService } from './decision-log.service';
@@ -308,14 +309,18 @@ export class MechanicalTradingService {
     // Load latest valid directive
     const directive = await this.loadDirective(portfolioId);
 
-    // Load open positions
+    // Load open positions — mapPositionRows ajoute les alias camelCase aux
+    // colonnes snake_case de Supabase (entry_price → entryPrice, etc.).
+    // SANS ce mapping, `pos.stopLossPrice` / `pos.takeProfitPrice` /
+    // `pos.assetClass` étaient undefined → checkStopTarget early-return
+    // ligne ~1446 → stops jamais déclenchés (incident 27/04/2026).
     const { data: positions } = await this.supabase.getClient()
       .from('lisa_positions')
       .select('*')
       .eq('portfolio_id', portfolioId)
       .eq('status', 'open');
 
-    const openPositions: OpenPosition[] = positions ?? [];
+    const openPositions: OpenPosition[] = mapPositionRows(positions) as unknown as OpenPosition[];
 
     // Step 0 — P4.1 Portfolio Drawdown Guard (protection capital niveau portefeuille)
     // Vérifie le drawdown intraday AVANT toute autre action. Si franchi :
@@ -373,7 +378,7 @@ export class MechanicalTradingService {
       .eq('portfolio_id', portfolioId)
       .eq('status', 'open');
 
-    const currentPositions: OpenPosition[] = positionsAfterClose ?? [];
+    const currentPositions: OpenPosition[] = mapPositionRows(positionsAfterClose) as unknown as OpenPosition[];
 
     // Step 2 — Stop-loss / take-profit checks (toutes positions, pas besoin de directive)
     const isHyperActiveProfile = cfg.profile === 'hyper_active';
@@ -491,7 +496,7 @@ export class MechanicalTradingService {
       .eq('portfolio_id', portfolioId)
       .eq('status', 'open');
 
-    const activePositions: OpenPosition[] = positionsForOpen ?? [];
+    const activePositions: OpenPosition[] = mapPositionRows(positionsForOpen) as unknown as OpenPosition[];
 
     const constraints = cfg.risk_constraints ?? {};
     // P4.3 — Defaults golden-trader diversifiés :
@@ -1883,6 +1888,12 @@ export class MechanicalTradingService {
     }
     if (metric === 'funding_annual_pct') {
       // Crypto only : convertit symbol → format Binance perp (BTCUSDT)
+      // Defensive `?.` : si le mapper a raté un load site, on log + skip
+      // au lieu de crasher le cycle entier (incident 27/04 BTC crash).
+      if (!pos.assetClass) {
+        this.logger.warn(`[AUTONOMY] funding_annual_pct skip ${pos.symbol}: assetClass undefined (mapper missed?)`);
+        return null;
+      }
       if (!pos.assetClass.toLowerCase().includes('crypto')) return null;
       const binSym = `${pos.symbol.toUpperCase()}USDT`;
       const stats = await this.binance.getFutureStats(binSym).catch(() => null);


### PR DESCRIPTION
## P0 — incident production 27/04/2026 ~17:38 UTC

BTC + RTX positions ouvertes ne déclenchaient ni stop ni take-profit. Logs Fly v167 répétés `[MechanicalTradingService] AutonomyRule eval failed for BTC: TypeError: Cannot read properties of undefined (reading 'toLowerCase')`.

Audit révèle **2 bugs cumulés**, tous deux fixés ici.

## Root cause 1 — `lisa_positions` rows non mappés

`mechanical-trading.service.ts:312, 370, 488` chargeaient les positions via :

```typescript
const { data: positions } = await this.supabase.getClient()
  .from('lisa_positions').select('*').eq(...);
const openPositions: OpenPosition[] = positions ?? [];
```

Les colonnes Supabase sont **snake_case** (`entry_price`, `asset_class`, `stop_loss_price`, `take_profit_price`...) mais le contrat `OpenPosition` les déclare en **camelCase**. Le cast direct laissait tous les champs camelCase à `undefined`.

Conséquences observées :

- **`checkStopTarget()` ligne 1446** : `if (!pos.stopLossPrice && !pos.takeProfitPrice) return;` → toujours `true` → **return early → stops jamais évalués sur AUCUNE position**. C'est le silent risk hole.
- **`evaluateAutonomyRules()` ligne ~1886** : `pos.assetClass.toLowerCase()` crashait chaque cycle sur BTC. Le crash loud des logs.
- **`new Decimal(pos.entryPrice)`** plusieurs sites : `Decimal(undefined)` throw silencieux dans les `try/catch`.

**Fix** : helper `apps/api/src/modules/lisa/helpers/position.mapper.ts` qui ajoute les alias camelCase tout en préservant les snake_case originaux (call sites mixtes continuent à fonctionner — ex. `lisa.service.ts:815, 1321`). Appliqué aux 3 load sites direct-Supabase.

Note : les paths via `paperBroker.getPositions()` étaient déjà corrects (`PaperBrokerService.mapRow` fait le même travail). Le bug ne touchait que les requêtes directes dans `mechanical-trading.service.ts`.

Defensive `?.assetClass` + log warn ligne 1886 : si un futur load site rate le mapper, l'autonomy rule skippe sans tuer le cycle.

## Root cause 2 — `take_profit_price = NULL` en DB

`lisa.service.ts:1442` passait `takeProfitPrice: null` en dur au paperBroker. Toutes les positions ouvertes via `approveProposal` (BTC + RTX en prod 27/04) avaient `take_profit_price=NULL` en DB → `checkStopTarget` skip TP automatiquement même après le fix root-cause-1.

**Fix** : compute `takeProfitPrice` depuis `sessionCfg.daily_harvest_config.takeProfitAbsolutePct` si `DAILY_HARVEST` actif, sinon defaults 2.5% (hyper_active) ou 4% (standard). Aligné avec le path mécanique `mechanical-trading.service.ts:938-940` et `lisa-thresholds.config.ts:136,161`.

## Tests — 14 tests verts

`apps/api/src/modules/lisa/helpers/__tests__/position-mapper.spec.ts` :

- Aliasing snake_case → camelCase de tous les champs critiques
- `null` préservé (pas `undefined`) sur stops absents
- **Reproduction du crash BTC** : `pos.assetClass.toLowerCase()` ne crashe plus sur row mappé
- **Reproduction du silent stop skip** : early-return ne se déclenche plus quand stop est défini
- `mapPositionRows` null/undefined/empty handling

## Validation

- ✅ `tsc --noEmit` clean
- ✅ Jest mapper : 14/14
- ✅ Pas de modif des call sites snake_case existants (rétrocompat préservée)

## Hors scope (PRs séparées à venir)

- **PR B** `fix/macro-vix-cascade-degraded` : investigation du fallback VIX/DXY + dataQuality block enrichi (ne modifie pas la logique de régime — Lisa détecte correctement `geopolitical_stress` cohérent avec la situation Iran/Hormuz).
- **PR C** `fix/quote-refresh-active-symbols` : `MarketDataScheduler` étendre la source de tickers aux `lisa_positions WHERE status='open'` (actuellement filtre `assets.provider_tickers` retourne 0).
- **PR E** (frontend) : `useLisaPositions` refetchInterval 30s→5s + realtime invalidation (RTX position invisible 30s post-INSERT).
- **Refactor unifié** `OpenPosition` ↔ `PaperPosition` : éliminer le mapper en double, après stabilisation prod.

## Action recommandée

Merger ce PR + redéployer Fly v168 **AVANT toute autre action**. Sans ce fix, BTC reste non-protégée (stop=$73031.90 ne sera pas appliqué même si BTC casse).

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_