### PR TITLE
fix(autonomy): defensive ?? guards on .toLowerCase() over position fields

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/autonomy-tolowercase-guard.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/autonomy-tolowercase-guard.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * PR B — defensive guards autour de `.toLowerCase()` sur des champs typés
+ * `string` mais provenant potentiellement d'objets Supabase non-mappés.
+ *
+ * Verifie le pattern `(field ?? '').toLowerCase()` plutôt que
+ * `field.toLowerCase()` qui throw TypeError si field est undefined.
+ *
+ * Tests purs : on isole le pattern (helpers privés inaccessibles), on
+ * vérifie le comportement attendu sur des inputs adversariaux.
+ *
+ * Cf. fix/position-data-integrity (PR #16) qui a fixé la root cause
+ * (mapper). Ce PR est une ceinture défensive pour défaillance future
+ * d'un load site futur qui contournerait le mapper.
+ */
+
+describe('toLowerCase defensive pattern (?? "")', () => {
+  it('returns empty string when field is undefined', () => {
+    const field: string | undefined = undefined;
+    expect((field ?? '').toLowerCase()).toBe('');
+    expect(() => (field ?? '').toLowerCase()).not.toThrow();
+  });
+
+  it('returns empty string when field is null', () => {
+    const field: string | null = null;
+    expect((field ?? '').toLowerCase()).toBe('');
+    expect(() => (field ?? '').toLowerCase()).not.toThrow();
+  });
+
+  it('lowercases the value when field is a real string', () => {
+    const f1: string | undefined = 'CRYPTO_BITCOIN';
+    const f2: string | undefined = 'Equity_US_Large';
+    expect((f1 ?? '').toLowerCase()).toBe('crypto_bitcoin');
+    expect((f2 ?? '').toLowerCase()).toBe('equity_us_large');
+  });
+
+  it('".includes(...)" returns false (not throw) on undefined input via ?? guard', () => {
+    const cls: string | undefined = undefined;
+    const result = (cls ?? '').toLowerCase().includes('crypto');
+    expect(result).toBe(false);
+  });
+
+  it('repro production bug 27/04 : pos.assetClass undefined avec guard ?? ne crashe pas', () => {
+    // Avant le mapper PR #16, `pos.assetClass` était undefined.
+    // Le `(pos.assetClass ?? '').toLowerCase()` est la ceinture si jamais
+    // un load site futur rate le mapper.
+    interface OpenPositionMinimal {
+      symbol: string;
+      assetClass: string;
+      direction: string;
+      entryPrice: string;
+    }
+    const fakeRawPos = {
+      symbol: 'BTC',
+      // assetClass intentionnellement absent (simule mapper miss)
+      direction: 'long',
+      entryPrice: '76875.69',
+    } as unknown as OpenPositionMinimal;
+
+    // Ancien code (crashait) : fakeRawPos.assetClass.toLowerCase()
+    expect(() => fakeRawPos.assetClass.toLowerCase()).toThrow();
+
+    // Nouveau code (defensive) : ne crashe pas
+    expect(() => (fakeRawPos.assetClass ?? '').toLowerCase()).not.toThrow();
+    expect((fakeRawPos.assetClass ?? '').toLowerCase().includes('crypto')).toBe(false);
+  });
+});

--- a/apps/api/src/modules/lisa/services/agent-lisa-sync.service.ts
+++ b/apps/api/src/modules/lisa/services/agent-lisa-sync.service.ts
@@ -285,7 +285,10 @@ export class AgentLisaSyncService {
     positions: OpenPositionMinimal[],
   ): Promise<TriggerContext | null> {
     const cryptos = positions.filter((p) =>
-      p.assetClass.toLowerCase().includes('crypto'),
+      // Defense-in-depth : si le mapper de la position a raté assetClass
+      // (cf. fix/position-data-integrity), `?? ''` évite le TypeError
+      // `Cannot read properties of undefined (reading 'toLowerCase')`.
+      (p.assetClass ?? '').toLowerCase().includes('crypto'),
     );
     for (const p of cryptos) {
       try {
@@ -310,7 +313,7 @@ export class AgentLisaSyncService {
     positions: OpenPositionMinimal[],
   ): Promise<TriggerContext | null> {
     const equities = positions.filter((p) => {
-      const cls = p.assetClass.toLowerCase();
+      const cls = (p.assetClass ?? '').toLowerCase();
       return cls.includes('equity') || cls.includes('etf') || cls.includes('stock');
     });
     for (const p of equities) {
@@ -340,7 +343,7 @@ export class AgentLisaSyncService {
   ): Promise<TriggerContext | null> {
     // On ne check que les positions equity/ETF (ADX EODHD = actions)
     const equities = positions.filter((p) => {
-      const cls = p.assetClass.toLowerCase();
+      const cls = (p.assetClass ?? '').toLowerCase();
       return cls.includes('equity') || cls.includes('etf') || cls.includes('stock');
     });
     for (const p of equities) {

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -203,7 +203,9 @@ export class MechanicalTradingService {
    * mieux sur actions/ETF. Pour ce commit on se concentre sur equity/ETF.
    */
   private toEodhdForCorrelation(symbol: string, assetClass: string): string {
-    const cls = assetClass.toLowerCase();
+    // Defensive guard : assetClass typé string mais peut être undefined si
+    // le caller passe un row Supabase non-mappé (cf. fix/position-data-integrity).
+    const cls = (assetClass ?? '').toLowerCase();
     if (cls.includes('crypto')) return `${symbol.toUpperCase()}-USD.CC`;
     if (cls.includes('fx') || cls.includes('forex')) return `${symbol.toUpperCase()}.FOREX`;
     // equity / etf / commodity ETF / bond ETF → suffixe .US si pas déjà présent
@@ -880,7 +882,9 @@ export class MechanicalTradingService {
       // pousserait l'exposition de la classe au-delà du seuil (default 25%).
       // PATCH 2 (PR#2 P0) — audit DECISION_LOG pour visibility (avant : simple
       // logger.debug invisible côté UI).
-      const classKey = target.assetClass.toLowerCase();
+      // Defense-in-depth : `?? ''` au cas où la directive Lisa serait corrompue
+      // (target.assetClass undefined). Évite un crash silencieux en plein cycle.
+      const classKey = (target.assetClass ?? '').toLowerCase();
       const currentClassExposure = exposureByClass.get(classKey) ?? 0;
       const projectedClassExposurePct = capitalUsd.gt(0)
         ? ((currentClassExposure + notional.toNumber()) / capitalUsd.toNumber()) * 100


### PR DESCRIPTION
## Defense-in-depth pour PR #16

PR #16 (`fix/position-data-integrity`) fixe la root cause du crash BTC en mappant snake_case → camelCase au load des positions Supabase. Cette PR ajoute la **ceinture défensive** sur les sites consommateurs qui faisaient `obj.assetClass.toLowerCase()` direct — si un load site futur rate le mapper, le pattern `(field ?? '').toLowerCase()` empêche le `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`.

## Sites hardenés (5)

### `agent-lisa-sync.service.ts` — wake-up triggers Tier 2
- **Ligne 288** — `detectLiquidationWave` filtrage crypto positions
- **Ligne 313** — `detectInsiderBulkBuy` filtrage equity/etf positions
- **Ligne 343** — `detectAdxRegimeShift` filtrage equity/etf positions

Si le caller (`mechanical-trading.service.ts:1218` qui construit `OpenPositionMinimal`) passe un objet mal formé, ces 3 méthodes crashaient → wake-up Lisa silencieusement cassé.

### `mechanical-trading.service.ts`
- **Ligne 206** — `toEodhdForCorrelation(symbol, assetClass)` : paramètre typé `string` mais call site corrélation portfolio peut passer undefined si la position parent est mal mappée.
- **Ligne 883** — `target.assetClass.toLowerCase()` sur target de directive Lisa. Si Lisa émet une directive corrompue (pré-PR #16, le briefing recevait `pos.assetClass=undefined` → Claude pouvait omettre `assetClass` dans la thèse), cycle complet crashait à l'open-pré-check classe.

## Pattern uniforme

```typescript
// Avant — TypeError si field undefined
const cls = obj.assetClass.toLowerCase();

// Après — empty string si undefined/null, comportement préservé sinon
const cls = (obj.assetClass ?? '').toLowerCase();
```

Coût runtime nul (short-circuit), zéro changement de comportement quand le champ est défini. `''.includes('crypto')` retourne `false` → pas de match parasite ni de filtrage erroné.

## Tests — 5 cas verts

`__tests__/autonomy-tolowercase-guard.spec.ts` :

- `field === undefined` → empty string + no throw
- `field === null` → empty string + no throw  
- `field === 'CRYPTO_BITCOIN'` → `'crypto_bitcoin'` (comportement préservé)
- `.includes('crypto')` retourne `false` (pas `true` parasite) sur undefined
- **Repro bug 27/04** : `pos.assetClass.toLowerCase()` throw, version `?? ''` ne crashe pas

## Validation

- ✅ `tsc --noEmit` clean
- ✅ Jest : 5/5 nouveau test
- ✅ Aucune modif de logique métier (pure défense)

## Hors scope

PR C (`fix/quote-refresh-vix-dxy-fallback`) — à venir :
- VIX/DXY tombant en fallback hardcoded
- `MarketDataScheduler` 0/0 succeeded — étendre source aux `lisa_positions` ouvertes

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_