### PR TITLE
fix(market-data): union active lisa_positions for quote refresh (P0 27/04)

### DIFF
--- a/apps/api/src/modules/market-data/helpers/__tests__/symbol-to-eodhd.spec.ts
+++ b/apps/api/src/modules/market-data/helpers/__tests__/symbol-to-eodhd.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests pour symbol-to-eodhd.helper — fix incident 27/04/2026.
+ *
+ * Vérifie que les symboles tenus en prod (BTC, RTX) produisent un
+ * ProviderAsset EODHD valide pour débloquer le quote refresh stérile.
+ */
+import { symbolToProviderAsset } from '../symbol-to-eodhd.helper';
+
+describe('symbolToProviderAsset', () => {
+  describe('crypto', () => {
+    it('maps BTC + crypto_bitcoin → BTC-USD.CC', () => {
+      const a = symbolToProviderAsset('id-btc', 'BTC', 'crypto_bitcoin');
+      expect(a).not.toBeNull();
+      expect(a!.providerTicker).toBe('BTC-USD.CC');
+      expect(a!.ticker).toBe('BTC');
+      expect(a!.currency).toBe('USD');
+    });
+
+    it('maps ETH + crypto_ethereum → ETH-USD.CC', () => {
+      const a = symbolToProviderAsset('id-eth', 'ETH', 'crypto_ethereum');
+      expect(a!.providerTicker).toBe('ETH-USD.CC');
+    });
+
+    it('strips USDT suffix : BTCUSDT → BTC-USD.CC', () => {
+      const a = symbolToProviderAsset('id-1', 'BTCUSDT', 'crypto_bitcoin');
+      expect(a!.providerTicker).toBe('BTC-USD.CC');
+      expect(a!.ticker).toBe('BTC');
+    });
+
+    it('strips -USD suffix : BTC-USD → BTC-USD.CC', () => {
+      const a = symbolToProviderAsset('id-1', 'BTC-USD', null);
+      expect(a!.providerTicker).toBe('BTC-USD.CC');
+    });
+
+    it('strips -SPOT suffix : BTC-SPOT → BTC-USD.CC', () => {
+      const a = symbolToProviderAsset('id-1', 'BTC-SPOT', null);
+      expect(a!.providerTicker).toBe('BTC-USD.CC');
+    });
+
+    it('detects crypto via symbol whitelist when assetClass is missing', () => {
+      // Cas réel : asset_class undefined sur position legacy
+      const a = symbolToProviderAsset('id-sol', 'SOL', undefined);
+      expect(a!.providerTicker).toBe('SOL-USD.CC');
+    });
+
+    it('detects crypto via crypto_ prefix even with unknown symbol', () => {
+      const a = symbolToProviderAsset('id-x', 'NEWCOIN', 'crypto_altcoins');
+      expect(a!.providerTicker).toBe('NEWCOIN-USD.CC');
+    });
+  });
+
+  describe('equity / ETF', () => {
+    it('maps RTX + equity_us_large → RTX.US (cas réel 27/04)', () => {
+      const a = symbolToProviderAsset('id-rtx', 'RTX', 'equity_us_large');
+      expect(a!.providerTicker).toBe('RTX.US');
+      expect(a!.ticker).toBe('RTX');
+    });
+
+    it('maps SPY + equity_us_large → SPY.US', () => {
+      const a = symbolToProviderAsset('id-spy', 'SPY', 'equity_us_large');
+      expect(a!.providerTicker).toBe('SPY.US');
+    });
+
+    it('maps GLD ETF (commodities_metals_precious) → GLD.US', () => {
+      const a = symbolToProviderAsset('id-gld', 'GLD', 'commodities_metals_precious');
+      expect(a!.providerTicker).toBe('GLD.US');
+    });
+
+    it('maps unknown symbol with no assetClass → .US fallback', () => {
+      const a = symbolToProviderAsset('id-x', 'NVDA', null);
+      expect(a!.providerTicker).toBe('NVDA.US');
+    });
+  });
+
+  describe('FX', () => {
+    it('maps EURUSD + fx_g10 → EURUSD.FOREX', () => {
+      const a = symbolToProviderAsset('id-eurusd', 'EURUSD', 'fx_g10');
+      expect(a!.providerTicker).toBe('EURUSD.FOREX');
+    });
+
+    it('detects FX via 6-letter pattern when assetClass missing', () => {
+      const a = symbolToProviderAsset('id-1', 'USDJPY', null);
+      expect(a!.providerTicker).toBe('USDJPY.FOREX');
+    });
+  });
+
+  describe('respect format complet existant', () => {
+    it('preserves AAPL.US when symbol already contains . (no double-suffix)', () => {
+      const a = symbolToProviderAsset('id-aapl', 'AAPL.US', 'equity_us_large');
+      expect(a!.providerTicker).toBe('AAPL.US');
+    });
+
+    it('preserves ASML.AS (EU equity)', () => {
+      const a = symbolToProviderAsset('id-asml', 'ASML.AS', 'equity_eu');
+      expect(a!.providerTicker).toBe('ASML.AS');
+    });
+
+    it('preserves XAUUSD.FOREX', () => {
+      const a = symbolToProviderAsset('id-xau', 'XAUUSD.FOREX', null);
+      expect(a!.providerTicker).toBe('XAUUSD.FOREX');
+    });
+  });
+
+  describe('cas insuffisants', () => {
+    it('returns null on empty symbol', () => {
+      expect(symbolToProviderAsset('id-1', '', null)).toBeNull();
+    });
+  });
+
+  describe('repro production 27/04', () => {
+    it('BTC long position (entry 76875.69) maps correctly', () => {
+      // Repro de la position BTC live 17:38 UTC
+      const a = symbolToProviderAsset('btc-pos-uuid', 'BTC', 'crypto_bitcoin');
+      expect(a).not.toBeNull();
+      expect(a!.providerTicker).toBe('BTC-USD.CC');
+      expect(a!.assetId).toBe('btc-pos-uuid');
+    });
+
+    it('RTX long position (entry 172.92) maps correctly', () => {
+      const a = symbolToProviderAsset('rtx-pos-uuid', 'RTX', 'equity_us_large');
+      expect(a).not.toBeNull();
+      expect(a!.providerTicker).toBe('RTX.US');
+    });
+  });
+});

--- a/apps/api/src/modules/market-data/helpers/symbol-to-eodhd.helper.ts
+++ b/apps/api/src/modules/market-data/helpers/symbol-to-eodhd.helper.ts
@@ -1,0 +1,97 @@
+/**
+ * Symbol → EODHD provider ticker conversion (subset).
+ *
+ * Permet à MarketDataService.refreshQuotes() de construire un ProviderAsset
+ * directement depuis un row `lisa_positions` (symbol + asset_class) sans
+ * dépendre d'un mapping pré-existant dans la table `assets`.
+ *
+ * INCIDENT 27/04/2026 : `MarketDataScheduler` retournait 0/0 succeeded car
+ * `getProviderAssets()` filtrait `assets.provider_tickers != '{}'` qui
+ * retournait 0 — la table `assets` n'avait pas (ou plus) de mappings pour
+ * les tickers actifs (BTC, RTX). Conséquence : aucun prix rafraîchi, donc
+ * aucun stop/TP ne se déclenchait au mécanique côté `lisa_positions`
+ * (couplé au bug snake_case/camelCase fixé en PR #16).
+ *
+ * Couvre les cas suffisants pour débloquer la prod :
+ *   - crypto : BTC/ETH/SOL/... → `{SYM}-USD.CC`
+ *   - equity / ETF : AAPL/RTX/SPY/... → `{SYM}.US`
+ *   - FX paires 6 lettres : EURUSD/USDJPY/... → `{SYM}.FOREX`
+ *
+ * Cas non gérés (retourne null, à étendre plus tard) :
+ *   - ADRs spécifiques (TSM, BABA — généralement `.US` fonctionne)
+ *   - Equities EU avec MIC code (ex. ASML.AS, MC.PA)
+ *   - Bonds (US10Y, US2Y nécessitent un format dédié)
+ *   - Indices avec préfixe (^VIX, ^SPX — gérés par fetchCascade côté Lisa)
+ */
+import type { ProviderAsset } from '../providers/market-data-provider.interface';
+
+const CRYPTO_SYMBOLS = new Set([
+  'BTC', 'ETH', 'SOL', 'BNB', 'XRP', 'ADA', 'DOGE', 'DOT', 'AVAX',
+  'MATIC', 'LINK', 'ATOM', 'UNI', 'LTC', 'NEAR', 'ARB', 'OP',
+]);
+
+/**
+ * Construit un ProviderAsset EODHD à partir d'un symbol + asset_class.
+ * Retourne null si la combinaison n'est pas couverte (caller fallback).
+ *
+ * @param assetId — id d'asset à utiliser pour le quote save (typiquement
+ *   l'id de la position, à défaut un UUID synthétique side-effect-free).
+ * @param symbol — ticker brut (BTC, RTX, EURUSD, ...). Insensible à la casse.
+ * @param assetClass — `asset_class` de la position (snake_case enum), ou
+ *   undefined / null si non disponible (heuristique sur symbol).
+ * @param currency — devise locale (default 'USD').
+ */
+export function symbolToProviderAsset(
+  assetId: string,
+  symbol: string,
+  assetClass: string | null | undefined,
+  currency: string = 'USD',
+): ProviderAsset | null {
+  if (!symbol) return null;
+  const sym = symbol.toUpperCase().trim();
+  const cls = (assetClass ?? '').toLowerCase();
+
+  // Si déjà un format EODHD complet (contient un '.'), le respecter tel quel.
+  if (sym.includes('.')) {
+    return { assetId, ticker: sym, providerTicker: sym, currency };
+  }
+
+  // Crypto : asset_class crypto_* OU symbol dans whitelist.
+  const isCrypto = cls.startsWith('crypto_') || CRYPTO_SYMBOLS.has(sym) ||
+    sym.endsWith('USDT') || sym.endsWith('-USD') || sym.endsWith('-SPOT');
+  if (isCrypto) {
+    // Normalize : BTCUSDT → BTC, BTC-USD → BTC, BTC-SPOT → BTC
+    const base = sym
+      .replace(/USDT$/, '')
+      .replace(/-USD$/, '')
+      .replace(/-SPOT$/, '');
+    if (!base) return null;
+    return {
+      assetId,
+      ticker: base,
+      providerTicker: `${base}-USD.CC`,
+      currency,
+    };
+  }
+
+  // FX 6 lettres : EURUSD, USDJPY, GBPUSD, ...
+  if (cls.startsWith('fx_') || /^[A-Z]{6}$/.test(sym)) {
+    return {
+      assetId,
+      ticker: sym,
+      providerTicker: `${sym}.FOREX`,
+      currency,
+    };
+  }
+
+  // Equity / ETF / commodity ETF / bond ETF : suffixe .US (default raisonnable
+  // — couvre AAPL/RTX/SPY/QQQ/GLD/SLV/TLT/HYG/LQD/VXX/UUP). Les EU/JP/etc.
+  // sont gérés par le mapping `assets.provider_tickers` qui prend le pas
+  // (cf. union dans MarketDataService.getActiveSymbolsForRefresh).
+  return {
+    assetId,
+    ticker: sym,
+    providerTicker: `${sym}.US`,
+    currency,
+  };
+}

--- a/apps/api/src/modules/market-data/services/market-data.service.ts
+++ b/apps/api/src/modules/market-data/services/market-data.service.ts
@@ -4,6 +4,7 @@ import { ProviderRegistryService } from './provider-registry.service';
 import { ProviderAsset } from '../providers/market-data-provider.interface';
 import { InstrumentQuote } from '../dto/instrument-quote.dto';
 import { PriceBar } from '../dto/price-bar.dto';
+import { symbolToProviderAsset } from '../helpers/symbol-to-eodhd.helper';
 
 @Injectable()
 export class MarketDataService {
@@ -43,8 +44,66 @@ export class MarketDataService {
     return assets;
   }
 
+  /**
+   * INCIDENT 27/04/2026 — Union avec les `lisa_positions` ouvertes pour
+   * que le quote refresh ne soit pas stérile quand la table `assets` n'a
+   * pas (ou plus) de mappings provider_tickers pour les tickers actifs.
+   *
+   * Avant le fix : `getProviderAssets()` filtrait `provider_tickers != '{}'`
+   * sur la table `assets` qui retournait 0 row → bot aveugle aux prix
+   * live → stops/TP jamais évalués sur les positions effectivement
+   * tenues (BTC, RTX 27/04).
+   *
+   * Sémantique : on UNION (déduplication par providerTicker) :
+   *   - mappings statiques de la table `assets` (préservé pour watchlist)
+   *   - mappings dérivés des `lisa_positions WHERE status='open'` via
+   *     symbolToProviderAsset (heuristique crypto_/.US/.FOREX)
+   */
+  async getActiveSymbolsForRefresh(): Promise<ProviderAsset[]> {
+    const staticAssets = await this.getProviderAssets();
+    const positionAssets = await this.getOpenPositionAssets();
+
+    // Déduplication par providerTicker (le mapping statique prend le pas
+    // sur l'heuristique car il porte un assetId DB stable et une devise
+    // potentiellement non-USD précise).
+    const byTicker = new Map<string, ProviderAsset>();
+    for (const a of positionAssets) byTicker.set(a.providerTicker, a);
+    for (const a of staticAssets) byTicker.set(a.providerTicker, a);
+    return Array.from(byTicker.values());
+  }
+
+  /**
+   * Charge les positions ouvertes de `lisa_positions` et construit un
+   * ProviderAsset par ligne via `symbolToProviderAsset`. Filtre les rows
+   * dont la combinaison symbol/asset_class n'est pas reconnue (helper
+   * retourne null).
+   */
+  private async getOpenPositionAssets(): Promise<ProviderAsset[]> {
+    if (!this.supabase.isReady()) return [];
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('lisa_positions')
+      .select('id, symbol, asset_class')
+      .eq('status', 'open');
+    if (error) {
+      this.logger.warn(`getOpenPositionAssets read failed: ${error.message}`);
+      return [];
+    }
+    const out: ProviderAsset[] = [];
+    for (const row of data ?? []) {
+      const a = symbolToProviderAsset(
+        String(row.id),
+        String(row.symbol ?? ''),
+        (row.asset_class as string | null | undefined) ?? null,
+      );
+      if (a) out.push(a);
+    }
+    return out;
+  }
+
   async refreshQuotes(): Promise<{ succeeded: number; failed: number }> {
-    const assets = await this.getProviderAssets();
+    // Union : assets statiques + positions ouvertes (fix incident 27/04).
+    const assets = await this.getActiveSymbolsForRefresh();
     if (assets.length === 0) return { succeeded: 0, failed: 0 };
 
     const quotes = await this.registry.fetchQuotesWithFailover(assets);
@@ -52,7 +111,7 @@ export class MarketDataService {
   }
 
   async refreshDailyBars(fromDate: string, toDate: string): Promise<{ succeeded: number; failed: number }> {
-    const assets = await this.getProviderAssets();
+    const assets = await this.getActiveSymbolsForRefresh();
     if (assets.length === 0) return { succeeded: 0, failed: 0 };
 
     const bars = await this.registry.fetchDailyBarsWithFailover(assets, fromDate, toDate);

--- a/apps/api/src/modules/market-data/services/quote-refresh.service.ts
+++ b/apps/api/src/modules/market-data/services/quote-refresh.service.ts
@@ -16,7 +16,7 @@ export class QuoteRefreshService {
     const startedAt = new Date().toISOString();
     const jobId = await this.createJob('quote_refresh');
 
-    const assets = await this.marketData.getProviderAssets();
+    const assets = await this.marketData.getActiveSymbolsForRefresh();
     const assetsRequested = assets.length;
 
     let assetsSucceeded = 0;
@@ -51,7 +51,7 @@ export class QuoteRefreshService {
     const startedAt = new Date().toISOString();
     const jobId = await this.createJob('bar_refresh');
 
-    const assets = await this.marketData.getProviderAssets();
+    const assets = await this.marketData.getActiveSymbolsForRefresh();
     const assetsRequested = assets.length;
 
     let assetsSucceeded = 0;


### PR DESCRIPTION
## P0 — incident production 27/04/2026

`MarketDataScheduler` retournait `Quote refresh done: 0/0 succeeded` à chaque cycle. `MarketDataService.getProviderAssets()` filtrait la table `assets` sur `provider_tickers != '{}'` qui retournait 0 row → bot aveugle aux prix live.

**Combiné au bug snake_case/camelCase fixé en PR #16, les stops/TP étaient doublement bloqués** : la position BTC ouverte à 17:38 (entry $76875.69, stop $73031.90, TP NULL) était totalement non-protégée.

## Fix

Nouvelle méthode `MarketDataService.getActiveSymbolsForRefresh()` qui **union** (déduplication par `providerTicker`) :

- mappings statiques de `assets.provider_tickers` — préservé pour watchlist / univers Lisa hors positions
- mappings dérivés des `lisa_positions WHERE status='open'` via le nouveau helper `symbolToProviderAsset()`

`refreshQuotes()` + `refreshDailyBars()` + `QuoteRefreshService` switchent vers la méthode union. Strictly additive, ne casse aucune source existante.

## Helper `symbol-to-eodhd.helper.ts`

Couvre 3 patterns courants :

| Pattern | Mapping | Exemple |
|---|---|---|
| crypto | `{SYM}-USD.CC` (strip USDT/-USD/-SPOT) | `BTC` → `BTC-USD.CC` |
| equity / ETF | `{SYM}.US` | `RTX` → `RTX.US`, `GLD` → `GLD.US` |
| FX 6 lettres | `{SYM}.FOREX` | `EURUSD` → `EURUSD.FOREX` |
| déjà complet | préservé tel quel | `ASML.AS` → `ASML.AS` |
| empty / null | `null` (caller filtre) | — |

Détection crypto multi-source : `asset_class.startsWith('crypto_')` OU symbol dans whitelist (BTC/ETH/SOL/BNB/XRP/ADA/DOGE/DOT/AVAX/MATIC/LINK/ATOM/UNI/LTC/NEAR/ARB/OP) OU suffixe `USDT`/`-USD`/`-SPOT`.

## Tests — 19/19 verts

`apps/api/src/modules/market-data/helpers/__tests__/symbol-to-eodhd.spec.ts` :

- 7 cas crypto (BTC/ETH normaux, suffixes BTCUSDT/-USD/-SPOT, whitelist sans assetClass, prefix `crypto_*`)
- 4 cas equity/ETF (RTX, SPY, GLD, NVDA fallback)
- 2 cas FX (EURUSD avec assetClass, USDJPY heuristique 6 lettres)
- 3 cas tickers déjà complets (AAPL.US, ASML.AS, XAUUSD.FOREX) — préservés sans double-suffix
- 1 cas empty (retour null)
- **2 repros positions live 27/04** : BTC long $76875.69 + RTX long $172.92

## Validation

- ✅ `tsc --noEmit` clean
- ✅ Jest helper : 19/19
- ✅ Strictly additive sur `MarketDataService` (no behavior change pour les call sites existants si `lisa_positions` est vide)

## Hors scope

- **PR D** (à venir) : VIX/DXY cascade instrumentation côté `lisa.service.ts.fetchCascade()` pour diagnostiquer pourquoi `VIX.INDX` tombe en fallback en prod. **Ne modifie pas les valeurs** — Lisa détecte correctement `geopolitical_stress` cohérent avec la situation Iran/Hormuz post-Natanz/Fordow. Juste log + dataQuality block enrichi pour signaler la dégradation à Lisa.
- **PR E** (frontend) : `useLisaPositions` refetchInterval 30s→5s + realtime invalidation pour visibilité immédiate des positions ouvertes par le mécanique.
- **Cleanup** : unifier `symbolToProviderAsset` ↔ `LisaService.toEodhdTicker` en une seule source de vérité partagée (refactor stable post-incident).

## Action recommandée

Merger PR #17 (toLowerCase guards) + ce PR + redéployer Fly v170. Combiné à PR #16 (déjà mergée), la chaîne complète est : positions correctement mappées → stops/TP évalués chaque cycle → quote refresh fournit les prix live → ces stops/TP se déclenchent réellement.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_