### PR TITLE
feat(macro): VIX/DXY cascade EODHD → Yahoo → Stooq → proxy ETF

### DIFF
--- a/apps/api/src/modules/lisa/helpers/__tests__/macro-fallback.spec.ts
+++ b/apps/api/src/modules/lisa/helpers/__tests__/macro-fallback.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests pour macro-fallback.helper — parsers Yahoo Finance + Stooq.
+ *
+ * Pure functions, pas de mock HTTP — on injecte directement les payloads
+ * que retourne chaque provider à des moments différents (success, partial,
+ * empty). Cela garantit que le caller (LisaService.fetchYahoo / fetchStooq)
+ * voit toujours soit un nombre > 0 valide, soit null (jamais NaN, jamais
+ * negative, jamais 0).
+ */
+import {
+  buildStooqCsvUrl,
+  buildYahooChartUrl,
+  parseStooqCsvResponse,
+  parseYahooChartResponse,
+} from '../macro-fallback.helper';
+
+describe('parseYahooChartResponse', () => {
+  it('extracts regularMarketPrice (path 1, fresh price)', () => {
+    const json = {
+      chart: {
+        result: [{
+          meta: { regularMarketPrice: 22.65, currency: 'USD' },
+          indicators: { quote: [{ close: [22.5, 22.6, 22.65] }] },
+        }],
+      },
+    };
+    expect(parseYahooChartResponse(json)).toBe(22.65);
+  });
+
+  it('falls back to last non-null close in indicators.quote (path 2)', () => {
+    const json = {
+      chart: {
+        result: [{
+          meta: { regularMarketPrice: NaN }, // path 1 fails
+          indicators: { quote: [{ close: [22.5, 22.6, null, 22.85] }] },
+        }],
+      },
+    };
+    expect(parseYahooChartResponse(json)).toBe(22.85);
+  });
+
+  it('skips trailing nulls and finds last valid close', () => {
+    const json = {
+      chart: {
+        result: [{
+          meta: {},
+          indicators: { quote: [{ close: [22.5, 22.6, null, null] }] },
+        }],
+      },
+    };
+    expect(parseYahooChartResponse(json)).toBe(22.6);
+  });
+
+  it('falls back to adjclose (path 3)', () => {
+    const json = {
+      chart: {
+        result: [{
+          meta: {},
+          indicators: {
+            quote: [{ close: [null, null] }],
+            adjclose: [{ adjclose: [22.4, null, 22.7] }],
+          },
+        }],
+      },
+    };
+    expect(parseYahooChartResponse(json)).toBe(22.7);
+  });
+
+  it('returns null on chart.error', () => {
+    const json = { chart: { error: { code: 'Not Found' }, result: null } };
+    expect(parseYahooChartResponse(json)).toBeNull();
+  });
+
+  it('returns null on missing chart', () => {
+    expect(parseYahooChartResponse({})).toBeNull();
+  });
+
+  it('returns null on empty result array', () => {
+    expect(parseYahooChartResponse({ chart: { result: [] } })).toBeNull();
+  });
+
+  it('returns null on non-object input', () => {
+    expect(parseYahooChartResponse(null)).toBeNull();
+    expect(parseYahooChartResponse(undefined)).toBeNull();
+    expect(parseYahooChartResponse('not json')).toBeNull();
+    expect(parseYahooChartResponse(42)).toBeNull();
+  });
+
+  it('rejects 0 and negative prices (would be corrupted data)', () => {
+    expect(parseYahooChartResponse({
+      chart: { result: [{ meta: { regularMarketPrice: 0 }, indicators: { quote: [{ close: [0] }] } }] },
+    })).toBeNull();
+    expect(parseYahooChartResponse({
+      chart: { result: [{ meta: { regularMarketPrice: -1 }, indicators: { quote: [{ close: [-1] }] } }] },
+    })).toBeNull();
+  });
+
+  it('extracts a realistic VIX value (~22.5) from a typical Yahoo response', () => {
+    // Snapshot d'une réponse réelle Yahoo /v8/finance/chart/^VIX
+    const realResponse = {
+      chart: {
+        result: [{
+          meta: {
+            currency: 'USD',
+            symbol: '^VIX',
+            regularMarketPrice: 22.41,
+            chartPreviousClose: 21.89,
+            regularMarketTime: 1714248000,
+          },
+          timestamp: [1714248000],
+          indicators: {
+            quote: [{
+              high: [22.85],
+              low: [21.95],
+              open: [22.05],
+              close: [22.41],
+              volume: [0],
+            }],
+          },
+        }],
+        error: null,
+      },
+    };
+    expect(parseYahooChartResponse(realResponse)).toBe(22.41);
+  });
+});
+
+describe('parseStooqCsvResponse', () => {
+  it('extracts close from a single-row CSV', () => {
+    const csv =
+      'Symbol,Date,Time,Open,High,Low,Close,Volume\n' +
+      '^VIX,2026-04-27,15:30:00,22.10,22.85,21.90,22.65,N/D';
+    expect(parseStooqCsvResponse(csv)).toBe(22.65);
+  });
+
+  it('handles CRLF line endings (Windows-style)', () => {
+    const csv =
+      'Symbol,Date,Time,Open,High,Low,Close,Volume\r\n' +
+      '^VIX,2026-04-27,15:30:00,22.10,22.85,21.90,22.65,N/D\r\n';
+    expect(parseStooqCsvResponse(csv)).toBe(22.65);
+  });
+
+  it('takes last numeric close when multiple data rows present', () => {
+    const csv =
+      'Symbol,Date,Time,Open,High,Low,Close,Volume\n' +
+      '^VIX,2026-04-27,15:00:00,22.10,22.85,21.90,22.65,N/D\n' +
+      '^VIX,2026-04-27,15:30:00,22.65,22.95,22.50,22.85,N/D';
+    expect(parseStooqCsvResponse(csv)).toBe(22.85);
+  });
+
+  it('skips rows where close is N/D', () => {
+    const csv =
+      'Symbol,Date,Time,Open,High,Low,Close,Volume\n' +
+      '^VIX,2026-04-27,15:00:00,22.10,22.85,21.90,22.65,N/D\n' +
+      '^VIX,2026-04-27,15:30:00,N/D,N/D,N/D,N/D,N/D';
+    // 2e ligne N/D → recule → 1re ligne 22.65
+    expect(parseStooqCsvResponse(csv)).toBe(22.65);
+  });
+
+  it('skips rows where close is "-"', () => {
+    const csv =
+      'Symbol,Date,Time,Open,High,Low,Close,Volume\n' +
+      '^VIX,2026-04-27,15:00:00,22.10,22.85,21.90,22.65,N/D\n' +
+      '^VIX,2026-04-27,15:30:00,-,-,-,-,-';
+    expect(parseStooqCsvResponse(csv)).toBe(22.65);
+  });
+
+  it('returns null when only the header is present (no data row)', () => {
+    expect(parseStooqCsvResponse('Symbol,Date,Time,Open,High,Low,Close,Volume')).toBeNull();
+  });
+
+  it('returns null when CSV is empty / whitespace', () => {
+    expect(parseStooqCsvResponse('')).toBeNull();
+    expect(parseStooqCsvResponse('   \n\n  ')).toBeNull();
+  });
+
+  it('returns null when Close column is missing from header', () => {
+    const csv =
+      'Symbol,Date,Time,Open,High,Low,Volume\n' +
+      '^VIX,2026-04-27,15:30:00,22.10,22.85,21.90,N/D';
+    expect(parseStooqCsvResponse(csv)).toBeNull();
+  });
+
+  it('returns null when all data rows have invalid close', () => {
+    const csv =
+      'Symbol,Date,Time,Open,High,Low,Close,Volume\n' +
+      '^VIX,2026-04-27,15:00:00,N/D,N/D,N/D,N/D,N/D\n' +
+      '^VIX,2026-04-27,15:30:00,N/D,N/D,N/D,-,N/D';
+    expect(parseStooqCsvResponse(csv)).toBeNull();
+  });
+
+  it('rejects 0 and negative close (corrupted data)', () => {
+    const csv =
+      'Symbol,Date,Time,Open,High,Low,Close,Volume\n' +
+      '^VIX,2026-04-27,15:30:00,22.10,22.85,21.90,0,N/D';
+    expect(parseStooqCsvResponse(csv)).toBeNull();
+  });
+
+  it('handles non-string input gracefully', () => {
+    expect(parseStooqCsvResponse(null as unknown as string)).toBeNull();
+    expect(parseStooqCsvResponse(undefined as unknown as string)).toBeNull();
+    expect(parseStooqCsvResponse(123 as unknown as string)).toBeNull();
+  });
+});
+
+describe('URL builders', () => {
+  it('buildYahooChartUrl encodes the symbol (^VIX → %5EVIX)', () => {
+    expect(buildYahooChartUrl('^VIX')).toBe(
+      'https://query1.finance.yahoo.com/v8/finance/chart/%5EVIX?interval=1d&range=1d',
+    );
+  });
+
+  it('buildYahooChartUrl supports DX-Y.NYB symbol', () => {
+    expect(buildYahooChartUrl('DX-Y.NYB')).toBe(
+      'https://query1.finance.yahoo.com/v8/finance/chart/DX-Y.NYB?interval=1d&range=1d',
+    );
+  });
+
+  it('buildStooqCsvUrl lowercases + encodes the symbol', () => {
+    expect(buildStooqCsvUrl('^VIX')).toBe(
+      'https://stooq.com/q/l/?s=%5Evix&f=sd2t2ohlcv&h&e=csv',
+    );
+  });
+
+  it('buildStooqCsvUrl handles ^dxy lowercased', () => {
+    expect(buildStooqCsvUrl('^DXY')).toBe(
+      'https://stooq.com/q/l/?s=%5Edxy&f=sd2t2ohlcv&h&e=csv',
+    );
+  });
+});

--- a/apps/api/src/modules/lisa/helpers/macro-fallback.helper.ts
+++ b/apps/api/src/modules/lisa/helpers/macro-fallback.helper.ts
@@ -1,0 +1,136 @@
+/**
+ * Parsers pour les sources fallback macro (Yahoo Finance + Stooq).
+ *
+ * Pour les indicateurs VIX/DXY où EODHD `*.INDX` retourne fréquemment
+ * `empty_price_field` en prod (cf. CLAUDE.md mécanique fetchCascade), on
+ * étend la cascade avec deux providers gratuits sans clé API :
+ *
+ *   - **Yahoo Finance** chart endpoint (no-auth, JSON)
+ *   - **Stooq** quote endpoint (no-auth, CSV)
+ *
+ * Les fonctions ci-dessous SONT PURES (no I/O) pour être testables sans
+ * mock HTTP. Le caller (LisaService.fetchYahooQuote / fetchStooqQuote)
+ * encapsule l'appel `fetch()` et délègue le parsing ici.
+ *
+ * Cf. PR fix/macro-vix-cascade-multi-provider (incident 27/04 — VIX
+ * en fallback hardcoded car cascade EODHD-only insuffisante).
+ */
+
+/**
+ * Parse la réponse JSON Yahoo Finance `/v8/finance/chart/{symbol}`.
+ *
+ * Shape attendu (extrait) :
+ * ```
+ * { chart: { result: [ { meta: { regularMarketPrice: 22.5 } } ] } }
+ * ```
+ *
+ * Plusieurs paths sont essayés (compat versions API anciennes/nouvelles) :
+ *   1. `chart.result[0].meta.regularMarketPrice` (préféré, frais)
+ *   2. dernière valeur non-null de `chart.result[0].indicators.quote[0].close`
+ *   3. dernière valeur non-null de `chart.result[0].indicators.adjclose[0].adjclose`
+ *
+ * Retourne null si :
+ *   - structure invalide
+ *   - aucun prix > 0 trouvé
+ *   - réponse `chart.error != null`
+ */
+export function parseYahooChartResponse(json: unknown): number | null {
+  if (!json || typeof json !== 'object') return null;
+  const chart = (json as Record<string, unknown>).chart as Record<string, unknown> | undefined;
+  if (!chart || chart.error) return null;
+  const result = chart.result as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(result) || result.length === 0) return null;
+
+  const r0 = result[0];
+  const meta = r0.meta as Record<string, unknown> | undefined;
+
+  // Path 1 : meta.regularMarketPrice (le plus frais)
+  const regular = meta ? Number(meta.regularMarketPrice) : NaN;
+  if (Number.isFinite(regular) && regular > 0) return regular;
+
+  // Path 2 : dernier close non-null dans indicators.quote[0].close[]
+  const indicators = r0.indicators as Record<string, unknown> | undefined;
+  const quoteArr = indicators?.quote as Array<Record<string, unknown>> | undefined;
+  const closeArr = quoteArr?.[0]?.close as Array<number | null> | undefined;
+  if (Array.isArray(closeArr)) {
+    for (let i = closeArr.length - 1; i >= 0; i--) {
+      const v = Number(closeArr[i]);
+      if (Number.isFinite(v) && v > 0) return v;
+    }
+  }
+
+  // Path 3 : adjclose dernière valeur (rare en intraday mais possible)
+  const adjArr = indicators?.adjclose as Array<Record<string, unknown>> | undefined;
+  const adjCloseArr = adjArr?.[0]?.adjclose as Array<number | null> | undefined;
+  if (Array.isArray(adjCloseArr)) {
+    for (let i = adjCloseArr.length - 1; i >= 0; i--) {
+      const v = Number(adjCloseArr[i]);
+      if (Number.isFinite(v) && v > 0) return v;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Parse la réponse CSV Stooq `/q/?s={symbol}&f=sd2t2ohlcv&h&e=csv`.
+ *
+ * Shape attendu (header + 1 ou plusieurs lignes data) :
+ * ```
+ * Symbol,Date,Time,Open,High,Low,Close,Volume
+ * ^VIX,2026-04-27,15:30:00,22.10,22.85,21.90,22.65,N/D
+ * ```
+ *
+ * Stratégie :
+ *   1. Split par lignes
+ *   2. Première ligne = header → identifier l'index de la colonne `Close`
+ *   3. Lignes suivantes : on prend la DERNIÈRE ligne avec un Close numérique > 0
+ *
+ * Tolère :
+ *   - retour windows-style (\r\n)
+ *   - colonnes "N/D" / "-" (Stooq retourne ça quand pas de cotation)
+ *   - lignes vides en fin
+ *
+ * Retourne null si la structure ne match pas ou aucun close valide.
+ */
+export function parseStooqCsvResponse(csv: string): number | null {
+  if (!csv || typeof csv !== 'string') return null;
+  const lines = csv
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  if (lines.length < 2) return null;
+
+  const header = lines[0].split(',').map((h) => h.trim().toLowerCase());
+  const closeIdx = header.indexOf('close');
+  if (closeIdx < 0) return null;
+
+  // Prend la dernière ligne avec un close valide (la plus récente).
+  for (let i = lines.length - 1; i >= 1; i--) {
+    const cells = lines[i].split(',');
+    const cell = (cells[closeIdx] ?? '').trim();
+    if (!cell || cell === 'N/D' || cell === '-') continue;
+    const v = Number(cell);
+    if (Number.isFinite(v) && v > 0) return v;
+  }
+  return null;
+}
+
+/**
+ * Construit l'URL Yahoo Finance chart API pour un symbol.
+ * Pas de clé requise. L'API accepte les User-Agent vides mais préfère un
+ * navigateur — on utilise un UA générique pour éviter les 429.
+ */
+export function buildYahooChartUrl(symbol: string): string {
+  const s = encodeURIComponent(symbol);
+  return `https://query1.finance.yahoo.com/v8/finance/chart/${s}?interval=1d&range=1d`;
+}
+
+/**
+ * Construit l'URL Stooq quote CSV pour un symbol.
+ * Symboles Stooq pour les cas critiques : `^vix`, `^dxy`, `^spx`, ...
+ */
+export function buildStooqCsvUrl(symbol: string): string {
+  const s = encodeURIComponent(symbol.toLowerCase());
+  return `https://stooq.com/q/l/?s=${s}&f=sd2t2ohlcv&h&e=csv`;
+}

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -49,6 +49,12 @@ import { EodhdInsiderService } from './eodhd-insider.service';
 import { EodhdOptionsService } from './eodhd-options.service';
 import { BinanceLiquidationsService } from './binance-liquidations.service';
 import { ApiCostTrackerService, BudgetExceededError } from './api-cost-tracker.service';
+import {
+  buildYahooChartUrl,
+  buildStooqCsvUrl,
+  parseYahooChartResponse,
+  parseStooqCsvResponse,
+} from '../helpers/macro-fallback.helper';
 
 /**
  * LisaService — orchestrateur principal du module AI analyst.
@@ -1974,7 +1980,9 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
   private logEodhdCall(row: {
     ticker: string;
     eodhdTicker: string | null;
-    source: 'eodhd' | 'fallback' | 'supabase_quotes';
+    /** PR D — `yahoo` + `stooq` ajoutés pour la cascade multi-provider
+     *  VIX/DXY (incident 27/04). */
+    source: 'eodhd' | 'fallback' | 'supabase_quotes' | 'yahoo' | 'stooq';
     success: boolean;
     statusCode?: number;
     latencyMs?: number;
@@ -2209,19 +2217,100 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     };
 
     /**
+     * PR D — fallback multi-provider pour VIX/DXY (incident 27/04 :
+     * VIX.INDX EODHD répétitivement empty_price_field en prod). Wrapper
+     * Yahoo Finance + Stooq pour augmenter le ratio "live" avant de
+     * tomber en proxy ETF (VXX/UUP).
+     *
+     * Pas de clé API. Logged via logEodhdCall avec source='yahoo'/'stooq'
+     * pour observability.
+     */
+    const fetchYahoo = async (symbol: string): Promise<number | null> => {
+      const tStart = Date.now();
+      try {
+        const url = buildYahooChartUrl(symbol);
+        const res = await fetch(url, {
+          signal: AbortSignal.timeout(5000),
+          headers: { 'User-Agent': 'Mozilla/5.0 (compatible; SmartVest/1.0)' },
+        });
+        const latencyMs = Date.now() - tStart;
+        if (!res.ok) {
+          this.logEodhdCall({ ticker: symbol, eodhdTicker: symbol, source: 'yahoo', success: false, statusCode: res.status, latencyMs, calledBy: 'market_snapshot', errorMessage: `HTTP_${res.status}` });
+          return null;
+        }
+        const json = await res.json() as unknown;
+        const v = parseYahooChartResponse(json);
+        if (v != null) {
+          this.logEodhdCall({ ticker: symbol, eodhdTicker: symbol, source: 'yahoo', success: true, statusCode: res.status, latencyMs, priceUsd: v, calledBy: 'market_snapshot' });
+        } else {
+          this.logEodhdCall({ ticker: symbol, eodhdTicker: symbol, source: 'yahoo', success: false, statusCode: res.status, latencyMs, calledBy: 'market_snapshot', errorMessage: 'parser_returned_null' });
+        }
+        return v;
+      } catch (e) {
+        this.logEodhdCall({ ticker: symbol, eodhdTicker: symbol, source: 'yahoo', success: false, latencyMs: Date.now() - tStart, calledBy: 'market_snapshot', errorMessage: String(e).slice(0, 200) });
+        return null;
+      }
+    };
+
+    const fetchStooq = async (symbol: string): Promise<number | null> => {
+      const tStart = Date.now();
+      try {
+        const url = buildStooqCsvUrl(symbol);
+        const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+        const latencyMs = Date.now() - tStart;
+        if (!res.ok) {
+          this.logEodhdCall({ ticker: symbol, eodhdTicker: symbol, source: 'stooq', success: false, statusCode: res.status, latencyMs, calledBy: 'market_snapshot', errorMessage: `HTTP_${res.status}` });
+          return null;
+        }
+        const text = await res.text();
+        const v = parseStooqCsvResponse(text);
+        if (v != null) {
+          this.logEodhdCall({ ticker: symbol, eodhdTicker: symbol, source: 'stooq', success: true, statusCode: res.status, latencyMs, priceUsd: v, calledBy: 'market_snapshot' });
+        } else {
+          this.logEodhdCall({ ticker: symbol, eodhdTicker: symbol, source: 'stooq', success: false, statusCode: res.status, latencyMs, calledBy: 'market_snapshot', errorMessage: 'parser_returned_null' });
+        }
+        return v;
+      } catch (e) {
+        this.logEodhdCall({ ticker: symbol, eodhdTicker: symbol, source: 'stooq', success: false, latencyMs: Date.now() - tStart, calledBy: 'market_snapshot', errorMessage: String(e).slice(0, 200) });
+        return null;
+      }
+    };
+
+    /**
      * Tente plusieurs tickers en cascade. Retourne la 1re valeur valide
      * + identifie la qualité (live primary OU proxy ETF).
+     *
+     * PR D — chaque attempt peut spécifier `source` (`'eodhd' | 'yahoo' | 'stooq'`).
+     * Default `'eodhd'` pour rétrocompat. Permet de chaîner EODHD →
+     * Yahoo → Stooq → proxy ETF avant de tomber en fallback hardcoded.
+     *
+     * Le label de dataQuality indique le provider qui a réussi pour
+     * faciliter le diagnostic post-mortem ("vix(via yahoo:^VIX)").
      */
     const fetchCascade = async (
       indicator: string,
-      attempts: Array<{ ticker: string; multiplier?: number; quality: 'live' | 'proxy' }>,
+      attempts: Array<{
+        ticker: string;
+        source?: 'eodhd' | 'yahoo' | 'stooq';
+        multiplier?: number;
+        quality: 'live' | 'proxy';
+      }>,
     ): Promise<number | null> => {
       for (const a of attempts) {
-        const v = await fetchNum(a.ticker);
+        const source = a.source ?? 'eodhd';
+        let v: number | null = null;
+        if (source === 'eodhd') v = await fetchNum(a.ticker);
+        else if (source === 'yahoo') v = await fetchYahoo(a.ticker);
+        else if (source === 'stooq') v = await fetchStooq(a.ticker);
         if (v !== null) {
           const finalValue = a.multiplier ? v * a.multiplier : v;
-          if (a.quality === 'live') dataQuality.live.push(indicator);
-          else dataQuality.proxy.push(`${indicator}(via ${a.ticker})`);
+          if (a.quality === 'live') {
+            // Marque le provider qui a finalement servi la valeur live :
+            // utile pour distinguer un fix EODHD d'un fix Yahoo en prod.
+            dataQuality.live.push(source === 'eodhd' ? indicator : `${indicator}(via ${source}:${a.ticker})`);
+          } else {
+            dataQuality.proxy.push(`${indicator}(via ${source}:${a.ticker})`);
+          }
           return finalValue;
         }
       }
@@ -2235,18 +2324,28 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       spy, qqq, eurusd, usdjpy,
       silver, hyg, lqd,
     ] = await Promise.all([
-      // VIX : ticker .INDX échoue (empty_price_field) → fallback ETF VXX
-      // VXX se trade ~à VIX × 0.8-1.0 (decay), pas exact mais directionnel OK
+      // VIX cascade — PR D : 4 sources avant proxy ETF
+      // EODHD VIX.INDX → Yahoo ^VIX → Stooq ^vix → VXX.US (proxy ETF)
+      // Justification : EODHD VIX.INDX retourne empty_price_field
+      // fréquemment (incident 27/04 — Lisa lisait la valeur fallback
+      // hardcoded 18.5 toute la journée). Yahoo + Stooq sont des sources
+      // gratuites no-auth qui exposent VIX en quasi-realtime aux heures
+      // de marché US.
       fetchCascade('vix', [
-        { ticker: 'VIX.INDX', quality: 'live' },
-        { ticker: 'VXX.US', quality: 'proxy' }, // proxy ETF
+        { ticker: 'VIX.INDX', source: 'eodhd', quality: 'live' },
+        { ticker: '^VIX', source: 'yahoo', quality: 'live' },
+        { ticker: '^vix', source: 'stooq', quality: 'live' },
+        { ticker: 'VXX.US', source: 'eodhd', quality: 'proxy' }, // proxy ETF, decay vs VIX
       ]),
-      // DXY : ticker FOREX échoue (empty) → fallback UUP ETF
-      // UUP $25 ≈ DXY 100 → multiplier 4.1 approximatif
+      // DXY cascade — PR D : 5 sources avant proxy ETF UUP
+      // Yahoo expose DX-Y.NYB (ICE Dollar Index futures spot).
+      // Stooq expose ^dxy (fallback CSV).
       fetchCascade('dxy', [
-        { ticker: 'DXY.INDX', quality: 'live' },
-        { ticker: 'USDX.INDX', quality: 'live' },
-        { ticker: 'UUP.US', multiplier: 4.1, quality: 'proxy' },
+        { ticker: 'DXY.INDX', source: 'eodhd', quality: 'live' },
+        { ticker: 'USDX.INDX', source: 'eodhd', quality: 'live' },
+        { ticker: 'DX-Y.NYB', source: 'yahoo', quality: 'live' },
+        { ticker: '^dxy', source: 'stooq', quality: 'live' },
+        { ticker: 'UUP.US', source: 'eodhd', multiplier: 4.1, quality: 'proxy' },
       ]),
       // Bonds : .BOND échoue → fallback TNX.INDX (ou ETF TLT yield-proxy)
       fetchCascade('us10y', [


### PR DESCRIPTION
## Pourquoi

Incident 27/04 : EODHD `VIX.INDX` retournait `empty_price_field` à chaque cycle → cascade tombait directement sur fallback hardcoded `vix=18.5`. Lisa lisait cette valeur stale toute la journée. La cascade actuelle ne couvre que EODHD ; quand EODHD foire un indicateur, on n'a qu'un proxy ETF avec décalage (VXX, UUP). Pas suffisant.

## Quoi

Étendre `fetchCascade` pour supporter **plusieurs providers** par attempt (default `'eodhd'`, options `'yahoo' | 'stooq'`). Wire VIX et DXY pour passer par 4-5 sources avant de tomber sur proxy ETF.

### VIX cascade

```
VIX.INDX (eodhd live) → ^VIX (yahoo live) → ^vix (stooq live) → VXX.US (eodhd proxy)
```

### DXY cascade

```
DXY.INDX (eodhd) → USDX.INDX (eodhd) → DX-Y.NYB (yahoo) → ^dxy (stooq) → UUP.US (×4.1 proxy)
```

## Providers ajoutés

**Yahoo Finance** — `/v8/finance/chart/{symbol}` JSON, no-auth.
Parser tente 3 paths en cascade :
1. `meta.regularMarketPrice` (le plus frais)
2. dernière valeur non-null de `indicators.quote[0].close[]`
3. dernière valeur non-null de `indicators.adjclose[0].adjclose[]`

**Stooq** — `/q/l/?s={symbol}&f=sd2t2ohlcv&h&e=csv`, no-auth, CSV.
Parser tolère :
- CRLF (Windows-style)
- valeurs `N/D` / `-` / chaîne vide
- prix 0 ou négatif (rejetés comme corrompus)

Les **parsers sont purs** (pas de I/O) — testés sans mock HTTP. Le caller `LisaService.fetchYahoo` / `fetchStooq` encapsule `fetch()` et délègue le parsing.

## Instrumentation

Chaque attempt logge via `logEodhdCall` avec `source='yahoo'` ou `'stooq'` (enum étendu). `dataQuality.live` tag le provider qui a finalement servi la valeur :

- `dataQuality.live = ['us10y']` → EODHD a réussi
- `dataQuality.live = ['us10y', 'vix(via yahoo:^VIX)']` → EODHD VIX a échoué, Yahoo a sauvé
- `dataQuality.proxy = ['vix(via eodhd:VXX.US)']` → tous les live providers ont échoué, fallback ETF

Cela permet de diagnostiquer **post-mortem** quel provider tombe en panne en prod.

## Tests — 25/25 verts

`apps/api/src/modules/lisa/helpers/__tests__/macro-fallback.spec.ts` :

- **`parseYahooChartResponse`** : 10 cas (3 paths, edge cases, payload Yahoo réaliste)
- **`parseStooqCsvResponse`** : 11 cas (single/multi-row, CRLF, N/D, `-`, missing column, invalid prices)
- **URL builders** : 4 cas (encoding `^VIX` → `%5EVIX`, `DX-Y.NYB` non-encoded, lowercase Stooq)

## Validation

- ✅ `tsc --noEmit` clean
- ✅ Jest helper : 25/25
- ✅ Aucune modif des autres cascades (us10y, brent, gold, silver, eurusd, ...) — strict additif sur VIX + DXY uniquement

## Hors scope

- **Logique de régime côté Lisa : NON modifiée.** Le régime `geopolitical_stress` observé en prod est cohérent avec la situation macro réelle (Iran/Hormuz post-Natanz/Fordow). Cette PR améliore seulement la **qualité du signal** VIX/DXY que Lisa reçoit, pas son interprétation.
- Autres indicateurs (us10y, brent, gold, silver) restent EODHD-only — cascadable plus tard via la même mécanique si on observe des fail modes similaires en prod.
- **PR E** (à venir, frontend) : `useLisaPositions` refetchInterval 30s→5s + realtime invalidation pour visibilité immédiate des positions ouvertes par le mécanique.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_