### PR TITLE
feat(web): lisa positions refetch 30s→5s + Realtime invalidation

### DIFF
--- a/apps/web/src/components/lisa/positions-table.tsx
+++ b/apps/web/src/components/lisa/positions-table.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Briefcase, TrendingUp, TrendingDown, AlertCircle } from 'lucide-react';
-import { useLisaPositions, type LisaPosition } from '@/hooks/use-lisa';
+import { useLisaPositions, useLisaPositionsRealtime, type LisaPosition } from '@/hooks/use-lisa';
 import { SkeletonCard } from '@/components/ui/skeleton';
 
 const STATUS_LABELS: Record<LisaPosition['status'], { label: string; color: string }> = {
@@ -15,6 +15,9 @@ const STATUS_LABELS: Record<LisaPosition['status'], { label: string; color: stri
 };
 
 export function LisaPositionsTable({ portfolioId }: { portfolioId: string }) {
+  // PR E — invalidation immédiate de la cache positions sur INSERT/UPDATE/DELETE
+  // côté DB (le mécanique ouvre/ferme sans interaction UI).
+  useLisaPositionsRealtime(portfolioId);
   const openQuery = useLisaPositions(portfolioId, true);
   const allQuery = useLisaPositions(portfolioId, false);
 

--- a/apps/web/src/hooks/use-lisa.ts
+++ b/apps/web/src/hooks/use-lisa.ts
@@ -365,9 +365,59 @@ export function useLisaPositions(portfolioId: string | null, openOnly = false) {
     queryKey: ['lisa', 'positions', portfolioId, openOnly],
     queryFn: () => apiFetch<LisaPosition[]>(`/lisa/positions/${portfolioId}?openOnly=${openOnly}`),
     enabled: !!portfolioId,
-    refetchInterval: 30_000,
+    // PR E — incident 27/04 : le mécanique ouvre RTX à 19:14, UI restait
+    // à "1 position" pendant 30s. Polling 5s + Realtime invalidation via
+    // useLisaPositionsRealtime ramène le délai à <1s perçu.
+    refetchInterval: 5_000,
+    refetchIntervalInBackground: true,
     ...LISA_QUERY_OPTIONS,
   });
+}
+
+/**
+ * PR E — Subscribe à Supabase Realtime sur `lisa_positions` filtré par
+ * portfolio_id et invalide la query React Query
+ * `['lisa', 'positions', portfolioId, ...]` à chaque INSERT/UPDATE/DELETE.
+ *
+ * Cas d'usage : le mécanique (cron 60s côté API) ouvre/ferme des positions
+ * sans interaction UI. Sans Realtime, l'UI n'a connaissance d'une
+ * nouvelle position qu'au prochain `refetchInterval`. Avec Realtime, la
+ * query est ré-exécutée immédiatement → le tableau positions apparaît
+ * instantanément.
+ *
+ * Pré-requis : migration 0073 doit avoir activé Realtime sur
+ * `lisa_positions` dans la publication `supabase_realtime`. Sans la
+ * migration, ce hook fait un subscribe inerte (aucun event reçu) — le
+ * polling 5s prend le relais comme fallback.
+ *
+ * Note : on invalide TOUTES les variantes de la query (openOnly true/false)
+ * via une queryKey préfixe, car un INSERT pertinent peut affecter les
+ * deux vues simultanément.
+ */
+export function useLisaPositionsRealtime(portfolioId: string | null): void {
+  const qc = useQueryClient();
+  useEffect(() => {
+    if (!portfolioId) return;
+    const client = createSupabaseBrowserClient();
+    const channel = client
+      .channel(`lisa_positions_${portfolioId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'lisa_positions',
+          filter: `portfolio_id=eq.${portfolioId}`,
+        },
+        () => {
+          void qc.invalidateQueries({ queryKey: ['lisa', 'positions', portfolioId] });
+        },
+      )
+      .subscribe();
+    return () => {
+      void client.removeChannel(channel);
+    };
+  }, [portfolioId, qc]);
 }
 
 export interface LisaOptionPosition {

--- a/supabase/migrations/0073_lisa_positions_realtime.sql
+++ b/supabase/migrations/0073_lisa_positions_realtime.sql
@@ -1,0 +1,25 @@
+-- Active Supabase Realtime sur lisa_positions.
+--
+-- Pourquoi : le mécanique (cron 60s) ouvre/ferme des positions de manière
+-- programmatique, sans interaction UI. Sans Realtime, le hook front
+-- `useLisaPositions` doit polling 5-30s avant de voir une nouvelle ligne →
+-- l'utilisateur voit "1 position" alors que le bot vient d'ouvrir RTX
+-- (incident 27/04 : RTX ouvert 19:14 UTC, UI affichait toujours 1 seule
+-- position pendant 30s).
+--
+-- Cette migration ajoute lisa_positions au publication supabase_realtime.
+-- Le hook `useLisaPositionsRealtime` côté front peut alors invalider la
+-- query React Query dès qu'un INSERT/UPDATE/DELETE arrive sur la table.
+--
+-- Idempotent : ne fait rien si la table est déjà dans la publication.
+-- Cf. fix/lisa-positions-refetch-realtime (PR E suite incident 27/04).
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime' AND tablename = 'lisa_positions'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.lisa_positions;
+  END IF;
+END $$;


### PR DESCRIPTION
## Pourquoi

Incident 27/04 : RTX ouverte par le mécanique à 19:14 UTC, mais l'UI affichait toujours "1 position" (BTC seule). `useLisaPositions` avait `refetchInterval: 30_000` et aucune invalidation côté Realtime → l'utilisateur perdait jusqu'à 30s avant de voir une nouvelle position.

C'est un bug **frontend uniquement** (l'API et la DB étaient correctes — cf. agent BUG #4 plus tôt dans la session).

## Quoi

### 1. `useLisaPositions` — refetchInterval 30s → 5s

```diff
- refetchInterval: 30_000,
+ refetchInterval: 5_000,
+ refetchIntervalInBackground: true,
```

Coût : 6× plus de requêtes mais l'endpoint est lightweight (`SELECT` par `portfolio_id` indexé). Fallback sûr si Realtime indisponible.

### 2. Nouveau hook `useLisaPositionsRealtime(portfolioId)`

Subscribe au channel `postgres_changes` filtré sur `portfolio_id=eq.<id>` et invalide la query React Query `['lisa', 'positions', portfolioId, ...]` à chaque `INSERT/UPDATE/DELETE`. **Délai perçu < 1s.**

Pattern identique à `useLisaConfigRealtime` (déjà en prod sur `lisa_session_configs` via migration 0056, sans régression).

### 3. Migration `0073_lisa_positions_realtime.sql`

Ajoute `lisa_positions` à la publication `supabase_realtime`. Idempotent, copy du pattern 0056. Sans cette migration, le hook subscribe inerte (no events) → le polling 5s prend le relais.

### 4. Wiring dans `LisaPositionsTable`

```typescript
export function LisaPositionsTable({ portfolioId }) {
  useLisaPositionsRealtime(portfolioId);  // ← invalidation INSERT/UPDATE/DELETE
  const openQuery = useLisaPositions(portfolioId, true);
  const allQuery = useLisaPositions(portfolioId, false);
  // ...
}
```

## Validation

- ✅ `tsc --noEmit` clean côté `apps/web`
- ✅ Aucune modif backend

## Pré-requis runtime

Migration `0073_lisa_positions_realtime.sql` à appliquer en prod via Supabase SQL Editor (idempotent, no-op si déjà fait). Sans la migration, le polling 5s suffit comme fallback — le hook Realtime restera inerte mais sans erreur.

## Hors scope

- Tests E2E Playwright sur le timing UI < 1s : possibles plus tard. Pattern éprouvé via `useLisaConfigRealtime`.
- Realtime sur `lisa_proposals` (pour voir les nouvelles propositions Lisa instantanément) : à ajouter dans une PR similaire si pertinent.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_