### PR TITLE
fix(deploy): fly.toml app revert 'smartvest-w7jpuw' -> 'smartvest'

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -15,7 +15,7 @@
 # pour que la connexion Binance fonctionne — `iad` (Washington DC) ne
 # convient pas.
 
-app = 'smartvest-w7jpuw'
+app = 'smartvest'
 primary_region = 'cdg'
 
 [build]


### PR DESCRIPTION
Le commit cc02b41 (Claude, 23/04) puis f6d9eee (24/04) ont basculé l'app Fly vers 'smartvest-w7jpuw' qui n'est pas accessible avec le FLY_API_TOKEN actuel.

Consequence: tous les runs CI 'Deploy SmartVest API to Fly.io' echouent avec 'Error: unauthorized' depuis 5 jours -> aucun fix P0 (LMT, macro fallback, mech-degraded-open, liquidations) n'est en prod. La machine weathered-bird-8944 (CDG) tourne du code obsolete.

Fix: revert app name vers 'smartvest' (l'app reelle qui contient la machine, les volumes et les secrets).