### PR TITLE
fix(cost): soft-budget at 100% + Haiku fallback (P0-A 28/04 incident)

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -742,6 +742,22 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         return '';
       });
 
+    // P0-A — Lecture per-cycle de la config budget Claude depuis
+    // lisa_session_configs. Permet à l'UI de remonter le budget (ex.
+    // $20 → $50) sans redéployer (cf. incident 28/04 05:02 UTC où le
+    // router lisait l'env var statique au lieu de la config DB).
+    // - daily_cost_budget_usd : budget cumulé en USD (null = pas d'override,
+    //   le router applique sa config constructor / env LLM_ROUTER_DAILY_BUDGET_USD)
+    // - cost_force_continue : à 100% du budget, soft warn + Haiku (true,
+    //   default DB via migration 0074) ou hard throw (false, mode strict)
+    const budgetOverride = config.daily_cost_budget_usd != null
+      ? Number(config.daily_cost_budget_usd)
+      : undefined;
+    const forceContinueOverride = (config as Record<string, unknown>).cost_force_continue;
+    const forceContinue = typeof forceContinueOverride === 'boolean'
+      ? forceContinueOverride
+      : true; // default DB true (migration 0074) — fail-soft par défaut
+
     let result: Awaited<ReturnType<ThesisGeneratorService['generateTheses']>>;
     try {
       result = await this.thesisGenerator.generateTheses({
@@ -760,6 +776,8 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         earningsBySymbol,
         ...(dailyHarvestContext ? { dailyHarvestContext } : {}),
         ...(adoptedPatternsBriefing ? { adoptedPatternsBriefing } : {}),
+        ...(budgetOverride != null ? { budgetUsd: budgetOverride } : {}),
+        forceContinue,
       });
     } catch (e) {
       // Parse failure ou erreur Claude : on log dans le decision log et on

--- a/packages/ai-analyst/src/claude/client.ts
+++ b/packages/ai-analyst/src/claude/client.ts
@@ -30,6 +30,17 @@ export interface ClaudeCallOptions {
   maxTokens?: number;
   /** @deprecated temperature n'est plus supporté par claude-opus-4-7+ */
   temperature?: number;
+  /** P0-A — Override per-call du budget journalier. Permet au caller de
+   *  relire `lisa_session_configs.daily_cost_budget_usd` à chaque cycle.
+   *  Si undefined, fallback sur le budget constructor du LlmRouter. */
+  budgetUsd?: number;
+  /** P0-A — Override per-call du flag soft-budget. À 100% du budget :
+   *  - `true` (default DB) : fallback Haiku + warn loggué
+   *  - `false` : throw `BudgetExceededError`
+   *  Si undefined, fallback sur la config constructor du LlmRouter
+   *  (par défaut `false` pour préserver le comportement legacy PR #15
+   *  des call sites qui n'ont pas migré). */
+  forceContinue?: boolean;
 }
 
 export interface ClaudeCallResult {
@@ -72,6 +83,8 @@ export class LisaClaudeClient {
       userMessage,
       task = 'thesis_generation',
       maxTokens = 16000,
+      budgetUsd,
+      forceContinue,
     } = options;
 
     const { cacheable, profileSpecific } = buildLisaSystemPrompt(profile);
@@ -91,16 +104,25 @@ export class LisaClaudeClient {
       },
     ];
 
-    const { response } = await this.router.call(task, {
-      max_tokens: maxTokens,
-      system: systemBlocks as unknown as Anthropic.TextBlockParam[],
-      messages: [
-        {
-          role: 'user',
-          content: userMessage,
-        },
-      ],
-    });
+    const { response } = await this.router.call(
+      task,
+      {
+        max_tokens: maxTokens,
+        system: systemBlocks as unknown as Anthropic.TextBlockParam[],
+        messages: [
+          {
+            role: 'user',
+            content: userMessage,
+          },
+        ],
+      },
+      // P0-A — propagation per-call (budget + force_continue) lus depuis
+      // lisa_session_configs côté caller à chaque cycle.
+      {
+        ...(budgetUsd !== undefined ? { budgetUsd } : {}),
+        ...(forceContinue !== undefined ? { forceContinue } : {}),
+      },
+    );
 
     // Extract text content (Claude can return multiple content blocks)
     const rawText = response.content
@@ -144,6 +166,8 @@ export class LisaClaudeClient {
       task = 'thesis_generation',
       maxTokens = 16000,
       tool,
+      budgetUsd,
+      forceContinue,
     } = options;
 
     const { cacheable, profileSpecific } = buildLisaSystemPrompt(profile);
@@ -152,13 +176,20 @@ export class LisaClaudeClient {
       { type: 'text' as const, text: profileSpecific },
     ];
 
-    const { response } = await this.router.call(task, {
-      max_tokens: maxTokens,
-      system: systemBlocks as unknown as Anthropic.TextBlockParam[],
-      tools: [tool] as unknown as Anthropic.Tool[],
-      tool_choice: { type: 'tool', name: tool.name },
-      messages: [{ role: 'user', content: userMessage }],
-    });
+    const { response } = await this.router.call(
+      task,
+      {
+        max_tokens: maxTokens,
+        system: systemBlocks as unknown as Anthropic.TextBlockParam[],
+        tools: [tool] as unknown as Anthropic.Tool[],
+        tool_choice: { type: 'tool', name: tool.name },
+        messages: [{ role: 'user', content: userMessage }],
+      },
+      {
+        ...(budgetUsd !== undefined ? { budgetUsd } : {}),
+        ...(forceContinue !== undefined ? { forceContinue } : {}),
+      },
+    );
 
     const toolBlock = response.content.find(
       (b): b is Anthropic.ToolUseBlock => b.type === 'tool_use',

--- a/packages/ai-analyst/src/llm/__tests__/llm-router.spec.ts
+++ b/packages/ai-analyst/src/llm/__tests__/llm-router.spec.ts
@@ -151,10 +151,10 @@ describe('LlmRouter — env var override', () => {
   });
 });
 
-describe('LlmRouter — circuit breaker à 80% budget (Opus fallback)', () => {
-  it('falls back to Sonnet when budget>=80% AND task is Opus AND fallbackOnBudget=true', async () => {
+describe('LlmRouter — circuit breaker à 80% budget (Opus → Haiku fallback)', () => {
+  it('falls back to HAIKU (P0-A change, ex-Sonnet) when budget>=80% AND task is Opus AND fallbackOnBudget=true', async () => {
     const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ model: 'claude-sonnet-4-6' }));
+    create.mockResolvedValue(fakeMessage({ model: 'claude-haiku-4-5-20251001' }));
     const { tracker, record } = makeCostTracker(85); // 85$ déjà consommé
     const { logger, warn } = makeAuditLogger();
     const router = new LlmRouter(
@@ -166,21 +166,22 @@ describe('LlmRouter — circuit breaker à 80% budget (Opus fallback)', () => {
 
     const result = await router.call('thesis_generation', baseParams);
 
-    expect(create.mock.calls[0][0].model).toBe('claude-sonnet-4-6');
-    expect(result.modelUsed).toBe('claude-sonnet-4-6');
+    expect(create.mock.calls[0][0].model).toBe('claude-haiku-4-5-20251001');
+    expect(result.modelUsed).toBe('claude-haiku-4-5-20251001');
     expect(result.fallback).toBe(true);
+    expect(result.fallbackReason).toBe('budget_80pct_haiku');
     expect(warn).toHaveBeenCalledWith(
-      'opus_fallback',
+      'opus_haiku_fallback',
       expect.objectContaining({
         task: 'thesis_generation',
         originalModel: 'claude-opus-4-7',
-        fallbackModel: 'claude-sonnet-4-6',
+        fallbackModel: 'claude-haiku-4-5-20251001',
         todayCostUsd: 85,
         budgetUsd: 100,
       }),
     );
     expect(record).toHaveBeenCalledTimes(1);
-    expect(record.mock.calls[0][0].model).toBe('claude-sonnet-4-6');
+    expect(record.mock.calls[0][0].model).toBe('claude-haiku-4-5-20251001');
   });
 
   it('does NOT fall back when task is not Opus (Sonnet stays Sonnet at 85%)', async () => {
@@ -322,9 +323,9 @@ describe('LlmRouter — calcul du coût + persistance', () => {
     expect(record.mock.calls[0][0].costUsd).toBeCloseTo(expectedCost, 6);
   });
 
-  it('records the FALLBACK model (Sonnet), not the original (Opus), on circuit breaker', async () => {
+  it('records the FALLBACK model (Haiku, P0-A change), not the original (Opus), on circuit breaker', async () => {
     const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ inputTokens: 2000, outputTokens: 1000, model: 'claude-sonnet-4-6' }));
+    create.mockResolvedValue(fakeMessage({ inputTokens: 2000, outputTokens: 1000, model: 'claude-haiku-4-5-20251001' }));
     const { tracker, record } = makeCostTracker(85);
     const router = new LlmRouter(client, tracker, {
       dailyCostBudgetUsd: 100,
@@ -333,10 +334,11 @@ describe('LlmRouter — calcul du coût + persistance', () => {
 
     await router.call('thesis_generation', baseParams);
 
-    expect(record.mock.calls[0][0].model).toBe('claude-sonnet-4-6');
+    expect(record.mock.calls[0][0].model).toBe('claude-haiku-4-5-20251001');
     expect(record.mock.calls[0][0].task).toBe('thesis_generation');
-    // Coût Sonnet, pas Opus : (2000*3 + 1000*15) / 1M = 0.021
-    expect(record.mock.calls[0][0].costUsd).toBeCloseTo(0.021, 6);
+    // Coût Haiku : (2000 × $0.80 + 1000 × $4.0) / 1M = 0.0056
+    // Avant P0-A c'était Sonnet : (2000*3 + 1000*15) / 1M = 0.021 → 3.7× réduction
+    expect(record.mock.calls[0][0].costUsd).toBeCloseTo(0.0056, 6);
   });
 
   it('does NOT record on Anthropic error (no double-counting failed calls)', async () => {
@@ -380,5 +382,214 @@ describe('LlmRouter — boot-time validator', () => {
     expect(
       () => new LlmRouter(client, tracker, { dailyCostBudgetUsd: 100, fallbackOnBudget: true }),
     ).not.toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P0-A — soft-budget + per-call override + Haiku fallback
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('LlmRouter — P0-A soft-budget at 100%', () => {
+  it('soft-warns + falls back to Haiku at 100% with forceContinue=true (no throw)', async () => {
+    const { client, create } = makeAnthropic();
+    create.mockResolvedValue(fakeMessage({ inputTokens: 1500, outputTokens: 800, model: 'claude-haiku-4-5-20251001' }));
+    const { tracker, record } = makeCostTracker(105); // 105% spend
+    const { logger, warn } = makeAuditLogger();
+    const router = new LlmRouter(
+      client,
+      tracker,
+      { dailyCostBudgetUsd: 100, fallbackOnBudget: true },
+      logger,
+    );
+
+    const result = await router.call('thesis_generation', baseParams, { forceContinue: true });
+
+    expect(create.mock.calls[0][0].model).toBe('claude-haiku-4-5-20251001');
+    expect(result.modelUsed).toBe('claude-haiku-4-5-20251001');
+    expect(result.fallback).toBe(true);
+    expect(result.fallbackReason).toBe('budget_100pct_soft_haiku');
+    expect(warn).toHaveBeenCalledWith(
+      'cost_budget_warn',
+      expect.objectContaining({
+        task: 'thesis_generation',
+        todayCostUsd: 105,
+        budgetUsd: 100,
+        fallbackModel: 'claude-haiku-4-5-20251001',
+        reason: 'soft_haiku_100pct',
+      }),
+    );
+    expect(record).toHaveBeenCalledTimes(1);
+  });
+
+  it('soft-warn applies to ALL tasks (even Sonnet), pas seulement Opus, à 100%', async () => {
+    const { client, create } = makeAnthropic();
+    create.mockResolvedValue(fakeMessage({ model: 'claude-haiku-4-5-20251001' }));
+    const { tracker } = makeCostTracker(150);
+    const router = new LlmRouter(client, tracker, {
+      dailyCostBudgetUsd: 100,
+      fallbackOnBudget: true,
+    });
+
+    // Même une tâche Sonnet (binary_decision) tombe sur Haiku quand
+    // forceContinue=true à 100% — la prio est de continuer, pas la qualité.
+    const result = await router.call('binary_decision', baseParams, { forceContinue: true });
+    expect(result.modelUsed).toBe('claude-haiku-4-5-20251001');
+    expect(result.fallback).toBe(true);
+  });
+
+  it('throws BudgetExceededError at 100% when forceContinue=false (legacy strict mode preserved)', async () => {
+    const { client, create } = makeAnthropic();
+    const { tracker, record } = makeCostTracker(110);
+    const router = new LlmRouter(client, tracker, {
+      dailyCostBudgetUsd: 100,
+      fallbackOnBudget: true,
+    });
+
+    await expect(
+      router.call('thesis_generation', baseParams, { forceContinue: false }),
+    ).rejects.toThrow(BudgetExceededError);
+    expect(create).not.toHaveBeenCalled();
+    expect(record).not.toHaveBeenCalled();
+  });
+
+  it('default behavior at 100% (no options) = throw — preserves legacy tests', async () => {
+    // Sécurité rétrocompat : sans options.forceContinue, le router ne sait
+    // pas si l'opérateur veut soft-mode → on garde le hard-throw historique.
+    // C'est pourquoi les tests legacy au-dessus n'ont pas changé.
+    const { client } = makeAnthropic();
+    const { tracker } = makeCostTracker(110);
+    const router = new LlmRouter(client, tracker, {
+      dailyCostBudgetUsd: 100,
+      fallbackOnBudget: true,
+    });
+
+    await expect(router.call('thesis_generation', baseParams)).rejects.toThrow(BudgetExceededError);
+  });
+});
+
+describe('LlmRouter — P0-A per-call budget override', () => {
+  it('uses options.budgetUsd over constructor budget', async () => {
+    const { client, create } = makeAnthropic();
+    create.mockResolvedValue(fakeMessage({ model: 'claude-haiku-4-5-20251001' }));
+    const { tracker } = makeCostTracker(40);
+    // Constructor : budget $100 (40% spend = pas de fallback)
+    // Override per-call : budget $50 (40/50 = 80% → trigger fallback Opus→Haiku)
+    const router = new LlmRouter(client, tracker, {
+      dailyCostBudgetUsd: 100,
+      fallbackOnBudget: true,
+    });
+
+    const result = await router.call('thesis_generation', baseParams, { budgetUsd: 50 });
+
+    expect(result.fallback).toBe(true);
+    expect(result.fallbackReason).toBe('budget_80pct_haiku');
+  });
+
+  it('options.budgetUsd raised triggers MORE permissive behavior (no fallback at 30%)', async () => {
+    const { client, create } = makeAnthropic();
+    create.mockResolvedValue(fakeMessage({ model: 'claude-opus-4-7' }));
+    const { tracker } = makeCostTracker(15);
+    // Constructor : budget $20 (75% spend → just under 80%)
+    // Override per-call : budget $50 (15/50 = 30% → no fallback)
+    const router = new LlmRouter(client, tracker, {
+      dailyCostBudgetUsd: 20,
+      fallbackOnBudget: true,
+    });
+
+    const result = await router.call('thesis_generation', baseParams, { budgetUsd: 50 });
+
+    expect(result.fallback).toBe(false);
+    expect(result.modelUsed).toBe('claude-opus-4-7');
+  });
+
+  it('UI raise budget $20→$50 unblocks autopilot (incident 28/04 05:02 UTC repro)', async () => {
+    // Repro exact : router config $20 (statique env), spend $20.46, UI
+    // remonte à $50, le caller relit DB et passe budgetUsd: 50 par cycle.
+    const { client, create } = makeAnthropic();
+    create.mockResolvedValue(fakeMessage());
+    const { tracker } = makeCostTracker(20.46);
+    const router = new LlmRouter(client, tracker, {
+      dailyCostBudgetUsd: 20, // ancien env, jamais re-read
+      fallbackOnBudget: true,
+    });
+
+    // Sans override : throw (situation prod 28/04)
+    await expect(router.call('thesis_generation', baseParams)).rejects.toThrow(BudgetExceededError);
+
+    // Avec override DB → budget $50 → 41% spend → no fallback
+    const result = await router.call('thesis_generation', baseParams, { budgetUsd: 50 });
+    expect(result.fallback).toBe(false);
+  });
+});
+
+describe('LlmRouter — P0-A 80% Opus fallback now goes to Haiku (cost saving)', () => {
+  it('saves ~3.75× vs ex-Sonnet fallback (Haiku $0.80/M vs Sonnet $3/M input)', async () => {
+    const { client, create } = makeAnthropic();
+    create.mockResolvedValue(fakeMessage({ inputTokens: 5000, outputTokens: 2000, model: 'claude-haiku-4-5-20251001' }));
+    const { tracker, record } = makeCostTracker(85);
+    const router = new LlmRouter(client, tracker, {
+      dailyCostBudgetUsd: 100,
+      fallbackOnBudget: true,
+    });
+
+    await router.call('thesis_generation', baseParams);
+
+    // Haiku 5000 input × $0.80 + 2000 output × $4 = 0.012
+    // ex-Sonnet aurait coûté : 5000 × $3 + 2000 × $15 = 0.045 → 3.75× plus cher
+    expect(record.mock.calls[0][0].costUsd).toBeCloseTo(0.012, 6);
+  });
+
+  it('binary_decision (Sonnet) UNCHANGED at 80%+ (only Opus tasks swap to Haiku)', async () => {
+    const { client, create } = makeAnthropic();
+    create.mockResolvedValue(fakeMessage({ model: 'claude-sonnet-4-6' }));
+    const { tracker } = makeCostTracker(85);
+    const router = new LlmRouter(client, tracker, {
+      dailyCostBudgetUsd: 100,
+      fallbackOnBudget: true,
+    });
+
+    // binary_decision est déjà mappé à Sonnet — pas de fallback nécessaire,
+    // le modèle est déjà bon marché. Notre check `nominalModel.includes('opus')`
+    // garantit qu'on ne touche que les tâches Opus.
+    const result = await router.call('binary_decision', baseParams);
+    expect(result.fallback).toBe(false);
+    expect(result.modelUsed).toBe('claude-sonnet-4-6');
+  });
+
+  it('audit_explanation (Sonnet) UNCHANGED at 80%+ (preserved for human readability)', async () => {
+    const { client, create } = makeAnthropic();
+    create.mockResolvedValue(fakeMessage({ model: 'claude-sonnet-4-6' }));
+    const { tracker } = makeCostTracker(95);
+    const router = new LlmRouter(client, tracker, {
+      dailyCostBudgetUsd: 100,
+      fallbackOnBudget: true,
+    });
+
+    const result = await router.call('audit_explanation', baseParams);
+    expect(result.fallback).toBe(false);
+    expect(result.modelUsed).toBe('claude-sonnet-4-6');
+  });
+});
+
+describe('LlmRouter — P0-A combined matrix', () => {
+  it('100% + forceContinue=true takes priority over 80% Opus path', async () => {
+    // À 100%, on ne passe PAS par le check 80% Opus (le 100% short-circuits).
+    const { client, create } = makeAnthropic();
+    create.mockResolvedValue(fakeMessage({ model: 'claude-haiku-4-5-20251001' }));
+    const { tracker } = makeCostTracker(120);
+    const { logger, warn } = makeAuditLogger();
+    const router = new LlmRouter(
+      client,
+      tracker,
+      { dailyCostBudgetUsd: 100, fallbackOnBudget: true },
+      logger,
+    );
+
+    const result = await router.call('thesis_generation', baseParams, { forceContinue: true });
+
+    expect(result.fallbackReason).toBe('budget_100pct_soft_haiku');
+    // Pas de log opus_haiku_fallback car on a court-circuité au 100%
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith('cost_budget_warn', expect.anything());
   });
 });

--- a/packages/ai-analyst/src/llm/router.ts
+++ b/packages/ai-analyst/src/llm/router.ts
@@ -146,10 +146,28 @@ export interface LlmRouterCallResult {
   response: Anthropic.Message;
   /** Modèle effectivement appelé (peut différer de MODEL_BY_TASK[task] si fallback). */
   modelUsed: string;
-  /** True si le circuit breaker a basculé Opus → Sonnet. */
+  /** True si le circuit breaker a basculé Opus → Haiku/Sonnet. */
   fallback: boolean;
+  /** Raison du fallback (pour audit). */
+  fallbackReason?: 'budget_80pct_haiku' | 'budget_100pct_soft_haiku';
   /** Coût de l'appel en USD (input + output, hors caching). */
   costUsd: number;
+}
+
+/**
+ * P0-A — Override per-call pour le budget. Permet au caller de relire
+ * `lisa_session_configs.daily_cost_budget_usd` + `cost_force_continue`
+ * à chaque cycle (vs config statique au constructor du router).
+ *
+ * Sans override → utilise les valeurs constructor (rétrocompat PR #15).
+ */
+export interface LlmRouterCallOptions {
+  /** Override du budget journalier USD pour CET appel uniquement. */
+  budgetUsd?: number;
+  /** Override du flag soft-budget pour CET appel.
+   *  - `true` (default DB) : à 100% du budget, soft-warn + Haiku au lieu de throw
+   *  - `false` : hard throw (comportement legacy PR #15) */
+  forceContinue?: boolean;
 }
 
 // Anthropic client minimal — on n'a besoin que de messages.create. Permet
@@ -235,16 +253,49 @@ export class LlmRouter {
    * Le caller fournit `params` SANS le champ `model` (le routeur l'écrase
    * de toute façon). Cette API rend impossible un override silencieux du
    * choix du modèle côté caller — la centralisation est imposée par le type.
+   *
+   * P0-A — `options.budgetUsd` / `options.forceContinue` permettent au
+   * caller de relire `lisa_session_configs.daily_cost_budget_usd` +
+   * `cost_force_continue` à chaque cycle plutôt que d'utiliser la config
+   * statique du constructor. Si non fournis, on retombe sur la config
+   * du constructor (rétrocompat PR #15).
+   *
+   * Matrice de comportement (`fc` = forceContinue effectif) :
+   *   - todayCost <  80%             → modèle nominal (MODEL_BY_TASK[task])
+   *   - todayCost ≥  80% & < 100% & opus task → fallback **Haiku** + warn
+   *     (Sonnet/Haiku tasks restent inchangées)
+   *   - todayCost ≥ 100% & fc=true   → soft warn + **Haiku** (toutes tâches)
+   *   - todayCost ≥ 100% & fc=false  → throw `BudgetExceededError`
    */
   async call(
     task: LlmTask,
     params: Omit<Anthropic.MessageCreateParamsNonStreaming, 'model'>,
+    options: LlmRouterCallOptions = {},
   ): Promise<LlmRouterCallResult> {
     const todayCost = await this.costTracker.getTodayTotalUsd();
-    const budget = this.config.dailyCostBudgetUsd;
+    const budget = options.budgetUsd ?? this.config.dailyCostBudgetUsd;
+    // forceContinue per-call > forceContinue inherent (= !fallbackOnBudget legacy ?
+    // non — fallbackOnBudget contrôlait le 80% Opus, pas le 100% hard-stop).
+    // Le default est `true` (soft mode) côté DB, `false` côté constructor pour
+    // ne pas changer le comportement de tests existants qui n'utilisent pas
+    // l'option per-call.
+    const forceContinue = options.forceContinue ?? false;
+    const haikuModel = MODEL_BY_TASK['news_classification']; // Haiku 4.5
 
-    // 100% budget — hard-stop quel que soit le modèle.
+    // 100% budget — soft warn + Haiku si forceContinue, sinon hard throw.
     if (todayCost >= budget) {
+      if (forceContinue) {
+        this.auditLogger?.warn('cost_budget_warn', {
+          task,
+          todayCostUsd: todayCost,
+          budgetUsd: budget,
+          originalModel: MODEL_BY_TASK[task],
+          fallbackModel: haikuModel,
+          reason: 'soft_haiku_100pct',
+        });
+        const result = await this.executeCall(task, params, haikuModel);
+        return { ...result, fallback: true, fallbackReason: 'budget_100pct_soft_haiku' };
+      }
       throw new BudgetExceededError(
         `Daily budget reached ($${todayCost.toFixed(2)}/${budget.toFixed(2)}), task '${task}' refused`,
         todayCost,
@@ -253,23 +304,17 @@ export class LlmRouter {
       );
     }
 
-    let model = MODEL_BY_TASK[task];
-    let fallback = false;
+    const nominalModel = MODEL_BY_TASK[task];
 
-    // 80% budget + tâche Opus — circuit breaker.
-    if (todayCost >= budget * 0.8 && model.includes('opus')) {
-      if (this.config.fallbackOnBudget) {
-        const fallbackModel = MODEL_BY_TASK['regime_classification']; // Sonnet
-        this.auditLogger?.warn('opus_fallback', {
-          task,
-          todayCostUsd: todayCost,
-          budgetUsd: budget,
-          originalModel: model,
-          fallbackModel,
-        });
-        model = fallbackModel;
-        fallback = true;
-      } else {
+    // 80% budget + tâche Opus — fallback Haiku (économie ~19× input vs Opus).
+    // Les tâches Sonnet (binary_decision, audit_explanation) restent
+    // inchangées — elles consomment déjà 5× moins que Opus, le saving
+    // marginal Haiku est moindre et les tâches binary_decision peuvent
+    // perdre en qualité sur Haiku.
+    if (todayCost >= budget * 0.8 && nominalModel.includes('opus')) {
+      // Le legacy `fallbackOnBudget=false` (constructor) reste honoré pour
+      // les opérateurs en mode strict — throw au lieu de fallback.
+      if (!this.config.fallbackOnBudget && !forceContinue) {
         throw new BudgetExceededError(
           `Daily budget 80% reached ($${todayCost.toFixed(2)}/${budget.toFixed(2)}), Opus task '${task}' refused`,
           todayCost,
@@ -277,8 +322,31 @@ export class LlmRouter {
           task,
         );
       }
+      this.auditLogger?.warn('opus_haiku_fallback', {
+        task,
+        todayCostUsd: todayCost,
+        budgetUsd: budget,
+        originalModel: nominalModel,
+        fallbackModel: haikuModel,
+        reason: 'opus_to_haiku_80pct',
+      });
+      const result = await this.executeCall(task, params, haikuModel);
+      return { ...result, fallback: true, fallbackReason: 'budget_80pct_haiku' };
     }
 
+    return this.executeCall(task, params, nominalModel);
+  }
+
+  /**
+   * P0-A — Helper privé pour l'exécution + tracking d'un appel Anthropic.
+   * Extrait pour éviter la duplication entre le path nominal et les 2
+   * paths de fallback (80% Haiku + 100% soft-Haiku).
+   */
+  private async executeCall(
+    task: LlmTask,
+    params: Omit<Anthropic.MessageCreateParamsNonStreaming, 'model'>,
+    model: string,
+  ): Promise<LlmRouterCallResult> {
     const response = await this.anthropic.messages.create({ ...params, model });
 
     const inputTokens = response.usage?.input_tokens ?? 0;
@@ -287,7 +355,7 @@ export class LlmRouter {
 
     await this.costTracker.record({ task, model, inputTokens, outputTokens, costUsd });
 
-    return { response, modelUsed: model, fallback, costUsd };
+    return { response, modelUsed: model, fallback: false, costUsd };
   }
 
   /**

--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -268,6 +268,12 @@ export interface GenerateThesesRequest {
    *  Généré par PatternBriefingService côté back. Empty string si aucun
    *  pattern adopté actif. */
   adoptedPatternsBriefing?: string;
+  /** P0-A — Budget journalier USD à appliquer au LlmRouter pour CET appel.
+   *  Lu depuis lisa_session_configs.daily_cost_budget_usd côté caller. */
+  budgetUsd?: number;
+  /** P0-A — Si true (default DB) : à 100% du budget, soft-warn + fallback
+   *  Haiku au lieu de throw. Lu depuis lisa_session_configs.cost_force_continue. */
+  forceContinue?: boolean;
 }
 
 export interface GenerateThesesResponse {
@@ -315,6 +321,10 @@ export class ThesisGeneratorService {
       profile: req.config.profile,
       userMessage,
       tool: PROPOSAL_TOOL as unknown as { name: string; description: string; input_schema: Record<string, unknown> },
+      // P0-A — propagation du budget per-cycle (lu depuis
+      // lisa_session_configs côté lisa.service.ts à chaque generateProposal).
+      ...(req.budgetUsd !== undefined ? { budgetUsd: req.budgetUsd } : {}),
+      ...(req.forceContinue !== undefined ? { forceContinue: req.forceContinue } : {}),
     });
 
     const parsed = toolResult.input;

--- a/supabase/migrations/0074_lisa_session_configs_cost_force_continue.sql
+++ b/supabase/migrations/0074_lisa_session_configs_cost_force_continue.sql
@@ -1,0 +1,32 @@
+-- Ajoute `cost_force_continue` à lisa_session_configs.
+--
+-- INCIDENT 28/04/2026 05:02 UTC : LlmRouter throw `BudgetExceededError` à
+-- $20.46/$20 budget → autopilot bloqué hard, Lisa ne génère plus de thèse.
+-- L'UI propose un budget mais ne peut pas configurer le comportement
+-- "soft warn vs hard stop" — le default historique est hard stop (PR #15).
+--
+-- Cette colonne expose le toggle :
+--   - `true` (DEFAULT) : à 100% du budget, on bascule sur Haiku 4.5 +
+--     warn loggué (cost_budget_warn). Le cycle continue, l'utilisateur
+--     reçoit un signal sans rupture de service.
+--   - `false` : comportement historique préservé pour les opérateurs qui
+--     veulent un hard stop strict (audit, démo, prod réglementée).
+--
+-- Idempotent : `IF NOT EXISTS` permet replay sans erreur.
+-- Cf. fix/cost-soft-budget (PR P0-A 28/04/2026).
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'lisa_session_configs'
+      AND column_name = 'cost_force_continue'
+  ) THEN
+    ALTER TABLE public.lisa_session_configs
+      ADD COLUMN cost_force_continue BOOLEAN NOT NULL DEFAULT true;
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.lisa_session_configs.cost_force_continue IS
+  'P0-A : à 100% du budget Claude API, soft-warn + Haiku fallback (true, default) ou hard throw (false).';


### PR DESCRIPTION
## Pourquoi (P0 prod live)

**Incident 28/04 05:02 UTC** :
```
BadRequestException: Daily budget reached ($20.46/$20.00),
task thesis_generation refused
```

`LlmRouter` (PR #15) hard-throw au franchissement du budget journalier → autopilot bloqué, **zéro thèse depuis reset 06:58 CEST**. UI montait le budget à $50 mais le router lisait l'env statique `LLM_ROUTER_DAILY_BUDGET_USD=20` au lieu de relire `lisa_session_configs.daily_cost_budget_usd` à chaque cycle.

## Quoi — fix multi-couches

### 1. Per-call budget override

`router.call(task, params, options)` accepte maintenant :
- `budgetUsd?` : override per-call (le caller relit la DB)
- `forceContinue?` : soft (true) vs hard (false) à 100%

Si non fournis → fallback sur la config constructor (rétrocompat PR #15).

### 2. Soft-budget à 100% (`forceContinue=true`, default DB)

| Avant | Après (`forceContinue=true`) | Après (`forceContinue=false` / legacy) |
|---|---|---|
| `throw BudgetExceededError` pour TOUTES tâches | warn `cost_budget_warn` + fallback Haiku 4.5 + return normal | throw préservé (mode strict) |

### 3. 80% Opus → Haiku (économie ~3.75×)

| Avant | Après |
|---|---|
| 80% Opus → Sonnet (event `opus_fallback`) | 80% Opus → **Haiku** (event `opus_haiku_fallback`) |

Sonnet/Haiku tasks (`binary_decision`, `audit_explanation`) **restent inchangées** à 80%+ — déjà bon marché et `binary_decision` pourrait perdre en qualité sur Haiku.

**Saving real** : 5000 input + 2000 output
- ex-Sonnet : `(5000×3 + 2000×15) / 1M = $0.045`
- Haiku P0-A : `(5000×0.80 + 2000×4) / 1M = $0.012` → **3.75×**

### 4. Lecture DB per-cycle dans `LisaService.generateProposal`

`config.daily_cost_budget_usd` + `config.cost_force_continue` lus à chaque appel et propagés via `GenerateThesesRequest` → `LisaClaudeClient` → `LlmRouter`.

Default `forceContinue = true` côté JS si la colonne DB n'existe pas encore (= avant migration 0074).

### 5. Migration 0074 (idempotente, `ADD COLUMN ... IF NOT EXISTS`)

```sql
ALTER TABLE lisa_session_configs
  ADD COLUMN cost_force_continue BOOLEAN NOT NULL DEFAULT true;
```

Default `true` = fail-soft (préfère continuer en Haiku qu'arrêter le bot). Opérateurs strict peuvent passer `false` via UI.

## Matrice de comportement finale

| `todayCost` | `forceContinue` | Task | Modèle | Log |
|---|---|---|---|---|
| < 80% | * | * | mapping normal | normal |
| ≥ 80% < 100% + Opus | * | thesis_generation | **Haiku** | `warn opus_haiku_fallback` |
| ≥ 80% < 100% + Opus | * | binary_decision / audit_explanation | Sonnet (inchangé) | normal |
| ≥ 100% | true (default DB) | * | **Haiku** | `warn cost_budget_warn` |
| ≥ 100% | false (strict) | * | — | `throw BudgetExceededError` |
| ≥ 100% | undefined (legacy callers) | * | — | `throw` (rétrocompat tests + callers non migrés) |

## Tests — 30/30 verts

`packages/ai-analyst/src/llm/__tests__/llm-router.spec.ts` :

- 11 nouveaux cas P0-A :
  - Soft-budget à 100% : Haiku + warn, no throw
  - Soft-budget appliqué à toutes les tâches (Sonnet incluses)
  - `forceContinue=false` → throw préservé
  - Default (no options) → throw préservé
  - Per-call budget override prend priorité sur constructor
  - **Repro incident 28/04** : router $20 + spend $20.46 → sans override throw, avec override $50 → no fallback
  - 80% Opus → Haiku (event renamed)
  - 80% Sonnet tasks UNCHANGED
  - Cost saving 3.75× chiffré
  - 100% + forceContinue=true short-circuits 80% path
- 19 legacy adaptés (Sonnet → Haiku sur path 80% Opus, event renamed)

## Validation

- ✅ `tsc --noEmit` clean (apps/api + ai-analyst)
- ✅ Jest router : 30/30
- ✅ Strictly additive : `LlmRouterCallOptions` est optionnel, callers existants intacts
- ✅ Migration 0074 idempotente

## Pré-requis runtime

Migration `0074_lisa_session_configs_cost_force_continue.sql` à appliquer en prod via Supabase SQL Editor (idempotent). Sans elle, le default JS `true` prend le relais — pas d'erreur, juste pas configurable via UI.

## Hors scope (à venir dans cette session)

- **PR P0-B** `fix/macro-vix-cascade` : VIX/DXY primary cascade `yahoo:^VIX → eodhd:VIX → alphavantage`, retry 2 backoff 250ms, log `dataQuality.live = source réelle`, all-fail → last-known + `dataQuality.stale=true`.
- **PR P1** `feat/market-regime` : `MarketRegimeService` classifiant 5 régimes (BULL/BEAR/RANGE/VOL_SPIKE/NEWS_SHOCK) toutes les 5 min, table `market_regimes_log`, injection dans `LisaAutopilotService.buildThesisPrompt` + `RiskEnforcer.sizePosition`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_