### PR TITLE
feat(regime): MarketRegimeService — 5 régimes tactiques (BULL/BEAR/RANGE/VOL_SPIKE/NEWS_SHOCK) (P1)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -17,6 +17,7 @@ import { EodhdScreenerService } from './services/eodhd-screener.service';
 import { EodhdInsiderService } from './services/eodhd-insider.service';
 import { EodhdOptionsService } from './services/eodhd-options.service';
 import { BinanceLiquidationsService } from './services/binance-liquidations.service';
+import { MarketRegimeService } from './services/market-regime.service';
 import { EodhdFxWsService } from './services/eodhd-fx-ws.service';
 import { PortfolioCorrelationService } from './services/portfolio-correlation.service';
 import { AgentLisaSyncService } from './services/agent-lisa-sync.service';
@@ -79,6 +80,8 @@ import { ApiCostTrackerService } from './services/api-cost-tracker.service';
     MacroModeService,
     // PATCH 4 — running total + hard-stop budget API
     ApiCostTrackerService,
+    // P1 — classifier de régime tactique (BULL/BEAR/RANGE/VOL_SPIKE/NEWS_SHOCK)
+    MarketRegimeService,
   ],
   exports: [
     LisaService,

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -49,6 +49,7 @@ import { EodhdInsiderService } from './eodhd-insider.service';
 import { EodhdOptionsService } from './eodhd-options.service';
 import { BinanceLiquidationsService } from './binance-liquidations.service';
 import { ApiCostTrackerService, BudgetExceededError } from './api-cost-tracker.service';
+import { MarketRegimeService } from './market-regime.service';
 import {
   buildYahooChartUrl,
   buildStooqCsvUrl,
@@ -103,6 +104,8 @@ export class LisaService {
     private readonly patternAdoption: PatternAdoptionService,
     // PATCH 4 — hard-stop budget journalier API
     private readonly apiCostTracker: ApiCostTrackerService,
+    // P1 — classifier de régime tactique
+    private readonly marketRegime: MarketRegimeService,
   ) {
     const anthropicKey = this.config.get<string>('ANTHROPIC_API_KEY');
     if (anthropicKey) {
@@ -2425,6 +2428,35 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       degraded: computeDataQualityDegraded(dataQuality.fallback),
     };
 
+    // P1 — Classifier le régime tactique courant à partir des indicateurs
+    // qu'on vient de fetcher. Le service cache 5 min en interne et persiste
+    // dans market_regimes_log. Si tous les inputs critiques sont absents,
+    // le classifier retourne NEUTRAL avec reason `inputs_unavailable`.
+    let tacticalRegime: ReturnType<typeof this.marketRegime.peekCurrentRegime> = null;
+    try {
+      const btc24hReturnPct = btc != null && fallback.btcUsd > 0
+        ? ((btc - fallback.btcUsd) / fallback.btcUsd) * 100
+        : null; // approx — compute avec last-known si dispo plus tard
+      const inputs = {
+        btc24hReturnPct: null as number | null,
+        btcFundingPct: null as number | null,
+        vix: vix ?? null,
+        atr14BtcPct: null as number | null,
+        atr50BtcPct: null as number | null,
+        newsScore: null as number | null,
+        realized1hPct: null as number | null,
+        redditSpikeSigma: null as number | null,
+      };
+      // btc24hReturnPct via fallback (approximation — V2 utilisera un
+      // historical price service dédié pour le calcul exact 24h).
+      if (btc24hReturnPct != null && Number.isFinite(btc24hReturnPct)) {
+        inputs.btc24hReturnPct = btc24hReturnPct;
+      }
+      tacticalRegime = await this.marketRegime.getCurrentRegime(inputs);
+    } catch (e) {
+      this.logger.warn(`[regime] classify failed (non-blocking): ${String(e).slice(0, 100)}`);
+    }
+
     // SPY ≈ SP500/10, QQQ ≈ NASDAQ/40
     return {
       timestamp: new Date().toISOString(),
@@ -2445,6 +2477,18 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       dataQuality: dataQualityWithDegraded,
       recentNews: [],
       upcomingEvents: [],
+      ...(tacticalRegime
+        ? {
+            tacticalRegime: {
+              regime: tacticalRegime.regime,
+              reasons: tacticalRegime.reasons,
+              sizingMultiplier: tacticalRegime.sizingMultiplier,
+              stopLossPct: tacticalRegime.stopLossPct,
+              takeProfitPct: tacticalRegime.takeProfitPct,
+              takeProfitLadderPct: tacticalRegime.takeProfitLadderPct,
+            },
+          }
+        : {}),
     };
   }
 

--- a/apps/api/src/modules/lisa/services/market-regime.service.ts
+++ b/apps/api/src/modules/lisa/services/market-regime.service.ts
@@ -1,0 +1,109 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  classifyTacticalRegime,
+  type RegimeClassification,
+  type RegimeInputs,
+  type TacticalRegime,
+} from '@smartvest/ai-analyst';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+/**
+ * MarketRegimeService — classifie le régime tactique du marché toutes les
+ * 5 min (cache TTL) et persiste chaque classification dans
+ * `market_regimes_log` pour audit + backtest.
+ *
+ * P1 (28/04/2026) — feat/market-regime.
+ *
+ * Le classifier est PUR (`classifyTacticalRegime` dans ai-analyst). Ce
+ * service est l'orchestrateur côté NestJS qui :
+ *   1. Lit les inputs (BTC 24h return, funding, VIX, ATR ratio, news score)
+ *      depuis le `MarketSnapshot` courant
+ *   2. Délègue au classifier pur
+ *   3. Cache 5 min en mémoire (évite de re-classifier à chaque cycle 60s)
+ *   4. Persiste dans `market_regimes_log` (best-effort, fail-soft)
+ *
+ * Lisa (LisaService.fetchMarketSnapshot) appelle `getCurrentRegime()` pour
+ * enrichir le briefing prompt + le RiskEnforcer applique le `sizingMultiplier`
+ * sur les nouvelles ouvertures.
+ */
+@Injectable()
+export class MarketRegimeService {
+  private readonly logger = new Logger(MarketRegimeService.name);
+  private readonly CACHE_MS = 5 * 60 * 1000;
+  private cached: { result: RegimeClassification; asOf: number; inputs: RegimeInputs } | null = null;
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  /**
+   * Classifie + cache + persiste. Si le cache est encore valide (< 5 min),
+   * retourne directement sans recalcul ni nouvelle écriture DB.
+   */
+  async getCurrentRegime(inputs: RegimeInputs): Promise<RegimeClassification> {
+    const now = Date.now();
+    if (this.cached && now - this.cached.asOf < this.CACHE_MS) {
+      return this.cached.result;
+    }
+
+    const result = classifyTacticalRegime(inputs);
+    this.cached = { result, asOf: now, inputs };
+
+    // Persistence best-effort — un fail DB ne doit pas bloquer le cycle Lisa.
+    void this.persist(result, inputs).catch((e) => {
+      this.logger.warn(`[regime] persist failed (non-blocking): ${String(e).slice(0, 120)}`);
+    });
+
+    return result;
+  }
+
+  /**
+   * Snapshot du régime courant SANS recalcul. Retourne null si pas encore
+   * classifié dans le cycle de vie du process. Utile pour les call sites
+   * qui veulent juste lire (ex: UI status sans déclencher une classif).
+   */
+  peekCurrentRegime(): RegimeClassification | null {
+    if (!this.cached) return null;
+    if (Date.now() - this.cached.asOf >= this.CACHE_MS) return null;
+    return this.cached.result;
+  }
+
+  /**
+   * Test helper / admin manual reset.
+   */
+  invalidateCache(): void {
+    this.cached = null;
+  }
+
+  /**
+   * Persiste dans market_regimes_log. Idempotent — on insère une ligne par
+   * classification (chaque transition de régime devient une ligne).
+   */
+  private async persist(result: RegimeClassification, inputs: RegimeInputs): Promise<void> {
+    if (!this.supabase.isReady()) return;
+    const { error } = await this.supabase
+      .getClient()
+      .from('market_regimes_log')
+      .insert({
+        regime: result.regime,
+        inputs: inputs as unknown as Record<string, unknown>,
+        reasons: result.reasons,
+        sizing_multiplier: result.sizingMultiplier,
+        stop_loss_pct: result.stopLossPct,
+        take_profit_pct: result.takeProfitPct,
+        take_profit_ladder_pct: result.takeProfitLadderPct,
+      });
+    if (error) {
+      // Si la migration 0075 n'a pas encore été appliquée, l'erreur
+      // contient `does not exist` — on log debug (pas warn, c'est attendu
+      // pendant la transition de déploiement).
+      const isMissingTable = /market_regimes_log.*does not exist/i.test(error.message);
+      if (isMissingTable) {
+        this.logger.debug('[regime] market_regimes_log table missing (migration 0075 not yet applied)');
+      } else {
+        this.logger.warn(`[regime] insert failed: ${error.message}`);
+      }
+    }
+  }
+}
+
+// Re-export types for convenience (callers can import from here directly).
+export type { TacticalRegime, RegimeInputs, RegimeClassification };

--- a/packages/ai-analyst/src/index.ts
+++ b/packages/ai-analyst/src/index.ts
@@ -13,3 +13,4 @@ export * from './thesis';
 export * from './allocation';
 export * from './simulation';
 export * from './llm';
+export * from './regime';

--- a/packages/ai-analyst/src/regime/__tests__/market-regime-classifier.spec.ts
+++ b/packages/ai-analyst/src/regime/__tests__/market-regime-classifier.spec.ts
@@ -1,0 +1,317 @@
+/**
+ * P1 — Tests du classifier de régime macro.
+ *
+ * Pure function → tests sans mock, sur la matrice de vérité des 5 régimes.
+ * Vérifie l'ordre de priorité (NEWS_SHOCK > VOL_SPIKE > BULL > BEAR >
+ * RANGE > NEUTRAL) et les sizing/SL/TP attendus pour chaque cas.
+ */
+import {
+  classifyTacticalRegime,
+  type RegimeInputs,
+} from '../market-regime-classifier';
+
+const NEUTRAL_INPUTS: RegimeInputs = {
+  btc24hReturnPct: 0,
+  btcFundingPct: 0,
+  vix: 18,
+  atr14BtcPct: 1.5,
+  atr50BtcPct: 1.5,
+  newsScore: 3,
+  realized1hPct: 0.5,
+  redditSpikeSigma: 1,
+};
+
+describe('classifyTacticalRegime — NEWS_SHOCK (priorité 1)', () => {
+  it('matches when news_score > 7', () => {
+    const r = classifyTacticalRegime({ ...NEUTRAL_INPUTS, newsScore: 8.5 });
+    expect(r.regime).toBe('NEWS_SHOCK');
+    expect(r.reasons.some((x) => x.includes('news_score=8.5'))).toBe(true);
+    expect(r.sizingMultiplier).toBe(1.0);
+    expect(r.stopLossPct).toBe(1.0);
+    expect(r.takeProfitPct).toBe(3.0);
+  });
+
+  it('matches when reddit_sigma > 5', () => {
+    const r = classifyTacticalRegime({ ...NEUTRAL_INPUTS, redditSpikeSigma: 6 });
+    expect(r.regime).toBe('NEWS_SHOCK');
+    expect(r.reasons.some((x) => x.includes('reddit_sigma=6.0'))).toBe(true);
+  });
+
+  it('takes priority over VOL_SPIKE (interrupt sémantique)', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      newsScore: 9,
+      vix: 30, // would also match VOL_SPIKE
+    });
+    expect(r.regime).toBe('NEWS_SHOCK');
+  });
+
+  it('does NOT match at threshold (>7 strict)', () => {
+    const r = classifyTacticalRegime({ ...NEUTRAL_INPUTS, newsScore: 7 });
+    expect(r.regime).not.toBe('NEWS_SHOCK');
+  });
+});
+
+describe('classifyTacticalRegime — VOL_SPIKE (priorité 2)', () => {
+  it('matches when VIX > 25', () => {
+    const r = classifyTacticalRegime({ ...NEUTRAL_INPUTS, vix: 28 });
+    expect(r.regime).toBe('VOL_SPIKE');
+    expect(r.sizingMultiplier).toBe(0); // skip 30 min
+    expect(r.stopLossPct).toBe(3.0);
+    expect(r.takeProfitPct).toBe(2.0);
+  });
+
+  it('matches when realized_1h > 3%', () => {
+    const r = classifyTacticalRegime({ ...NEUTRAL_INPUTS, realized1hPct: 4 });
+    expect(r.regime).toBe('VOL_SPIKE');
+  });
+
+  it('takes priority over BULL', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      vix: 30,
+      btc24hReturnPct: 5,
+      btcFundingPct: 0.05,
+    });
+    expect(r.regime).toBe('VOL_SPIKE');
+  });
+
+  it('takes priority over BEAR', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      vix: 30,
+      btc24hReturnPct: -5,
+      btcFundingPct: -0.05,
+    });
+    expect(r.regime).toBe('VOL_SPIKE');
+  });
+
+  it('does NOT match at VIX exact threshold (>25 strict)', () => {
+    const r = classifyTacticalRegime({ ...NEUTRAL_INPUTS, vix: 25 });
+    expect(r.regime).not.toBe('VOL_SPIKE');
+  });
+});
+
+describe('classifyTacticalRegime — BULL (priorité 3)', () => {
+  it('matches when btc_24h > +2% AND funding > 0.01%', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      btc24hReturnPct: 3,
+      btcFundingPct: 0.02,
+    });
+    expect(r.regime).toBe('BULL');
+    expect(r.sizingMultiplier).toBe(1.2);
+    expect(r.stopLossPct).toBe(2.0);
+    expect(r.takeProfitLadderPct).toEqual([1.5, 2.5, 4.0]);
+  });
+
+  it('does NOT match when only btc_24h > +2% (funding low)', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      btc24hReturnPct: 3,
+      btcFundingPct: 0.005, // sous le threshold
+    });
+    expect(r.regime).not.toBe('BULL');
+  });
+
+  it('does NOT match when only funding > 0.01% (btc flat)', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      btc24hReturnPct: 0.5, // sous le +2%
+      btcFundingPct: 0.02,
+    });
+    expect(r.regime).not.toBe('BULL');
+  });
+
+  it('takes priority over BEAR (mutually exclusive on direction)', () => {
+    // Impossible cas physique mais testons : BTC up + funding up bat un
+    // hypothétique BEAR sur autre indicateur. NEUTRAL_INPUTS funding=0
+    // donc pas de conflit en pratique.
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      btc24hReturnPct: 3,
+      btcFundingPct: 0.02,
+    });
+    expect(r.regime).toBe('BULL');
+  });
+});
+
+describe('classifyTacticalRegime — BEAR (priorité 4)', () => {
+  it('matches when btc_24h < -2% AND funding < -0.005%', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      btc24hReturnPct: -3,
+      btcFundingPct: -0.01,
+    });
+    expect(r.regime).toBe('BEAR');
+    expect(r.sizingMultiplier).toBe(0.7);
+    expect(r.stopLossPct).toBe(2.0);
+    expect(r.takeProfitPct).toBe(1.5);
+  });
+
+  it('does NOT match when only btc_24h < -2% (funding ok)', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      btc24hReturnPct: -3,
+      btcFundingPct: 0,
+    });
+    expect(r.regime).not.toBe('BEAR');
+  });
+
+  it('does NOT match when only funding < -0.005% (btc up)', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      btc24hReturnPct: 1,
+      btcFundingPct: -0.01,
+    });
+    expect(r.regime).not.toBe('BEAR');
+  });
+});
+
+describe('classifyTacticalRegime — RANGE (priorité 5)', () => {
+  it('matches when ATR14 < 0.8*ATR50 AND |btc_24h| < 1%', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      atr14BtcPct: 0.5,
+      atr50BtcPct: 1.0, // ratio 0.5 < 0.8
+      btc24hReturnPct: 0.3, // |0.3| < 1
+    });
+    expect(r.regime).toBe('RANGE');
+    expect(r.sizingMultiplier).toBe(1.0);
+    expect(r.stopLossPct).toBe(1.2);
+    expect(r.takeProfitPct).toBe(0.8);
+  });
+
+  it('does NOT match when ATR ratio is high (> 0.8)', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      atr14BtcPct: 1.0,
+      atr50BtcPct: 1.0, // ratio = 1.0
+      btc24hReturnPct: 0.3,
+    });
+    expect(r.regime).not.toBe('RANGE');
+  });
+
+  it('does NOT match when btc_24h moves > 1%', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      atr14BtcPct: 0.5,
+      atr50BtcPct: 1.0,
+      btc24hReturnPct: 1.5, // |1.5| > 1
+    });
+    expect(r.regime).not.toBe('RANGE');
+  });
+
+  it('does NOT match when ATR50 is 0 (avoid div by 0)', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      atr14BtcPct: 0.5,
+      atr50BtcPct: 0,
+      btc24hReturnPct: 0.3,
+    });
+    expect(r.regime).not.toBe('RANGE');
+  });
+});
+
+describe('classifyTacticalRegime — NEUTRAL (default)', () => {
+  it('falls through to NEUTRAL when no condition matches', () => {
+    const r = classifyTacticalRegime(NEUTRAL_INPUTS);
+    expect(r.regime).toBe('NEUTRAL');
+    expect(r.sizingMultiplier).toBe(1.0);
+    expect(r.reasons).toContain('no_threshold_matched');
+  });
+
+  it('returns NEUTRAL with inputs_unavailable reason when all critical inputs are null', () => {
+    const r = classifyTacticalRegime({
+      btc24hReturnPct: null,
+      btcFundingPct: null,
+      vix: null,
+      atr14BtcPct: null,
+      atr50BtcPct: null,
+      newsScore: null,
+    });
+    expect(r.regime).toBe('NEUTRAL');
+    expect(r.reasons).toContain('inputs_unavailable');
+  });
+});
+
+describe('classifyTacticalRegime — sizing/SL/TP coherence (matrix)', () => {
+  it('NEWS_SHOCK : sizing 1.0 / SL 1% / TP 3%', () => {
+    const r = classifyTacticalRegime({ ...NEUTRAL_INPUTS, newsScore: 9 });
+    expect(r.sizingMultiplier).toBe(1.0);
+    expect(r.stopLossPct).toBe(1.0);
+    expect(r.takeProfitPct).toBe(3.0);
+  });
+
+  it('VOL_SPIKE : sizing 0 (skip) / SL 3% / TP 2%', () => {
+    const r = classifyTacticalRegime({ ...NEUTRAL_INPUTS, vix: 30 });
+    expect(r.sizingMultiplier).toBe(0);
+    expect(r.stopLossPct).toBe(3.0);
+    expect(r.takeProfitPct).toBe(2.0);
+  });
+
+  it('BULL : sizing +20% / TP étagé / SL trail 2%', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      btc24hReturnPct: 3,
+      btcFundingPct: 0.02,
+    });
+    expect(r.sizingMultiplier).toBe(1.2);
+    expect(r.takeProfitLadderPct).toEqual([1.5, 2.5, 4.0]);
+    expect(r.stopLossPct).toBe(2.0);
+  });
+
+  it('BEAR : sizing -30% / SL 2% / TP 1.5%', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      btc24hReturnPct: -3,
+      btcFundingPct: -0.01,
+    });
+    expect(r.sizingMultiplier).toBe(0.7);
+    expect(r.stopLossPct).toBe(2.0);
+    expect(r.takeProfitPct).toBe(1.5);
+  });
+
+  it('RANGE : sizing 1.0 / SL 1.2% / TP 0.8% (scalping)', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      atr14BtcPct: 0.5,
+      atr50BtcPct: 1.0,
+      btc24hReturnPct: 0.3,
+    });
+    expect(r.sizingMultiplier).toBe(1.0);
+    expect(r.stopLossPct).toBe(1.2);
+    expect(r.takeProfitPct).toBe(0.8);
+  });
+
+  it('NEUTRAL : sizing 1.0 / SL 2% / TP 2.5% (nominal)', () => {
+    const r = classifyTacticalRegime(NEUTRAL_INPUTS);
+    expect(r.sizingMultiplier).toBe(1.0);
+    expect(r.stopLossPct).toBe(2.0);
+    expect(r.takeProfitPct).toBe(2.5);
+  });
+});
+
+describe('classifyTacticalRegime — reasons text quality', () => {
+  it('includes the actual values in reasons (audit-friendly)', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      btc24hReturnPct: 2.55,
+      btcFundingPct: 0.0123,
+    });
+    expect(r.regime).toBe('BULL');
+    expect(r.reasons.some((x) => x.includes('2.55%'))).toBe(true);
+    expect(r.reasons.some((x) => x.includes('0.0123%'))).toBe(true);
+  });
+
+  it('emits ratio in RANGE reasons', () => {
+    const r = classifyTacticalRegime({
+      ...NEUTRAL_INPUTS,
+      atr14BtcPct: 0.6,
+      atr50BtcPct: 1.0,
+      btc24hReturnPct: 0.5,
+    });
+    expect(r.regime).toBe('RANGE');
+    expect(r.reasons.some((x) => x.includes('atr14/atr50=0.60'))).toBe(true);
+  });
+});

--- a/packages/ai-analyst/src/regime/index.ts
+++ b/packages/ai-analyst/src/regime/index.ts
@@ -1,0 +1,1 @@
+export * from './market-regime-classifier';

--- a/packages/ai-analyst/src/regime/market-regime-classifier.ts
+++ b/packages/ai-analyst/src/regime/market-regime-classifier.ts
@@ -1,0 +1,215 @@
+/**
+ * TacticalRegimeClassifier — classification déterministe du régime macro.
+ *
+ * P1 (28/04/2026) — feat/market-regime.
+ *
+ * Pure function (no I/O) qui classifie le marché en 5 régimes mutuellement
+ * exclusifs basés sur des inputs factuels (BTC 24h return, funding, VIX,
+ * ATR ratio, news score). Permet à Lisa + au RiskEnforcer d'adapter le
+ * sizing/SL/TP par régime sans nécessiter un appel LLM.
+ *
+ * **Régimes (ordre de priorité — first-match wins)** :
+ *
+ *  1. **NEWS_SHOCK** — choc d'information (sens du catalyseur prime sur le
+ *     contexte macro normal). Trigger : news_score > 7 OU reddit spike > 5σ.
+ *     Sizing/SL/TP : SL 1%, TP 3% (sens catalyst).
+ *
+ *  2. **VOL_SPIKE** — pic de volatilité (panique, désordre cross-asset).
+ *     Trigger : VIX > 25 OU realized 1h > 3%.
+ *     Sizing : skip 30 min (pas de nouvelle ouverture, fade les overshoots).
+ *     SL 3% / TP 2%.
+ *
+ *  3. **BULL** — tendance haussière forte.
+ *     Trigger : BTC 24h > +2% ET funding > 0.01% (long bias).
+ *     Sizing +20%, TP étagé 1.5/2.5/4%, SL trail 2%.
+ *
+ *  4. **BEAR** — tendance baissière forte.
+ *     Trigger : BTC 24h < -2% ET funding < -0.005% (short bias / cash bias).
+ *     Sizing -30%, TP 1.5%, SL 2%.
+ *
+ *  5. **RANGE** — marché latéral, faible momentum, ATR comprimé.
+ *     Trigger : ATR14 < 0.8 × ATR50 ET |BTC 24h| < 1%.
+ *     Sizing grid-like, TP 0.8% (scalping mean-reversion), SL 1.2%.
+ *
+ *  6. **NEUTRAL** — défaut quand aucun régime ne match. Sizing nominal.
+ *
+ * Cohérence : les 5 régimes sont mutually exclusive grâce à l'ordre de
+ * priorité. NEWS_SHOCK/VOL_SPIKE prennent le pas car ils sont des
+ * "interrupts" qui invalident l'analyse macro normale.
+ */
+
+export type TacticalRegime =
+  | 'BULL'
+  | 'BEAR'
+  | 'RANGE'
+  | 'VOL_SPIKE'
+  | 'NEWS_SHOCK'
+  | 'NEUTRAL';
+
+export interface RegimeInputs {
+  /** BTC return 24h en % (ex: +2.5 pour +2.5%). Null si indisponible. */
+  btc24hReturnPct: number | null;
+  /** Funding rate Binance perp BTC en % (ex: 0.01 pour 1bp / 8h). Null si indispo. */
+  btcFundingPct: number | null;
+  /** VIX index value (ex: 22.5). Null si indisponible. */
+  vix: number | null;
+  /** ATR14 BTC en % du prix. Null si indisponible. */
+  atr14BtcPct: number | null;
+  /** ATR50 BTC en % du prix (référence "long-terme" pour ratio compression). Null si indispo. */
+  atr50BtcPct: number | null;
+  /** News score normalisé 0-10 du flux récent (high impact = haut). Null si indispo. */
+  newsScore: number | null;
+  /** Realized vol BTC sur 1h en % (mouvements intra-cycle). Null si indispo. */
+  realized1hPct?: number | null;
+  /** Reddit/social activity z-score (sigma). Null si indisponible. */
+  redditSpikeSigma?: number | null;
+}
+
+export interface RegimeClassification {
+  regime: TacticalRegime;
+  /** Raisons textuelles concises pour audit (chaque condition qui a matché). */
+  reasons: string[];
+  /** Multiplicateur de sizing à appliquer (1.0 = nominal, 0.7 = -30%, 1.2 = +20%, 0 = skip). */
+  sizingMultiplier: number;
+  /** SL recommandé en % (positif). */
+  stopLossPct: number;
+  /** TP "principal" en % (premier palier si TP étagé). */
+  takeProfitPct: number;
+  /** TP étagés (BULL : 1.5/2.5/4%). Empty si pas de TP étagé. */
+  takeProfitLadderPct: number[];
+}
+
+const NEWS_SCORE_THRESHOLD = 7;
+const REDDIT_SPIKE_SIGMA_THRESHOLD = 5;
+const VIX_SPIKE_THRESHOLD = 25;
+const REALIZED_1H_VOL_SPIKE_THRESHOLD = 3;
+const BULL_BTC_24H_THRESHOLD = 2;
+const BULL_FUNDING_THRESHOLD = 0.01;
+const BEAR_BTC_24H_THRESHOLD = -2;
+const BEAR_FUNDING_THRESHOLD = -0.005;
+const RANGE_ATR_RATIO_THRESHOLD = 0.8;
+const RANGE_BTC_24H_ABS_THRESHOLD = 1;
+
+/**
+ * Classifie le régime de marché à partir des inputs factuels.
+ * Pure function — déterministe, testable sans dépendance.
+ *
+ * Si plusieurs régimes pourraient matcher, NEWS_SHOCK > VOL_SPIKE > BULL >
+ * BEAR > RANGE > NEUTRAL (ordre déclaré ci-dessus).
+ *
+ * Si tous les inputs critiques sont null → NEUTRAL avec reason
+ * `inputs_unavailable`. Lisa peut décider de skipper le cycle ou de
+ * fonctionner sur les inputs disponibles.
+ */
+export function classifyTacticalRegime(inputs: RegimeInputs): RegimeClassification {
+  const reasons: string[] = [];
+
+  // ── 1. NEWS_SHOCK ────────────────────────────────────────────────
+  const newsHit = inputs.newsScore != null && inputs.newsScore > NEWS_SCORE_THRESHOLD;
+  const redditHit =
+    inputs.redditSpikeSigma != null && inputs.redditSpikeSigma > REDDIT_SPIKE_SIGMA_THRESHOLD;
+  if (newsHit || redditHit) {
+    if (newsHit) reasons.push(`news_score=${inputs.newsScore!.toFixed(1)} > ${NEWS_SCORE_THRESHOLD}`);
+    if (redditHit) reasons.push(`reddit_sigma=${inputs.redditSpikeSigma!.toFixed(1)} > ${REDDIT_SPIKE_SIGMA_THRESHOLD}`);
+    return {
+      regime: 'NEWS_SHOCK',
+      reasons,
+      sizingMultiplier: 1.0, // taille nominale, on suit le catalyseur
+      stopLossPct: 1.0,
+      takeProfitPct: 3.0,
+      takeProfitLadderPct: [],
+    };
+  }
+
+  // ── 2. VOL_SPIKE ─────────────────────────────────────────────────
+  const vixHit = inputs.vix != null && inputs.vix > VIX_SPIKE_THRESHOLD;
+  const realizedHit =
+    inputs.realized1hPct != null && inputs.realized1hPct > REALIZED_1H_VOL_SPIKE_THRESHOLD;
+  if (vixHit || realizedHit) {
+    if (vixHit) reasons.push(`vix=${inputs.vix!.toFixed(1)} > ${VIX_SPIKE_THRESHOLD}`);
+    if (realizedHit) reasons.push(`realized_1h=${inputs.realized1hPct!.toFixed(2)}% > ${REALIZED_1H_VOL_SPIKE_THRESHOLD}%`);
+    return {
+      regime: 'VOL_SPIKE',
+      reasons,
+      sizingMultiplier: 0, // skip 30 min — fade les overshoots
+      stopLossPct: 3.0,
+      takeProfitPct: 2.0,
+      takeProfitLadderPct: [],
+    };
+  }
+
+  // ── 3. BULL ───────────────────────────────────────────────────────
+  // Conditions cumulatives ET — BTC up 24h ET funding crowded long.
+  const bullBtcHit =
+    inputs.btc24hReturnPct != null && inputs.btc24hReturnPct > BULL_BTC_24H_THRESHOLD;
+  const bullFundingHit =
+    inputs.btcFundingPct != null && inputs.btcFundingPct > BULL_FUNDING_THRESHOLD;
+  if (bullBtcHit && bullFundingHit) {
+    reasons.push(`btc_24h=+${inputs.btc24hReturnPct!.toFixed(2)}% > +${BULL_BTC_24H_THRESHOLD}%`);
+    reasons.push(`funding=${inputs.btcFundingPct!.toFixed(4)}% > ${BULL_FUNDING_THRESHOLD}%`);
+    return {
+      regime: 'BULL',
+      reasons,
+      sizingMultiplier: 1.2, // +20%
+      stopLossPct: 2.0,      // trail 2%
+      takeProfitPct: 1.5,    // 1er palier (TP étagé)
+      takeProfitLadderPct: [1.5, 2.5, 4.0],
+    };
+  }
+
+  // ── 4. BEAR ───────────────────────────────────────────────────────
+  const bearBtcHit =
+    inputs.btc24hReturnPct != null && inputs.btc24hReturnPct < BEAR_BTC_24H_THRESHOLD;
+  const bearFundingHit =
+    inputs.btcFundingPct != null && inputs.btcFundingPct < BEAR_FUNDING_THRESHOLD;
+  if (bearBtcHit && bearFundingHit) {
+    reasons.push(`btc_24h=${inputs.btc24hReturnPct!.toFixed(2)}% < ${BEAR_BTC_24H_THRESHOLD}%`);
+    reasons.push(`funding=${inputs.btcFundingPct!.toFixed(4)}% < ${BEAR_FUNDING_THRESHOLD}%`);
+    return {
+      regime: 'BEAR',
+      reasons,
+      sizingMultiplier: 0.7, // -30%
+      stopLossPct: 2.0,
+      takeProfitPct: 1.5,
+      takeProfitLadderPct: [],
+    };
+  }
+
+  // ── 5. RANGE ─────────────────────────────────────────────────────
+  const rangeAtrHit =
+    inputs.atr14BtcPct != null &&
+    inputs.atr50BtcPct != null &&
+    inputs.atr50BtcPct > 0 &&
+    inputs.atr14BtcPct < RANGE_ATR_RATIO_THRESHOLD * inputs.atr50BtcPct;
+  const rangeBtc24hHit =
+    inputs.btc24hReturnPct != null &&
+    Math.abs(inputs.btc24hReturnPct) < RANGE_BTC_24H_ABS_THRESHOLD;
+  if (rangeAtrHit && rangeBtc24hHit) {
+    const ratio = (inputs.atr14BtcPct! / inputs.atr50BtcPct!).toFixed(2);
+    reasons.push(`atr14/atr50=${ratio} < ${RANGE_ATR_RATIO_THRESHOLD}`);
+    reasons.push(`|btc_24h|=${Math.abs(inputs.btc24hReturnPct!).toFixed(2)}% < ${RANGE_BTC_24H_ABS_THRESHOLD}%`);
+    return {
+      regime: 'RANGE',
+      reasons,
+      sizingMultiplier: 1.0,
+      stopLossPct: 1.2,
+      takeProfitPct: 0.8, // scalping mean-reversion
+      takeProfitLadderPct: [],
+    };
+  }
+
+  // ── 6. NEUTRAL (default) ─────────────────────────────────────────
+  if (inputs.btc24hReturnPct == null && inputs.vix == null && inputs.btcFundingPct == null) {
+    reasons.push('inputs_unavailable');
+  } else {
+    reasons.push('no_threshold_matched');
+  }
+  return {
+    regime: 'NEUTRAL',
+    reasons,
+    sizingMultiplier: 1.0,
+    stopLossPct: 2.0,    // SL nominal
+    takeProfitPct: 2.5,  // TP nominal
+    takeProfitLadderPct: [],
+  };
+}

--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -117,6 +117,18 @@ export interface MarketSnapshot {
    *  bucket, par conviction, par symbole. Calibre la confiance de Lisa
    *  sur des données empiriques de SON portfolio, pas des intuitions. */
   performanceAnalytics?: string;
+  /** P1 — Régime tactique courant (BULL/BEAR/RANGE/VOL_SPIKE/NEWS_SHOCK/
+   *  NEUTRAL) calculé par MarketRegimeService toutes les 5 min. Donne à
+   *  Lisa une vue déterministe du contexte sizing/SL/TP qu'elle peut
+   *  utiliser comme cadre tactique (≠ régime stratégique 14-valeurs). */
+  tacticalRegime?: {
+    regime: string;
+    reasons: string[];
+    sizingMultiplier: number;
+    stopLossPct: number;
+    takeProfitPct: number;
+    takeProfitLadderPct: number[];
+  };
 }
 
 /**
@@ -428,6 +440,7 @@ ${m.macroContext.gdpYoyPct != null ? `- GDP YoY : ${m.macroContext.gdpYoyPct >= 
 - S&P 500: ${m.sp500}
 - Nasdaq: ${m.nasdaq}
 ${this.formatDataQualityBlock(m.dataQuality)}
+${this.formatTacticalRegimeBlock(m.tacticalRegime)}
 ${m.lisaMemory ? `## YOUR PAST DECISIONS — mémoire contextuelle sur ce portefeuille
 ${m.lisaMemory}
 
@@ -575,6 +588,36 @@ défini, sans markdown, sans explications hors JSON.
       );
     }
     return lines.join('\n') + '\n';
+  }
+
+  /**
+   * P1 — Bloc de briefing tactique. Donne à Lisa la classification
+   * déterministe du régime courant (BULL/BEAR/RANGE/VOL_SPIKE/NEWS_SHOCK)
+   * + sizing / SL / TP attendus pour ce régime. Lisa peut DEVIER (elle
+   * reste libre de proposer un setup non-aligné si elle a une raison
+   * solide), mais le bloc agit comme garde-fou implicite et facilite
+   * l'audit a posteriori.
+   */
+  private formatTacticalRegimeBlock(tr?: MarketSnapshot['tacticalRegime']): string {
+    if (!tr) return '';
+    const ladder = tr.takeProfitLadderPct.length > 0
+      ? ` (ladder ${tr.takeProfitLadderPct.map((p) => `${p}%`).join('/')})`
+      : '';
+    const sizingNote = tr.sizingMultiplier === 0
+      ? '⛔ skip 30 min recommandé'
+      : tr.sizingMultiplier === 1
+      ? 'taille nominale'
+      : tr.sizingMultiplier > 1
+      ? `+${Math.round((tr.sizingMultiplier - 1) * 100)}%`
+      : `-${Math.round((1 - tr.sizingMultiplier) * 100)}%`;
+    return `
+## TACTICAL REGIME — cadre déterministe (BULL/BEAR/RANGE/VOL_SPIKE/NEWS_SHOCK)
+- Régime : **${tr.regime}**
+- Raisons : ${tr.reasons.join(' · ')}
+- Sizing recommandé : ${sizingNote} (× ${tr.sizingMultiplier.toFixed(2)})
+- Stop-loss : ${tr.stopLossPct}% · Take-profit : ${tr.takeProfitPct}%${ladder}
+- Tu peux dévier si tu as une raison solide (à expliciter dans [DIAGNOSTIC]).
+`;
   }
 
   private formatDailyHarvestBlock(ctx?: DailyHarvestBriefingContext): string {

--- a/supabase/migrations/0075_market_regimes_log.sql
+++ b/supabase/migrations/0075_market_regimes_log.sql
@@ -1,0 +1,41 @@
+-- P1 — Persiste l'historique des classifications de régime tactique.
+--
+-- Permet :
+--   1. Audit a posteriori : "à 14h32 on était en BULL, sizing 1.2x → trade
+--      RTX ouvert, comprendre la cohérence"
+--   2. Backtests : reconstituer la séquence de régimes pour analyser
+--      win-rate par régime sur l'historique
+--   3. UI dashboard : courbe colorée par régime (vert BULL, rouge BEAR,
+--      gris RANGE, jaune VOL_SPIKE, orange NEWS_SHOCK)
+--
+-- Cf. feat/market-regime (PR P1 28/04/2026).
+
+CREATE TABLE IF NOT EXISTS public.market_regimes_log (
+  id uuid primary key default gen_random_uuid(),
+  classified_at timestamptz NOT NULL DEFAULT now(),
+  -- Nom du régime (BULL/BEAR/RANGE/VOL_SPIKE/NEWS_SHOCK/NEUTRAL).
+  regime text NOT NULL CHECK (regime IN (
+    'BULL', 'BEAR', 'RANGE', 'VOL_SPIKE', 'NEWS_SHOCK', 'NEUTRAL'
+  )),
+  -- Inputs factuels au moment de la classification (pour reproductibilité).
+  inputs jsonb NOT NULL,
+  -- Conditions textuelles qui ont matché (audit-friendly, ex:
+  -- ['btc_24h=+3.2% > +2%', 'funding=0.020% > 0.01%']).
+  reasons text[] NOT NULL DEFAULT ARRAY[]::text[],
+  -- Sizing/SL/TP appliqués (snapshot pour audit, le classifier peut évoluer).
+  sizing_multiplier numeric(5,2) NOT NULL,
+  stop_loss_pct numeric(5,3) NOT NULL,
+  take_profit_pct numeric(5,3) NOT NULL,
+  take_profit_ladder_pct numeric(5,3)[] NOT NULL DEFAULT ARRAY[]::numeric(5,3)[]
+);
+
+-- Index pour query "régime courant" (la dernière ligne) :
+CREATE INDEX IF NOT EXISTS market_regimes_log_classified_at_desc_idx
+  ON public.market_regimes_log (classified_at DESC);
+
+-- Index pour query "transitions de régime" :
+CREATE INDEX IF NOT EXISTS market_regimes_log_regime_classified_at_idx
+  ON public.market_regimes_log (regime, classified_at DESC);
+
+COMMENT ON TABLE public.market_regimes_log IS
+  'P1 — historique des classifications tactiques (BULL/BEAR/RANGE/VOL_SPIKE/NEWS_SHOCK). Une ligne par classification (toutes les 5 min côté MarketRegimeService). Inputs + reasons + sizing/SL/TP snapshotted pour audit reproductible.';


### PR DESCRIPTION
## Pourquoi (objectif business)

**Cible : 1%/jour net sur 10k USD**. Benchmarks 2025-2026 : DCA bots 0.3-0.6%/j, grid 0.2%/j net. 1%/j = limite haute = nécessite **sizing/SL/TP régime-aware**. Cette PR câble la couche déterministe sur laquelle Lisa + RiskEnforcer pourront s'appuyer.

## Quoi — 5 régimes mutually exclusive (priorité first-match)

| # | Régime | Trigger | Sizing | SL | TP |
|---|---|---|---|---|---|
| 1 | **NEWS_SHOCK** (interrupt) | `news_score > 7` OU `reddit_σ > 5` | nominal | 1% | 3% |
| 2 | **VOL_SPIKE** (interrupt) | `VIX > 25` OU `realized_1h > 3%` | **0 (skip 30 min)** | 3% | 2% |
| 3 | **BULL** | `BTC 24h > +2%` ET `funding > 0.01%` | **+20%** | 2% trail | ladder 1.5/2.5/4% |
| 4 | **BEAR** | `BTC 24h < -2%` ET `funding < -0.005%` | **-30%** | 2% | 1.5% |
| 5 | **RANGE** | `ATR14 < 0.8×ATR50` ET `|BTC 24h| < 1%` | nominal | 1.2% | 0.8% (scalping) |
| 6 | **NEUTRAL** (default) | aucun | nominal | 2% | 2.5% |

## Implémentation 4 couches

### 1. Pure classifier (`packages/ai-analyst/src/regime/`)

`classifyTacticalRegime(inputs)` — fonction pure, déterministe, no I/O. Type `TacticalRegime` (au lieu de `MarketRegime` pour éviter collision avec le `MarketRegime` Lisa 14-valeurs strategic).

### 2. Migration `0075_market_regimes_log.sql` (idempotente)

Table append-only avec inputs + reasons + sizing/SL/TP snapshot. Permet :
- Audit reproductible (chaque classification stockée avec ses inputs)
- Backtests par régime
- UI dashboard (courbe colorée par régime)

2 index : `(classified_at DESC)` pour "régime courant" et `(regime, classified_at DESC)` pour "transitions".

### 3. NestJS `MarketRegimeService`

- `getCurrentRegime(inputs)` : classifie + cache 5 min + persiste best-effort
- `peekCurrentRegime()` : lit le cache sans recalculer (UI status)
- `invalidateCache()` : test helper / admin reset
- Persist non-bloquant : si table absente (migration pas appliquée) → debug log silent, service fonctionne quand même

### 4. Wire dans `LisaService.fetchMarketSnapshot` + briefing

- `LisaModule` : `MarketRegimeService` déclaré dans providers
- `LisaService` : injecté + appelé dans `fetchMarketSnapshot()` après calcul indicateurs
- `MarketSnapshot.tacticalRegime` : nouveau field optionnel
- `formatTacticalRegimeBlock()` : bloc dans prompt Claude entre `DATA QUALITY` et `YOUR PAST DECISIONS`

Lisa reçoit le régime + raisons + sizing/SL/TP recommandés. **Elle peut DÉVIER** avec justification dans `[DIAGNOSTIC]` — la classif est un cadre, pas une obligation.

Exemple briefing rendu :

```
## TACTICAL REGIME — cadre déterministe (BULL/BEAR/RANGE/VOL_SPIKE/NEWS_SHOCK)
- Régime : **BULL**
- Raisons : btc_24h=+3.20% > +2% · funding=0.0200% > 0.01%
- Sizing recommandé : +20% (× 1.20)
- Stop-loss : 2% · Take-profit : 1.5% (ladder 1.5%/2.5%/4%)
- Tu peux dévier si tu as une raison solide (à expliciter dans [DIAGNOSTIC]).
```

## Tests — 30/30 verts

`packages/ai-analyst/src/regime/__tests__/market-regime-classifier.spec.ts` :

- **NEWS_SHOCK** (4 cas) : trigger, priorité sur VOL_SPIKE, threshold strict
- **VOL_SPIKE** (5 cas) : VIX/realized triggers, priorité sur BULL/BEAR, threshold strict
- **BULL** (4 cas) : conditions cumulatives ET, négatifs si un seul, priorité
- **BEAR** (3 cas) : symétrique BULL
- **RANGE** (4 cas) : ATR ratio + |btc 24h|, négatifs, **div-by-zero protection** (ATR50=0)
- **NEUTRAL** (2 cas) : default + `inputs_unavailable`
- **Sizing/SL/TP matrix** (6 cas — un par régime, vérifie sizing + SL + TP cohérents)
- **Reasons text quality** (2 cas — values dans le texte, ratio formaté)

Suite globale apps/api : **407/408 verts** (1 fail pré-existant `adapters.spec.ts` regex `/API publique/` sans rapport).

## Validation

- ✅ `tsc --noEmit` clean (apps/api + ai-analyst)
- ✅ Jest classifier : 30/30
- ✅ Jest global : 407/408 (1 pré-existant)
- ✅ Migration 0075 idempotente

## Pré-requis runtime

Migration `0075_market_regimes_log.sql` à appliquer en prod via Supabase SQL Editor (idempotent). Sans elle, le service fonctionne quand même (cache only, persist debug-logged).

## Inputs partiellement câblés (V2 follow-up)

Pour cette PR, les inputs au classifier sont conservativement minimalistes :
- ✅ **VIX** : direct depuis le fetchMarketSnapshot result (yahoo/eodhd cascade)
- 🟡 **BTC 24h return** : approximation via fallback baseline — V2 utilisera `HistoricalPriceService.get24hReturn('BTC')`
- ❌ **funding, ATR14/50, news_score, reddit_σ, realized_1h** : null pour l'instant → la majorité des cycles tomberont en NEUTRAL/VOL_SPIKE selon le seul VIX

C'est volontaire pour cette PR : valider la couche déterministe + persistance avant d'enrichir les inputs (chaque source nécessite son propre câblage).

## Hors scope (PR de suivi)

- **Câbler les inputs manquants** : ATR14/50 (déjà calc par EodhdTechnicalService), news_score (NewsRankerService), reddit_σ (RedditService), funding (BinanceMarketService), realized_1h (BinanceMarketService 1m bars)
- **Wire `RiskEnforcer.sizePosition`** avec `sizingMultiplier` du régime — spec initial mentionnait l'intégration, fait dans une PR suivante pour garder cette PR reviewable + déjà large
- **UI bandeau régime courant** (lit `getCurrentRegime` ou directement `market_regimes_log` via Realtime)
- **Backtest historique** régime-aware sur les `lisa_positions` fermées

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_