### PR TITLE
test(brokers): fix adapters.spec regex to match "API retail publique"

### DIFF
--- a/apps/api/src/modules/brokers/__tests__/adapters.spec.ts
+++ b/apps/api/src/modules/brokers/__tests__/adapters.spec.ts
@@ -130,7 +130,11 @@ describe('createBrokerAdapter factory', () => {
     expect(createBrokerAdapter('DEGIRO', { ...allFlagsOn, BROKER_ADAPTER_DEGIRO_ENABLED: false })).toBeInstanceOf(DegiroAdapter);
   });
   it('refuses BOURSE_DIRECT / FORTUNEO (no public API)', () => {
-    expect(() => createBrokerAdapter('BOURSE_DIRECT', allFlagsOn)).toThrow(/API publique/);
-    expect(() => createBrokerAdapter('FORTUNEO', allFlagsOn)).toThrow(/API publique/);
+    // Le message exact de adapter-factory.ts est :
+    // "${provider} n'expose pas d'API retail publique — utilisez l'import CSV via /imports."
+    // Regex `/API.*publique/` matche "API retail publique" + tolère un futur
+    // ajustement (ex: "API retail publique standard").
+    expect(() => createBrokerAdapter('BOURSE_DIRECT', allFlagsOn)).toThrow(/API.*publique/);
+    expect(() => createBrokerAdapter('FORTUNEO', allFlagsOn)).toThrow(/API.*publique/);
   });
 });


### PR DESCRIPTION
## Pourquoi

Test pré-existant qui faisait échouer la suite globale apps/api à 407/408 depuis plusieurs sessions. Le message de `adapter-factory.ts:68` est :

```typescript
throw new NotSupportedError(
  `${provider} n'expose pas d'API retail publique — utilisez l'import CSV via /imports.`,
);
```

Le test à `adapters.spec.ts:133-134` cherchait `/API publique/` qui ne matche pas à cause de **"retail"** intercalé. Le test a été cassé quand quelqu'un a ajouté "retail" au message pour clarifier que c'est l'absence d'API CLIENTS retail (pas l'API entreprise/B2B).

## Fix

Regex `/API.*publique/` qui :
- ✅ Match le message actuel `"...d'API retail publique..."`
- ✅ Match l'ancien wording `"...d'API publique..."` (rétrocompat)
- ✅ Tolère un futur ajustement de texte (`"...API retail publique standard..."`)

## Impact

| Avant | Après |
|---|---|
| Suite apps/api : **407/408** (1 fail pré-existant) | **408/408** |

## Validation

- ✅ Jest `adapters` : 21/21
- ✅ Aucune modif du code de prod (`adapter-factory.ts` intact)
- ✅ Pas de migration / pas d'effet runtime

Mini-PR isolée — pas de dépendance avec les autres PRs en flight (#26 P1).

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_