### PR TITLE
feat(regime): wire Binance ticker24h + funding inputs to TacticalRegime classifier

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -2567,16 +2567,39 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
 
     // P1 — Classifier le régime tactique courant à partir des indicateurs
     // qu'on vient de fetcher. Le service cache 5 min en interne et persiste
-    // dans market_regimes_log. Si tous les inputs critiques sont absents,
-    // le classifier retourne NEUTRAL avec reason `inputs_unavailable`.
+    // dans market_regimes_log.
+    //
+    // PR feat/regime-inputs-binance — enrichissement des inputs depuis
+    // Binance Spot/Futures :
+    //  - btc24hReturnPct exact via /api/v3/ticker/24hr (priceChangePct)
+    //  - btcFundingPct via /fapi/v1/premiumIndex (fundingRatePct, 8h period)
+    //
+    // Inputs encore null (cycles à venir) :
+    //  - atr14BtcPct, atr50BtcPct → EodhdTechnicalService BTC bars
+    //  - newsScore → NewsRankerService aggregate
+    //  - realized1hPct → BinanceMarketService 1m klines 60min
+    //  - redditSpikeSigma → RedditService
     let tacticalRegime: ReturnType<typeof this.marketRegime.peekCurrentRegime> = null;
     try {
-      const btc24hReturnPct = btc != null && fallback.btcUsd > 0
-        ? ((btc - fallback.btcUsd) / fallback.btcUsd) * 100
-        : null; // approx — compute avec last-known si dispo plus tard
+      // Fetch Binance enrichment (avec timeout court + parallèle pour éviter
+      // de bloquer le snapshot si Binance ralentit).
+      const [ticker24h, futureStats] = await Promise.all([
+        this.binanceMarket.getTicker24h('BTCUSDT').catch(() => null),
+        this.binanceMarket.getFutureStats('BTCUSDT').catch(() => null),
+      ]);
+
+      const btc24hReturnPct =
+        ticker24h && Number.isFinite(ticker24h.priceChangePct)
+          ? ticker24h.priceChangePct
+          : null;
+      const btcFundingPct =
+        futureStats && Number.isFinite(futureStats.fundingRatePct)
+          ? futureStats.fundingRatePct
+          : null;
+
       const inputs = {
-        btc24hReturnPct: null as number | null,
-        btcFundingPct: null as number | null,
+        btc24hReturnPct,
+        btcFundingPct,
         vix: vix ?? null,
         atr14BtcPct: null as number | null,
         atr50BtcPct: null as number | null,
@@ -2584,11 +2607,6 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         realized1hPct: null as number | null,
         redditSpikeSigma: null as number | null,
       };
-      // btc24hReturnPct via fallback (approximation — V2 utilisera un
-      // historical price service dédié pour le calcul exact 24h).
-      if (btc24hReturnPct != null && Number.isFinite(btc24hReturnPct)) {
-        inputs.btc24hReturnPct = btc24hReturnPct;
-      }
       tacticalRegime = await this.marketRegime.getCurrentRegime(inputs);
     } catch (e) {
       this.logger.warn(`[regime] classify failed (non-blocking): ${String(e).slice(0, 100)}`);


### PR DESCRIPTION
## Pourquoi (continuité PR #26)

PR #26 a livré le `MarketRegimeService` + classifier mais les inputs `btc24hReturnPct` / `btcFundingPct` étaient **null** faute de câblage. Conséquence en prod : la majorité des cycles tombaient en `NEUTRAL` avec reason `inputs_unavailable` ou juste sur VIX seul → BULL/BEAR n'auraient jamais pu se déclencher → couche tactique inerte.

## Quoi

Cette PR câble les 2 inputs critiques BULL/BEAR depuis `BinanceMarketService` (déjà injecté dans `LisaService`) :

| Input classifier | Source Binance | Endpoint |
|---|---|---|
| `btc24hReturnPct` | `getTicker24h('BTCUSDT').priceChangePct` | `/api/v3/ticker/24hr` (Spot) |
| `btcFundingPct` | `getFutureStats('BTCUSDT').fundingRatePct` | `/fapi/v1/premiumIndex` (Futures) |

### Détails implem

- Les 2 fetches en parallèle avec `.catch(() => null)` chacun → pas de blocage du snapshot si Binance ralentit
- Validation `Number.isFinite` avant push dans `inputs` (defensive)
- Fall-through vers `NEUTRAL` si tous null (comportement préservé du PR #26)

## Comportement attendu post-deploy

| Scénario marché | Classifier output |
|---|---|
| BTC +2.5% en 24h + funding +0.015% | **BULL** (sizing +20%, TP ladder 1.5/2.5/4%) |
| BTC -3% + funding -0.02% | **BEAR** (sizing -30%, TP 1.5%) |
| BTC stable, ATR comprimé encore null | NEUTRAL (jusqu'au câblage ATR — PR suivante) |
| VIX > 25 | **VOL_SPIKE** (interrupt prio 2, peu importe BTC) |

## Inputs encore à câbler (PRs follow-up)

- `atr14BtcPct` + `atr50BtcPct` → `EodhdTechnicalService.getIndicators` sur BTC
- `newsScore` → `NewsRankerService` aggregate top score
- `realized1hPct` → `BinanceMarketService.getKlines '1m'` × 60 → stddev rolling
- `redditSpikeSigma` → `RedditService` — déjà compute, à exposer

## Tests

- ✅ 30/30 classifier preserved (rebase sur main post #26 + #27)
- Pas de nouveau test ajouté ici : la modification est purement plumbing (`ticker24h?.priceChangePct ?? null`). La logique métier est couverte par les 30 cas du classifier qui prennent `btc24hReturnPct` + `btcFundingPct` directement en input.

## Validation post-deploy

- Inspecter `LisaService.getMacroQuoteSourceCounters()` (P0-B) pour confirmer que Binance répond bien
- Lire les lignes `market_regimes_log` (P1) : si on commence à voir des BULL/BEAR au lieu de NEUTRAL constant, le câblage marche

## Pré-requis runtime

Aucun. Binance Spot/Futures sont des endpoints publics no-auth. Si Binance est unreachable depuis Fly.io (rare), `inputs.btc24hReturnPct = null` → fall-through NEUTRAL silent (comportement déjà testé en PR #26).

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_