### PR TITLE
feat(regime): wire ATR14/ATR50 BTC inputs (débloque RANGE detection)

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -50,6 +50,7 @@ import { EodhdOptionsService } from './eodhd-options.service';
 import { BinanceLiquidationsService } from './binance-liquidations.service';
 import { ApiCostTrackerService, BudgetExceededError } from './api-cost-tracker.service';
 import { MarketRegimeService } from './market-regime.service';
+import { computeAtrPct } from '@smartvest/ai-analyst';
 import {
   buildYahooChartUrl,
   buildStooqCsvUrl,
@@ -2583,9 +2584,13 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     try {
       // Fetch Binance enrichment (avec timeout court + parallèle pour éviter
       // de bloquer le snapshot si Binance ralentit).
-      const [ticker24h, futureStats] = await Promise.all([
+      // - 24h ticker : btc24hReturnPct
+      // - futures premium index : btcFundingPct
+      // - 51 daily klines : ATR14 + ATR50 BTC pour détection RANGE
+      const [ticker24h, futureStats, dailyKlines] = await Promise.all([
         this.binanceMarket.getTicker24h('BTCUSDT').catch(() => null),
         this.binanceMarket.getFutureStats('BTCUSDT').catch(() => null),
+        this.binanceMarket.getKlines('BTCUSDT', '1d', 51).catch(() => null),
       ]);
 
       const btc24hReturnPct =
@@ -2597,12 +2602,20 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
           ? futureStats.fundingRatePct
           : null;
 
+      // ATR14 / ATR50 en % du dernier close (BTC daily). Pure helper, no I/O.
+      let atr14BtcPct: number | null = null;
+      let atr50BtcPct: number | null = null;
+      if (dailyKlines && dailyKlines.length >= 51) {
+        atr14BtcPct = computeAtrPct(dailyKlines, 14);
+        atr50BtcPct = computeAtrPct(dailyKlines, 50);
+      }
+
       const inputs = {
         btc24hReturnPct,
         btcFundingPct,
         vix: vix ?? null,
-        atr14BtcPct: null as number | null,
-        atr50BtcPct: null as number | null,
+        atr14BtcPct,
+        atr50BtcPct,
         newsScore: null as number | null,
         realized1hPct: null as number | null,
         redditSpikeSigma: null as number | null,

--- a/packages/ai-analyst/src/regime/__tests__/atr-helper.spec.ts
+++ b/packages/ai-analyst/src/regime/__tests__/atr-helper.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests pour computeAtrPct — pure helper.
+ */
+import { computeAtrPct, type OhlcBar } from '../atr-helper';
+
+function bar(high: number, low: number, close: number): OhlcBar {
+  return { high, low, close };
+}
+
+describe('computeAtrPct — happy path', () => {
+  it('computes ATR14 on 15 bars (minimum)', () => {
+    // 15 bars : besoin de prev close pour le 1er TR du fenêtre 14.
+    // Tous les bars : high-low = 1, prev_close gap = 0 → TR = 1
+    // ATR = 1, last close = 100 → ATR% = 1%
+    const bars: OhlcBar[] = Array.from({ length: 15 }, (_, i) => bar(101 + i, 100 + i, 100 + i));
+    const atrPct = computeAtrPct(bars, 14);
+    expect(atrPct).not.toBeNull();
+    // ATR depends on gap close-to-high, but for our linear sequence it's
+    // dominated by the same daily range (1 USD on $100-115). Anyway just
+    // verify it's positive and reasonable.
+    expect(atrPct!).toBeGreaterThan(0);
+    expect(atrPct!).toBeLessThan(5);
+  });
+
+  it('returns higher ATR when bars are more volatile', () => {
+    // Volatile : range 5, calm : range 0.1
+    const calm: OhlcBar[] = Array.from({ length: 20 }, () => bar(100.05, 99.95, 100));
+    const volatile: OhlcBar[] = Array.from({ length: 20 }, () => bar(102.5, 97.5, 100));
+    const atrCalm = computeAtrPct(calm, 14)!;
+    const atrVolatile = computeAtrPct(volatile, 14)!;
+    expect(atrVolatile).toBeGreaterThan(atrCalm * 10); // ordre de magnitude
+  });
+
+  it('ratio ATR14/ATR50 < 0.8 when last 14 bars are calmer than the 50', () => {
+    // 37 bars volatile + 14 bars calm = 51 bars (need period+1=51 pour ATR50)
+    const bars: OhlcBar[] = [
+      ...Array.from({ length: 37 }, () => bar(102, 98, 100)),
+      ...Array.from({ length: 14 }, () => bar(100.2, 99.8, 100)),
+    ];
+    const atr14 = computeAtrPct(bars, 14)!;
+    const atr50 = computeAtrPct(bars, 50)!;
+    expect(atr14).not.toBeNull();
+    expect(atr50).not.toBeNull();
+    expect(atr14 / atr50).toBeLessThan(0.8); // déclenche RANGE
+  });
+
+  it('ratio ATR14/ATR50 ≈ 1 when bars are uniformly volatile', () => {
+    const bars: OhlcBar[] = Array.from({ length: 51 }, () => bar(101, 99, 100));
+    const atr14 = computeAtrPct(bars, 14)!;
+    const atr50 = computeAtrPct(bars, 50)!;
+    const ratio = atr14 / atr50;
+    expect(ratio).toBeGreaterThan(0.85);
+    expect(ratio).toBeLessThan(1.15);
+  });
+});
+
+describe('computeAtrPct — edge cases', () => {
+  it('returns null when bars.length < period + 1', () => {
+    const bars: OhlcBar[] = Array.from({ length: 14 }, () => bar(101, 99, 100));
+    expect(computeAtrPct(bars, 14)).toBeNull();
+    expect(computeAtrPct(Array.from({ length: 50 }, () => bar(101, 99, 100)), 50)).toBeNull();
+  });
+
+  it('returns null when bars.length === period (need period+1 minimum)', () => {
+    const bars: OhlcBar[] = Array.from({ length: 14 }, () => bar(101, 99, 100));
+    expect(computeAtrPct(bars, 14)).toBeNull();
+  });
+
+  it('accepts exactly period + 1 bars (boundary)', () => {
+    const bars: OhlcBar[] = Array.from({ length: 15 }, () => bar(101, 99, 100));
+    expect(computeAtrPct(bars, 14)).not.toBeNull();
+  });
+
+  it('returns null on period < 1', () => {
+    const bars: OhlcBar[] = Array.from({ length: 20 }, () => bar(101, 99, 100));
+    expect(computeAtrPct(bars, 0)).toBeNull();
+    expect(computeAtrPct(bars, -1)).toBeNull();
+  });
+
+  it('returns null when bars is not an array', () => {
+    expect(computeAtrPct(null as unknown as OhlcBar[], 14)).toBeNull();
+    expect(computeAtrPct(undefined as unknown as OhlcBar[], 14)).toBeNull();
+  });
+
+  it('returns null when bars contain NaN/Infinity', () => {
+    const bars: OhlcBar[] = [
+      ...Array.from({ length: 14 }, () => bar(101, 99, 100)),
+      bar(NaN, 99, 100),
+    ];
+    expect(computeAtrPct(bars, 14)).toBeNull();
+  });
+
+  it('returns null when bars contain 0 or negative prices', () => {
+    const bars1: OhlcBar[] = [
+      ...Array.from({ length: 14 }, () => bar(101, 99, 100)),
+      bar(0, 0, 0),
+    ];
+    expect(computeAtrPct(bars1, 14)).toBeNull();
+
+    const bars2: OhlcBar[] = [
+      ...Array.from({ length: 14 }, () => bar(101, 99, 100)),
+      bar(-1, 99, 100),
+    ];
+    expect(computeAtrPct(bars2, 14)).toBeNull();
+  });
+
+  it('returns null when high < low (data corruption)', () => {
+    const bars: OhlcBar[] = [
+      ...Array.from({ length: 14 }, () => bar(101, 99, 100)),
+      bar(99, 101, 100), // inversed
+    ];
+    expect(computeAtrPct(bars, 14)).toBeNull();
+  });
+
+  it('handles realistic BTC daily bars (50 days, ~2-4% range)', () => {
+    // Simule ~50 jours BTC avec range typique 2-4% du prix
+    const bars: OhlcBar[] = Array.from({ length: 51 }, (_, i) => {
+      const close = 70000 + i * 100;
+      return { high: close * 1.025, low: close * 0.975, close };
+    });
+    const atr14 = computeAtrPct(bars, 14)!;
+    const atr50 = computeAtrPct(bars, 50)!;
+    expect(atr14).toBeGreaterThan(2); // > 2%
+    expect(atr14).toBeLessThan(6);    // < 6%
+    expect(atr50).toBeGreaterThan(2);
+    expect(atr50).toBeLessThan(6);
+  });
+});

--- a/packages/ai-analyst/src/regime/atr-helper.ts
+++ b/packages/ai-analyst/src/regime/atr-helper.ts
@@ -1,0 +1,65 @@
+/**
+ * P1 — ATR (Average True Range) helper pour TacticalRegime classifier.
+ *
+ * Pure function (no I/O). Le caller fetch les bars via le provider (Binance
+ * klines) et passe le tableau ici pour calcul.
+ *
+ * Définition ATR (Wilder simplifié) :
+ *   TR_i = max(high_i - low_i, |high_i - close_{i-1}|, |low_i - close_{i-1}|)
+ *   ATR_N = moyenne arithmétique des N derniers TR
+ *
+ * On retourne ATR en POURCENTAGE du dernier close (réf. close pour
+ * comparer entre actifs / horizons / conditions de prix). Le classifier
+ * compare `atr14_pct < 0.8 × atr50_pct` pour détecter RANGE.
+ */
+
+export interface OhlcBar {
+  high: number;
+  low: number;
+  close: number;
+}
+
+/**
+ * Calcule l'ATR sur N périodes en POURCENTAGE du dernier close.
+ *
+ * Conditions :
+ *  - bars.length >= period + 1 (besoin de close_{i-1} pour le 1er TR)
+ *  - dernier close > 0 (sinon division par zéro)
+ *  - tous les prix high/low/close finite et > 0
+ *
+ * Retourne null si les conditions ne sont pas réunies.
+ */
+export function computeAtrPct(bars: OhlcBar[], period: number): number | null {
+  if (!Array.isArray(bars)) return null;
+  if (period < 1) return null;
+  if (bars.length < period + 1) return null;
+
+  // Sanity check : tous les bars doivent avoir des nombres valides.
+  for (const b of bars) {
+    if (!Number.isFinite(b.high) || !Number.isFinite(b.low) || !Number.isFinite(b.close)) {
+      return null;
+    }
+    if (b.high <= 0 || b.low <= 0 || b.close <= 0) return null;
+    if (b.high < b.low) return null; // cohérence
+  }
+
+  // Calcule TR sur les `period` derniers bars (en utilisant le close du
+  // bar précédent comme référence).
+  const startIdx = bars.length - period;
+  let sumTr = 0;
+  for (let i = startIdx; i < bars.length; i++) {
+    const cur = bars[i];
+    const prev = bars[i - 1]; // garanti existant car bars.length >= period+1
+    const tr = Math.max(
+      cur.high - cur.low,
+      Math.abs(cur.high - prev.close),
+      Math.abs(cur.low - prev.close),
+    );
+    sumTr += tr;
+  }
+  const atr = sumTr / period;
+
+  const lastClose = bars[bars.length - 1].close;
+  if (lastClose <= 0) return null;
+  return (atr / lastClose) * 100;
+}

--- a/packages/ai-analyst/src/regime/index.ts
+++ b/packages/ai-analyst/src/regime/index.ts
@@ -1,1 +1,2 @@
 export * from './market-regime-classifier';
+export * from './atr-helper';


### PR DESCRIPTION
## Pourquoi

Suite directe de PR #28. Sans ATR câblés, le régime **RANGE** ne pouvait jamais fire (trigger : `ATR14 < 0.8 × ATR50` ET `|btc_24h| < 1%`). Conséquence : zéro détection de compression de range → zéro mode scalping intraday (TP 0.8% / SL 1.2%) → opportunités MTF perdues quand BTC stagne.

## Quoi

### `packages/ai-analyst/src/regime/atr-helper.ts` (nouveau)

`computeAtrPct(bars, period)` — pure helper :
- Calcule ATR Wilder simplifié (SMA des True Range sur N périodes)
- Retourne en **% du dernier close** (comparable cross-asset/horizon)
- Defensive : null si bars insuffisants, prix invalides, high<low, period<1

### `LisaService.fetchMarketSnapshot`

Fetch 51 daily klines BTC en parallèle des autres inputs Binance :
```typescript
const [ticker24h, futureStats, dailyKlines] = await Promise.all([
  binanceMarket.getTicker24h('BTCUSDT'),
  binanceMarket.getFutureStats('BTCUSDT'),
  binanceMarket.getKlines('BTCUSDT', '1d', 51),
]);
// ...
atr14BtcPct = computeAtrPct(dailyKlines, 14);
atr50BtcPct = computeAtrPct(dailyKlines, 50);
```

## Tests — 13/13 verts

`atr-helper.spec.ts` :
- Happy : 15 bars min, ratio < 0.8 sur compression (37 volatile + 14 calm), ratio ≈ 1 uniforme
- Edges : boundary period+1, period<1, NaN/Infinity, 0/négatif, high<low corruption
- Realistic : 50 jours BTC ~2-4% range → ATR% in [2%, 6%]

## Validation

- ✅ `tsc --noEmit` clean
- ✅ Jest classifier : 30/30 préservé
- ✅ Strictement additif (pas de breaking change)

## Inputs restants (PRs B-E)

- `newsScore` → NewsRankerService (PR B)
- `realized1hPct` → 1m klines stddev (PR D)
- `redditSpikeSigma` → RedditService (PR E)
- `RiskEnforcer.sizingMultiplier` (PR C)

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_