### PR TITLE
feat(regime): wire newsScore (NewsRankerService) — débloque NEWS_SHOCK regime

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -569,6 +569,26 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
           relevance: r.scores.final >= 70 ? 'high' : r.scores.final >= 40 ? 'medium' : 'low',
           sentiment: r.sentiment,
         }));
+
+        // P1 — re-classify le régime tactique avec le newsScore enrichi.
+        // NewsRanker scores 0-100, classifier seuil > 7 sur échelle 0-10
+        // → on divise par 10 pour aligner. Top item = max score.final.
+        const topNewsScore = ranked.length > 0 ? ranked[0].scores.final / 10 : null;
+        if (topNewsScore != null && Number.isFinite(topNewsScore)) {
+          const reclassified = await this.marketRegime.reclassifyWithExtras({
+            newsScore: topNewsScore,
+          });
+          if (reclassified && marketSnapshot.tacticalRegime) {
+            marketSnapshot.tacticalRegime = {
+              regime: reclassified.regime,
+              reasons: reclassified.reasons,
+              sizingMultiplier: reclassified.sizingMultiplier,
+              stopLossPct: reclassified.stopLossPct,
+              takeProfitPct: reclassified.takeProfitPct,
+              takeProfitLadderPct: reclassified.takeProfitLadderPct,
+            };
+          }
+        }
       }
     } catch (e) {
       this.logger.warn(`news aggregator failure (non-blocking): ${String(e).slice(0, 200)}`);

--- a/apps/api/src/modules/lisa/services/market-regime.service.ts
+++ b/apps/api/src/modules/lisa/services/market-regime.service.ts
@@ -56,6 +56,25 @@ export class MarketRegimeService {
   }
 
   /**
+   * Re-classifie en mergeant des inputs supplémentaires fetchés tardivement
+   * dans le cycle (ex: newsScore disponible après NewsRankerService, ou
+   * realized_1h après klines 1m). Met à jour le cache + persiste.
+   *
+   * No-op si pas de cache initial — le caller est censé avoir appelé
+   * `getCurrentRegime` avant.
+   */
+  async reclassifyWithExtras(extras: Partial<RegimeInputs>): Promise<RegimeClassification | null> {
+    if (!this.cached) return null;
+    const merged: RegimeInputs = { ...this.cached.inputs, ...extras };
+    const result = classifyTacticalRegime(merged);
+    this.cached = { result, asOf: Date.now(), inputs: merged };
+    void this.persist(result, merged).catch((e) => {
+      this.logger.warn(`[regime] reclassify persist failed (non-blocking): ${String(e).slice(0, 120)}`);
+    });
+    return result;
+  }
+
+  /**
    * Snapshot du régime courant SANS recalcul. Retourne null si pas encore
    * classifié dans le cycle de vie du process. Utile pour les call sites
    * qui veulent juste lire (ex: UI status sans déclencher une classif).


### PR DESCRIPTION
## Pourquoi

Suite directe PRs #28 + #29. Le régime **NEWS_SHOCK** (interrupt prio 1) nécessite `newsScore > 7` sur échelle 0-10. Sans câblage, ce régime ne pouvait jamais fire → catalyseurs majeurs (Fed pivot, geopolitical shock, Iran/Hormuz news) ignorés par la couche tactique.

## Quoi

### `MarketRegimeService.reclassifyWithExtras(extras)` (nouveau)

Permet de re-classifier en mergeant des inputs fetchés tardivement (après le 1er appel `getCurrentRegime`). Met à jour le cache + persiste dans `market_regimes_log`.

### `LisaService.generateProposal` (post-news ranking)

```typescript
const topNewsScore = ranked[0].scores.final / 10;  // 0-100 → 0-10
const reclassified = await marketRegime.reclassifyWithExtras({
  newsScore: topNewsScore,
});
marketSnapshot.tacticalRegime = reclassified ? mapped(reclassified) : original;
```

## Pattern à 2 phases

| Phase | Inputs | Résultat |
|---|---|---|
| 1 (fetchMarketSnapshot) | BTC ticker24h, funding, ATR14/50, VIX | Régime initial (BULL/BEAR/RANGE/VOL_SPIKE/NEUTRAL) |
| 2 (post-news) | + newsScore | Enrichi → peut override en NEWS_SHOCK |

Lisa reçoit toujours la classification la plus complète disponible.

## Validation

- ✅ `tsc --noEmit` clean
- ✅ Pas de nouveau test nécessaire — `classifyTacticalRegime` déjà couvert par 30 cas (PR #26) dont NEWS_SHOCK priorité 1, threshold strict (>7), priority sur VOL_SPIKE
- ✅ Strictement additif (no-op si pas de cache initial)

## Inputs restants (PRs D + E + C)

- `realized1hPct` → 1m klines stddev (PR D)
- `redditSpikeSigma` → RedditService (PR E)
- `RiskEnforcer.sizePosition` avec `sizingMultiplier` (PR C — applique +20%/-30% sur sizing réel)

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_