### PR TITLE
feat(risk): wire RegimeSizingOption to RiskEnforcer.enforce (PR C)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/risk-enforcer-regime-sizing.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/risk-enforcer-regime-sizing.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * PR C — RiskEnforcer wire sizingMultiplier du régime tactique.
+ *
+ * Vérifie que :
+ *  - multiplier 1.2 (BULL) : pctCapital × 1.2, amountUsd × 1.2
+ *  - multiplier 0.7 (BEAR) : pctCapital × 0.7
+ *  - multiplier 0   (VOL_SPIKE) : toutes allocations à 0, cash 100%
+ *  - multiplier 1.0 (NEUTRAL) : no-op (pas de warning)
+ *  - cashReservePct recompute cohérent post-shrink
+ *  - warning REGIME_SIZING_APPLIED (ou REGIME_SKIP) émis pour audit
+ *  - sans regimeSizing : comportement legacy préservé
+ */
+import {
+  RiskEnforcer,
+  type AllocationProposal,
+  type RegimeSizingOption,
+} from '@smartvest/ai-analyst';
+
+function baseProposal(allocPct: number = 25): AllocationProposal {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    capitalUsd: '10000',
+    baseCurrency: 'EUR',
+    detectedRegime: 'mid_cycle_expansion',
+    marketMomentum: 'neutral',
+    regimeSummary: 'test',
+    favoredPockets: [],
+    avoidedPockets: [],
+    theses: [
+      {
+        id: '00000000-0000-0000-0000-000000000010',
+        title: 'test thesis',
+        summary: 'test',
+        catalyst: 'test catalyst',
+        whoIsWrong: 'consensus',
+        category: 'flow_timing',
+        kind: 'momentum',
+        themes: [],
+        autonomyRules: [],
+        expressions: [
+          {
+            symbol: 'TEST',
+            name: 'Test',
+            assetClass: 'equity_us_large',
+            preferredVenue: 'IBKR',
+            direction: 'long',
+            sizingMethod: 'pct_portfolio',
+            sizingValue: '0.25',
+            estimatedCostBps: 5,
+            averageDailyVolumeUsd: '5000000',
+            whyThisExpression: 'liquid',
+          },
+        ],
+        preferredExpressionIndex: 0,
+        expressionChoiceRationale: 'best',
+        riskReward: {
+          centralScenarioReturnPct: { low: 5, mid: 10, high: 15 },
+          adverseScenarioReturnPct: -5,
+          riskRewardRatio: 2,
+          horizonDays: 7,
+          convexitySources: [],
+        },
+        invalidation: {
+          conditions: [
+            { description: 'broken', metricType: 'price', thresholdValue: '90', thresholdDirection: 'below' as const },
+          ],
+          qualitativeConditions: [],
+        },
+        antiBullshit: {
+          isCrowded: false,
+          isCrowdedRationale: 'low coverage',
+          driverType: 'fundamentals_cashflow' as const,
+          evidenceType: 'hard_data' as const,
+          selfCritique: 'minor',
+        },
+        analogSlugs: [],
+        confidenceScore: 70,
+        generatedAt: new Date().toISOString(),
+        claudeMeta: { model: 'opus', inputTokens: 100, outputTokens: 50 },
+      },
+    ],
+    allocations: [
+      { thesisId: '00000000-0000-0000-0000-000000000010', pctCapital: allocPct, amountUsd: String(100 * allocPct) },
+    ],
+    cashReservePct: 100 - allocPct,
+    portfolioRiskLens: {
+      annualizedVolatilityPct: 15,
+      var95_1day_pct: 2,
+      expectedShortfall95_1day_pct: 2.5,
+      historicalMaxDrawdownPct: 10,
+      daysToExit50pct: 1,
+      correlationsToBenchmarks: { sp500: 0.5, gold: 0, btc: 0, dxy: 0, us10y: 0 },
+      stressTests: [],
+    },
+    constraints: {
+      maxDrawdown2DaysPct: 10,
+      maxDrawdown7DaysPct: 15,
+      maxDrawdown30DaysPct: 25,
+      maxPositionSizePct: 30,
+      maxOpenPositions: 10,
+      maxLeverage: 1,
+      maxExposurePerAssetClassPct: 40,
+      maxPortfolioVolatilityPct: 20,
+      targetDeploymentPct: 60,
+      autoLiquidateOnKill: true,
+    },
+    warnings: [],
+    generatedAt: new Date().toISOString(),
+    status: 'proposed',
+  };
+}
+
+describe('RiskEnforcer — regime sizing (PR C)', () => {
+  const enforcer = new RiskEnforcer();
+
+  it('multiplier 1.2 (BULL) : applique × 1.2 sur pctCapital + amountUsd', () => {
+    const sizing: RegimeSizingOption = { multiplier: 1.2, regime: 'BULL', reason: 'btc_24h>+2% AND funding>0.01%' };
+    const result = enforcer.enforce(baseProposal(20), undefined, undefined, sizing);
+    expect(result.adjustedProposal).not.toBeNull();
+    expect(result.adjustedProposal!.allocations[0].pctCapital).toBeCloseTo(24, 5); // 20 × 1.2
+    expect(Number(result.adjustedProposal!.allocations[0].amountUsd)).toBeCloseTo(2400, 1); // 2000 × 1.2
+    expect(result.adjustedProposal!.cashReservePct).toBeCloseTo(76, 5);
+    expect(result.violations.some((v) => v.code === 'REGIME_SIZING_APPLIED')).toBe(true);
+  });
+
+  it('multiplier 0.7 (BEAR) : applique × 0.7 (-30%)', () => {
+    const sizing: RegimeSizingOption = { multiplier: 0.7, regime: 'BEAR' };
+    const result = enforcer.enforce(baseProposal(20), undefined, undefined, sizing);
+    expect(result.adjustedProposal!.allocations[0].pctCapital).toBeCloseTo(14, 5);
+    expect(Number(result.adjustedProposal!.allocations[0].amountUsd)).toBeCloseTo(1400, 1);
+    expect(result.adjustedProposal!.cashReservePct).toBeCloseTo(86, 5);
+  });
+
+  it('multiplier 0 (VOL_SPIKE) : drop TOUTES allocations + cash 100%', () => {
+    const sizing: RegimeSizingOption = { multiplier: 0, regime: 'VOL_SPIKE', reason: 'vix=30 > 25' };
+    const result = enforcer.enforce(baseProposal(20), undefined, undefined, sizing);
+    expect(result.adjustedProposal).not.toBeNull();
+    expect(result.adjustedProposal!.allocations[0].pctCapital).toBe(0);
+    expect(result.adjustedProposal!.allocations[0].amountUsd).toBe('0');
+    expect(result.adjustedProposal!.cashReservePct).toBe(100);
+    expect(result.violations.some((v) => v.code === 'REGIME_SKIP')).toBe(true);
+  });
+
+  it('multiplier 1.0 (NEUTRAL) : no-op (pas de warning REGIME_SIZING_APPLIED)', () => {
+    const sizing: RegimeSizingOption = { multiplier: 1.0, regime: 'NEUTRAL' };
+    const result = enforcer.enforce(baseProposal(20), undefined, undefined, sizing);
+    expect(result.adjustedProposal!.allocations[0].pctCapital).toBe(20);
+    expect(result.violations.some((v) => v.code === 'REGIME_SIZING_APPLIED')).toBe(false);
+  });
+
+  it('sans regimeSizing : comportement legacy préservé (pas de warning)', () => {
+    const result = enforcer.enforce(baseProposal(20));
+    expect(result.adjustedProposal!.allocations[0].pctCapital).toBe(20);
+    expect(result.violations.some((v) => v.code.startsWith('REGIME_'))).toBe(false);
+  });
+
+  it('warning message inclut le regime + reason', () => {
+    const sizing: RegimeSizingOption = { multiplier: 1.2, regime: 'BULL', reason: 'btc_24h+3% funding+0.02%' };
+    const result = enforcer.enforce(baseProposal(20), undefined, undefined, sizing);
+    const warning = result.violations.find((v) => v.code === 'REGIME_SIZING_APPLIED');
+    expect(warning?.message).toContain('BULL');
+    expect(warning?.message).toContain('1.20');
+  });
+
+  it('proposal.warnings reçoit la trace [regime] sizing×X', () => {
+    const sizing: RegimeSizingOption = { multiplier: 1.2, regime: 'BULL' };
+    const result = enforcer.enforce(baseProposal(20), undefined, undefined, sizing);
+    const traced = result.adjustedProposal!.warnings.find((w) => w.startsWith('[regime]'));
+    expect(traced).toBeDefined();
+    expect(traced).toContain('BULL');
+    expect(traced).toContain('1.20');
+  });
+
+  it('post-shrink size 24% reste sous maxPositionSizePct=30 (no false POSITION_SIZE_EXCEEDED)', () => {
+    // BULL × 1.2 sur alloc 25% → 30% post-shrink. Borderline.
+    const sizing: RegimeSizingOption = { multiplier: 1.2, regime: 'BULL' };
+    const result = enforcer.enforce(baseProposal(25), undefined, undefined, sizing);
+    // 25 × 1.2 = 30 = exactly at the cap → ne fail pas
+    expect(result.violations.some((v) => v.code === 'POSITION_SIZE_EXCEEDED')).toBe(false);
+  });
+
+  it('post-shrink size > maxPositionSizePct triggers POSITION_SIZE_EXCEEDED check', () => {
+    // BULL × 1.2 sur alloc 28% → 33.6% > maxPositionSize 30%
+    const sizing: RegimeSizingOption = { multiplier: 1.2, regime: 'BULL' };
+    const result = enforcer.enforce(baseProposal(28), undefined, undefined, sizing);
+    expect(result.violations.some((v) => v.code === 'POSITION_SIZE_EXCEEDED')).toBe(true);
+  });
+
+  it('multiplier non-finite (NaN, Infinity) : ignoré (no-op safety)', () => {
+    const sizing: RegimeSizingOption = { multiplier: NaN, regime: 'CORRUPTED' };
+    const result = enforcer.enforce(baseProposal(20), undefined, undefined, sizing);
+    expect(result.adjustedProposal!.allocations[0].pctCapital).toBe(20); // no shrink
+    expect(result.violations.some((v) => v.code.startsWith('REGIME_'))).toBe(false);
+  });
+});

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -892,7 +892,25 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       const pct = capitalNum > 0 ? (notional / capitalNum) * 100 : 0;
       existingExposureByAssetClassPct[cls] = (existingExposureByAssetClassPct[cls] ?? 0) + pct;
     }
-    const enforcement = this.riskEnforcer.enforce(result.proposal, existingExposureByAssetClassPct);
+    // P1 — Régime tactique : applique sizingMultiplier sur les allocations
+    // AVANT les checks de cap. Lit le régime cached par MarketRegimeService
+    // (pas de re-fetch — le snapshot a déjà classifié post-fetchMarketSnapshot
+    // et possiblement re-classifié post-news ranking).
+    const cachedRegime = this.marketRegime.peekCurrentRegime();
+    const regimeSizing = cachedRegime
+      ? {
+          multiplier: cachedRegime.sizingMultiplier,
+          regime: cachedRegime.regime,
+          reason: cachedRegime.reasons.join(' · ').slice(0, 200),
+        }
+      : undefined;
+
+    const enforcement = this.riskEnforcer.enforce(
+      result.proposal,
+      existingExposureByAssetClassPct,
+      undefined, // existingExposureByThemePct (PATCH 3 — non câblé encore)
+      regimeSizing,
+    );
     const finalProposal = enforcement.adjustedProposal ?? result.proposal;
 
     if (!enforcement.adjustedProposal) {

--- a/packages/ai-analyst/src/allocation/risk-enforcer.ts
+++ b/packages/ai-analyst/src/allocation/risk-enforcer.ts
@@ -115,6 +115,26 @@ export function canOpen(
   return { ok: true };
 }
 
+/**
+ * P1 — Sizing multiplier dérivé du régime tactique courant. Appliqué par
+ * `RiskEnforcer.enforce()` AVANT les checks de size pour que les caps
+ * absolus opèrent sur la valeur post-shrink.
+ *
+ * Cas typiques (cf. classifyTacticalRegime) :
+ *   - BULL       : multiplier 1.2  (+20%)
+ *   - NEUTRAL/RANGE/NEWS_SHOCK : multiplier 1.0 (no-op)
+ *   - BEAR       : multiplier 0.7  (-30%)
+ *   - VOL_SPIKE  : multiplier 0.0  (skip cycle)
+ */
+export interface RegimeSizingOption {
+  /** Facteur multiplicateur sur pctCapital + amountUsd. 0 = skip total. */
+  multiplier: number;
+  /** Nom du régime (BULL/BEAR/...) pour audit + warning message. */
+  regime: string;
+  /** Reasons textuelles concises (cf. classifier output). Optionnel. */
+  reason?: string;
+}
+
 export interface RiskEnforcementResult {
   /** True si la proposition passe toutes les contraintes */
   passes: boolean;
@@ -150,11 +170,67 @@ export class RiskEnforcer {
    *   + RTX equity = 1 thème geopolitical_safehaven concentré).
    */
   enforce(
-    proposal: AllocationProposal,
+    proposalInput: AllocationProposal,
     existingExposureByAssetClassPct?: Record<string, number>,
     existingExposureByThemePct?: Record<string, number>,
+    regimeSizing?: RegimeSizingOption,
   ): RiskEnforcementResult {
     const violations: RiskEnforcementResult['violations'] = [];
+
+    // P1 — RegimeSizing : applique le sizingMultiplier du régime tactique
+    // courant (BULL +20%, BEAR -30%, VOL_SPIKE skip=0, RANGE/NEWS_SHOCK
+    // 1.0 nominal). Appliqué AVANT tous les autres checks de size pour
+    // que les caps absolus se calculent sur la valeur post-shrink.
+    //
+    // Si multiplier === 0 (VOL_SPIKE), on drop TOUT (équivalent skip
+    // cycle — Lisa peut quand même proposer mais le sizing est neutralisé,
+    // RiskEnforcer ajoute un warning pour audit).
+    let proposal: AllocationProposal = proposalInput;
+    if (regimeSizing && Number.isFinite(regimeSizing.multiplier)) {
+      const m = regimeSizing.multiplier;
+      if (m <= 0) {
+        proposal = {
+          ...proposalInput,
+          allocations: proposalInput.allocations.map((a) => ({
+            ...a,
+            pctCapital: 0,
+            amountUsd: '0',
+          })),
+          cashReservePct: 100,
+          warnings: [
+            ...proposalInput.warnings,
+            `[regime] sizing×${m} (regime=${regimeSizing.regime}) → cycle skip, cash à 100%`,
+          ],
+        };
+        violations.push({
+          code: 'REGIME_SKIP',
+          severity: 'warning',
+          message: `Regime ${regimeSizing.regime} (multiplier=${m}) : cycle skip — toutes les allocations mises à 0`,
+        });
+      } else if (m !== 1.0) {
+        const adjusted = proposalInput.allocations.map((a) => ({
+          ...a,
+          pctCapital: a.pctCapital * m,
+          amountUsd: String(Number(a.amountUsd) * m),
+        }));
+        const totalAfter = adjusted.reduce((s, a) => s + a.pctCapital, 0);
+        proposal = {
+          ...proposalInput,
+          allocations: adjusted,
+          cashReservePct: Math.max(0, Math.min(100, 100 - totalAfter)),
+          warnings: [
+            ...proposalInput.warnings,
+            `[regime] sizing×${m.toFixed(2)} (regime=${regimeSizing.regime}${regimeSizing.reason ? ` — ${regimeSizing.reason}` : ''})`,
+          ],
+        };
+        violations.push({
+          code: 'REGIME_SIZING_APPLIED',
+          severity: 'warning',
+          message: `Regime ${regimeSizing.regime} : multiplier=${m.toFixed(2)} appliqué (allocations × ${m.toFixed(2)})`,
+        });
+      }
+    }
+
     const constraints = proposal.constraints;
 
     // 1. Sum des allocations <= 100%


### PR DESCRIPTION
## Pourquoi (PR C — backlog regime)

Jusqu'ici le `sizingMultiplier` du régime tactique apparaissait **uniquement dans le briefing Lisa** (suggestion textuelle). Lisa pouvait suivre volontairement mais aucune protection si elle ignorait. Cette PR applique enfin **BULL +20% / BEAR -30% / VOL_SPIKE skip / RANGE-NEWS_SHOCK 1.0** sur le sizing **réel**, déterministe.

## Quoi

### `RegimeSizingOption` interface (exportée)

```typescript
export interface RegimeSizingOption {
  multiplier: number;     // 1.2 (BULL), 0.7 (BEAR), 0 (skip), 1.0 (no-op)
  regime: string;         // 'BULL' | 'BEAR' | ... pour audit
  reason?: string;        // raisons textuelles classifier
}
```

### `RiskEnforcer.enforce()` 4ᵉ param optionnel

```typescript
enforce(
  proposal,
  existingExposureByAssetClassPct?,
  existingExposureByThemePct?,
  regimeSizing?: RegimeSizingOption,  // ← nouveau
)
```

### Matrice comportement

| `multiplier` | Action | Audit |
|---|---|---|
| ≤ 0 | Drop **TOUTES** allocations à 0 + cash 100% | violation `REGIME_SKIP` |
| === 1.0 | no-op | rien |
| ≠ 1 finite | `pctCapital × m`, `amountUsd × m`, recompute cash | violation `REGIME_SIZING_APPLIED` + trace dans `proposal.warnings` |
| NaN / Infinity | ignoré | rien (defensive) |

**Appliqué AVANT tous les autres checks de size** → les caps absolus (POSITION_SIZE_EXCEEDED, ASSET_CLASS_CONCENTRATION) opèrent sur la valeur **post-shrink**.

### Wire dans `LisaService.generateProposal`

```typescript
const cachedRegime = this.marketRegime.peekCurrentRegime();
const regimeSizing = cachedRegime ? {
  multiplier: cachedRegime.sizingMultiplier,
  regime: cachedRegime.regime,
  reason: cachedRegime.reasons.join(' · ').slice(0, 200),
} : undefined;

enforcer.enforce(proposal, classExposure, undefined, regimeSizing);
```

`peekCurrentRegime()` lit le cache 5min sans re-fetch — le régime a déjà été classifié dans `fetchMarketSnapshot` puis re-classifié post-news (PRs précédentes).

## Tests — 10/10 verts

`risk-enforcer-regime-sizing.spec.ts` :
- BULL × 1.2, BEAR × 0.7, VOL_SPIKE × 0, NEUTRAL × 1.0, sans regimeSizing
- Cap interaction : post-shrink respecte `maxPositionSizePct=30`
- Cap interaction : post-shrink > cap déclenche `POSITION_SIZE_EXCEEDED`
- Defensive : NaN/Infinity ignoré
- Audit trail : warning + `proposal.warnings` contiennent regime + reason

## Comportement attendu post-deploy v184+

| Scénario | Régime | Action |
|---|---|---|
| BTC +3% + funding +0.02% | BULL | allocations × 1.2 (Lisa propose 20% → ouvre 24%) |
| BTC -3% + funding -0.01% | BEAR | × 0.7 (20% → 14%, réduction risque) |
| VIX > 25 | VOL_SPIKE | toutes positions à 0 (cycle skip déterministe) |
| Reste | NEUTRAL/RANGE/NEWS_SHOCK | nominal (no-op) |

## Validation

- ✅ `tsc --noEmit` clean
- ✅ Jest : 10/10 nouveaux + 7/7 legacy theme caps préservés
- ✅ Strictement additif (no-op si pas de regimeSizing)
- ✅ Cap interactions testées (post-shrink correctement vérifié)

## Hors scope (suite backlog)

- **PR D** : `realized1hPct` from 1m klines stddev (affine VOL_SPIKE detection)
- **PR E** : `redditSpikeSigma` from RedditService (affine NEWS_SHOCK)

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_