### PR TITLE
fix(ci): hotfix reddit test + add CI typecheck workflow (P0 build Fly)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI — typecheck + tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - principal
+  push:
+    branches:
+      - main
+      - principal
+
+# Évite de cumuler N jobs CI quand on push plusieurs commits rapidement.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: TypeScript build (workspace)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        # `npm ci --include=dev` garantit ts-jest + @types/* présents.
+        run: npm ci
+
+      - name: Build ai-analyst (génère dist/ pour les imports apps/api)
+        run: npm run build --workspace=@smartvest/ai-analyst
+
+      - name: Typecheck workspace (tsc -b)
+        # tsc -b exécute le typecheck en cascade sur tous les projets
+        # référencés (apps/api → packages/*). Échoue si un .spec.ts ou
+        # une source casse — bloque le merge auto avant deploy Fly.
+        run: npx tsc -b
+
+  test:
+    name: Jest unit tests
+    runs-on: ubuntu-latest
+    needs: typecheck
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build ai-analyst
+        run: npm run build --workspace=@smartvest/ai-analyst
+
+      - name: Run jest (apps/api)
+        # passWithNoTests géré par config jest, on laisse échouer si suite KO.
+        run: npm test --workspace=@smartvest/api
+
+      - name: Run jest (ai-analyst)
+        run: npm test --workspace=@smartvest/ai-analyst

--- a/apps/api/src/modules/lisa/services/__tests__/reddit-spike-sigma.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/reddit-spike-sigma.spec.ts
@@ -8,17 +8,18 @@
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { RedditService } from '../reddit.service';
-import type { EodhdNewsItem } from '@smartvest/ai-analyst';
+import type { EodhdNewsItem } from '../eodhd-enrichment.service';
 
 function fakeItem(score: number): EodhdNewsItem {
   return {
     title: 'Test post',
-    content: 'body',
     date: new Date().toISOString(),
-    sourceDomain: 'reddit.com',
     symbols: [],
     sentiment: 0,
     tags: [`source:reddit/wallstreetbets`, `score:${score}`],
+    link: null,
+    sourceDomain: 'reddit.com',
+    contentPreview: 'body',
   };
 }
 
@@ -35,36 +36,32 @@ async function makeService(): Promise<RedditService> {
 describe('RedditService.getSpikeSigma', () => {
   it('returns null with insufficient samples (< 10)', async () => {
     const svc = await makeService();
-    // Push 5 samples (sous le minimum 10)
     for (let i = 0; i < 5; i++) {
-      // Hack : appel direct à la méthode privée via cast (test-only)
       (svc as unknown as { recordEngagement: (items: EodhdNewsItem[]) => void })
         .recordEngagement([fakeItem(100)]);
     }
     expect(svc.getSpikeSigma()).toBeNull();
   });
 
-  it('returns 0 when current matches mean exactly (10 identical samples)', async () => {
+  it('returns null when 10 samples are identical (stddev=0, no div by zero)', async () => {
     const svc = await makeService();
     for (let i = 0; i < 10; i++) {
       (svc as unknown as { recordEngagement: (items: EodhdNewsItem[]) => void })
         .recordEngagement([fakeItem(1000)]);
     }
-    // 10 samples identiques → stddev=0 → returns null (no division by zero)
     expect(svc.getSpikeSigma()).toBeNull();
   });
 
   it('returns positive sigma when current >> baseline', async () => {
     const svc = await makeService();
-    // 9 samples baseline ~1000, 1 sample current 5000
     for (let i = 0; i < 9; i++) {
       (svc as unknown as { recordEngagement: (items: EodhdNewsItem[]) => void })
-        .recordEngagement([fakeItem(1000 + (i % 3) * 50)]); // léger noise
+        .recordEngagement([fakeItem(1000 + (i % 3) * 50)]);
     }
     (svc as unknown as { recordEngagement: (items: EodhdNewsItem[]) => void })
-      .recordEngagement([fakeItem(5000)]); // spike
+      .recordEngagement([fakeItem(5000)]);
     const sigma = svc.getSpikeSigma()!;
-    expect(sigma).toBeGreaterThan(5); // > 5σ → trigger NEWS_SHOCK
+    expect(sigma).toBeGreaterThan(5);
   });
 
   it('returns negative sigma when current << baseline', async () => {
@@ -74,49 +71,40 @@ describe('RedditService.getSpikeSigma', () => {
         .recordEngagement([fakeItem(1000 + (i % 3) * 50)]);
     }
     (svc as unknown as { recordEngagement: (items: EodhdNewsItem[]) => void })
-      .recordEngagement([fakeItem(100)]); // chute
+      .recordEngagement([fakeItem(100)]);
     const sigma = svc.getSpikeSigma()!;
     expect(sigma).toBeLessThan(0);
   });
 
   it('caps history at MAX (24) — drops oldest', async () => {
     const svc = await makeService();
-    // Push 30 samples : value = i pour traçabilité
     for (let i = 1; i <= 30; i++) {
       (svc as unknown as { recordEngagement: (items: EodhdNewsItem[]) => void })
         .recordEngagement([fakeItem(i * 100)]);
     }
-    // History should contain values 7..30 (24 last). Sigma is computed
-    // over those. Sample current = 30*100, baseline = mean of 7..29 = ~18*100
     const sigma = svc.getSpikeSigma()!;
     expect(Number.isFinite(sigma)).toBe(true);
   });
 
-  it('handles items with malformed score tags (NaN, missing) → 0 contribution', async () => {
+  it('handles items with malformed score tags (non-numeric → 0 contribution)', async () => {
     const svc = await makeService();
     const malformed: EodhdNewsItem = {
       ...fakeItem(0),
-      tags: ['source:reddit', 'score:abc'], // non-numeric score
+      tags: ['source:reddit', 'score:abc'],
     };
-    // Should not throw, score parse fail → 0
     (svc as unknown as { recordEngagement: (items: EodhdNewsItem[]) => void })
       .recordEngagement([malformed]);
-    // Pas de crash + history a gardé un sample (avec totalScore=0 valide)
-    // Note : 0 est < 0 ? Non, 0 n'est ni >0 ni Infinite → ignoré dans la somme
-    // mais l'item lui-même produit un push d'engagement total 0.
+    // No crash + history kept (totalScore=0 still pushed)
   });
 
   it('skips empty items array (no record)', async () => {
     const svc = await makeService();
-    // Push 9 samples normaux
     for (let i = 0; i < 9; i++) {
       (svc as unknown as { recordEngagement: (items: EodhdNewsItem[]) => void })
         .recordEngagement([fakeItem(1000)]);
     }
-    // Call avec []
     (svc as unknown as { recordEngagement: (items: EodhdNewsItem[]) => void })
       .recordEngagement([]);
-    // Sigma should still be null (history at 9, sub-threshold)
     expect(svc.getSpikeSigma()).toBeNull();
   });
 
@@ -127,6 +115,6 @@ describe('RedditService.getSpikeSigma', () => {
         .recordEngagement([fakeItem(1000 + i * 100)]);
     }
     svc.resetEngagementHistory();
-    expect(svc.getSpikeSigma()).toBeNull(); // history vide → < 10 samples
+    expect(svc.getSpikeSigma()).toBeNull();
   });
 });


### PR DESCRIPTION
## 🚨 HOTFIX URGENT — débloque le build Fly v183

PR #35 (reddit-spike-sigma) avait un test cassé qui bloquait le build Fly :

```
apps/api/src/modules/lisa/services/__tests__/reddit-spike-sigma.spec.ts
  - error TS2305: Module '"@smartvest/ai-analyst"' has no exported member 'EodhdNewsItem'
  - error TS2353: Object literal may only specify known properties, and 'content' does not exist in type 'EodhdNewsItem'
```

**Cause** : j'ai écrit le test rapidement dans PR #35 sans avoir vérifié que `EodhdNewsItem` :
1. Vit dans `apps/api/.../eodhd-enrichment.service.ts`, pas dans `@smartvest/ai-analyst`
2. A `contentPreview: string | null` (pas `content`), plus `link` + `sourceDomain` requis

## Fix

`reddit-spike-sigma.spec.ts` corrigé :
- Import depuis le bon fichier
- `fakeItem()` avec les vraies props de `EodhdNewsItem`

8/8 tests jest toujours verts. Typecheck workspace propre.

## CI workflow (le vrai garde-fou)

Nouveau `.github/workflows/ci.yml` :
- Trigger sur **`pull_request`** + push main
- Job 1 : `npx tsc -b` workspace (échoue si test ou src casse)
- Job 2 : jest sur `apps/api` + `ai-analyst` (dépend du typecheck)
- `concurrency: cancel-in-progress` pour éviter les jobs cumulatifs

**Permet d'éviter le scénario actuel** : avant ce PR, seul `Vercel Preview Comments` (frontend Next.js) checkait les PRs. Aucune validation backend → un test cassé pouvait être merged → build Fly explose en prod.

Désormais le check `CI / TypeScript build (workspace)` apparaît sur chaque PR. Le merge auto attendra qu'il soit vert.

## Validation

- ✅ `tsc --noEmit` clean
- ✅ Jest reddit-spike-sigma : 8/8
- ✅ Workflow YAML syntax valide

## Suite

Une fois cette PR mergée + CI déployée, je reprends le ticket en cours :
- Cleanup `alphavantage` paths des cascades (user n'a pas la clé) + ajouter `fred:VIXCLS` au VIX cascade

Je laisse le merge à l'auto-merge basé sur CI vert (nouveau workflow + Vercel).

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_