### PR TITLE
feat(regime): healthcheck macro inputs + WARN fail-fast (P2-A)

### DIFF
--- a/apps/api/src/modules/lisa/helpers/__tests__/regime-healthcheck.spec.ts
+++ b/apps/api/src/modules/lisa/helpers/__tests__/regime-healthcheck.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * P2-A — Tests unitaires du healthcheck inputs régime.
+ */
+import {
+  assertRegimeInputsHealthy,
+  RegimeHealthInputs,
+} from '../regime-healthcheck.helper';
+
+const HEALTHY: RegimeHealthInputs = {
+  vix: 16.5,
+  dxy: 102.3,
+  us10y: 4.2,
+  us2y: 4.8,
+  realized1hPct: 1.2,
+};
+
+describe('assertRegimeInputsHealthy', () => {
+  it('returns healthy when all 5 inputs live + no fallback', () => {
+    const v = assertRegimeInputsHealthy(HEALTHY, { fallback: [] });
+    expect(v.healthy).toBe(true);
+    expect(v.degraded).toEqual([]);
+    expect(v.shouldWarn).toBe(false);
+  });
+
+  it('does NOT warn when 1 input is null (below threshold)', () => {
+    const v = assertRegimeInputsHealthy(
+      { ...HEALTHY, vix: null },
+      { fallback: [] },
+    );
+    expect(v.healthy).toBe(false);
+    expect(v.degraded).toEqual(['vix=null']);
+    expect(v.shouldWarn).toBe(false);
+  });
+
+  it('warns when 2 inputs are null', () => {
+    const v = assertRegimeInputsHealthy(
+      { ...HEALTHY, vix: null, dxy: null },
+      { fallback: [] },
+    );
+    expect(v.shouldWarn).toBe(true);
+    expect(v.degraded).toContain('vix=null');
+    expect(v.degraded).toContain('dxy=null');
+  });
+
+  it('treats NaN/Infinity as null', () => {
+    const v = assertRegimeInputsHealthy(
+      { ...HEALTHY, vix: NaN, dxy: Infinity },
+      { fallback: [] },
+    );
+    expect(v.shouldWarn).toBe(true);
+    expect(v.degraded).toEqual(['vix=null', 'dxy=null']);
+  });
+
+  it('warns when 2 inputs are in dataQuality.fallback (stale >24h)', () => {
+    const v = assertRegimeInputsHealthy(HEALTHY, {
+      fallback: ['vix', 'us10y'],
+    });
+    expect(v.shouldWarn).toBe(true);
+    expect(v.degraded).toEqual(['vix=fallback>24h', 'us10y=fallback>24h']);
+  });
+
+  it('mixes null and fallback in the degraded count', () => {
+    const v = assertRegimeInputsHealthy(
+      { ...HEALTHY, dxy: null },
+      { fallback: ['us2y'] },
+    );
+    expect(v.shouldWarn).toBe(true);
+    expect(v.degraded).toContain('dxy=null');
+    expect(v.degraded).toContain('us2y=fallback>24h');
+  });
+
+  it('null takes precedence over fallback flag for the same key', () => {
+    const v = assertRegimeInputsHealthy(
+      { ...HEALTHY, vix: null },
+      { fallback: ['vix', 'dxy'] },
+    );
+    // vix counted once (as null), dxy counted (as fallback) → 2 entries
+    expect(v.degraded).toEqual(['vix=null', 'dxy=fallback>24h']);
+    expect(v.shouldWarn).toBe(true);
+  });
+
+  it('realized1hPct null counts but is never flagged via fallback array', () => {
+    // realized1hPct n'est pas tracké dans dataQuality (calculé en local).
+    // Même si caller met "realized1hPct" dans fallback, on ignore.
+    const v = assertRegimeInputsHealthy(
+      { ...HEALTHY, realized1hPct: null },
+      { fallback: ['realized1hPct'] },
+    );
+    expect(v.degraded).toEqual(['realized1hPct=null']);
+    expect(v.shouldWarn).toBe(false);
+  });
+
+  it('warns when 5/5 are degraded (worst case)', () => {
+    const v = assertRegimeInputsHealthy(
+      { vix: null, dxy: null, us10y: null, us2y: null, realized1hPct: null },
+      { fallback: [] },
+    );
+    expect(v.degraded).toHaveLength(5);
+    expect(v.shouldWarn).toBe(true);
+  });
+
+  it('ignores irrelevant keys in dataQuality.fallback', () => {
+    const v = assertRegimeInputsHealthy(HEALTHY, {
+      fallback: ['brent', 'gold', 'btc'],
+    });
+    expect(v.healthy).toBe(true);
+    expect(v.shouldWarn).toBe(false);
+  });
+});

--- a/apps/api/src/modules/lisa/helpers/regime-healthcheck.helper.ts
+++ b/apps/api/src/modules/lisa/helpers/regime-healthcheck.helper.ts
@@ -1,0 +1,70 @@
+/**
+ * P2-A — Healthcheck des inputs macro qui alimentent la classification régime.
+ *
+ * Si ≥ 2 indicateurs sur {vix, dxy, us10y, us2y, realized1hPct} sont null
+ * (cascade complètement échouée + cache last-known >24h périmé) ou en
+ * `dataQuality.fallback` (valeur hardcoded de dernier recours), Lisa
+ * raisonne sur une photo majoritairement statique → le verdict
+ * HORS_TRAJECTOIRE qui en sort n'est pas fiable.
+ *
+ * Pure function, testable sans I/O. Le caller décide quoi faire du verdict
+ * (log WARN structuré, métrique, alerte Sentry…).
+ *
+ * Note : `realized1hPct` ici remplace `spx_vol_realized` du backlog —
+ * notre seul réalisé disponible est BTC 1m via Binance klines (cf.
+ * computeRealizedVolPct). Mêmes propriétés (cross-asset, intraday) côté
+ * détection VOL_SPIKE, donc équivalent fonctionnel pour le healthcheck.
+ */
+
+export interface RegimeHealthInputs {
+  vix: number | null;
+  dxy: number | null;
+  us10y: number | null;
+  us2y: number | null;
+  realized1hPct: number | null;
+}
+
+export interface RegimeHealthDataQuality {
+  /** Indicateurs tombés au fallback hardcoded (toutes sources échouées
+   *  + last-known cache >24h périmé). */
+  fallback: string[];
+}
+
+export interface RegimeHealthVerdict {
+  healthy: boolean;
+  /** Liste « name=cause » des indicateurs en panne. Empty si healthy. */
+  degraded: string[];
+  /** True dès que `degraded.length >= 2` — déclenche le WARN. */
+  shouldWarn: boolean;
+}
+
+const TRACKED = ['vix', 'dxy', 'us10y', 'us2y', 'realized1hPct'] as const;
+
+export function assertRegimeInputsHealthy(
+  inputs: RegimeHealthInputs,
+  dataQuality: RegimeHealthDataQuality,
+): RegimeHealthVerdict {
+  const degraded: string[] = [];
+
+  for (const key of TRACKED) {
+    const value = inputs[key];
+    const isNull = value === null || !Number.isFinite(value);
+    // `realized1hPct` n'est pas tracké dans dataQuality (calculé en local
+    // depuis Binance klines, pas via fetchCascade). Pour les autres on
+    // considère fallback = stale > 24h.
+    const isFallback =
+      key !== 'realized1hPct' && dataQuality.fallback.includes(key);
+
+    if (isNull) {
+      degraded.push(`${key}=null`);
+    } else if (isFallback) {
+      degraded.push(`${key}=fallback>24h`);
+    }
+  }
+
+  return {
+    healthy: degraded.length === 0,
+    degraded,
+    shouldWarn: degraded.length >= 2,
+  };
+}

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -61,6 +61,7 @@ import {
   parseFredObservationsResponse,
   fetchWithRetry,
 } from '../helpers/macro-fallback.helper';
+import { assertRegimeInputsHealthy } from '../helpers/regime-healthcheck.helper';
 
 /**
  * LisaService — orchestrateur principal du module AI analyst.
@@ -2682,6 +2683,28 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         realized1hPct,
         redditSpikeSigma: null as number | null,
       };
+
+      // P2-A — Healthcheck fail-fast : si ≥2 indicateurs macro core
+      // (vix/dxy/us10y/us2y/realized1hPct) sont null ou en fallback >24h,
+      // on log un WARN structuré pour signaler que le verdict
+      // HORS_TRAJECTOIRE qui sortira de cette classification est peu fiable.
+      // Pure check, non-bloquant — on continue la classification.
+      const health = assertRegimeInputsHealthy(
+        {
+          vix: vix ?? null,
+          dxy: dxy ?? null,
+          us10y: us10y ?? null,
+          us2y: us2y ?? null,
+          realized1hPct,
+        },
+        { fallback: dataQuality.fallback },
+      );
+      if (health.shouldWarn) {
+        this.logger.warn(
+          `[regime-healthcheck] ${health.degraded.length}/5 macro inputs degraded: ${health.degraded.join(', ')} — HORS_TRAJECTOIRE potentially unreliable this cycle`,
+        );
+      }
+
       tacticalRegime = await this.marketRegime.getCurrentRegime(inputs);
     } catch (e) {
       this.logger.warn(`[regime] classify failed (non-blocking): ${String(e).slice(0, 100)}`);


### PR DESCRIPTION
## Pourquoi (P2-A)

Empêche les décisions `HORS_TRAJECTOIRE` silencieuses sur snapshot dégradé. Si plusieurs indicateurs macro core retombent en fallback hardcoded sans qu'on s'en rende compte, Lisa raisonne sur une photo statique → verdict bidon, sur-trading non-fondé. Le healthcheck logue un WARN avant la classification.

## Quoi

### Pure helper

```ts
assertRegimeInputsHealthy(
  { vix, dxy, us10y, us2y, realized1hPct },
  { fallback: dataQuality.fallback }
): { healthy, degraded[], shouldWarn }
```

`shouldWarn = degraded.length >= 2`. Critères de dégradation par indicateur :
- `value === null || !Number.isFinite(value)` → `name=null`
- `dataQuality.fallback.includes(name)` (cascade complètement échouée **+** last-known cache TTL 24h périmé) → `name=fallback>24h`

`realized1hPct` n'est pas tracké dans `dataQuality` (calculé en local depuis Binance klines, pas via `fetchCascade`) → seul le check null s'applique.

### Wiring

Dans `lisa.service.fetchMarketSnapshot()`, juste avant `marketRegime.getCurrentRegime(inputs)` :

```
[regime-healthcheck] N/5 macro inputs degraded: vix=null, us10y=fallback>24h
  — HORS_TRAJECTOIRE potentially unreliable this cycle
```

Non-bloquant : la classification continue, on ajoute juste de l'observability.

### Tests Jest (10 specs)

- Cas healthy (5/5 live) → no warn
- 1 dégradé → no warn (sous le seuil)
- 2 nulls → warn
- NaN/Infinity traités comme null
- 2 fallback → warn
- Mix null + fallback → warn
- Edge case `realized1hPct` (jamais flaggable via fallback)
- 5/5 worst case
- Clés non-trackées (brent, gold…) ignorées

## Tests passés

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/api` : 41 suites / **484 tests** ✅
- `regime-healthcheck.spec.ts` : 10/10 ✅

## Risques

Aucun — pure check non-bloquant, n'impacte pas la décision elle-même. Juste une ligne WARN supplémentaire si dégradation détectée.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_