### PR TITLE
feat(harvest): HARVEST_POLL_MS env override safety net cadence (P2-B)

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { PerformanceService } from '../../performance/performance.service';
@@ -66,6 +67,7 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
     private readonly materialDetector: MaterialChangeDetectorService,
     private readonly dailyProfitGovernor: DailyProfitGovernor,
     private readonly lisaReplay: LisaReplayConnectorService,
+    private readonly config: ConfigService,
   ) {}
 
   /**
@@ -251,6 +253,9 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
           // PATCH 1 — kill-switch dataQuality. Si false (default), le cycle
           // sera skippé quand le snapshot macro est dégradé. Cf. PR#1 P0.
           cfg.allow_degraded_macro === true,
+          // P2-B — discipline mode plumbé pour override du filet de garantie
+          // par HARVEST_POLL_MS (default 5 min) en mode DAILY_HARVEST.
+          (cfg.capital_discipline_mode as string | null) ?? null,
         );
       } catch (e) {
         this.logger.error(
@@ -299,6 +304,7 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
     cycleMinutes: number,
     autoApprove: boolean = false,
     allowDegradedMacro: boolean = false,
+    disciplineMode: string | null = null,
   ): Promise<void> {
     // Mutex in-memory : skip si un cycle est déjà en cours pour ce portfolio
     if (this.runningCycles.has(portfolioId)) {
@@ -319,7 +325,7 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
     this.runningCycles.add(portfolioId);
     this.cycleStartedAt.set(portfolioId, Date.now());
     try {
-      await this.runPortfolioCycleInner(userId, portfolioId, cycleMinutes, autoApprove, allowDegradedMacro);
+      await this.runPortfolioCycleInner(userId, portfolioId, cycleMinutes, autoApprove, allowDegradedMacro, disciplineMode);
     } finally {
       this.runningCycles.delete(portfolioId);
       this.cycleStartedAt.delete(portfolioId);
@@ -332,6 +338,7 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
     cycleMinutes: number,
     autoApprove: boolean = false,
     allowDegradedMacro: boolean = false,
+    disciplineMode: string | null = null,
   ): Promise<void> {
     // 1. Rate limit baseline = MAX(dernier cycle_started OU completed,
     //    dernière proposal). Source de vérité = lisa_proposals.created_at
@@ -372,7 +379,15 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
     //    son appétit (5 min = très réactif, 60 min = passif). Default 30 min.
     const RATE_LIMIT_MIN = 3;
     const configuredCycleMin = Number(cycleMinutes) || 30;
-    const baseMin = Math.max(5, Math.min(60, configuredCycleMin));
+    // P2-B — En mode DAILY_HARVEST (scalping intraday TP 2.5%), on remplace
+    // la cadence DB (15min default ou 7min preset HARVEST) par HARVEST_POLL_MS
+    // (default 300_000ms = 5 min). Granularité 5 min capture mieux les pics
+    // intraday pour l'objectif $100/jour. Le clamp [5, 60] s'applique toujours.
+    const harvestPollMs = Number(this.config.get<string>('HARVEST_POLL_MS')) || 300_000;
+    const harvestPollMin = Math.round(harvestPollMs / 60_000);
+    const isDailyHarvest = disciplineMode === 'DAILY_HARVEST';
+    const effectiveCycleMin = isDailyHarvest ? harvestPollMin : configuredCycleMin;
+    const baseMin = Math.max(5, Math.min(60, effectiveCycleMin));
     // PATCH 4 — backoff progressif quand le régime est stable.
     // Le helper retient un compteur par portfolio (clé = portfolioId) et
     // étire le filet jusqu'à 8× le base quand 10+ cycles consécutifs n'ont


### PR DESCRIPTION
## Pourquoi (P2-B)

En mode `capital_discipline_mode = 'DAILY_HARVEST'` (scalping intraday avec take-profit 2.5% absolu), le filet de garantie qui force un cycle Lisa "même si calme" tournait à **15 min** (default DB) ou **7 min** (preset HARVEST). Pour l'objectif **$100/jour** ($2/position × 5 positions × ~10 cycles/jour), une granularité **5 min** capture mieux les pics intraday.

## Quoi

### Override par env

```env
HARVEST_POLL_MS=300000   # 5 min (default si non set)
HARVEST_POLL_MS=600000   # 10 min (autorisé, dans clamp [5,60])
HARVEST_POLL_MS=180000   # 3 min (clamp ramène à 5 min)
```

L'utilisateur peut surcharger globalement via env Fly.io. Le knob DB `autopilot_cycle_minutes` reste actif pour les autres presets — l'override ne s'applique **que** quand `disciplineMode === 'DAILY_HARVEST'`.

### Implémentation

- Plumb `cfg.capital_discipline_mode` → `runPortfolioCycle` → `runPortfolioCycleInner` via param `disciplineMode: string | null`
- Inject `ConfigService` (déjà global via `app.module.ts`)
- `apps/api/src/modules/lisa/services/lisa-autopilot.service.ts` : override `baseMin` uniquement quand `isDailyHarvest`, sinon comportement legacy intact
- Clamp `[5, 60]` s'applique toujours (safety bound contre HARVEST_POLL_MS=0 ou valeur aberrante)

```ts
const harvestPollMs = Number(this.config.get<string>('HARVEST_POLL_MS')) || 300_000;
const harvestPollMin = Math.round(harvestPollMs / 60_000);
const isDailyHarvest = disciplineMode === 'DAILY_HARVEST';
const effectiveCycleMin = isDailyHarvest ? harvestPollMin : configuredCycleMin;
const baseMin = Math.max(5, Math.min(60, effectiveCycleMin));
```

### Coût

8 cycles/h vs 3 cycles/h → ~3× LLM cost en HARVEST. Assumé : en mode scalping intraday la cadence d'analyse compte plus que les frais marginaux. Le soft-budget (PR #24) reste en place comme garde-fou.

## Tests

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/api` : 41 suites / **484 tests** ✅
- Pas de spec dédiée : pas de helper pur extractible sans refacto disproportionnée. La logique est du plumbing trivial sur 3 paramètres.

## Risques

- Aucun en mode non-HARVEST (legacy preserved)
- En mode HARVEST sans env : passe de 15min/7min à 5min — **comportement attendu / objectif du ticket**
- Clamp `[5, 60]` empêche les valeurs aberrantes

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_