### PR TITLE
feat(regime): risk-on/risk-off deployment scaler (P2-C)

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -51,7 +51,11 @@ import { BinanceLiquidationsService } from './binance-liquidations.service';
 import { ApiCostTrackerService, BudgetExceededError } from './api-cost-tracker.service';
 import { MarketRegimeService } from './market-regime.service';
 import { RedditService } from './reddit.service';
-import { computeAtrPct, computeRealizedVolPct } from '@smartvest/ai-analyst';
+import {
+  computeAtrPct,
+  computeRealizedVolPct,
+  computeRegimeAdjustedDeployment,
+} from '@smartvest/ai-analyst';
 import {
   buildYahooChartUrl,
   buildStooqCsvUrl,
@@ -437,6 +441,32 @@ export class LisaService {
     };
 
     const marketSnapshot = await this.fetchMarketSnapshot();
+
+    // P2-C — Sizing dynamique selon régime risk-on / risk-off.
+    // Ajuste targetDeploymentPct AVANT envoi prompt Lisa :
+    //   - RISK_ON  (VIX<20 ET spread us10y-us2y > 0)  → +5 pp (90 → 95)
+    //   - RISK_OFF (VIX≥20 ET spread us10y-us2y ≤ 0)  → -20 pp (90 → 70)
+    //   - NEUTRAL  (signaux mixtes ou inputs incomplets) → no-op
+    // Aligne le levier de cash deployment sur l'environnement macro :
+    // pousse le déploiement quand la vol implicite est calme + curve
+    // steepening (signal classique appétit risque), réduit en stress.
+    {
+      const baseline = sessionConfig.riskConstraints.targetDeploymentPct;
+      const verdict = computeRegimeAdjustedDeployment(
+        {
+          vix: Number.isFinite(marketSnapshot.vix) ? marketSnapshot.vix : null,
+          us10yYield: Number.isFinite(marketSnapshot.us10yYield) ? marketSnapshot.us10yYield : null,
+          us2yYield: Number.isFinite(marketSnapshot.us2yYield) ? marketSnapshot.us2yYield : null,
+        },
+        baseline,
+      );
+      if (verdict.deltaPct !== 0) {
+        sessionConfig.riskConstraints.targetDeploymentPct = verdict.adjustedDeploymentPct;
+        this.logger.log(
+          `[regime-deployment] ${verdict.regime} (${verdict.reasons.join(', ')}) → targetDeploymentPct ${baseline}% → ${verdict.adjustedDeploymentPct}% (Δ${verdict.deltaPct >= 0 ? '+' : ''}${verdict.deltaPct}pp)`,
+        );
+      }
+    }
 
     // Enrichissement EODHD Premium : calendrier économique + macro +
     // screener (pas dépendants des positions). News fetchée plus bas une

--- a/packages/ai-analyst/src/regime/__tests__/deployment-scaler.spec.ts
+++ b/packages/ai-analyst/src/regime/__tests__/deployment-scaler.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * P2-C — Tests unitaires deployment-scaler.
+ */
+import {
+  computeRegimeAdjustedDeployment,
+  RiskOnOffInputs,
+} from '../deployment-scaler';
+
+const RISK_ON_INPUTS: RiskOnOffInputs = {
+  vix: 16.5,
+  us10yYield: 4.4,
+  us2yYield: 4.0,
+};
+const RISK_OFF_INPUTS: RiskOnOffInputs = {
+  vix: 28.0,
+  us10yYield: 3.8,
+  us2yYield: 4.5,
+};
+
+describe('computeRegimeAdjustedDeployment', () => {
+  it('flags RISK_ON when VIX<20 AND spread>0 → +5pp', () => {
+    const v = computeRegimeAdjustedDeployment(RISK_ON_INPUTS, 90);
+    expect(v.regime).toBe('RISK_ON');
+    expect(v.deltaPct).toBe(5);
+    expect(v.adjustedDeploymentPct).toBe(95);
+    expect(v.reasons.some((r) => r.includes('vix=16.5'))).toBe(true);
+    expect(v.reasons.some((r) => r.includes('spread=40bps>0'))).toBe(true);
+  });
+
+  it('flags RISK_OFF when VIX>=20 AND spread<=0 → -20pp', () => {
+    const v = computeRegimeAdjustedDeployment(RISK_OFF_INPUTS, 90);
+    expect(v.regime).toBe('RISK_OFF');
+    expect(v.deltaPct).toBe(-20);
+    expect(v.adjustedDeploymentPct).toBe(70);
+    expect(v.reasons.some((r) => r.includes('vix=28.0>=20'))).toBe(true);
+    expect(v.reasons.some((r) => r.includes('spread=-70bps<=0'))).toBe(true);
+  });
+
+  it('returns NEUTRAL when VIX<20 but curve inverted (mixed signals)', () => {
+    const v = computeRegimeAdjustedDeployment(
+      { vix: 16.5, us10yYield: 3.8, us2yYield: 4.5 },
+      90,
+    );
+    expect(v.regime).toBe('NEUTRAL');
+    expect(v.deltaPct).toBe(0);
+    expect(v.adjustedDeploymentPct).toBe(90);
+  });
+
+  it('returns NEUTRAL when VIX>=20 but curve steepening (mixed signals)', () => {
+    const v = computeRegimeAdjustedDeployment(
+      { vix: 25.0, us10yYield: 4.4, us2yYield: 4.0 },
+      90,
+    );
+    expect(v.regime).toBe('NEUTRAL');
+    expect(v.deltaPct).toBe(0);
+    expect(v.adjustedDeploymentPct).toBe(90);
+  });
+
+  it('returns NEUTRAL with inputs_incomplete when vix is null', () => {
+    const v = computeRegimeAdjustedDeployment(
+      { vix: null, us10yYield: 4.4, us2yYield: 4.0 },
+      90,
+    );
+    expect(v.regime).toBe('NEUTRAL');
+    expect(v.reasons).toContain('inputs_incomplete');
+    expect(v.adjustedDeploymentPct).toBe(90);
+  });
+
+  it('returns NEUTRAL when us10y is null', () => {
+    const v = computeRegimeAdjustedDeployment(
+      { vix: 16, us10yYield: null, us2yYield: 4.0 },
+      90,
+    );
+    expect(v.regime).toBe('NEUTRAL');
+    expect(v.reasons).toContain('inputs_incomplete');
+    expect(v.deltaPct).toBe(0);
+  });
+
+  it('returns NEUTRAL with NaN/Infinity treated as missing', () => {
+    const v1 = computeRegimeAdjustedDeployment(
+      { vix: NaN, us10yYield: 4.4, us2yYield: 4.0 },
+      90,
+    );
+    expect(v1.regime).toBe('NEUTRAL');
+    const v2 = computeRegimeAdjustedDeployment(
+      { vix: 16, us10yYield: Infinity, us2yYield: 4.0 },
+      90,
+    );
+    expect(v2.regime).toBe('NEUTRAL');
+  });
+
+  it('clamps adjusted deployment within [0, 100]', () => {
+    // Baseline 98 + RISK_ON +5 = 103 → clamp 100
+    const v1 = computeRegimeAdjustedDeployment(RISK_ON_INPUTS, 98);
+    expect(v1.adjustedDeploymentPct).toBe(100);
+    expect(v1.deltaPct).toBe(5);
+
+    // Baseline 10 - RISK_OFF -20 = -10 → clamp 0
+    const v2 = computeRegimeAdjustedDeployment(RISK_OFF_INPUTS, 10);
+    expect(v2.adjustedDeploymentPct).toBe(0);
+    expect(v2.deltaPct).toBe(-20);
+  });
+
+  it('clamps non-finite baseline to 0', () => {
+    const v = computeRegimeAdjustedDeployment(RISK_ON_INPUTS, NaN);
+    expect(v.adjustedDeploymentPct).toBeGreaterThanOrEqual(0);
+    expect(v.adjustedDeploymentPct).toBeLessThanOrEqual(100);
+  });
+
+  it('boundary: VIX exactly 20 is treated as not-calm (RISK_OFF eligible)', () => {
+    const v = computeRegimeAdjustedDeployment(
+      { vix: 20.0, us10yYield: 3.8, us2yYield: 4.5 },
+      90,
+    );
+    expect(v.regime).toBe('RISK_OFF');
+  });
+
+  it('boundary: spread exactly 0 is treated as not-steepening (RISK_OFF eligible)', () => {
+    const v = computeRegimeAdjustedDeployment(
+      { vix: 25, us10yYield: 4.0, us2yYield: 4.0 },
+      90,
+    );
+    expect(v.regime).toBe('RISK_OFF');
+  });
+
+  it('respects different presets: HARVEST baseline 85 + RISK_ON → 90', () => {
+    const v = computeRegimeAdjustedDeployment(RISK_ON_INPUTS, 85);
+    expect(v.adjustedDeploymentPct).toBe(90);
+  });
+
+  it('respects different presets: INVESTMENT baseline 90 - RISK_OFF → 70', () => {
+    const v = computeRegimeAdjustedDeployment(RISK_OFF_INPUTS, 90);
+    expect(v.adjustedDeploymentPct).toBe(70);
+  });
+});

--- a/packages/ai-analyst/src/regime/deployment-scaler.ts
+++ b/packages/ai-analyst/src/regime/deployment-scaler.ts
@@ -1,0 +1,120 @@
+/**
+ * P2-C — Sizing dynamique selon régime risk-on / risk-off.
+ *
+ * Ajuste `targetDeploymentPct` (% capital cible déployé en positions actives,
+ * le reste en cash reserve) en fonction de l'environnement macro.
+ *
+ *   RISK_ON  (VIX < 20  ET  spread us10y-us2y > 0)        → baseline + 5 pp
+ *   RISK_OFF (VIX ≥ 20  ET  spread us10y-us2y ≤ 0)        → baseline − 20 pp
+ *   NEUTRAL  (signaux mixtes ou inputs incomplets)         → no-op
+ *
+ * Symétrie volontaire conservatrice : on ne bascule en RISK_OFF que si
+ * les DEUX signaux de stress sont présents (volatilité implicite haute
+ * ET yield curve inversée). Sur signal mixte (VIX bas + curve inversée
+ * OU VIX haut + curve steepening) on reste au baseline plutôt que de
+ * scaler une décision sur un seul indicateur.
+ *
+ * Note : "DXY descendant" du backlog initial n'est pas implémenté —
+ * MarketSnapshot n'expose qu'une valeur instantanée de DXY, sans delta
+ * historique. Les deux critères retenus (vol implicite + slope yield
+ * curve) sont les proxies les plus robustes du risk appetite.
+ *
+ * Pure function, testable sans I/O. Le caller substitue la valeur
+ * retournée à `RiskConstraints.targetDeploymentPct` AVANT envoi prompt
+ * Lisa.
+ */
+
+export interface RiskOnOffInputs {
+  /** VIX index (volatilité implicite SP500 30j). null si snapshot dégradé. */
+  vix: number | null;
+  /** US 10-year Treasury yield (%). null si cascade échouée. */
+  us10yYield: number | null;
+  /** US 2-year Treasury yield (%). null si cascade échouée. */
+  us2yYield: number | null;
+}
+
+export type RiskOnOffRegime = 'RISK_ON' | 'RISK_OFF' | 'NEUTRAL';
+
+export interface DeploymentScaleVerdict {
+  regime: RiskOnOffRegime;
+  /** Raisons humaines (`vix=18.5<20`, `spread=42bps>0`…). */
+  reasons: string[];
+  /** Nouveau targetDeploymentPct après ajustement régime, clampé [0,100]. */
+  adjustedDeploymentPct: number;
+  /** Delta en points appliqué au baseline (+5 / -20 / 0). */
+  deltaPct: number;
+}
+
+const VIX_CALM_THRESHOLD = 20;
+const RISK_ON_BONUS_PCT = 5;
+const RISK_OFF_PENALTY_PCT = -20;
+
+export function computeRegimeAdjustedDeployment(
+  inputs: RiskOnOffInputs,
+  baselineDeploymentPct: number,
+): DeploymentScaleVerdict {
+  const baseline = clampPct(baselineDeploymentPct);
+
+  // Inputs incomplets → on garde le baseline (NEUTRAL).
+  const vix = isFiniteNumber(inputs.vix) ? (inputs.vix as number) : null;
+  const us10y = isFiniteNumber(inputs.us10yYield) ? (inputs.us10yYield as number) : null;
+  const us2y = isFiniteNumber(inputs.us2yYield) ? (inputs.us2yYield as number) : null;
+
+  if (vix === null || us10y === null || us2y === null) {
+    return {
+      regime: 'NEUTRAL',
+      reasons: ['inputs_incomplete'],
+      adjustedDeploymentPct: baseline,
+      deltaPct: 0,
+    };
+  }
+
+  // spread en bps pour lisibilité (pp × 100). Steepening = spread > 0.
+  const spreadBps = (us10y - us2y) * 100;
+  const vixCalm = vix < VIX_CALM_THRESHOLD;
+  const curveSteepening = spreadBps > 0;
+
+  if (vixCalm && curveSteepening) {
+    return {
+      regime: 'RISK_ON',
+      reasons: [
+        `vix=${vix.toFixed(1)}<${VIX_CALM_THRESHOLD}`,
+        `spread=${spreadBps.toFixed(0)}bps>0`,
+      ],
+      adjustedDeploymentPct: clampPct(baseline + RISK_ON_BONUS_PCT),
+      deltaPct: RISK_ON_BONUS_PCT,
+    };
+  }
+
+  if (!vixCalm && !curveSteepening) {
+    return {
+      regime: 'RISK_OFF',
+      reasons: [
+        `vix=${vix.toFixed(1)}>=${VIX_CALM_THRESHOLD}`,
+        `spread=${spreadBps.toFixed(0)}bps<=0`,
+      ],
+      adjustedDeploymentPct: clampPct(baseline + RISK_OFF_PENALTY_PCT),
+      deltaPct: RISK_OFF_PENALTY_PCT,
+    };
+  }
+
+  // Signaux mixtes → NEUTRAL (no-op).
+  return {
+    regime: 'NEUTRAL',
+    reasons: [
+      vixCalm ? `vix=${vix.toFixed(1)}<${VIX_CALM_THRESHOLD}` : `vix=${vix.toFixed(1)}>=${VIX_CALM_THRESHOLD}`,
+      curveSteepening ? `spread=${spreadBps.toFixed(0)}bps>0` : `spread=${spreadBps.toFixed(0)}bps<=0`,
+    ],
+    adjustedDeploymentPct: baseline,
+    deltaPct: 0,
+  };
+}
+
+function clampPct(v: number): number {
+  if (!Number.isFinite(v)) return 0;
+  return Math.max(0, Math.min(100, v));
+}
+
+function isFiniteNumber(v: unknown): boolean {
+  return typeof v === 'number' && Number.isFinite(v);
+}

--- a/packages/ai-analyst/src/regime/index.ts
+++ b/packages/ai-analyst/src/regime/index.ts
@@ -1,2 +1,3 @@
 export * from './market-regime-classifier';
 export * from './atr-helper';
+export * from './deployment-scaler';


### PR DESCRIPTION
## Pourquoi (P2-C)

Aligner le levier de cash deployment sur l'environnement macro **avant** la génération de prompt Lisa, plutôt que de laisser un baseline statique (60% / 85% HARVEST / 90% INVESTMENT) traverser tous les régimes.

## Quoi

```
RISK_ON  (VIX<20  ET  spread us10y-us2y > 0)  → +5 pp  (90 → 95)
RISK_OFF (VIX≥20  ET  spread us10y-us2y ≤ 0)  → -20 pp (90 → 70)
NEUTRAL  (signaux mixtes ou inputs incomplets) → no-op
```

**Symétrie volontaire conservatrice** : on ne bascule en RISK_OFF que si les **deux** signaux de stress sont présents (volatilité implicite haute **ET** yield curve inversée). Sur signal mixte (VIX bas + curve inversée OU VIX haut + curve steepening) on reste au baseline plutôt que de scaler sur un seul indicateur.

**DXY descendant** du backlog initial NON implémenté — MarketSnapshot n'expose qu'une valeur instantanée, sans delta historique. Les deux critères retenus (vol implicite + slope yield curve) sont les proxies les plus robustes du risk appetite.

## Implémentation

### Pure helper

`packages/ai-analyst/src/regime/deployment-scaler.ts`

```ts
computeRegimeAdjustedDeployment(
  { vix, us10yYield, us2yYield },
  baselineDeploymentPct
): { regime, reasons[], adjustedDeploymentPct, deltaPct }
```

Clamp `[0, 100]` sur le résultat (safety).

### Wiring

`apps/api/src/modules/lisa/services/lisa.service.ts` — call site juste après `fetchMarketSnapshot`, avant les enrichements et la génération de prompt. Mute `riskConstraints.targetDeploymentPct` en place et log :

```
[regime-deployment] RISK_ON (vix=16.5<20, spread=42bps>0) → targetDeploymentPct 90% → 95% (Δ+5pp)
```

## Tests Jest (13 specs)

- Cas RISK_ON / RISK_OFF / NEUTRAL principaux
- Signaux mixtes (VIX bas + curve inversée, VIX haut + curve steepening)
- NaN / Infinity traités comme inputs manquants
- Inputs partiels (vix=null, us10y=null) → NEUTRAL inputs_incomplete
- Clamp `[0, 100]` (baseline 98 + RISK_ON → 100 ; baseline 10 - RISK_OFF → 0)
- Boundaries : VIX exactement 20 → not-calm ; spread exactement 0 → not-steepening
- Presets : HARVEST 85 → 90 RISK_ON ; INVESTMENT 90 → 70 RISK_OFF

## Tests passés

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/api` : 41 suites / 484 tests ✅
- `npm test --workspace=@smartvest/ai-analyst` : 4 suites / **97 tests** (13 nouveaux) ✅

## Risques

- Aucun en mode NEUTRAL (no-op)
- En RISK_ON : déploiement +5pp → marginal. En RISK_OFF : -20pp → significatif mais aligné spec utilisateur
- Pas de feedback loop : le scaler est appliqué par cycle, pas itéré
- Baseline existant (60/85/90) reste défini en DB ; le scaler ne touche pas la valeur DB, seulement le runtime constraints

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_