### PR TITLE
feat(lisa): GET /lisa/daily-pnl/:portfolioId vs $100 target (P2-D)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -505,4 +505,26 @@ export class LisaController {
     );
     return { sessions };
   }
+
+  /**
+   * P2-D — Telemetry P&L journalier vs objectif fixe $100/jour.
+   *
+   *   GET /lisa/daily-pnl/:portfolioId
+   *
+   * Retourne :
+   *   { realized, latent, target: 100, achievementPct, drift }
+   *
+   * realized       = closes UTC du jour depuis lisa_positions
+   * latent         = unrealizedPnlUsd live snapshot
+   * achievementPct = (realized + latent) / target × 100, clamp [0, 999]
+   * drift          = realized + latent - target (peut être négatif)
+   */
+  @Get('daily-pnl/:portfolioId')
+  async getDailyPnl(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+  ) {
+    const userId = extractUserId(headers);
+    return this.lisa.getDailyPnl(userId, portfolioId);
+  }
 }

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1744,6 +1744,70 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     };
   }
 
+  /**
+   * P2-D — Telemetry P&L journalier vs objectif fixe $100/jour.
+   *
+   *   realized       : somme realized_pnl_usd des positions fermées aujourd'hui (UTC)
+   *   latent         : unrealizedPnlUsd live du portfolio snapshot
+   *   target         : objectif fixe $100 (constante produit)
+   *   achievementPct : (realized + latent) / target × 100, clamp [0, 999]
+   *   drift          : realized + latent - target  (peut être négatif)
+   *
+   * Source de vérité realized = lisa_positions filter `closed_*` aujourd'hui
+   * (pas daily_trading_sessions qui n'est qu'un cache resync). Source de
+   * vérité latent = paperBroker.computeSnapshot (live valuation marketplace).
+   */
+  async getDailyPnl(
+    userId: string,
+    portfolioId: string,
+  ): Promise<{
+    realized: number;
+    latent: number;
+    target: number;
+    achievementPct: number;
+    drift: number;
+  }> {
+    await this.assertPortfolioOwner(userId, portfolioId);
+
+    const TARGET_USD = 100;
+    const dayStartUtc = new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00.000Z').toISOString();
+    const dayEndUtc = new Date(new Date(dayStartUtc).getTime() + 86_400_000).toISOString();
+
+    const [closesRes, snap] = await Promise.all([
+      this.supabase.getClient()
+        .from('lisa_positions')
+        .select('realized_pnl_usd')
+        .eq('portfolio_id', portfolioId)
+        .like('status', 'closed_%')
+        .gte('exit_timestamp', dayStartUtc)
+        .lt('exit_timestamp', dayEndUtc)
+        .not('exit_timestamp', 'is', null),
+      this.paperBroker.computeSnapshot(portfolioId),
+    ]);
+
+    let realized = 0;
+    for (const c of closesRes.data ?? []) {
+      const pnl = parseFloat((c.realized_pnl_usd as string | null) ?? '0');
+      if (Number.isFinite(pnl)) realized += pnl;
+    }
+    const latent = parseFloat(snap.unrealizedPnlUsd ?? '0');
+    const safeLatent = Number.isFinite(latent) ? latent : 0;
+
+    const total = realized + safeLatent;
+    const achievementPctRaw = (total / TARGET_USD) * 100;
+    const achievementPct = Math.max(0, Math.min(999, Number.isFinite(achievementPctRaw) ? achievementPctRaw : 0));
+    const drift = total - TARGET_USD;
+
+    const round2 = (n: number) => Math.round(n * 100) / 100;
+    return {
+      realized: round2(realized),
+      latent: round2(safeLatent),
+      target: TARGET_USD,
+      achievementPct: round2(achievementPct),
+      drift: round2(drift),
+    };
+  }
+
   async getSnapshotHistory(userId: string, portfolioId: string, windowDays: number) {
     await this.assertPortfolioOwner(userId, portfolioId);
     const since = new Date(Date.now() - windowDays * 86_400_000).toISOString();


### PR DESCRIPTION
## Pourquoi (P2-D)

Telemetry endpoint pour suivre l'objectif **$100 nets/jour**. Permet à l'UI dashboard d'afficher l'avancement vers la cible et le drift en temps réel sans polling de plusieurs sources hétérogènes (positions + snapshot + sessions).

## Endpoint

```
GET /api/lisa/daily-pnl/:portfolioId
```

Auth : `extractUserId(headers)` + `assertPortfolioOwner(userId, portfolioId)` (pattern existant).

## Réponse

```ts
{
  realized: number,        // sum(realized_pnl_usd) closes UTC du jour
  latent: number,          // unrealizedPnlUsd live snapshot
  target: 100,             // constante produit
  achievementPct: number,  // (realized + latent) / target × 100, clamp [0, 999]
  drift: number            // realized + latent - target (peut être négatif)
}
```

## Sources de vérité

Alignées sur le pattern `resyncSessionFromPositions` de `daily-session.service.ts` :

| Champ | Requête | Note |
|---|---|---|
| `realized` | `SELECT lisa_positions WHERE status LIKE 'closed_%' AND exit_timestamp ∈ [today_utc_start, today_utc_end)` | **Pas** `daily_trading_sessions` qui n'est qu'un cache resync. CLAUDE.md le dit explicitement |
| `latent` | `paperBroker.computeSnapshot().unrealizedPnlUsd` | Live valuation : entry_price × qty vs marketplace |

Les deux requêtes tournent en parallèle via `Promise.all`. Aucun cache supplémentaire — endpoint léger, appelé à la demande de l'UI.

## Implémentation

### Service

`LisaService.getDailyPnl(userId, portfolioId)` — `apps/api/src/modules/lisa/services/lisa.service.ts`

### Controller

`LisaController.getDailyPnl()` — `apps/api/src/modules/lisa/lisa.controller.ts`

Pas de DTO class-validator (cohérent avec le reste du contrôleur : réponses raw JSON).

## Tests

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/api` : 41 suites / **484 tests** ✅
- Pas de spec Jest dédiée : pas de business logic nouvelle au-delà de l'aggregation des données existantes (les sources sont déjà testées)

## Risques

- Aucun — endpoint en lecture seule, ne modifie aucun état.
- Pas de pagination car un portfolio fait au plus quelques dizaines de closes par jour.
- En l'absence de positions fermées : `realized=0`, `latent` reste valide (open positions dans le snapshot).

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_