### PR TITLE
feat(strategy): rebound-tp scanner + Lisa integration (P3-A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,104 @@ Variables d'environnement requises côté plateforme : voir `.env.example`.
 
 ---
 
+## Rebound TP strategy (P3-A)
+
+Stratégie mean-reversion sur tickers liquides survendus avec sortie mécanique TP1/TP2/TP3 + SL discipliné. Vise l'objectif **$100 nets/jour** en captant des rebonds courts post-capitulation, complémentaire au sizing macro de Lisa (PR #41).
+
+### Flow
+
+```
+                  ┌──────────────────────┐
+                  │  Lisa cycle (5 min)  │
+                  └──────────┬───────────┘
+                             │
+                             ▼
+          ┌──────────────────────────────────────┐
+          │  scanRebound(history, cfg)           │  ← pure helper
+          │  packages/ai-analyst/src/strategies/ │
+          └──────────┬───────────────────────────┘
+                     │
+        ┌────────────┼─────────────┐
+        ▼            ▼             ▼
+   condition 1  condition 2  …  condition 5
+   RSI<30       close<bbLower   reversal candle
+        │            │             │
+        └────┬───────┴─────────────┘
+             ▼
+    ┌────────────────────┐
+    │  ReboundSignal     │  { type: 'BUY' | 'HOLD', … }
+    └─────────┬──────────┘
+              │ if BUY
+              ▼
+   ┌────────────────────────────┐
+   │  INSERT rebound_positions  │  status='OPEN', filled=100%
+   └────────────┬───────────────┘
+                │
+                ▼
+   ┌────────────────────────────────┐
+   │  ReboundMonitorService cron    │  every 5 min
+   │  - fetch live price            │
+   │  - skip if fallback source     │
+   │  - SL hit  → status='SL_HIT'   │
+   │  - TP1 hit → status='TP1_HIT', filled=50%  │
+   │  - TP2 hit → status='TP2_HIT', filled=20%  │
+   │  - TP3 hit → status='TP3_HIT', filled=0%   │
+   │  - timeout → status='TIMEOUT'  │
+   └────────────────────────────────┘
+                │
+                ▼
+   ┌────────────────────────────┐
+   │  GET /lisa/daily-pnl       │  PR #42 + dailyTargetHit
+   │  realized + latent ≥ 100$  │  freeze nouvelles entrées
+   └────────────────────────────┘
+```
+
+### Conditions BUY (TOUTES requises sur la dernière bougie close)
+
+1. RSI(14) < `REBOUND_RSI_OVERSOLD` (default 30)
+2. close < BollingerLower(20, 2)
+3. drawdown 20-bar ≤ -`REBOUND_MIN_DD_PCT` (default 15%)
+4. volume > `REBOUND_VOL_SPIKE` × SMA(volume, 20) (default 1.5×)
+5. Bougie de retournement : close > open ET RSI[t] > RSI[t-1] ET RSI[t-1] < oversold
+
+### Niveaux et sortie mécanique
+
+| Palier | Niveau | Sortie qty | Status DB |
+|---|---|---|---|
+| TP1 | entry × 1.05 | 50% | `TP1_HIT` |
+| TP2 | entry × 1.10 | 30% | `TP2_HIT` |
+| TP3 | entry × 1.15 | 20% | `TP3_HIT` |
+| SL  | entry × 0.96 | 100% restants | `SL_HIT` |
+| Time stop | 10 jours après entrée | 100% restants | `TIMEOUT` |
+
+### Variables d'environnement
+
+```env
+REBOUND_RSI_OVERSOLD=30
+REBOUND_MIN_DD_PCT=15
+REBOUND_VOL_SPIKE=1.5
+REBOUND_TP1_PCT=5
+REBOUND_TP2_PCT=10
+REBOUND_TP3_PCT=15
+REBOUND_SL_PCT=4
+REBOUND_TIME_STOP_DAYS=10
+DAILY_TARGET_USD=100
+```
+
+### Garde-fous
+
+- **Source fallback** : si `LisaService.getLivePrice` retourne `source` préfixé par `fallback*`, le cron skip l'évaluation pour ne pas trigger une sortie sur prix corrompu (cf. CLAUDE.md « Garde-fous prix fallback »).
+- **Pas d'exécution réelle** : aucun appel `BrokerAdapter.placeOrder()`. Les positions sont simulées (paper trading), cohérent avec `MANUAL_EXPLICIT` par défaut.
+- **Daily target hit** : `GET /lisa/daily-pnl` expose `dailyTargetHit: boolean`. Le scanner ne doit pas créer de nouvelles positions quand cumul ≥ target (responsabilité du caller).
+
+### Tests
+
+`packages/ai-analyst/src/strategies/__tests__/rebound-tp.spec.ts` — 12 specs couvrant : capitulation full setup → BUY, bull trap → HOLD (RSI), no volume spike → HOLD, reversal candle baissière → HOLD, drawdown insuffisant → HOLD, NaN/négatifs → HOLD, custom TP/SL configs, threshold strict.
+
+Backtest hit-rate TP1 ≥ 55% : ticket P3-B séparé.
+
+---
+
 ## Contribution
 
 Règles de wording, feature flags, conventions de code : [`CLAUDE.md`](./CLAUDE.md).

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -38,6 +38,7 @@ import { ProfitSweepService } from './services/profit-sweep.service';
 import { DailyProfitGovernor } from './services/daily-profit-governor.service';
 import { MacroModeService } from './services/macro-mode.service';
 import { ApiCostTrackerService } from './services/api-cost-tracker.service';
+import { ReboundMonitorService } from './services/rebound-monitor.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule, BotLabModule],
@@ -82,6 +83,8 @@ import { ApiCostTrackerService } from './services/api-cost-tracker.service';
     ApiCostTrackerService,
     // P1 — classifier de régime tactique (BULL/BEAR/RANGE/VOL_SPIKE/NEWS_SHOCK)
     MarketRegimeService,
+    // P3-A — cron monitor pour rebound_positions (TP/SL/timeout toutes les 5 min)
+    ReboundMonitorService,
   ],
   exports: [
     LisaService,

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1766,10 +1766,12 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     target: number;
     achievementPct: number;
     drift: number;
+    dailyTargetHit: boolean;
   }> {
     await this.assertPortfolioOwner(userId, portfolioId);
 
-    const TARGET_USD = 100;
+    // P3-A — DAILY_TARGET_USD configurable via env (default $100).
+    const TARGET_USD = Number(this.config.get<string>('DAILY_TARGET_USD')) || 100;
     const dayStartUtc = new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00.000Z').toISOString();
     const dayEndUtc = new Date(new Date(dayStartUtc).getTime() + 86_400_000).toISOString();
 
@@ -1805,6 +1807,10 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       target: TARGET_USD,
       achievementPct: round2(achievementPct),
       drift: round2(drift),
+      // P3-A — flag consommé par le cron pour freeze nouvelles entrées
+      // rebound + signalé à l'UI dashboard. Latent compte (un trade
+      // rebound non encore fermé est de l'avancement vers l'objectif).
+      dailyTargetHit: total >= TARGET_USD,
     };
   }
 

--- a/apps/api/src/modules/lisa/services/rebound-monitor.service.ts
+++ b/apps/api/src/modules/lisa/services/rebound-monitor.service.ts
@@ -1,0 +1,227 @@
+/**
+ * P3-A — Cron monitor pour rebound_positions.
+ *
+ * Tourne toutes les 5 minutes. Pour chaque position OPEN :
+ *   1. Fetch prix live (LisaService.getLivePrice).
+ *   2. Évalue la sortie palier le plus haut atteint depuis la dernière
+ *      évaluation (TP3 > TP2 > TP1) ou SL ou time stop.
+ *   3. Update status, filled_qty_pct, realized_pnl_usd dans Supabase.
+ *
+ * Ne déclenche AUCUN ordre réel — c'est un monitor de simulation /
+ * paper trading. La sortie réelle (broker) sera ajoutée plus tard
+ * via le chemin `BrokerAdapter` standard sous `AUTONOMOUS_GUARDED`.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { LisaService } from './lisa.service';
+
+interface ReboundPositionRow {
+  id: string;
+  portfolio_id: string;
+  ticker: string;
+  entry_price: string;
+  entry_at: string;
+  tp1: string;
+  tp2: string;
+  tp3: string;
+  sl: string;
+  time_stop_at: string;
+  status: 'OPEN' | 'TP1_HIT' | 'TP2_HIT' | 'TP3_HIT' | 'SL_HIT' | 'TIMEOUT' | 'CLOSED';
+  filled_qty_pct: string;
+  realized_pnl_usd: string;
+}
+
+const QTY_TP1_PCT = 50;
+const QTY_TP2_PCT = 30;
+const QTY_TP3_PCT = 20;
+
+@Injectable()
+export class ReboundMonitorService {
+  private readonly logger = new Logger(ReboundMonitorService.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly lisa: LisaService,
+    private readonly config: ConfigService,
+  ) {}
+
+  /**
+   * Cron toutes les 5 minutes. Évalue les sorties pour toutes les
+   * positions rebound OPEN.
+   */
+  @Cron(CronExpression.EVERY_5_MINUTES, { name: 'rebound-monitor' })
+  async runMonitor(): Promise<void> {
+    try {
+      await this.runMonitorInner();
+    } catch (e) {
+      this.logger.error(`[rebound-monitor] cycle failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  private async runMonitorInner(): Promise<void> {
+    const { data: positions, error } = await this.supabase
+      .getClient()
+      .from('rebound_positions')
+      .select('*')
+      .eq('status', 'OPEN');
+
+    if (error) {
+      this.logger.error(`[rebound-monitor] fetch failed: ${error.message}`);
+      return;
+    }
+    if (!positions || positions.length === 0) return;
+
+    this.logger.log(`[rebound-monitor] evaluating ${positions.length} OPEN position(s)`);
+
+    for (const raw of positions as ReboundPositionRow[]) {
+      try {
+        await this.evaluatePosition(raw);
+      } catch (e) {
+        this.logger.warn(
+          `[rebound-monitor] eval failed for ${raw.ticker} (${raw.id.slice(0, 8)}): ${String(e).slice(0, 120)}`,
+        );
+      }
+    }
+  }
+
+  private async evaluatePosition(row: ReboundPositionRow): Promise<void> {
+    const entry = parseFloat(row.entry_price);
+    const tp1 = parseFloat(row.tp1);
+    const tp2 = parseFloat(row.tp2);
+    const tp3 = parseFloat(row.tp3);
+    const sl = parseFloat(row.sl);
+    const filledQtyPct = parseFloat(row.filled_qty_pct);
+    const currentPnl = parseFloat(row.realized_pnl_usd);
+
+    // Time stop : prioritaire, indépendant du prix.
+    const now = Date.now();
+    const stopAt = new Date(row.time_stop_at).getTime();
+    if (now >= stopAt) {
+      await this.closePosition(row.id, 'TIMEOUT', filledQtyPct, entry, currentPnl, entry);
+      this.logger.log(
+        `[rebound-monitor] ${row.ticker} TIMEOUT (time stop ${row.time_stop_at}) — close ${filledQtyPct}% remaining`,
+      );
+      return;
+    }
+
+    // Fetch prix live. Si fallback / fallback_unknown → skip ce cycle
+    // pour ne pas trigger des sorties sur prix corrompus (cf. CLAUDE.md
+    // section "Garde-fous prix fallback").
+    const live = await this.lisa.getLivePrice(row.ticker).catch(() => null);
+    if (!live) {
+      this.logger.warn(`[rebound-monitor] ${row.ticker}: getLivePrice failed — skip cycle`);
+      return;
+    }
+    if (this.isFallbackSource(live.source)) {
+      this.logger.warn(
+        `[rebound-monitor] ${row.ticker}: source=${live.source} (fallback) — skip cycle`,
+      );
+      return;
+    }
+    const price = parseFloat(live.price);
+    if (!Number.isFinite(price) || price <= 0) {
+      this.logger.warn(`[rebound-monitor] ${row.ticker}: invalid price ${live.price} — skip`);
+      return;
+    }
+
+    // SL check : prioritaire sur TP. Close totalement.
+    if (price <= sl) {
+      const closeQtyPct = filledQtyPct;
+      const pnlAdd = ((sl - entry) / entry) * closeQtyPct; // approx pnl en %
+      await this.closePosition(row.id, 'SL_HIT', closeQtyPct, sl, currentPnl, entry);
+      this.logger.warn(
+        `[rebound-monitor] ${row.ticker} SL_HIT @${price.toFixed(2)} (sl=${sl.toFixed(2)}, pnlPct≈${pnlAdd.toFixed(2)})`,
+      );
+      return;
+    }
+
+    // TP cascade : on teste du palier le plus haut au plus bas.
+    let exitQtyPct = 0;
+    let newStatus: ReboundPositionRow['status'] | null = null;
+    let exitPrice = 0;
+
+    if (price >= tp3 && row.status === 'OPEN') {
+      // Cas où on saute directement à TP3 (gap up)
+      exitQtyPct = filledQtyPct;
+      newStatus = 'TP3_HIT';
+      exitPrice = tp3;
+    } else if (price >= tp3) {
+      exitQtyPct = filledQtyPct;
+      newStatus = 'TP3_HIT';
+      exitPrice = tp3;
+    } else if (price >= tp2 && row.status !== 'TP2_HIT' && row.status !== 'TP3_HIT') {
+      exitQtyPct = QTY_TP2_PCT;
+      newStatus = 'TP2_HIT';
+      exitPrice = tp2;
+    } else if (price >= tp1 && row.status === 'OPEN') {
+      exitQtyPct = QTY_TP1_PCT;
+      newStatus = 'TP1_HIT';
+      exitPrice = tp1;
+    }
+
+    if (newStatus && exitQtyPct > 0) {
+      const remaining = Math.max(0, filledQtyPct - exitQtyPct);
+      // Approximation du P&L en % (le cron ne connaît pas la qty USD,
+      // il stocke le P&L pct cumulatif comme proxy. Le service caller
+      // qui open la position peut renormaliser avec le notionnel réel).
+      const pnlAddPct = ((exitPrice - entry) / entry) * exitQtyPct;
+      const newPnl = currentPnl + pnlAddPct;
+      await this.closePosition(
+        row.id,
+        newStatus === 'TP3_HIT' ? 'TP3_HIT' : newStatus,
+        remaining,
+        exitPrice,
+        newPnl,
+        entry,
+        remaining === 0,
+      );
+      this.logger.log(
+        `[rebound-monitor] ${row.ticker} ${newStatus} @${price.toFixed(2)} → exit ${exitQtyPct}%, remaining ${remaining}%`,
+      );
+    }
+  }
+
+  private async closePosition(
+    id: string,
+    status: ReboundPositionRow['status'],
+    remainingQtyPct: number,
+    exitPrice: number,
+    newPnlPct: number,
+    _entry: number,
+    finalize: boolean = true,
+  ): Promise<void> {
+    const updates: Record<string, unknown> = {
+      status,
+      filled_qty_pct: remainingQtyPct.toFixed(2),
+      realized_pnl_usd: newPnlPct.toFixed(6),
+    };
+    if (finalize && remainingQtyPct === 0) {
+      updates['closed_at'] = new Date().toISOString();
+      // Override status with 'CLOSED' if all quantity exited (all TP hit)
+      if (status === 'TP3_HIT' || status === 'SL_HIT' || status === 'TIMEOUT') {
+        // Keep specific status (TP3_HIT/SL_HIT/TIMEOUT) for audit
+      }
+    }
+    const { error } = await this.supabase
+      .getClient()
+      .from('rebound_positions')
+      .update(updates)
+      .eq('id', id);
+    if (error) {
+      this.logger.error(`[rebound-monitor] update ${id} failed: ${error.message}`);
+    }
+    void exitPrice; // tagué pour audit futur (column exit_price si on l'ajoute)
+  }
+
+  /**
+   * Détecte les sources fallback (cascade complètement échouée → prix
+   * hardcoded ou inconnu). Cf. CLAUDE.md "Garde-fous prix fallback".
+   */
+  private isFallbackSource(source: string): boolean {
+    if (!source) return true;
+    return source.startsWith('fallback');
+  }
+}

--- a/packages/ai-analyst/src/index.ts
+++ b/packages/ai-analyst/src/index.ts
@@ -14,3 +14,4 @@ export * from './allocation';
 export * from './simulation';
 export * from './llm';
 export * from './regime';
+export * from './strategies/rebound-tp';

--- a/packages/ai-analyst/src/strategies/__tests__/rebound-tp.spec.ts
+++ b/packages/ai-analyst/src/strategies/__tests__/rebound-tp.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * P3-A — Tests rebound-tp scanner.
+ *
+ * Note importante sur le design du fixture : Bollinger Bands(20,2) sur
+ * une chute LINÉAIRE produit des bandes très larges (forte stddev), si
+ * bien que `close < bbLower` ne se déclenche jamais sur un trend
+ * one-way. Le pattern réaliste de capitulation = consolidation prolongée
+ * + drop sharp en quelques barres + amorce de rebond. C'est ce que
+ * `capitulationSetup` modélise (stable 12 bars + drop 4 bars + bounce 1).
+ */
+import { scanRebound, Candle } from '../rebound-tp';
+
+function makeBars(
+  count: number,
+  closeFn: (i: number) => number,
+  volFn: (i: number) => number,
+): Candle[] {
+  const bars: Candle[] = [];
+  let prevClose = closeFn(0);
+  for (let i = 0; i < count; i++) {
+    const close = closeFn(i);
+    const open = i === 0 ? close * 0.999 : prevClose;
+    const high = Math.max(open, close) * 1.003;
+    const low = Math.min(open, close) * 0.997;
+    bars.push({ timestamp: i, open, high, low, close, volume: volFn(i) });
+    prevClose = close;
+  }
+  return bars;
+}
+
+/**
+ * Setup de capitulation classique :
+ *  - 16 bougies stables ≈ 100 (consolidation)
+ *  - 3 bougies de drop sharp (92 → 88 → 82)
+ *  - 1 bougie reversal (close 85 > open 82, volume spike ×3)
+ *
+ * RSI[t]   ≈ 14 (très bas)
+ * RSI[t-1] ≈ 0  (avgGain=0 sur les 14 retours précédents)
+ * Drawdown 20 ≈ -15.5% (peak high=100.5 → close=85)
+ * BBLower ≈ 86.3 → close=85 < BBLower ✓
+ */
+function capitulationSetup(volSpikeRatio = 3.5): Candle[] {
+  const closes = [
+    100, 100, 100, 100, 100, 100, 100, 100, 100, 100,
+    100, 100, 100, 100, 100, 100,    // 16 stable bars
+    92, 88, 82, 85,                  // drop + reversal
+  ];
+  return closes.map((close, i) => {
+    const open = i === 0 ? close * 0.999 : closes[i - 1];
+    const high = Math.max(open, close) * 1.005;
+    const low = Math.min(open, close) * 0.995;
+    return {
+      timestamp: i,
+      open,
+      high,
+      low,
+      close,
+      volume: i === closes.length - 1 ? Math.round(1000 * volSpikeRatio) : 1000,
+    };
+  });
+}
+
+describe('scanRebound', () => {
+  it('returns BUY on full capitulation setup with all conditions met', () => {
+    const bars = capitulationSetup();
+    const sig = scanRebound(bars);
+    expect(sig.type).toBe('BUY');
+    if (sig.type !== 'BUY') return;
+    expect(sig.entry).toBe(85);
+    expect(sig.tp1).toBe(89.25); // 85 × 1.05
+    expect(sig.tp2).toBe(93.5);  // 85 × 1.10
+    expect(sig.tp3).toBe(97.75); // 85 × 1.15
+    expect(sig.sl).toBe(81.6);   // 85 × 0.96
+    expect(sig.timeStopDays).toBe(10);
+    expect(sig.confidence).toBeGreaterThan(0);
+    expect(sig.confidence).toBeLessThanOrEqual(1);
+    expect(sig.indicators.rsi14).toBeLessThan(30);
+    expect(sig.indicators.rsi14Prev).toBeLessThan(30);
+    expect(sig.indicators.volSpikeRatio).toBeGreaterThan(1.5);
+    expect(sig.indicators.drawdown20Pct).toBeLessThan(-15);
+    expect(sig.indicators.bbLower).toBeGreaterThan(0);
+  });
+
+  it('returns HOLD insufficient_bars when history < min', () => {
+    const bars = makeBars(15, () => 100, () => 1000);
+    const sig = scanRebound(bars);
+    expect(sig.type).toBe('HOLD');
+    if (sig.type === 'HOLD') {
+      expect(sig.reason).toMatch(/insufficient_bars/);
+    }
+  });
+
+  it('returns HOLD on bull trap (RSI not oversold)', () => {
+    // Steady bull trend → RSI well above 30
+    const bars = makeBars(30, (i) => 100 + i * 0.5, () => 1000);
+    const sig = scanRebound(bars);
+    expect(sig.type).toBe('HOLD');
+    if (sig.type === 'HOLD') {
+      expect(sig.reason).toMatch(/rsi=/);
+    }
+  });
+
+  it('returns HOLD when no volume spike (false positive filter)', () => {
+    const bars = capitulationSetup(1.0); // pas de spike, vol nominal
+    const sig = scanRebound(bars);
+    expect(sig.type).toBe('HOLD');
+    if (sig.type === 'HOLD') {
+      expect(sig.reason).toMatch(/volRatio/);
+    }
+  });
+
+  it('returns HOLD when reversal candle is bearish (close < open)', () => {
+    const setup = capitulationSetup();
+    // Override last bar pour close < open (chandelle baissière)
+    const last = setup[setup.length - 1];
+    setup[setup.length - 1] = { ...last, open: 88, close: 82 };
+    const sig = scanRebound(setup);
+    expect(sig.type).toBe('HOLD');
+    if (sig.type === 'HOLD') {
+      expect(sig.reason).toMatch(/candle_not_bullish/);
+    }
+  });
+
+  it('returns HOLD when drawdown insufficient (price stable)', () => {
+    // Range tight → drawdown faible
+    const bars = makeBars(30, (i) => 100 + Math.sin(i / 3) * 0.5, () => 1000);
+    const sig = scanRebound(bars);
+    expect(sig.type).toBe('HOLD');
+    if (sig.type === 'HOLD') {
+      // Plusieurs failures possibles (rsi pas oversold, dd faible…) — on
+      // vérifie juste qu'on a un diagnostic.
+      expect(sig.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns HOLD on invalid bar (negative price)', () => {
+    const bars = capitulationSetup();
+    bars[5] = { ...bars[5], close: -1 };
+    const sig = scanRebound(bars);
+    expect(sig.type).toBe('HOLD');
+    if (sig.type === 'HOLD') {
+      expect(sig.reason).toMatch(/invalid_bar_values/);
+    }
+  });
+
+  it('returns HOLD on invalid bar (high < low)', () => {
+    const bars = capitulationSetup();
+    bars[5] = { ...bars[5], high: 50, low: 100 };
+    const sig = scanRebound(bars);
+    expect(sig.type).toBe('HOLD');
+  });
+
+  it('returns HOLD when input is not an array', () => {
+    const sig = scanRebound(null as unknown as Candle[]);
+    expect(sig.type).toBe('HOLD');
+    if (sig.type === 'HOLD') {
+      expect(sig.reason).toMatch(/invalid_history_not_array/);
+    }
+  });
+
+  it('respects custom cfg overrides (TP/SL percentages)', () => {
+    const sig = scanRebound(capitulationSetup(), {
+      tp1Pct: 3,
+      tp2Pct: 6,
+      tp3Pct: 9,
+      slPct: 2,
+      timeStopDays: 5,
+    });
+    expect(sig.type).toBe('BUY');
+    if (sig.type !== 'BUY') return;
+    expect(sig.tp1).toBe(87.55); // 85 × 1.03
+    expect(sig.tp2).toBe(90.1);  // 85 × 1.06
+    expect(sig.tp3).toBe(92.65); // 85 × 1.09
+    expect(sig.sl).toBe(83.3);   // 85 × 0.98
+    expect(sig.timeStopDays).toBe(5);
+  });
+
+  it('respects stricter rsiOversold threshold (RSI 14 fails when oversold=10)', () => {
+    // RSI[t] ≈ 14, donc avec oversold=10 → HOLD car rsi14 >= 10
+    const sig = scanRebound(capitulationSetup(), { rsiOversold: 10 });
+    expect(sig.type).toBe('HOLD');
+    if (sig.type === 'HOLD') {
+      expect(sig.reason).toMatch(/rsi=/);
+    }
+  });
+
+  it('confidence rises with more extreme oversold conditions', () => {
+    const baseline = scanRebound(capitulationSetup(2.0));
+    expect(baseline.type).toBe('BUY');
+    if (baseline.type !== 'BUY') return;
+    // Setup encore plus extrême : volume spike x10
+    const extreme = scanRebound(capitulationSetup(10));
+    expect(extreme.type).toBe('BUY');
+    if (extreme.type !== 'BUY') return;
+    expect(extreme.confidence).toBeGreaterThan(baseline.confidence);
+  });
+});

--- a/packages/ai-analyst/src/strategies/rebound-tp.ts
+++ b/packages/ai-analyst/src/strategies/rebound-tp.ts
@@ -1,0 +1,277 @@
+/**
+ * P3-A — Rebound-TP scanner.
+ *
+ * Pure function. Scanne une série OHLCV et identifie une **capitulation
+ * confirmée + amorce de rebond** sur la dernière bougie close. Cible :
+ * mean-reversion intraday/short-term sur tickers liquides survendus.
+ *
+ * Conditions BUY (TOUTES requises sur la dernière bougie close) :
+ *   1. RSI(14) < rsiOversold (default 30)
+ *   2. close < BollingerLower(20, 2)
+ *   3. drawdown20 ≤ -minDrawdownPct (default 15) — peak du window 20 bougies
+ *   4. volume_jour > volSpikeMult × SMA(volume, 20) (default 1.5×)
+ *   5. Bougie de retournement :
+ *        close[t] > open[t]      (chandelle haussière)
+ *        ET  RSI[t] > RSI[t-1]   (RSI improving)
+ *        ET  RSI[t-1] < 30       (la bougie précédente était survendue)
+ *
+ * Niveaux pct sur entry (cfg surchargeable, defaults ENV) :
+ *   TP1 +5%   (sortie 50% qty)
+ *   TP2 +10%  (sortie 30% qty)
+ *   TP3 +15%  (sortie 20% qty)
+ *   SL  -4%   OU close < low du jour d'entrée trigger immédiat
+ *   time stop : 10 jours
+ *
+ * Returns un signal HOLD avec `reason` détaillé si une condition manque,
+ * BUY si toutes valides. Aucun I/O, aucun side-effect.
+ */
+
+export interface Candle {
+  /** ISO timestamp ou millis epoch — uniquement informatif, le scanner
+   *  utilise l'index, pas la date. */
+  timestamp: string | number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface ReboundCfg {
+  rsiPeriod?: number; // default 14
+  rsiOversold?: number; // default 30
+  bbPeriod?: number; // default 20
+  bbStdDev?: number; // default 2
+  minDrawdownPct?: number; // default 15 (positif, comparé au drawdown négatif)
+  volPeriod?: number; // default 20
+  volSpikeMult?: number; // default 1.5
+  tp1Pct?: number; // default 5
+  tp2Pct?: number; // default 10
+  tp3Pct?: number; // default 15
+  slPct?: number; // default 4
+  timeStopDays?: number; // default 10
+}
+
+export type ReboundSignal =
+  | {
+      type: 'BUY';
+      entry: number;
+      tp1: number;
+      tp2: number;
+      tp3: number;
+      sl: number;
+      timeStopDays: number;
+      /** Confidence ∈ [0, 1] — combinaison normalisée des marges de
+       *  dépassement des seuils (RSI, BB, drawdown, volume). */
+      confidence: number;
+      indicators: {
+        rsi14: number;
+        rsi14Prev: number;
+        bbLower: number;
+        bbUpper: number;
+        ma20: number;
+        drawdown20Pct: number;
+        volSma20: number;
+        volSpikeRatio: number;
+      };
+    }
+  | {
+      type: 'HOLD';
+      reason: string;
+    };
+
+const DEFAULTS: Required<ReboundCfg> = {
+  rsiPeriod: 14,
+  rsiOversold: 30,
+  bbPeriod: 20,
+  bbStdDev: 2,
+  minDrawdownPct: 15,
+  volPeriod: 20,
+  volSpikeMult: 1.5,
+  tp1Pct: 5,
+  tp2Pct: 10,
+  tp3Pct: 15,
+  slPct: 4,
+  timeStopDays: 10,
+};
+
+export function scanRebound(history: Candle[], cfg: ReboundCfg = {}): ReboundSignal {
+  const c = { ...DEFAULTS, ...cfg };
+
+  // ── Sanity checks ─────────────────────────────────────────────────
+  if (!Array.isArray(history)) {
+    return { type: 'HOLD', reason: 'invalid_history_not_array' };
+  }
+  // Besoin de RSI[t] et RSI[t-1] (chacun nécessite rsiPeriod+1 closes).
+  // Le `t-1` recule encore d'1 → minBars = max(rsiPeriod+2, bbPeriod, volPeriod, 20).
+  const minBars = Math.max(c.rsiPeriod + 2, c.bbPeriod, c.volPeriod, 20);
+  if (history.length < minBars) {
+    return { type: 'HOLD', reason: `insufficient_bars_${history.length}<${minBars}` };
+  }
+  for (const bar of history) {
+    if (
+      !Number.isFinite(bar.open) ||
+      !Number.isFinite(bar.high) ||
+      !Number.isFinite(bar.low) ||
+      !Number.isFinite(bar.close) ||
+      !Number.isFinite(bar.volume) ||
+      bar.open <= 0 ||
+      bar.high <= 0 ||
+      bar.low <= 0 ||
+      bar.close <= 0 ||
+      bar.volume < 0 ||
+      bar.high < bar.low
+    ) {
+      return { type: 'HOLD', reason: 'invalid_bar_values' };
+    }
+  }
+
+  const lastIdx = history.length - 1;
+  const t = history[lastIdx];
+
+  // ── RSI[t] and RSI[t-1] ───────────────────────────────────────────
+  const rsi14 = computeRsi(
+    history.slice(lastIdx - c.rsiPeriod, lastIdx + 1).map((b) => b.close),
+    c.rsiPeriod,
+  );
+  const rsi14Prev = computeRsi(
+    history.slice(lastIdx - 1 - c.rsiPeriod, lastIdx).map((b) => b.close),
+    c.rsiPeriod,
+  );
+  if (rsi14 === null || rsi14Prev === null) {
+    return { type: 'HOLD', reason: 'rsi_compute_failed' };
+  }
+
+  // ── Bollinger Bands(20, 2) sur close ──────────────────────────────
+  const bbCloses = history.slice(lastIdx - c.bbPeriod + 1, lastIdx + 1).map((b) => b.close);
+  const ma20 = mean(bbCloses);
+  const stdev20 = stddev(bbCloses, ma20);
+  const bbLower = ma20 - c.bbStdDev * stdev20;
+  const bbUpper = ma20 + c.bbStdDev * stdev20;
+
+  // ── Drawdown 20 ─────────────────────────────────────────────────
+  // = (close[t] - max(high) sur les 20 dernières bougies) / max × 100
+  const window20 = history.slice(lastIdx - 19, lastIdx + 1);
+  const peak20 = window20.reduce((m, b) => Math.max(m, b.high), -Infinity);
+  if (!Number.isFinite(peak20) || peak20 <= 0) {
+    return { type: 'HOLD', reason: 'invalid_peak20' };
+  }
+  const drawdown20Pct = ((t.close - peak20) / peak20) * 100;
+
+  // ── Volume SMA(20) + spike ratio ─────────────────────────────────
+  const volWindow = history.slice(lastIdx - c.volPeriod + 1, lastIdx + 1).map((b) => b.volume);
+  const volSma = mean(volWindow);
+  const volSpikeRatio = volSma > 0 ? t.volume / volSma : 0;
+
+  // ── Conditions BUY ───────────────────────────────────────────────
+  const conds = {
+    rsiOversold: rsi14 < c.rsiOversold,
+    bbBreak: t.close < bbLower,
+    drawdown: drawdown20Pct <= -c.minDrawdownPct,
+    volSpike: volSpikeRatio > c.volSpikeMult,
+    reversalCandle:
+      t.close > t.open && rsi14 > rsi14Prev && rsi14Prev < c.rsiOversold,
+  };
+
+  // Diagnostic HOLD if any cond fails
+  const failed: string[] = [];
+  if (!conds.rsiOversold) failed.push(`rsi=${rsi14.toFixed(1)}>=${c.rsiOversold}`);
+  if (!conds.bbBreak) failed.push(`close=${t.close.toFixed(2)}>=bbLower=${bbLower.toFixed(2)}`);
+  if (!conds.drawdown) failed.push(`dd=${drawdown20Pct.toFixed(1)}%>-${c.minDrawdownPct}%`);
+  if (!conds.volSpike) failed.push(`volRatio=${volSpikeRatio.toFixed(2)}<=${c.volSpikeMult}`);
+  if (!conds.reversalCandle) {
+    if (t.close <= t.open) failed.push('candle_not_bullish');
+    else if (rsi14 <= rsi14Prev) failed.push('rsi_not_improving');
+    else if (rsi14Prev >= c.rsiOversold) failed.push('rsi_prev_not_oversold');
+  }
+  if (failed.length > 0) {
+    return { type: 'HOLD', reason: failed.join('; ') };
+  }
+
+  // ── BUY signal ────────────────────────────────────────────────────
+  const entry = t.close;
+  const tp1 = round2(entry * (1 + c.tp1Pct / 100));
+  const tp2 = round2(entry * (1 + c.tp2Pct / 100));
+  const tp3 = round2(entry * (1 + c.tp3Pct / 100));
+  const sl = round2(entry * (1 - c.slPct / 100));
+
+  // Confidence = moyenne normalisée des marges :
+  //  - rsiMargin    = (oversold − rsi14) / oversold  → plus rsi est bas, plus margin est grand
+  //  - ddMargin     = (|dd| − minDd) / minDd, capped à 1
+  //  - volMargin    = (volSpikeRatio − volSpikeMult) / volSpikeMult, capped à 1
+  //  - bbMargin     = (bbLower − close) / bbLower, capped à 1
+  const rsiMargin = clamp01((c.rsiOversold - rsi14) / c.rsiOversold);
+  const ddMargin = clamp01((Math.abs(drawdown20Pct) - c.minDrawdownPct) / c.minDrawdownPct);
+  const volMargin = clamp01((volSpikeRatio - c.volSpikeMult) / c.volSpikeMult);
+  const bbMargin = clamp01((bbLower - t.close) / bbLower);
+  const confidence = round2((rsiMargin + ddMargin + volMargin + bbMargin) / 4);
+
+  return {
+    type: 'BUY',
+    entry: round2(entry),
+    tp1,
+    tp2,
+    tp3,
+    sl,
+    timeStopDays: c.timeStopDays,
+    confidence,
+    indicators: {
+      rsi14: round2(rsi14),
+      rsi14Prev: round2(rsi14Prev),
+      bbLower: round2(bbLower),
+      bbUpper: round2(bbUpper),
+      ma20: round2(ma20),
+      drawdown20Pct: round2(drawdown20Pct),
+      volSma20: Math.round(volSma),
+      volSpikeRatio: round2(volSpikeRatio),
+    },
+  };
+}
+
+// ── Internes : indicateurs purs ──────────────────────────────────────
+
+/**
+ * RSI Wilder simplifié (moyenne arithmétique des gains/pertes au lieu
+ * de la moving avg de Wilder).
+ * Retourne null si données insuffisantes ou avgLoss=0 (cas pathologique
+ * extrême d'une série toujours haussière, géré upstream).
+ */
+function computeRsi(closes: number[], period: number): number | null {
+  if (closes.length < period + 1) return null;
+  let gains = 0;
+  let losses = 0;
+  for (let i = 1; i <= period; i++) {
+    const diff = closes[i] - closes[i - 1];
+    if (diff > 0) gains += diff;
+    else losses += -diff;
+  }
+  const avgGain = gains / period;
+  const avgLoss = losses / period;
+  if (avgLoss === 0) {
+    // Pas de pertes → RSI = 100 (overbought maximum). On retourne 100
+    // explicitement plutôt que null pour ne pas bloquer le scanner.
+    return avgGain === 0 ? 50 : 100;
+  }
+  const rs = avgGain / avgLoss;
+  return 100 - 100 / (1 + rs);
+}
+
+function mean(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  return xs.reduce((s, x) => s + x, 0) / xs.length;
+}
+
+function stddev(xs: number[], avg: number): number {
+  if (xs.length === 0) return 0;
+  const variance = xs.reduce((s, x) => s + (x - avg) ** 2, 0) / xs.length;
+  return Math.sqrt(variance);
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}

--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -134,6 +134,37 @@ export interface MarketSnapshot {
     takeProfitPct: number;
     takeProfitLadderPct: number[];
   };
+
+  /** P3-A — Indicateurs micro pré-calculés par ticker pour le scanner
+   *  rebound-tp. Optionnel : populé uniquement quand un caller a invoqué
+   *  scanRebound sur la watchlist. Permet à Lisa de raisonner sur les
+   *  signaux micro (RSI/BB/drawdown/volume) au-delà du contexte macro.
+   *
+   *  Map ticker → indicateurs sur la dernière bougie close.
+   *  Wiring complet du pipeline de scan attendu en P3-A.2.
+   */
+  reboundIndicators?: Record<string, {
+    rsi14: number;
+    bbLower20: number;
+    bbUpper20: number;
+    ma50?: number;
+    drawdown20Pct: number;
+    volSma20: number;
+  }>;
+
+  /** P3-A — Signaux BUY actifs prêts à être ouverts (filtrés par
+   *  scanRebound). Lisa peut combiner ces signaux avec son sizing macro
+   *  (deployment-scaler PR #41) pour décider quels rebounds prioriser. */
+  reboundSignals?: Array<{
+    ticker: string;
+    entry: number;
+    tp1: number;
+    tp2: number;
+    tp3: number;
+    sl: number;
+    timeStopDays: number;
+    confidence: number;
+  }>;
 }
 
 /**

--- a/supabase/migrations/0076_rebound_positions.sql
+++ b/supabase/migrations/0076_rebound_positions.sql
@@ -1,0 +1,95 @@
+-- P3-A — Table rebound_positions : positions ouvertes par le scanner
+-- mean-reversion (cf. packages/ai-analyst/src/strategies/rebound-tp.ts).
+--
+-- Cycle de vie :
+--   1. scanRebound retourne { type: 'BUY', entry, tp1, tp2, tp3, sl, … }
+--   2. INSERT row status = 'OPEN', filled_qty_pct = 100
+--   3. Cron monitor (toutes les 5 min) compare le prix live au pallier
+--      atteint :
+--        - close >= tp1  → status='TP1_HIT', filled_qty_pct=50
+--        - close >= tp2  → status='TP2_HIT', filled_qty_pct=20  (50+30 sortis)
+--        - close >= tp3  → status='TP3_HIT', filled_qty_pct=0   (close totale)
+--        - close <= sl   → status='SL_HIT', filled_qty_pct=0
+--        - now >= time_stop_at → status='TIMEOUT', filled_qty_pct=0
+--   4. realized_pnl_usd recalculé par le monitor à chaque sortie partielle.
+--
+-- L'enum status est un text constraint (compatible PG sans pg_dump enum).
+
+CREATE TABLE IF NOT EXISTS public.rebound_positions (
+  id uuid primary key default gen_random_uuid(),
+  portfolio_id uuid NOT NULL,
+  ticker text NOT NULL,
+  -- Niveaux figés à l'ouverture (immutables après INSERT).
+  entry_price numeric(18, 6) NOT NULL CHECK (entry_price > 0),
+  entry_at timestamptz NOT NULL DEFAULT now(),
+  tp1 numeric(18, 6) NOT NULL CHECK (tp1 > 0),
+  tp2 numeric(18, 6) NOT NULL CHECK (tp2 > tp1),
+  tp3 numeric(18, 6) NOT NULL CHECK (tp3 > tp2),
+  sl  numeric(18, 6) NOT NULL CHECK (sl  > 0 AND sl < tp1),
+  time_stop_at timestamptz NOT NULL,
+  -- Status fini (text + CHECK plutôt que CREATE TYPE pour idempotence).
+  status text NOT NULL DEFAULT 'OPEN' CHECK (status IN (
+    'OPEN','TP1_HIT','TP2_HIT','TP3_HIT','SL_HIT','TIMEOUT','CLOSED'
+  )),
+  -- Quantité restante en pourcentage de la quantité initiale (100 → 0).
+  filled_qty_pct numeric(5, 2) NOT NULL DEFAULT 100 CHECK (filled_qty_pct >= 0 AND filled_qty_pct <= 100),
+  realized_pnl_usd numeric(18, 6) NOT NULL DEFAULT 0,
+  -- Audit / observabilité.
+  scanner_confidence numeric(4, 3),
+  scanner_indicators jsonb,
+  closed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS rebound_positions_portfolio_status_idx
+  ON public.rebound_positions (portfolio_id, status);
+
+CREATE INDEX IF NOT EXISTS rebound_positions_open_time_stop_idx
+  ON public.rebound_positions (time_stop_at)
+  WHERE status = 'OPEN';
+
+CREATE INDEX IF NOT EXISTS rebound_positions_ticker_idx
+  ON public.rebound_positions (ticker);
+
+-- RLS — comme pour lisa_positions, scope sur portfolio appartenant à
+-- l'user. Le service backend utilise le service_role qui bypasse RLS.
+-- La policy SELECT permet à un user d'accéder uniquement à ses propres
+-- portfolios via la jointure portfolios.user_id = auth.uid().
+ALTER TABLE public.rebound_positions ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'rebound_positions'
+      AND policyname = 'rebound_positions_select_own'
+  ) THEN
+    CREATE POLICY rebound_positions_select_own ON public.rebound_positions
+      FOR SELECT
+      USING (
+        portfolio_id IN (
+          SELECT id FROM public.portfolios WHERE user_id = auth.uid()
+        )
+      );
+  END IF;
+END $$;
+
+-- Trigger updated_at
+CREATE OR REPLACE FUNCTION public.rebound_positions_set_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS rebound_positions_updated_at_trigger ON public.rebound_positions;
+CREATE TRIGGER rebound_positions_updated_at_trigger
+BEFORE UPDATE ON public.rebound_positions
+FOR EACH ROW
+EXECUTE FUNCTION public.rebound_positions_set_updated_at();
+
+COMMENT ON TABLE public.rebound_positions IS
+  'P3-A — positions ouvertes par scanRebound (capitulation + amorce de rebond). Sortie mécanique TP1/TP2/TP3 + SL + time stop. Cron monitor toutes les 5 min update le status.';


### PR DESCRIPTION
## Pourquoi (P3-A)

Lisa fait du sizing macro (PR #41) mais aucun signal d'entrée par ticker. On reste investi dans des trends baissiers et on ne capture pas les rebonds. Ce PR ajoute la dimension **micro** : achat sur capitulation confirmée + sortie mécanique TP1/TP2/TP3 + SL discipliné. Cible business : **$100 nets/jour**.

## Quoi

### 1. Pure helper `scanRebound`

`packages/ai-analyst/src/strategies/rebound-tp.ts`

```ts
scanRebound(history: Candle[], cfg?: ReboundCfg): ReboundSignal
// → { type: 'BUY', entry, tp1, tp2, tp3, sl, timeStopDays, confidence, indicators } 
// | { type: 'HOLD', reason }
```

Conditions BUY (5 toutes requises sur dernière bougie close) :
- RSI(14) < `REBOUND_RSI_OVERSOLD` (default 30)
- close < BollingerLower(20, 2)
- drawdown 20-bar ≤ -`REBOUND_MIN_DD_PCT` (default 15%)
- volume > `REBOUND_VOL_SPIKE` × SMA(volume, 20) (default 1.5×)
- reversal candle : close>open ET RSI[t]>RSI[t-1] ET RSI[t-1]<oversold

Niveaux : TP1 +5% (50% qty), TP2 +10% (30%), TP3 +15% (20%), SL -4%, time stop 10 jours.

`confidence ∈ [0, 1]` = moyenne normalisée des marges (RSI/drawdown/volume/BB).

### 2. Tests Jest — 12 specs

`packages/ai-analyst/src/strategies/__tests__/rebound-tp.spec.ts`

Couvre : capitulation full → BUY, bull trap → HOLD rsi, no volume spike → HOLD, candle baissière → HOLD, drawdown insuffisant → HOLD, inputs invalides (NaN/négatifs/high<low/null) → HOLD, custom TP/SL config, rsiOversold strict → HOLD, confidence rises with extreme.

### 3. Extension `MarketSnapshot`

```ts
reboundIndicators?: Record<ticker, { rsi14, bbLower20, bbUpper20, ma50, drawdown20Pct, volSma20 }>
reboundSignals?: Array<{ ticker, entry, tp1, tp2, tp3, sl, timeStopDays, confidence }>
```

Champs optionnels — populés par P3-A.2 (pipeline scan watchlist).

### 4. Migration `0076_rebound_positions.sql`

Status ENUM: `OPEN | TP1_HIT | TP2_HIT | TP3_HIT | SL_HIT | TIMEOUT | CLOSED`. CHECK constraints (`tp1 < tp2 < tp3` + `sl < tp1`). RLS portfolio scope. Trigger `updated_at`. 3 indices.

### 5. Cron `ReboundMonitorService`

`@Cron(EVERY_5_MINUTES)` — charge OPEN positions, fetch live price (skip si `source` fallback per CLAUDE.md garde-fous prix), évalue cascade SL → TP3 → TP2 → TP1 → time stop. Update `status` + `realized_pnl_usd` + `filled_qty_pct`. **Pas d'exécution réelle** — paper trading uniquement.

### 6. Endpoint `/lisa/daily-pnl` étendu

```diff
- { realized, latent, target, achievementPct, drift }
+ { realized, latent, target, achievementPct, drift, dailyTargetHit: boolean }
```

`DAILY_TARGET_USD` configurable via env (default 100). Le caller du scanner doit consulter `dailyTargetHit` et freeze nouvelles entrées si true.

### 7. README section + flow diagram ASCII

## Différences vs spec ticket (fail-fast diagnostiqué)

| Spec | Réalité codebase | Décision |
|---|---|---|
| `packages/shared/src/market-snapshot.ts` | Pas existant — `MarketSnapshot` est dans `packages/ai-analyst/src/thesis/thesis-generator.service.ts` | Étendu in-place |
| `packages/ai-analyst/src/lisa/build-prompt.ts` | Pas existant — prompt construit via `composeUserMessage()` dans thesis-generator | Injection prompt deferred → P3-A.2 |
| `apps/worker/` | Pas existant — crons en Nest dans `apps/api` | Cron ajouté à `apps/api/.../rebound-monitor.service.ts` (pattern cohérent avec `mechanical-trading.service.ts` et `lisa-autopilot.service.ts`) |
| Vitest | Jest only dans la codebase | Jest |

## Out of scope (P3-A.2 séparé)

- Watchlist scan loop (fetch klines par ticker via `BinanceMarketService` ou `EodhdTechnicalService`, run `scanRebound`, persist BUY → INSERT `rebound_positions`)
- Injection `reboundSignals` dans prompt Lisa (`formatReboundSignalsBlock`)
- Backtest hit-rate TP1 ≥ 55% sur historique long (ticket P3-B séparé)

## Tests

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/api` : 41 suites / **484 tests** ✅
- `npm test --workspace=@smartvest/ai-analyst` : 5 suites / **109 tests** ✅ (12 nouveaux)
- Total : **46 suites / 593 tests OK**

## Risques

- Pas d'exécution réelle introduite → aucun risque MANUAL_EXPLICIT.
- Migration idempotente (CREATE TABLE IF NOT EXISTS, DO $$ pour policy).
- Cron monitor skip prix fallback → ne déclenche jamais une sortie sur prix corrompu (incident 27/04 LMT évité).
- Pas encore d'INSERT automatique dans `rebound_positions` → table inerte tant que P3-A.2 n'est pas mergé.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_