### PR TITLE
feat(strategy): rebound watchlist scan loop (P3-A.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,27 @@ REBOUND_TP3_PCT=15
 REBOUND_SL_PCT=4
 REBOUND_TIME_STOP_DAYS=10
 DAILY_TARGET_USD=100
+
+# P3-A.2 — Scanner watchlist
+REBOUND_WATCHLIST=AAPL.US,MSFT.US,NVDA.US,...   # CSV, override default
+MAX_CONCURRENT_REBOUND_POSITIONS=5
 ```
+
+### Scanner watchlist (P3-A.2)
+
+`ReboundScannerService` ferme la boucle d'entrée :
+
+- Cron `'0 */15 * * * 1-5'` toutes les 15 min, lun-ven
+- Body check heures marché US (14:30-21:00 UTC) — sinon no-op
+- Pour chaque portfolio actif × chaque ticker watchlist :
+  - Fetch 60 daily bars via EODHD `/api/eod/{ticker}` (cache 1h)
+  - Run `scanRebound(bars, cfg)`
+  - Si BUY ET pas de position OPEN sur ce (portfolio, ticker) → INSERT
+- Garde-fous : `dailyTargetHit` freeze, `openCount >= MAX_CONCURRENT` skip
+- Audit : `lisa_decision_log` kind=`rebound_scan_completed` (hash chain)
+- Lisa pipeline : `MarketSnapshot.reboundSignals` injecté dans le prompt sous `## Positions rebound ouvertes` pour empêcher les doubles signaux
+
+Watchlist par défaut : 12 tickers US liquides (mega-cap tech + ETF index + énergie). Surchargeable via env CSV.
 
 ### Garde-fous
 

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -39,6 +39,7 @@ import { DailyProfitGovernor } from './services/daily-profit-governor.service';
 import { MacroModeService } from './services/macro-mode.service';
 import { ApiCostTrackerService } from './services/api-cost-tracker.service';
 import { ReboundMonitorService } from './services/rebound-monitor.service';
+import { ReboundScannerService } from './services/rebound-scanner.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule, BotLabModule],
@@ -85,6 +86,8 @@ import { ReboundMonitorService } from './services/rebound-monitor.service';
     MarketRegimeService,
     // P3-A — cron monitor pour rebound_positions (TP/SL/timeout toutes les 5 min)
     ReboundMonitorService,
+    // P3-A.2 — cron scanner watchlist (toutes les 15 min, heures marché US)
+    ReboundScannerService,
   ],
   exports: [
     LisaService,

--- a/apps/api/src/modules/lisa/services/__tests__/rebound-scanner.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/rebound-scanner.spec.ts
@@ -1,0 +1,303 @@
+/**
+ * P3-A.2 — Tests pour ReboundScannerService.
+ *
+ * Mocks pragmatiques (supabase chained API + LisaService + ConfigService).
+ * Couvre :
+ *   - DAILY_TARGET_HIT bloque tout scan
+ *   - MAX_CONCURRENT_REBOUND_POSITIONS respecté
+ *   - duplicate guard sur (portfolio_id, ticker) OPEN
+ *   - mock provider history → INSERT correct sur signal BUY
+ *   - HOLD signal → no INSERT
+ */
+import { ReboundScannerService } from '../rebound-scanner.service';
+
+// ── Helpers : factories pour fixtures de bougies ─────────────────────
+
+function buyFixture() {
+  // Setup capitulation reproduit du spec scanRebound (PR #43).
+  const closes = [
+    100, 100, 100, 100, 100, 100, 100, 100, 100, 100,
+    100, 100, 100, 100, 100, 100,
+    92, 88, 82, 85,
+  ];
+  return closes.map((close, i) => {
+    const open = i === 0 ? close * 0.999 : closes[i - 1];
+    return {
+      timestamp: i,
+      open,
+      high: Math.max(open, close) * 1.005,
+      low: Math.min(open, close) * 0.995,
+      close,
+      volume: i === closes.length - 1 ? 3500 : 1000,
+    };
+  });
+}
+
+function holdFixture() {
+  // Trend bull stable → RSI > 30 → HOLD
+  const bars = [];
+  for (let i = 0; i < 30; i++) {
+    const close = 100 + i * 0.5;
+    bars.push({ timestamp: i, open: close, high: close * 1.003, low: close * 0.997, close, volume: 1000 });
+  }
+  return bars;
+}
+
+// ── Mock supabase chainable API ──────────────────────────────────────
+
+interface MockState {
+  configs: Array<{ user_id: string; portfolio_id: string }>;
+  openPositions: Array<{ ticker: string }>;
+  /** Tracker des INSERT effectués sur rebound_positions */
+  inserts: Array<Record<string, unknown>>;
+  /** Si true, le double-check insert (select before insert) trouve la row */
+  insertConflict: boolean;
+}
+
+function makeSupabaseMock(state: MockState) {
+  const fromBuilder = (table: string) => {
+    const chain: Record<string, unknown> = {};
+    chain.select = () => chain;
+    chain.eq = () => chain;
+    chain.like = () => chain;
+    chain.gte = () => chain;
+    chain.lt = () => chain;
+    chain.not = () => chain;
+    chain.order = () => chain;
+    chain.limit = () => chain;
+    chain.maybeSingle = async () => {
+      if (table === 'rebound_positions' && state.insertConflict) {
+        return { data: { id: 'existing-row' }, error: null };
+      }
+      return { data: null, error: null };
+    };
+    chain.insert = async (row: Record<string, unknown>) => {
+      if (table === 'rebound_positions') {
+        state.inserts.push(row);
+      }
+      return { data: null, error: null };
+    };
+    chain.update = async () => ({ data: null, error: null });
+    // For `.then()`-able promise (e.g., `.from('x').select(...)` awaited directly)
+    (chain as { then: (resolve: (v: { data: unknown; error: null }) => void) => void }).then = (
+      resolve,
+    ) => {
+      if (table === 'lisa_session_configs') {
+        resolve({ data: state.configs, error: null });
+      } else if (table === 'rebound_positions') {
+        resolve({ data: state.openPositions, error: null });
+      } else {
+        resolve({ data: [], error: null });
+      }
+    };
+    return chain;
+  };
+
+  return {
+    getClient: () => ({
+      from: (table: string) => fromBuilder(table),
+    }),
+  };
+}
+
+// ── Mock LisaService ─────────────────────────────────────────────────
+
+function makeLisaMock(opts: { dailyTargetHit?: boolean }) {
+  return {
+    getDailyPnl: jest.fn(async () => ({
+      realized: 0,
+      latent: 0,
+      target: 100,
+      achievementPct: 0,
+      drift: -100,
+      dailyTargetHit: opts.dailyTargetHit ?? false,
+    })),
+  };
+}
+
+// ── Mock DecisionLogService ──────────────────────────────────────────
+
+function makeDecisionLogMock() {
+  return { append: jest.fn(async () => ({ id: 'log-id', hashChainCurrent: 'h', hashChainPrev: null })) };
+}
+
+// ── Mock ConfigService (key/value) ───────────────────────────────────
+
+function makeConfigMock(env: Record<string, string>) {
+  return { get: jest.fn((key: string) => env[key]) };
+}
+
+// ── Helper : construit le scanner avec stubs ─────────────────────────
+
+function buildScanner(opts: {
+  state: MockState;
+  dailyTargetHit?: boolean;
+  env?: Record<string, string>;
+  barsByTicker?: Record<string, ReturnType<typeof buyFixture> | null>;
+}): ReboundScannerService {
+  const supabase = makeSupabaseMock(opts.state);
+  const lisa = makeLisaMock({ ...(opts.dailyTargetHit !== undefined ? { dailyTargetHit: opts.dailyTargetHit } : {}) });
+  const decisionLog = makeDecisionLogMock();
+  const config = makeConfigMock({
+    EODHD_API_KEY: 'test-key',
+    REBOUND_WATCHLIST: 'AAPL.US',
+    ...(opts.env ?? {}),
+  });
+  const scanner = new ReboundScannerService(
+    supabase as never,
+    lisa as never,
+    decisionLog as never,
+    config as never,
+  );
+  // Override fetch via getDailyBars : on patche la méthode privée pour
+  // retourner un fixture déterministe sans appel réseau.
+  (scanner as unknown as { getDailyBars: (t: string) => Promise<unknown> }).getDailyBars = async (
+    ticker: string,
+  ) => {
+    const k = ticker.split('.')[0] + '.US';
+    return opts.barsByTicker?.[k] ?? opts.barsByTicker?.[ticker] ?? buyFixture();
+  };
+  return scanner;
+}
+
+describe('ReboundScannerService', () => {
+  describe('runScannerInner', () => {
+    it('skips scan when dailyTargetHit=true (audit recorded, no INSERT)', async () => {
+      const state: MockState = {
+        configs: [{ user_id: 'u1', portfolio_id: 'p1' }],
+        openPositions: [],
+        inserts: [],
+        insertConflict: false,
+      };
+      const scanner = buildScanner({ state, dailyTargetHit: true });
+      // @ts-expect-error access private
+      await scanner.runScannerInner();
+      expect(state.inserts).toHaveLength(0);
+    });
+
+    it('skips scan when openCount >= MAX_CONCURRENT_REBOUND_POSITIONS', async () => {
+      const state: MockState = {
+        configs: [{ user_id: 'u1', portfolio_id: 'p1' }],
+        openPositions: [
+          { ticker: 'A' },
+          { ticker: 'B' },
+          { ticker: 'C' },
+        ],
+        inserts: [],
+        insertConflict: false,
+      };
+      const scanner = buildScanner({
+        state,
+        env: { MAX_CONCURRENT_REBOUND_POSITIONS: '3', REBOUND_WATCHLIST: 'AAPL.US' },
+      });
+      // @ts-expect-error access private
+      await scanner.runScannerInner();
+      expect(state.inserts).toHaveLength(0);
+    });
+
+    it('inserts rebound_positions on BUY signal (mock provider history)', async () => {
+      const state: MockState = {
+        configs: [{ user_id: 'u1', portfolio_id: 'p1' }],
+        openPositions: [],
+        inserts: [],
+        insertConflict: false,
+      };
+      const scanner = buildScanner({
+        state,
+        env: { REBOUND_WATCHLIST: 'AAPL.US', MAX_CONCURRENT_REBOUND_POSITIONS: '5' },
+      });
+      // @ts-expect-error access private
+      await scanner.runScannerInner();
+      expect(state.inserts).toHaveLength(1);
+      const insert = state.inserts[0];
+      expect(insert.portfolio_id).toBe('p1');
+      expect(insert.ticker).toBe('AAPL');
+      expect(insert.status).toBe('OPEN');
+      expect(parseFloat(insert.entry_price as string)).toBe(85);
+      expect(parseFloat(insert.tp1 as string)).toBe(89.25);
+      expect(parseFloat(insert.sl as string)).toBe(81.6);
+    });
+
+    it('does NOT insert on HOLD signal', async () => {
+      const state: MockState = {
+        configs: [{ user_id: 'u1', portfolio_id: 'p1' }],
+        openPositions: [],
+        inserts: [],
+        insertConflict: false,
+      };
+      const scanner = buildScanner({
+        state,
+        barsByTicker: { 'AAPL.US': holdFixture() as never },
+        env: { REBOUND_WATCHLIST: 'AAPL.US' },
+      });
+      // @ts-expect-error access private
+      await scanner.runScannerInner();
+      expect(state.inserts).toHaveLength(0);
+    });
+
+    it('duplicate guard : second scan with existing OPEN does not insert', async () => {
+      const state: MockState = {
+        configs: [{ user_id: 'u1', portfolio_id: 'p1' }],
+        openPositions: [{ ticker: 'AAPL' }], // déjà OPEN
+        inserts: [],
+        insertConflict: false,
+      };
+      const scanner = buildScanner({
+        state,
+        env: { REBOUND_WATCHLIST: 'AAPL.US' },
+      });
+      // @ts-expect-error access private
+      await scanner.runScannerInner();
+      expect(state.inserts).toHaveLength(0);
+    });
+
+    it('race-condition guard : insertConflict prevents double insert', async () => {
+      const state: MockState = {
+        configs: [{ user_id: 'u1', portfolio_id: 'p1' }],
+        openPositions: [], // openPositions empty mais le SELECT-before-INSERT trouve une row
+        inserts: [],
+        insertConflict: true,
+      };
+      const scanner = buildScanner({
+        state,
+        env: { REBOUND_WATCHLIST: 'AAPL.US' },
+      });
+      // @ts-expect-error access private
+      await scanner.runScannerInner();
+      expect(state.inserts).toHaveLength(0);
+    });
+  });
+
+  describe('config helpers', () => {
+    it('parses REBOUND_WATCHLIST CSV', async () => {
+      const state: MockState = { configs: [], openPositions: [], inserts: [], insertConflict: false };
+      const scanner = buildScanner({
+        state,
+        env: { REBOUND_WATCHLIST: 'AAPL.US, MSFT.US , NVDA.US' },
+      });
+      // @ts-expect-error access private
+      const wl = scanner.getWatchlist();
+      expect(wl).toEqual(['AAPL.US', 'MSFT.US', 'NVDA.US']);
+    });
+
+    it('falls back to default watchlist when REBOUND_WATCHLIST empty', async () => {
+      const state: MockState = { configs: [], openPositions: [], inserts: [], insertConflict: false };
+      const scanner = buildScanner({ state, env: { REBOUND_WATCHLIST: '' } });
+      // @ts-expect-error access private
+      const wl = scanner.getWatchlist();
+      expect(wl.length).toBeGreaterThan(0);
+      expect(wl).toContain('AAPL.US');
+    });
+
+    it('uses MAX_CONCURRENT_REBOUND_POSITIONS env (default 5 if unset)', async () => {
+      const state: MockState = { configs: [], openPositions: [], inserts: [], insertConflict: false };
+      const scanner1 = buildScanner({ state, env: {} });
+      // @ts-expect-error access private
+      expect(scanner1.getMaxConcurrent()).toBe(5);
+
+      const scanner2 = buildScanner({ state, env: { MAX_CONCURRENT_REBOUND_POSITIONS: '8' } });
+      // @ts-expect-error access private
+      expect(scanner2.getMaxConcurrent()).toBe(8);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -505,6 +505,31 @@ export class LisaService {
       this.logger.warn(`EODHD enrichment partial failure: ${String(e).slice(0, 120)}`);
     }
 
+    // P3-A.2 — injecte les positions rebound OPEN dans le snapshot pour
+    // que Lisa connaisse les rebounds en cours (paper trading) et évite
+    // de doubler une position sur le même ticker. Mappage léger en mode
+    // "signals" (les TP/SL sont déjà figés à l'ouverture, pas négociables).
+    try {
+      const reboundOpen = await this.getReboundOpenPositions(portfolioId);
+      if (reboundOpen.length > 0) {
+        marketSnapshot.reboundSignals = reboundOpen.map((r) => ({
+          ticker: r.ticker,
+          entry: r.entry,
+          tp1: r.tp1,
+          tp2: r.tp2,
+          tp3: r.tp3,
+          sl: r.sl,
+          timeStopDays: Math.max(
+            0,
+            Math.round((new Date(r.timeStopAt).getTime() - Date.now()) / 86_400_000),
+          ),
+          confidence: r.confidence ?? 0,
+        }));
+      }
+    } catch (e) {
+      this.logger.debug(`rebound positions inject skipped: ${String(e).slice(0, 80)}`);
+    }
+
     // Persona "chasseur EV+" injectée en amont du user focus si le flag est actif.
     // N'ajoute AUCUN droit d'exécution réelle — elle modifie juste le cadrage de
     // l'analyse produite par Claude (plus de turnover, sizing plus agressif dans
@@ -1742,6 +1767,45 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       open_positions_count: snap.openPositionsCount,
       drawdown_from_peak_pct: snap.drawdownFromPeakPct,
     };
+  }
+
+  /**
+   * P3-A.2 — Liste les positions rebound OPEN d'un portfolio pour
+   * injection dans le prompt Lisa. Retourne un format léger (pas tout
+   * le row DB), prêt à être formaté par le builder de prompt.
+   */
+  async getReboundOpenPositions(portfolioId: string): Promise<Array<{
+    ticker: string;
+    entry: number;
+    tp1: number;
+    tp2: number;
+    tp3: number;
+    sl: number;
+    timeStopAt: string;
+    filledQtyPct: number;
+    confidence: number | null;
+  }>> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('rebound_positions')
+      .select('ticker, entry_price, tp1, tp2, tp3, sl, time_stop_at, filled_qty_pct, scanner_confidence')
+      .eq('portfolio_id', portfolioId)
+      .eq('status', 'OPEN');
+    if (error) {
+      this.logger.warn(`getReboundOpenPositions failed: ${error.message}`);
+      return [];
+    }
+    return (data ?? []).map((r) => ({
+      ticker: String(r.ticker),
+      entry: parseFloat(r.entry_price as string),
+      tp1: parseFloat(r.tp1 as string),
+      tp2: parseFloat(r.tp2 as string),
+      tp3: parseFloat(r.tp3 as string),
+      sl: parseFloat(r.sl as string),
+      timeStopAt: r.time_stop_at as string,
+      filledQtyPct: parseFloat(r.filled_qty_pct as string),
+      confidence: r.scanner_confidence != null ? parseFloat(r.scanner_confidence as string) : null,
+    }));
   }
 
   /**

--- a/apps/api/src/modules/lisa/services/rebound-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/rebound-scanner.service.ts
@@ -1,0 +1,396 @@
+/**
+ * P3-A.2 — Rebound watchlist scan loop.
+ *
+ * Cron toutes les 15 minutes pendant heures marché US (lun-ven, 14:30-21:00
+ * UTC). Pour chaque portfolio actif :
+ *   1. Charge la watchlist (hardcodée pour le moment, cf. WATCHLIST_DEFAULT).
+ *   2. Pour chaque ticker → fetch 60 daily bars via EODHD `/api/eod/`.
+ *   3. Appel `scanRebound(history)`. Si BUY ET pas de position OPEN
+ *      existante sur (portfolio_id, ticker) → INSERT rebound_positions.
+ *   4. Garde-fous :
+ *      - dailyTargetHit (cumul réalisé+latent ≥ DAILY_TARGET_USD) → freeze
+ *      - count(OPEN) ≥ MAX_CONCURRENT_REBOUND_POSITIONS → skip
+ *      - hors heures marché US → no-op
+ *   5. Audit `lisa_decision_log` kind='rebound_scan_completed'.
+ *
+ * Pas d'exécution réelle. Les positions insérées sont du paper trading
+ * géré ensuite par ReboundMonitorService (PR #43).
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { LisaService } from './lisa.service';
+import { DecisionLogService } from './decision-log.service';
+import { scanRebound, type Candle, type ReboundCfg } from '@smartvest/ai-analyst';
+
+/**
+ * Watchlist par défaut : 12 tickers US liquides à mid/high cap, couvrant
+ * tech méga-cap, semi, ETF index, énergie. Choix pour avoir une diversité
+ * sectorielle sans table watchlist dédiée. Surchargeable par env
+ * `REBOUND_WATCHLIST` (CSV).
+ */
+const WATCHLIST_DEFAULT = [
+  'AAPL.US', 'MSFT.US', 'NVDA.US', 'META.US', 'GOOGL.US', 'TSLA.US',
+  'AMD.US', 'AVGO.US', 'SPY.US', 'QQQ.US', 'IWM.US', 'XOM.US',
+];
+
+interface EodhdEodBar {
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  adjusted_close?: number;
+  volume: number;
+}
+
+interface SkipReason {
+  reason: string;
+  ticker?: string;
+}
+
+@Injectable()
+export class ReboundScannerService {
+  private readonly logger = new Logger(ReboundScannerService.name);
+  private readonly barsCache = new Map<string, { bars: Candle[]; asOf: number }>();
+  private readonly BARS_CACHE_MS = 60 * 60 * 1000; // 1h — bars daily, pas d'intérêt à refetch < 1h
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly lisa: LisaService,
+    private readonly decisionLog: DecisionLogService,
+    private readonly config: ConfigService,
+  ) {}
+
+  /**
+   * Cron toutes les 15 minutes. La fenêtre marché US est checkée
+   * dans le body pour permettre des tests manuels en dehors.
+   */
+  @Cron('0 */15 * * * 1-5', { name: 'rebound-scanner' })
+  async runScanner(): Promise<void> {
+    try {
+      // Heures marché US : lun-ven 14:30-21:00 UTC.
+      // Le cron pattern restreint déjà les jours (1-5) mais pas les heures.
+      const now = new Date();
+      const utcMin = now.getUTCHours() * 60 + now.getUTCMinutes();
+      const MARKET_OPEN_MIN = 14 * 60 + 30;
+      const MARKET_CLOSE_MIN = 21 * 60;
+      if (utcMin < MARKET_OPEN_MIN || utcMin >= MARKET_CLOSE_MIN) {
+        this.logger.debug(`[rebound-scanner] hors heures marché US (UTC ${now.getUTCHours()}:${now.getUTCMinutes()}) — skip`);
+        return;
+      }
+      await this.runScannerInner();
+    } catch (e) {
+      this.logger.error(`[rebound-scanner] cycle failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  private async runScannerInner(): Promise<void> {
+    // Charge tous les portfolios autopilot actifs (mêmes que lisa-autopilot).
+    const { data: configs, error } = await this.supabase
+      .getClient()
+      .from('lisa_session_configs')
+      .select('user_id, portfolio_id')
+      .eq('autopilot_enabled', true)
+      .eq('kill_switch_active', false);
+
+    if (error) {
+      this.logger.error(`[rebound-scanner] fetch configs failed: ${error.message}`);
+      return;
+    }
+    if (!configs || configs.length === 0) {
+      this.logger.debug('[rebound-scanner] no active portfolios');
+      return;
+    }
+
+    const watchlist = this.getWatchlist();
+    for (const cfg of configs) {
+      const portfolioId = cfg.portfolio_id as string;
+      const userId = cfg.user_id as string;
+      try {
+        await this.scanPortfolio(userId, portfolioId, watchlist);
+      } catch (e) {
+        this.logger.warn(
+          `[rebound-scanner] portfolio ${portfolioId.slice(0, 8)} scan failed: ${String(e).slice(0, 120)}`,
+        );
+      }
+    }
+  }
+
+  private async scanPortfolio(
+    userId: string,
+    portfolioId: string,
+    watchlist: string[],
+  ): Promise<void> {
+    const skipped: SkipReason[] = [];
+    let signalsFound = 0;
+    let opened = 0;
+
+    // ── Garde-fou 1 : dailyTargetHit ─────────────────────────────────
+    let dailyTargetHit = false;
+    try {
+      const dailyPnl = await this.lisa.getDailyPnl(userId, portfolioId);
+      dailyTargetHit = dailyPnl.dailyTargetHit;
+    } catch (e) {
+      this.logger.debug(`getDailyPnl failed (non-blocking): ${String(e).slice(0, 80)}`);
+    }
+    if (dailyTargetHit) {
+      skipped.push({ reason: 'daily_target_hit' });
+      await this.writeAudit(portfolioId, watchlist.length, 0, 0, skipped);
+      return;
+    }
+
+    // ── Garde-fou 2 : MAX_CONCURRENT positions OPEN ──────────────────
+    const maxConcurrent = this.getMaxConcurrent();
+    const { data: openPositions, error: openErr } = await this.supabase
+      .getClient()
+      .from('rebound_positions')
+      .select('ticker')
+      .eq('portfolio_id', portfolioId)
+      .eq('status', 'OPEN');
+    if (openErr) {
+      this.logger.warn(`[rebound-scanner] count OPEN failed: ${openErr.message}`);
+      return;
+    }
+    const openCount = (openPositions ?? []).length;
+    const openTickers = new Set((openPositions ?? []).map((p) => String(p.ticker)));
+    if (openCount >= maxConcurrent) {
+      skipped.push({ reason: `max_concurrent_${openCount}>=${maxConcurrent}` });
+      await this.writeAudit(portfolioId, watchlist.length, 0, 0, skipped);
+      return;
+    }
+
+    // ── Loop watchlist ───────────────────────────────────────────────
+    const cfg = this.scannerCfg();
+    const slotsAvailable = maxConcurrent - openCount;
+
+    for (const eodhdTicker of watchlist) {
+      // Duplicate guard : skip si position OPEN existe déjà sur ce ticker.
+      const baseSymbol = eodhdTicker.split('.')[0];
+      if (openTickers.has(eodhdTicker) || openTickers.has(baseSymbol)) {
+        skipped.push({ reason: 'already_open', ticker: eodhdTicker });
+        continue;
+      }
+
+      // Fetch bars (60 demandés, minimum 20 requis par scanRebound).
+      const bars = await this.getDailyBars(eodhdTicker, 60).catch(() => null);
+      if (!bars || bars.length < 20) {
+        skipped.push({ reason: 'insufficient_bars', ticker: eodhdTicker });
+        continue;
+      }
+
+      // Run scanner
+      const sig = scanRebound(bars, cfg);
+      if (sig.type !== 'BUY') {
+        // Diagnostic dispo via sig.reason — on l'évite pour ne pas bloater
+        // l'audit (la majorité des scans sont HOLD).
+        continue;
+      }
+      signalsFound++;
+
+      if (opened >= slotsAvailable) {
+        skipped.push({ reason: 'slot_exhausted', ticker: eodhdTicker });
+        continue;
+      }
+
+      // INSERT rebound_positions.
+      const inserted = await this.insertReboundPosition(
+        portfolioId,
+        baseSymbol,
+        sig,
+      );
+      if (inserted) {
+        opened++;
+        this.logger.log(
+          `[rebound-scanner] ${baseSymbol} BUY signaled → INSERT rebound_position (entry=${sig.entry}, tp1=${sig.tp1}, sl=${sig.sl}, conf=${sig.confidence})`,
+        );
+      } else {
+        skipped.push({ reason: 'insert_failed', ticker: eodhdTicker });
+      }
+    }
+
+    await this.writeAudit(portfolioId, watchlist.length, signalsFound, opened, skipped);
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────
+
+  private getWatchlist(): string[] {
+    const env = this.config.get<string>('REBOUND_WATCHLIST');
+    if (env && env.trim().length > 0) {
+      return env
+        .split(',')
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0);
+    }
+    return WATCHLIST_DEFAULT;
+  }
+
+  private getMaxConcurrent(): number {
+    const v = Number(this.config.get<string>('MAX_CONCURRENT_REBOUND_POSITIONS'));
+    return Number.isFinite(v) && v > 0 ? Math.floor(v) : 5;
+  }
+
+  private scannerCfg(): ReboundCfg {
+    const num = (k: string) => {
+      const v = Number(this.config.get<string>(k));
+      return Number.isFinite(v) && v > 0 ? v : undefined;
+    };
+    const cfg: ReboundCfg = {};
+    const rsi = num('REBOUND_RSI_OVERSOLD');
+    if (rsi !== undefined) cfg.rsiOversold = rsi;
+    const dd = num('REBOUND_MIN_DD_PCT');
+    if (dd !== undefined) cfg.minDrawdownPct = dd;
+    const vol = num('REBOUND_VOL_SPIKE');
+    if (vol !== undefined) cfg.volSpikeMult = vol;
+    const tp1 = num('REBOUND_TP1_PCT');
+    if (tp1 !== undefined) cfg.tp1Pct = tp1;
+    const tp2 = num('REBOUND_TP2_PCT');
+    if (tp2 !== undefined) cfg.tp2Pct = tp2;
+    const tp3 = num('REBOUND_TP3_PCT');
+    if (tp3 !== undefined) cfg.tp3Pct = tp3;
+    const sl = num('REBOUND_SL_PCT');
+    if (sl !== undefined) cfg.slPct = sl;
+    const ts = num('REBOUND_TIME_STOP_DAYS');
+    if (ts !== undefined) cfg.timeStopDays = ts;
+    return cfg;
+  }
+
+  /**
+   * Fetch les N dernières bougies daily OHLCV depuis EODHD `/api/eod/`.
+   * Cache mémoire 1h pour éviter de spammer l'API en cycle 15min.
+   *
+   * Retourne null si :
+   *   - EODHD_API_KEY non set
+   *   - HTTP error / timeout
+   *   - Réponse mal formée ou < N bars
+   */
+  private async getDailyBars(eodhdTicker: string, count: number): Promise<Candle[] | null> {
+    const cached = this.barsCache.get(eodhdTicker);
+    if (cached && Date.now() - cached.asOf < this.BARS_CACHE_MS) {
+      return cached.bars.slice(-count);
+    }
+
+    const apiKey = this.config.get<string>('EODHD_API_KEY');
+    if (!apiKey) {
+      this.logger.warn('[rebound-scanner] EODHD_API_KEY missing — cannot fetch bars');
+      return null;
+    }
+
+    // Sur 60 daily bars, on demande 90 jours calendaires pour couvrir
+    // weekends + holidays (ratio ~252 trading days / 365 cal days).
+    const calendarDays = Math.ceil(count * 1.5);
+    const to = new Date();
+    const from = new Date(Date.now() - calendarDays * 86_400_000);
+    const url = `https://eodhd.com/api/eod/${encodeURIComponent(eodhdTicker)}?from=${from.toISOString().slice(0, 10)}&to=${to.toISOString().slice(0, 10)}&api_token=${encodeURIComponent(apiKey)}&fmt=json&order=a`;
+
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+      if (!res.ok) {
+        this.logger.warn(`[rebound-scanner] EODHD ${eodhdTicker} HTTP_${res.status}`);
+        return null;
+      }
+      const data = (await res.json()) as EodhdEodBar[];
+      if (!Array.isArray(data) || data.length < count) return null;
+
+      const bars: Candle[] = data
+        .filter(
+          (d) =>
+            typeof d.open === 'number' &&
+            typeof d.high === 'number' &&
+            typeof d.low === 'number' &&
+            typeof d.close === 'number' &&
+            typeof d.volume === 'number',
+        )
+        .map((d) => ({
+          timestamp: d.date,
+          open: d.open,
+          high: d.high,
+          low: d.low,
+          close: d.close,
+          volume: d.volume,
+        }));
+
+      this.barsCache.set(eodhdTicker, { bars, asOf: Date.now() });
+      return bars.slice(-count);
+    } catch (e) {
+      this.logger.warn(`[rebound-scanner] EODHD ${eodhdTicker} fetch failed: ${String(e).slice(0, 80)}`);
+      return null;
+    }
+  }
+
+  /**
+   * INSERT rebound_positions row. Idempotence garantie côté caller (vérif
+   * openTickers Set + duplicate guard sur (portfolio_id, ticker, status='OPEN')
+   * géré par requête .select avant INSERT).
+   *
+   * Retourne true sur INSERT réussi, false sinon.
+   */
+  private async insertReboundPosition(
+    portfolioId: string,
+    ticker: string,
+    sig: Extract<ReturnType<typeof scanRebound>, { type: 'BUY' }>,
+  ): Promise<boolean> {
+    // Anti race-condition : double-check qu'aucune position OPEN n'existe
+    // sur ce ticker (un autre tick parallèle pourrait avoir inséré entre
+    // notre lecture initiale et maintenant).
+    const { data: existing } = await this.supabase
+      .getClient()
+      .from('rebound_positions')
+      .select('id')
+      .eq('portfolio_id', portfolioId)
+      .eq('ticker', ticker)
+      .eq('status', 'OPEN')
+      .limit(1)
+      .maybeSingle();
+    if (existing) return false;
+
+    const stopAt = new Date(Date.now() + sig.timeStopDays * 86_400_000).toISOString();
+    const { error } = await this.supabase.getClient().from('rebound_positions').insert({
+      portfolio_id: portfolioId,
+      ticker,
+      entry_price: sig.entry.toFixed(6),
+      tp1: sig.tp1.toFixed(6),
+      tp2: sig.tp2.toFixed(6),
+      tp3: sig.tp3.toFixed(6),
+      sl: sig.sl.toFixed(6),
+      time_stop_at: stopAt,
+      status: 'OPEN',
+      filled_qty_pct: '100.00',
+      realized_pnl_usd: '0',
+      scanner_confidence: sig.confidence.toFixed(3),
+      scanner_indicators: sig.indicators,
+    });
+    if (error) {
+      this.logger.error(`[rebound-scanner] insert ${ticker} failed: ${error.message}`);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Trace le résultat du scan dans lisa_decision_log (chaîne hash, audit
+   * immutable côté Supabase).
+   */
+  private async writeAudit(
+    portfolioId: string,
+    scanned: number,
+    signalsFound: number,
+    opened: number,
+    skipped: SkipReason[],
+  ): Promise<void> {
+    try {
+      await this.decisionLog.append({
+        portfolioId,
+        kind: 'rebound_scan_completed',
+        summary: `Scan ${scanned} tickers · signals=${signalsFound} · opened=${opened} · skipped=${skipped.length}`,
+        rationale: skipped.slice(0, 6).map((s) => `${s.reason}${s.ticker ? `(${s.ticker})` : ''}`).join(', '),
+        payload: { scanned, signals_found: signalsFound, opened, skipped_reasons: skipped },
+        triggeredBy: 'mechanical_cron',
+      });
+    } catch (e) {
+      this.logger.debug(`[rebound-scanner] audit append failed: ${String(e).slice(0, 80)}`);
+    }
+  }
+}

--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -495,7 +495,7 @@ ${m.performanceAnalytics}
 
 ` : ''}${this.formatDailyHarvestBlock(req.dailyHarvestContext)}${req.adoptedPatternsBriefing ? `${req.adoptedPatternsBriefing}\n` : ''}## Recent news (24-72h) — analyse scorée et filtrée
 ${m.newsAnalysis ? m.newsAnalysis : (recentNewsBlock || '- (no recent news provided)')}${m.newsAnalysis ? '' : sentimentLine}
-${m.screenerCandidates ? `\n## Screener candidates (scans de découverte EODHD)\n${m.screenerCandidates}\n` : ''}${m.insiderSignals ? `\n## Insider signals (SEC Form 4, 30j)\n${m.insiderSignals}\n` : ''}${m.optionsSignals ? `\n## Options flow (IV ATM · put/call ratio)\n${m.optionsSignals}\n` : ''}${m.liquidationsSignals ? `\n## Crypto liquidations (waves reversal)\n${m.liquidationsSignals}\n` : ''}
+${m.screenerCandidates ? `\n## Screener candidates (scans de découverte EODHD)\n${m.screenerCandidates}\n` : ''}${m.insiderSignals ? `\n## Insider signals (SEC Form 4, 30j)\n${m.insiderSignals}\n` : ''}${m.optionsSignals ? `\n## Options flow (IV ATM · put/call ratio)\n${m.optionsSignals}\n` : ''}${m.liquidationsSignals ? `\n## Crypto liquidations (waves reversal)\n${m.liquidationsSignals}\n` : ''}${this.formatReboundOpenPositionsBlock(m.reboundSignals)}
 
 ## Upcoming events (7 days)
 ${upcomingEventsBlock || '- (no upcoming events provided)'}
@@ -664,6 +664,25 @@ défini, sans markdown, sans explications hors JSON.
 - Stop-loss : ${tr.stopLossPct}% · Take-profit : ${tr.takeProfitPct}%${ladder}
 - Tu peux dévier si tu as une raison solide (à expliciter dans [DIAGNOSTIC]).
 `;
+  }
+
+  /**
+   * P3-A.2 — Bloc « Positions rebound ouvertes » injecté dans le prompt
+   * pour informer Lisa des paper trades en cours sur la stratégie
+   * mean-reversion. Empêche Lisa de dupliquer un signal sur un ticker
+   * déjà ouvert et lui donne la visibilité TP/SL/timeStop.
+   *
+   * Inerte si reboundSignals est vide ou absent.
+   */
+  private formatReboundOpenPositionsBlock(
+    signals?: MarketSnapshot['reboundSignals'],
+  ): string {
+    if (!signals || signals.length === 0) return '';
+    const rows = signals.map((s) => {
+      const conf = s.confidence > 0 ? ` · conf=${(s.confidence * 100).toFixed(0)}%` : '';
+      return `- **${s.ticker}** entry=${s.entry} → TP1=${s.tp1} TP2=${s.tp2} TP3=${s.tp3} · SL=${s.sl} · time stop ${s.timeStopDays}j${conf}`;
+    });
+    return `\n## Positions rebound ouvertes (paper trading, sortie mécanique)\n${rows.join('\n')}\n→ Ne pas re-signaler ces tickers. Les sorties TP/SL sont gérées par ReboundMonitor (cron 5 min).\n`;
   }
 
   private formatDailyHarvestBlock(ctx?: DailyHarvestBriefingContext): string {


### PR DESCRIPTION
## Pourquoi (P3-A.2)

P3-A (PR #43) a livré le scanner pur + la table `rebound_positions` + le `ReboundMonitorService` de **sortie** (TP/SL/timeout). Mais **aucune source ne peuplait la table** → scanner inerte. Ce PR ferme la boucle d'**entrée** : un cron qui tourne toutes les 15 min en heures marché US, scanne une watchlist, et INSERT les signaux BUY confirmés.

## Cycle complet

```
ReboundScannerService (cron 15min, marché US) ─── ENTRÉE ────────────
  ├─ scanRebound(history) sur watchlist
  └─ INSERT rebound_positions { OPEN, TP1/2/3, SL, time_stop_at }
        │
        ▼
ReboundMonitorService (cron 5min, livré PR #43) ─── SORTIE ──────────
  ├─ fetch live price · skip si fallback
  ├─ cascade SL → TP3 → TP2 → TP1 → timeout
  └─ UPDATE status + filled_qty_pct + realized_pnl_usd
```

## Quoi

### 1. `ReboundScannerService` cron

`apps/api/src/modules/lisa/services/rebound-scanner.service.ts`

- `@Cron('0 */15 * * * 1-5')` lun-ven toutes les 15 min
- Body check heures marché US 14:30-21:00 UTC
- Pour chaque portfolio autopilot actif × chaque ticker watchlist :
  - Garde-fou `dailyTargetHit` (lecture `LisaService.getDailyPnl`)
  - Garde-fou `openCount >= MAX_CONCURRENT_REBOUND_POSITIONS` (env, default 5)
  - Duplicate guard sur `(portfolio_id, ticker, status='OPEN')`
  - Fetch 60 daily bars EODHD `/api/eod/{ticker}` (cache 1h)
  - Run `scanRebound(bars, cfg)` — cfg lit ENV `REBOUND_*`
  - Race-condition guard : SELECT-before-INSERT pour éviter double row
  - INSERT avec `scanner_confidence` + `scanner_indicators jsonb`

### 2. Watchlist

Hardcodée par défaut : 12 tickers US liquides (mega-cap tech + ETF index + énergie). Surchargeable via `REBOUND_WATCHLIST=AAPL.US,MSFT.US,NVDA.US,...`.

### 3. Audit hash-chaîné

```ts
decisionLog.append({
  kind: 'rebound_scan_completed',
  summary: 'Scan N tickers · signals=X · opened=Y · skipped=Z',
  payload: { scanned, signals_found, opened, skipped_reasons[] }
})
```

### 4. Pipeline Lisa : injection prompt

`MarketSnapshot.reboundSignals` populé par `getReboundOpenPositions(portfolioId)` post-enrichment. `composeUserMessage` injecte sous le bloc liquidations :

```
## Positions rebound ouvertes (paper trading, sortie mécanique)
- AAPL entry=180 → TP1=189 TP2=198 TP3=207 · SL=172.8 · time stop 8j · conf=42%
- ...
→ Ne pas re-signaler ces tickers. Les sorties TP/SL sont gérées par ReboundMonitor (cron 5 min).
```

### 5. Tests Jest (9 specs)

`apps/api/src/modules/lisa/services/__tests__/rebound-scanner.spec.ts`

| Spec | Couvre |
|---|---|
| dailyTargetHit=true | skip total, no INSERT |
| openCount ≥ MAX_CONCURRENT | skip |
| BUY signal mock | INSERT entry/TP/SL corrects |
| HOLD signal | no INSERT |
| duplicate guard | ticker déjà OPEN ignoré |
| race-condition guard | SELECT-before-INSERT bloque double |
| REBOUND_WATCHLIST CSV | parsing |
| default watchlist | fallback |
| MAX_CONCURRENT env | override (default 5) |

## Différences vs spec ticket (fail-fast diagnostiqué)

| Spec | Réalité | Décision |
|---|---|---|
| `apps/worker/` | absent | cron dans `apps/api` (Nest `@Cron`, pattern existant ReboundMonitor + lisa-autopilot) |
| `watchlists` table | absente | hardcoded 12 tickers + override `REBOUND_WATCHLIST` CSV |
| `autonomy_audit_events` | absente | audit dans `lisa_decision_log` (existant, hash-chained) |
| `portfolio.cash_available` | absente | sizing notionnel précis deferred → `qty=100%` au INSERT, monitor calcule pnl pct |
| `assets.industry` | absente | sector cap omis (deferred P3-A.3) |
| `Vitest` | Jest only | Jest |

## Tests

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/api` : 41 suites / **493 tests** ✅ (9 nouveaux)
- `npm test --workspace=@smartvest/ai-analyst` : 5 suites / 109 tests ✅
- Total : **46 suites / 602 tests OK**

## Risques

- Pas d'exécution réelle (paper trading uniquement, cohérent MANUAL_EXPLICIT)
- Migration P3-A déjà appliquée — pas de migration nouvelle nécessaire
- Cron cap par `MAX_CONCURRENT_REBOUND_POSITIONS` empêche l'inflation de positions
- Skip silencieux quand EODHD_API_KEY absent (log warn, pas de crash)
- Bypass possible des heures marché US via tests manuels en stub (cf. spec)

## Out of scope (P3-A.3 séparé)

- Sector cap respecté (nécessite enrichissement `assets.industry`)
- Sizing notionnel précis basé sur cash_available + deployment_scaler
- Watchlist par-portfolio (table dédiée + UI CRUD)
- Backtest hit-rate TP1 ≥ 55% (ticket P3-B)

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_