### PR TITLE
ci(backtest): GitHub Action workflow_dispatch pour backtest sans terminal (P3-B.2)

### DIFF
--- a/.github/workflows/backtest-rebound.yml
+++ b/.github/workflows/backtest-rebound.yml
@@ -1,0 +1,134 @@
+name: Backtest Rebound
+
+# Lance le runner historique rebound-tp à la demande depuis l'UI GitHub.
+# Aucun trigger automatique — le coût LLM/data est trop élevé pour
+# le faire tourner sur chaque push. L'utilisateur déclenche depuis
+# Actions → "Backtest Rebound" → Run workflow.
+#
+# Pré-requis (Settings → Secrets and variables → Actions) :
+#   - EODHD_API_KEY              (clé EODHD pour fetch OHLCV daily)
+#   - SUPABASE_URL               (insert row backtest_runs)
+#   - SUPABASE_SERVICE_ROLE_KEY  (idem, bypass RLS)
+#
+# Verdict GO/NO-GO visible directement dans Job summary après le run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      universe:
+        description: 'Univers de tickers à scanner'
+        required: true
+        type: choice
+        default: 'both'
+        options:
+          - sp500
+          - nasdaq100
+          - both
+      start:
+        description: 'Date début (YYYY-MM-DD)'
+        required: true
+        type: string
+        default: '2024-04-28'
+      end:
+        description: 'Date fin (YYYY-MM-DD)'
+        required: true
+        type: string
+        default: '2026-04-28'
+      cfg:
+        description: 'Config scanRebound de départ'
+        required: true
+        type: choice
+        default: 'default'
+        options:
+          - default
+          - strict
+      auto_tune:
+        description: 'Si NO_GO, run 3 variantes (rsi_25, vol_2_0, dd_20) et retourne la meilleure'
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  backtest:
+    name: Run rebound-tp backtest
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Env check (fail-fast secrets manquants)
+        env:
+          EODHD_API_KEY: ${{ secrets.EODHD_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          missing=()
+          [ -z "$EODHD_API_KEY" ] && missing+=("EODHD_API_KEY")
+          [ -z "$SUPABASE_URL" ] && missing+=("SUPABASE_URL")
+          [ -z "$SUPABASE_SERVICE_ROLE_KEY" ] && missing+=("SUPABASE_SERVICE_ROLE_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            echo "::error::Add them in Settings → Secrets and variables → Actions"
+            exit 1
+          fi
+          echo "✓ All required secrets present"
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build ai-analyst (compile dist/cli/backtest-rebound.js)
+        run: npm run build --workspace=@smartvest/ai-analyst
+
+      - name: Run backtest
+        env:
+          EODHD_API_KEY: ${{ secrets.EODHD_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          AUTO_TUNE_FLAG=""
+          if [ "${{ inputs.auto_tune }}" = "true" ]; then
+            AUTO_TUNE_FLAG="--auto-tune"
+          fi
+          npm run backtest:rebound --workspace=@smartvest/ai-analyst -- \
+            --universe=${{ inputs.universe }} \
+            --start=${{ inputs.start }} \
+            --end=${{ inputs.end }} \
+            --cfg=${{ inputs.cfg }} \
+            $AUTO_TUNE_FLAG
+
+      - name: Append Markdown report to job summary
+        if: always()
+        run: |
+          # Le runner écrit dans le cwd du workspace appelant. npm workspaces
+          # exécute la commande depuis le package, donc tmp/ est sous
+          # packages/ai-analyst/tmp/.
+          MD=$(ls -t packages/ai-analyst/tmp/backtest-rebound-*.md 2>/dev/null | head -1)
+          if [ -z "$MD" ]; then
+            MD=$(ls -t tmp/backtest-rebound-*.md 2>/dev/null | head -1)
+          fi
+          if [ -n "$MD" ] && [ -f "$MD" ]; then
+            cat "$MD" >> "$GITHUB_STEP_SUMMARY"
+            echo "✓ Appended $MD to job summary"
+          else
+            echo "::warning::Markdown report not found — backtest may have failed before writing"
+          fi
+
+      - name: Upload backtest artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backtest-rebound-${{ inputs.universe }}-${{ inputs.start }}-to-${{ inputs.end }}
+          path: |
+            packages/ai-analyst/tmp/backtest-rebound-*.json
+            packages/ai-analyst/tmp/backtest-rebound-*.md
+            tmp/backtest-rebound-*.json
+            tmp/backtest-rebound-*.md
+          retention-days: 30
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -311,6 +311,22 @@ MAX_CONCURRENT_REBOUND_POSITIONS=5
 
 Avant de déployer du capital significatif sur la stratégie rebound-tp, valider l'expectancy via un backtest historique.
 
+#### Lancer depuis l'UI GitHub (recommandé, P3-B.2)
+
+1. Ouvre **GitHub → Actions → Backtest Rebound → Run workflow**
+2. Sélectionne les inputs (defaults : `both`, 2 ans, `default`, auto-tune `true`)
+3. Clique **Run workflow** — durée ~5-10 min
+4. Le verdict GO/NO-GO + métriques apparaissent directement dans le **Job summary** (pas besoin de télécharger l'artifact)
+5. Historique longitudinal : table `backtest_runs` Supabase
+
+Pré-requis Settings → Secrets and variables → Actions :
+- `EODHD_API_KEY` (clé EODHD pour fetch OHLCV)
+- `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (insert row `backtest_runs`)
+
+Le workflow fail-fast au step `Env check` si un secret manque, avec message explicite indiquant lequel ajouter.
+
+#### Lancer en local (alternative)
+
 ```bash
 # Run par défaut (SP500 + NASDAQ100, 2 ans glissants, cfg default)
 EODHD_API_KEY=... npm run backtest:rebound -w @smartvest/ai-analyst


### PR DESCRIPTION
## Pourquoi (P3-B.2)

Le runner backtest P3-B (#45) tourne déjà côté code — manquait le **trigger UI** pour permettre à un utilisateur sans terminal de lancer un run. `workflow_dispatch` = 1 clic dans Actions.

## Quoi

### `.github/workflows/backtest-rebound.yml`

```yaml
on:
  workflow_dispatch:
    inputs:
      universe: choice [sp500, nasdaq100, both] default=both
      start:    string default=2024-04-28
      end:      string default=2026-04-28
      cfg:      choice [default, strict] default=default
      auto_tune: boolean default=true
```

Steps :
1. **Env check** fail-fast — vérifie les 3 secrets et émet `::error` si manquants avec message indiquant où les ajouter (Settings → Secrets and variables → Actions)
2. Setup Node 20 + `npm ci`
3. Build `@smartvest/ai-analyst` (compile `dist/cli/backtest-rebound.js`)
4. Run backtest avec args injectés depuis les inputs (auto-tune via shell var pour robustesse vs syntaxe ternaire GH Actions)
5. **Append MD report à `$GITHUB_STEP_SUMMARY`** — verdict GO/NO-GO directement visible dans l'UI sans télécharger l'artifact
6. Upload artifacts JSON + MD (rétention 30 j)

`timeout-minutes: 30`.

### README mis à jour

Section "Backtest validation" enrichie avec la méthode UI recommandée (5 étapes user-friendly), pré-requis secrets explicités, méthode locale toujours présente comme alternative.

## Pré-requis utilisateur (avant 1er run)

Settings → Secrets and variables → Actions :
- `EODHD_API_KEY`
- `SUPABASE_URL`
- `SUPABASE_SERVICE_ROLE_KEY`

Le step `Env check` fait fail-fast si l'un manque, avec message indiquant lequel.

## Différences vs spec ticket

| Spec | Réalité | Décision |
|---|---|---|
| `pnpm install --frozen-lockfile` | codebase npm only | `npm ci` (cohérent avec `ci.yml` existant) |
| `${{ inputs.auto_tune && '--auto-tune' || '' }}` syntax | parfois fragile sur boolean | shell var + `if` pour robustesse |
| Tests | aucun (YAML validé par GH au push) | + `python3 yaml.safe_load` smoke local ✅ |

## Tests

- `npx tsc -b` ✅
- `python3 -c "import yaml; yaml.safe_load(...)"` ✅
- ai-analyst : 7 suites / 137 tests ✅ (inchangé)
- apps/api  : 42 suites / 493 tests ✅ (inchangé)

## Action utilisateur post-merge

1. Vérifier les 3 secrets dans Settings → Secrets and variables → Actions
2. GitHub → Actions → **Backtest Rebound** → **Run workflow**
3. Defaults OK → **Run workflow**
4. ~5-10 min plus tard :
   - Verdict GO/NO-GO directement dans le Job summary
   - Artifacts JSON/MD téléchargeables 30 jours
   - Row dans `backtest_runs` Supabase

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_