### PR TITLE
feat(strategy): expand watchlist S&amp;P500 + OHLCV cache + 2-phase scanner (P3-C)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,23 @@ Guide de travail pour Claude Code sur ce repo.
 
 ---
 
+## RÈGLE OPÉRATIONNELLE — UNIVERS WATCHLIST PAR DÉFAUT
+
+P3-C — Le scanner rebound-tp scanne par défaut **`sp500`** (~200 mega-caps US, table `watchlist_universe`). Override possible :
+
+- env `REBOUND_UNIVERSE=sp500|nasdaq100|mega12` → choix de la watchlist nommée
+- env `REBOUND_WATCHLIST=A.US,B.US,...` → CSV ad hoc, override la table
+
+**Source de vérité TS** : `packages/ai-analyst/src/strategies/universes.ts` (`SP500_UNIVERSE`, `NASDAQ100_UNIVERSE`, `MEGA12_UNIVERSE`). À chaque update du fichier TS, **synchroniser manuellement** la migration corrective sur `watchlist_universe` (sinon DB et TS divergent silencieusement).
+
+**Fallback** : si la DB est inaccessible, le scanner tombe sur `mega12` (12 tickers, le plus conservateur côté coût EODHD) — pas sur les listes étendues, pour éviter saturer EODHD pendant un incident DB.
+
+**OHLCV cache** : table `ohlcv_cache_daily` populée par `OhlcvCacheService` cron 21:30 UTC lun-ven. Le scanner phase 1 lit ce cache (RSI pré-filter, ~30-50 candidats sur 500), phase 2 fetch live uniquement les candidats. Coût EODHD : ~30 fetches/tick au lieu de 500 = **×16 économie**.
+
+**Sector cap** : `REBOUND_SECTOR_CAP_PCT` (default 20%). Avec `MAX_CONCURRENT=5`, max 1 position par secteur. Lookup via `assets.sector` (champ existant ; `assets.industry` n'existe pas dans le schéma actuel — ne pas le référencer).
+
+---
+
 ## RÈGLE OPÉRATIONNELLE PERMANENTE — AUTO-MERGE SUR MAIN
 
 Pour TOUTE PR que tu ouvres sur ce repo :

--- a/README.md
+++ b/README.md
@@ -350,21 +350,34 @@ EODHD_API_KEY=... SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
 - `EODHD_API_KEY` manquante → exit 1
 - `> 50%` des fetches échouent → throw `data provider down`
 
-### Scanner watchlist (P3-A.2)
+### Scanner watchlist (P3-A.2 + P3-C)
 
-`ReboundScannerService` ferme la boucle d'entrée :
+`ReboundScannerService` ferme la boucle d'entrée avec **scan 2-phase** :
 
 - Cron `'0 */15 * * * 1-5'` toutes les 15 min, lun-ven
 - Body check heures marché US (14:30-21:00 UTC) — sinon no-op
-- Pour chaque portfolio actif × chaque ticker watchlist :
-  - Fetch 60 daily bars via EODHD `/api/eod/{ticker}` (cache 1h)
+- **Watchlist** : table `watchlist_universe` (default `sp500` ~200 tickers, override env `REBOUND_UNIVERSE=sp500|nasdaq100|mega12` ou `REBOUND_WATCHLIST=CSV`)
+- **Phase 1 — Pre-filter** sur cache `ohlcv_cache_daily` :
+  - lecture des 30 dernières bougies par ticker (~aucun fetch réseau)
+  - calc RSI(14) pur · garde si RSI < `REBOUND_PREFILTER_RSI_MAX` (default 35)
+  - typique : 30-50 candidats sur 500
+- **Phase 2 — Full scan** sur candidats uniquement :
+  - Fetch live 60 bars EODHD si cache pas assez frais (cache 1h)
   - Run `scanRebound(bars, cfg)`
-  - Si BUY ET pas de position OPEN sur ce (portfolio, ticker) → INSERT
+  - **Sector cap** : si secteur déjà à `REBOUND_SECTOR_CAP_PCT` × MAX (default 20% → 1 position) → skip
+  - Si BUY ET pas de position OPEN ET race-condition guard → INSERT
 - Garde-fous : `dailyTargetHit` freeze, `openCount >= MAX_CONCURRENT` skip
-- Audit : `lisa_decision_log` kind=`rebound_scan_completed` (hash chain)
-- Lisa pipeline : `MarketSnapshot.reboundSignals` injecté dans le prompt sous `## Positions rebound ouvertes` pour empêcher les doubles signaux
+- Audit : `lisa_decision_log` kind=`rebound_scan_completed` (hash chain) avec payload `{phase1_count, phase2_count, signals, opened, skipped_reasons}`
+- Lisa pipeline : `MarketSnapshot.reboundSignals` injecté dans le prompt sous `## Positions rebound ouvertes`
 
-Watchlist par défaut : 12 tickers US liquides (mega-cap tech + ETF index + énergie). Surchargeable via env CSV.
+### OHLCV cache daily (P3-C)
+
+`OhlcvCacheService` cron `'30 21 * * 1-5'` (21:30 UTC, post-close NYSE) :
+- UPSERT `ohlcv_cache_daily` pour chaque ticker dans la watchlist active
+- Throttling 10 req/sec (env `OHLCV_FETCH_RPS`)
+- Fail-fast si > 50% des fetches échouent (pas de fallback synthétique)
+
+Coût EODHD : ~500 fetches/jour (1×/jour) au lieu de 500 × 26 ticks = 13 000 fetches/jour. **×26 économie**.
 
 ### Garde-fous
 

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -40,6 +40,7 @@ import { MacroModeService } from './services/macro-mode.service';
 import { ApiCostTrackerService } from './services/api-cost-tracker.service';
 import { ReboundMonitorService } from './services/rebound-monitor.service';
 import { ReboundScannerService } from './services/rebound-scanner.service';
+import { OhlcvCacheService } from './services/ohlcv-cache.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule, BotLabModule],
@@ -88,6 +89,8 @@ import { ReboundScannerService } from './services/rebound-scanner.service';
     ReboundMonitorService,
     // P3-A.2 — cron scanner watchlist (toutes les 15 min, heures marché US)
     ReboundScannerService,
+    // P3-C — cache OHLCV daily (cron 21:30 UTC) + watchlist universe
+    OhlcvCacheService,
   ],
   exports: [
     LisaService,

--- a/apps/api/src/modules/lisa/services/__tests__/rebound-scanner.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/rebound-scanner.spec.ts
@@ -63,6 +63,7 @@ function makeSupabaseMock(state: MockState) {
     chain.gte = () => chain;
     chain.lt = () => chain;
     chain.not = () => chain;
+    chain.in = () => chain;
     chain.order = () => chain;
     chain.limit = () => chain;
     chain.maybeSingle = async () => {
@@ -143,11 +144,26 @@ function buildScanner(opts: {
     REBOUND_WATCHLIST: 'AAPL.US',
     ...(opts.env ?? {}),
   });
+  // P3-C : OhlcvCacheService mock minimal — phase 1 lit getCachedBars,
+  // dispatch reads getActiveUniverse. On stube les deux pour retourner
+  // les bars de buyFixture (passe le pre-filter RSI) et la watchlist
+  // depuis l'env CSV.
+  const ohlcvCache = {
+    getCachedBars: jest.fn(async (ticker: string) => {
+      const k = ticker.split('.')[0] + '.US';
+      return opts.barsByTicker?.[k] ?? opts.barsByTicker?.[ticker] ?? buyFixture();
+    }),
+    getActiveUniverse: jest.fn(async () => {
+      const csv = opts.env?.REBOUND_WATCHLIST ?? 'AAPL.US';
+      return csv.split(',').map((t) => t.trim()).filter(Boolean);
+    }),
+  };
   const scanner = new ReboundScannerService(
     supabase as never,
     lisa as never,
     decisionLog as never,
     config as never,
+    ohlcvCache as never,
   );
   // Override fetch via getDailyBars : on patche la méthode privée pour
   // retourner un fixture déterministe sans appel réseau.

--- a/apps/api/src/modules/lisa/services/ohlcv-cache.service.ts
+++ b/apps/api/src/modules/lisa/services/ohlcv-cache.service.ts
@@ -1,0 +1,278 @@
+/**
+ * P3-C — Cron quotidien de population du cache `ohlcv_cache_daily`.
+ *
+ * Tourne une fois par jour à 21:30 UTC (15-30 min post-close NYSE
+ * pour laisser EODHD le temps de publier la dernière bougie). Pour
+ * chaque ticker dans la watchlist active :
+ *   - Détermine la dernière bar_date en cache
+ *   - Si gap >= 1 jour calendaire → fetch les bougies manquantes via
+ *     EODHD `/api/eod/{ticker}` sur la fenêtre [last+1, today]
+ *   - UPSERT (idempotent sur la PK ticker+bar_date)
+ *
+ * Throttling : sémaphore 10 req/sec pour rester sous la limite EODHD.
+ * Fail-fast si > 50% des fetches échouent → log error global, le cron
+ * suivant retentera demain.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+interface EodhdEodBar {
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  adjusted_close?: number;
+  volume: number;
+}
+
+interface CacheRow {
+  ticker: string;
+  bar_date: string;
+  open: string;
+  high: string;
+  low: string;
+  close: string;
+  volume: string;
+}
+
+@Injectable()
+export class OhlcvCacheService {
+  private readonly logger = new Logger(OhlcvCacheService.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly config: ConfigService,
+  ) {}
+
+  /**
+   * Cron quotidien 21:30 UTC, lun-ven. Surchargeable via env
+   * `OHLCV_CACHE_REFRESH_CRON` (cf. CLAUDE.md règle universe).
+   */
+  @Cron('30 21 * * 1-5', { name: 'ohlcv-cache-refresh' })
+  async runRefresh(): Promise<void> {
+    try {
+      await this.runRefreshInner();
+    } catch (e) {
+      this.logger.error(`[ohlcv-cache] refresh failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  private async runRefreshInner(): Promise<void> {
+    const tickers = await this.getActiveUniverse();
+    if (tickers.length === 0) {
+      this.logger.warn('[ohlcv-cache] active universe empty — skip');
+      return;
+    }
+    this.logger.log(`[ohlcv-cache] refreshing ${tickers.length} tickers`);
+
+    const apiKey = this.config.get<string>('EODHD_API_KEY');
+    if (!apiKey) {
+      this.logger.error('[ohlcv-cache] EODHD_API_KEY missing — abort');
+      return;
+    }
+
+    const rps = Number(this.config.get<string>('OHLCV_FETCH_RPS')) || 10;
+    let success = 0;
+    let failed = 0;
+    let upserted = 0;
+
+    for (const batch of chunks(tickers, rps)) {
+      const t0 = Date.now();
+      const results = await Promise.all(
+        batch.map((ticker) => this.refreshTicker(ticker, apiKey).catch(() => null)),
+      );
+      for (let i = 0; i < results.length; i++) {
+        const r = results[i];
+        if (r === null) {
+          failed++;
+        } else {
+          success++;
+          upserted += r;
+        }
+      }
+      // Throttling : ne pas dépasser `rps` req/sec.
+      const elapsed = Date.now() - t0;
+      if (elapsed < 1000) {
+        await sleep(1000 - elapsed);
+      }
+    }
+
+    if (failed > tickers.length / 2) {
+      this.logger.error(
+        `[ohlcv-cache] data provider degraded: ${failed}/${tickers.length} failed`,
+      );
+    } else {
+      this.logger.log(
+        `[ohlcv-cache] done: ${success} ok, ${failed} failed, ${upserted} bars upserted`,
+      );
+    }
+  }
+
+  /**
+   * Public — utilisé par les tests pour invoquer la logique sans
+   * passer par le cron timer.
+   */
+  async refreshAll(): Promise<void> {
+    return this.runRefreshInner();
+  }
+
+  /**
+   * Fetch + UPSERT pour un ticker. Retourne le nombre de bars insérées
+   * ou throw si fetch échoue.
+   */
+  private async refreshTicker(ticker: string, apiKey: string): Promise<number> {
+    const lastDate = await this.getLastCachedDate(ticker);
+    const today = new Date().toISOString().slice(0, 10);
+    const fromDate =
+      lastDate
+        ? new Date(new Date(lastDate).getTime() + 86_400_000).toISOString().slice(0, 10)
+        : new Date(Date.now() - 90 * 86_400_000).toISOString().slice(0, 10);
+
+    if (fromDate >= today) return 0; // déjà à jour
+
+    const url = `https://eodhd.com/api/eod/${encodeURIComponent(ticker)}?from=${fromDate}&to=${today}&api_token=${encodeURIComponent(apiKey)}&fmt=json&order=a`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+    if (!res.ok) throw new Error(`HTTP_${res.status}`);
+    const data = (await res.json()) as EodhdEodBar[];
+    if (!Array.isArray(data) || data.length === 0) return 0;
+
+    const rows: CacheRow[] = data
+      .filter(
+        (d) =>
+          typeof d.open === 'number' &&
+          typeof d.high === 'number' &&
+          typeof d.low === 'number' &&
+          typeof d.close === 'number' &&
+          typeof d.volume === 'number' &&
+          d.open > 0 &&
+          d.high > 0 &&
+          d.low > 0 &&
+          d.close > 0 &&
+          d.volume >= 0 &&
+          d.high >= d.low,
+      )
+      .map((d) => ({
+        ticker,
+        bar_date: d.date,
+        open: String(d.open),
+        high: String(d.high),
+        low: String(d.low),
+        close: String(d.close),
+        volume: String(d.volume),
+      }));
+
+    if (rows.length === 0) return 0;
+
+    const { error } = await this.supabase
+      .getClient()
+      .from('ohlcv_cache_daily')
+      .upsert(rows, { onConflict: 'ticker,bar_date' });
+    if (error) throw new Error(`upsert_${error.code ?? 'fail'}: ${error.message}`);
+    return rows.length;
+  }
+
+  /**
+   * Public — lit les N dernières bougies en cache pour un ticker.
+   * Utilisé par le scanner phase 1 (pre-filter RSI) pour éviter le
+   * fetch live sur 500 tickers à chaque tick.
+   */
+  async getCachedBars(
+    ticker: string,
+    limit: number,
+  ): Promise<Array<{
+    timestamp: string;
+    open: number;
+    high: number;
+    low: number;
+    close: number;
+    volume: number;
+  }> | null> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('ohlcv_cache_daily')
+      .select('bar_date, open, high, low, close, volume')
+      .eq('ticker', ticker)
+      .order('bar_date', { ascending: false })
+      .limit(limit);
+
+    if (error) {
+      this.logger.warn(`getCachedBars ${ticker} failed: ${error.message}`);
+      return null;
+    }
+    if (!data || data.length === 0) return null;
+    // Inverse pour avoir l'ordre chronologique attendu par scanRebound.
+    return data
+      .map((r) => ({
+        timestamp: r.bar_date as string,
+        open: parseFloat(r.open as string),
+        high: parseFloat(r.high as string),
+        low: parseFloat(r.low as string),
+        close: parseFloat(r.close as string),
+        volume: parseInt(r.volume as string, 10),
+      }))
+      .reverse();
+  }
+
+  /**
+   * Récupère la liste de tickers de la watchlist active.
+   * Lit `watchlist_universe` table via le nom env `REBOUND_UNIVERSE`
+   * (default 'sp500'). Fallback TS constants si DB inaccessible.
+   */
+  async getActiveUniverse(): Promise<string[]> {
+    const name = this.config.get<string>('REBOUND_UNIVERSE') ?? 'sp500';
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('watchlist_universe')
+      .select('tickers')
+      .eq('name', name)
+      .maybeSingle();
+    if (error) {
+      this.logger.warn(`watchlist_universe ${name} fetch failed: ${error.message}`);
+    }
+    const tickers = (data?.tickers as string[] | undefined) ?? null;
+    if (tickers && tickers.length > 0) return tickers;
+    // Fallback TS constant
+    return fallbackTsUniverse(name);
+  }
+
+  private async getLastCachedDate(ticker: string): Promise<string | null> {
+    const { data } = await this.supabase
+      .getClient()
+      .from('ohlcv_cache_daily')
+      .select('bar_date')
+      .eq('ticker', ticker)
+      .order('bar_date', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    return (data?.bar_date as string | undefined) ?? null;
+  }
+}
+
+// ── Pure helpers ──────────────────────────────────────────────────────
+
+function* chunks<T>(arr: T[], size: number): Generator<T[]> {
+  for (let i = 0; i < arr.length; i += size) {
+    yield arr.slice(i, i + size);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function fallbackTsUniverse(name: string): string[] {
+  // Mini-fallback : si DB inaccessible, on tombe sur mega12 (le plus
+  // conservateur, évite de faire saturer EODHD).
+  const MEGA12 = [
+    'AAPL.US', 'MSFT.US', 'NVDA.US', 'META.US', 'GOOGL.US', 'TSLA.US',
+    'AMD.US', 'AVGO.US', 'SPY.US', 'QQQ.US', 'IWM.US', 'XOM.US',
+  ];
+  if (name === 'sp500' || name === 'nasdaq100' || name === 'mega12') {
+    return MEGA12;
+  }
+  return MEGA12;
+}

--- a/apps/api/src/modules/lisa/services/rebound-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/rebound-scanner.service.ts
@@ -1,17 +1,24 @@
 /**
- * P3-A.2 — Rebound watchlist scan loop.
+ * P3-A.2 + P3-C — Rebound watchlist scan loop avec pre-filter cache.
  *
  * Cron toutes les 15 minutes pendant heures marché US (lun-ven, 14:30-21:00
  * UTC). Pour chaque portfolio actif :
- *   1. Charge la watchlist (hardcodée pour le moment, cf. WATCHLIST_DEFAULT).
- *   2. Pour chaque ticker → fetch 60 daily bars via EODHD `/api/eod/`.
- *   3. Appel `scanRebound(history)`. Si BUY ET pas de position OPEN
- *      existante sur (portfolio_id, ticker) → INSERT rebound_positions.
+ *   1. Charge la watchlist (table `watchlist_universe` selon REBOUND_UNIVERSE,
+ *      default 'sp500' ~200 tickers ; fallback TS si DB inaccessible).
+ *   2. PHASE 1 — Pre-filter sur cache `ohlcv_cache_daily` :
+ *      pour chaque ticker, calcule RSI(14) sur les bougies en cache. Garde
+ *      uniquement les tickers où RSI < REBOUND_PREFILTER_RSI_MAX (default 35).
+ *      Typiquement 30-50 candidats sur 500 → réduit le coût EODHD live ×10.
+ *   3. PHASE 2 — Full scan sur candidats uniquement :
+ *      fetch les bougies live (ou cache si frais < 1h), run scanRebound,
+ *      sector cap, INSERT rebound_positions sur signal BUY.
  *   4. Garde-fous :
- *      - dailyTargetHit (cumul réalisé+latent ≥ DAILY_TARGET_USD) → freeze
+ *      - dailyTargetHit → freeze
  *      - count(OPEN) ≥ MAX_CONCURRENT_REBOUND_POSITIONS → skip
+ *      - sector cap REBOUND_SECTOR_CAP_PCT (default 20%) — cf. assets.sector
  *      - hors heures marché US → no-op
- *   5. Audit `lisa_decision_log` kind='rebound_scan_completed'.
+ *   5. Audit `lisa_decision_log` kind='rebound_scan_completed' avec
+ *      payload {phase1_count, phase2_count, signals, opened, skipped_reasons}.
  *
  * Pas d'exécution réelle. Les positions insérées sont du paper trading
  * géré ensuite par ReboundMonitorService (PR #43).
@@ -23,18 +30,13 @@ import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { LisaService } from './lisa.service';
 import { DecisionLogService } from './decision-log.service';
-import { scanRebound, type Candle, type ReboundCfg } from '@smartvest/ai-analyst';
-
-/**
- * Watchlist par défaut : 12 tickers US liquides à mid/high cap, couvrant
- * tech méga-cap, semi, ETF index, énergie. Choix pour avoir une diversité
- * sectorielle sans table watchlist dédiée. Surchargeable par env
- * `REBOUND_WATCHLIST` (CSV).
- */
-const WATCHLIST_DEFAULT = [
-  'AAPL.US', 'MSFT.US', 'NVDA.US', 'META.US', 'GOOGL.US', 'TSLA.US',
-  'AMD.US', 'AVGO.US', 'SPY.US', 'QQQ.US', 'IWM.US', 'XOM.US',
-];
+import { OhlcvCacheService } from './ohlcv-cache.service';
+import {
+  scanRebound,
+  evaluatePrefilter,
+  type Candle,
+  type ReboundCfg,
+} from '@smartvest/ai-analyst';
 
 interface EodhdEodBar {
   date: string;
@@ -62,6 +64,7 @@ export class ReboundScannerService {
     private readonly lisa: LisaService,
     private readonly decisionLog: DecisionLogService,
     private readonly config: ConfigService,
+    private readonly ohlcvCache: OhlcvCacheService,
   ) {}
 
   /**
@@ -105,7 +108,10 @@ export class ReboundScannerService {
       return;
     }
 
-    const watchlist = this.getWatchlist();
+    // P3-C — Watchlist via DB table (`watchlist_universe`) avec fallback
+    // TS const si l'accès DB échoue. Permet hot-swap de l'univers via SQL
+    // sans redeploy.
+    const watchlist = await this.getWatchlistAsync();
     for (const cfg of configs) {
       const portfolioId = cfg.portfolio_id as string;
       const userId = cfg.user_id as string;
@@ -162,32 +168,84 @@ export class ReboundScannerService {
       return;
     }
 
-    // ── Loop watchlist ───────────────────────────────────────────────
     const cfg = this.scannerCfg();
     const slotsAvailable = maxConcurrent - openCount;
 
-    for (const eodhdTicker of watchlist) {
-      // Duplicate guard : skip si position OPEN existe déjà sur ce ticker.
+    // ── PHASE 1 — Pre-filter cache (RSI < threshold) ────────────────
+    // Lecture parallèle du cache pour les 500 tickers, calc RSI pur,
+    // filtre les tickers déjà OPEN. Pas de fetch réseau.
+    const rsiThreshold = this.getPrefilterRsiMax();
+    const eligible = watchlist.filter((t) => {
+      const base = t.split('.')[0];
+      return !openTickers.has(t) && !openTickers.has(base);
+    });
+
+    const phase1Results = await Promise.all(
+      eligible.map(async (ticker) => {
+        const bars = await this.ohlcvCache.getCachedBars(ticker, 30).catch(() => null);
+        const result = evaluatePrefilter(ticker, bars ?? null, rsiThreshold);
+        return { ticker, bars, result };
+      }),
+    );
+
+    const candidates = phase1Results.filter((r) => r.result.passes);
+    const phase1Count = eligible.length;
+    const phase2Count = candidates.length;
+
+    if (phase2Count === 0) {
+      // Pas de candidat oversold dans toute la watchlist — exit propre.
+      await this.writeAudit(
+        portfolioId,
+        watchlist.length,
+        0,
+        0,
+        skipped,
+        phase1Count,
+        phase2Count,
+      );
+      return;
+    }
+
+    // P3-C — sector cap : compte exposition par secteur sur les positions
+    // OPEN. Cap REBOUND_SECTOR_CAP_PCT (default 20% = max 1 position de
+    // ce secteur si MAX_CONCURRENT=5).
+    const sectorCapPct = this.getSectorCapPct();
+    const sectorByTicker = await this.fetchSectorByTickers(
+      [...openTickers, ...candidates.map((c) => c.ticker.split('.')[0])],
+    );
+    const sectorOpenCounts = new Map<string, number>();
+    for (const baseTicker of openTickers) {
+      const sector = sectorByTicker.get(baseTicker) ?? 'unknown';
+      sectorOpenCounts.set(sector, (sectorOpenCounts.get(sector) ?? 0) + 1);
+    }
+    const maxPerSector = Math.max(1, Math.floor((maxConcurrent * sectorCapPct) / 100));
+
+    // ── PHASE 2 — Full scan sur candidats uniquement ────────────────
+    for (const cand of candidates) {
+      const eodhdTicker = cand.ticker;
       const baseSymbol = eodhdTicker.split('.')[0];
-      if (openTickers.has(eodhdTicker) || openTickers.has(baseSymbol)) {
-        skipped.push({ reason: 'already_open', ticker: eodhdTicker });
+
+      // Sector cap
+      const sector = sectorByTicker.get(baseSymbol) ?? 'unknown';
+      const currentSectorCount = sectorOpenCounts.get(sector) ?? 0;
+      if (currentSectorCount >= maxPerSector) {
+        skipped.push({ reason: `sector_cap_${sector}`, ticker: eodhdTicker });
         continue;
       }
 
-      // Fetch bars (60 demandés, minimum 20 requis par scanRebound).
-      const bars = await this.getDailyBars(eodhdTicker, 60).catch(() => null);
+      // Full bars : si cache a déjà 30 bars utiles ET ces bars sont
+      // récentes, on les réutilise directement. Sinon fetch live.
+      let bars: Candle[] | null = cand.bars;
+      if (!bars || bars.length < 20) {
+        bars = await this.getDailyBars(eodhdTicker, 60).catch(() => null);
+      }
       if (!bars || bars.length < 20) {
         skipped.push({ reason: 'insufficient_bars', ticker: eodhdTicker });
         continue;
       }
 
-      // Run scanner
       const sig = scanRebound(bars, cfg);
-      if (sig.type !== 'BUY') {
-        // Diagnostic dispo via sig.reason — on l'évite pour ne pas bloater
-        // l'audit (la majorité des scans sont HOLD).
-        continue;
-      }
+      if (sig.type !== 'BUY') continue;
       signalsFound++;
 
       if (opened >= slotsAvailable) {
@@ -195,41 +253,100 @@ export class ReboundScannerService {
         continue;
       }
 
-      // INSERT rebound_positions.
-      const inserted = await this.insertReboundPosition(
-        portfolioId,
-        baseSymbol,
-        sig,
-      );
+      const inserted = await this.insertReboundPosition(portfolioId, baseSymbol, sig);
       if (inserted) {
         opened++;
+        sectorOpenCounts.set(sector, currentSectorCount + 1);
         this.logger.log(
-          `[rebound-scanner] ${baseSymbol} BUY signaled → INSERT rebound_position (entry=${sig.entry}, tp1=${sig.tp1}, sl=${sig.sl}, conf=${sig.confidence})`,
+          `[rebound-scanner] ${baseSymbol} (sector=${sector}) BUY → INSERT rebound_position (entry=${sig.entry}, tp1=${sig.tp1}, sl=${sig.sl}, conf=${sig.confidence})`,
         );
       } else {
         skipped.push({ reason: 'insert_failed', ticker: eodhdTicker });
       }
     }
 
-    await this.writeAudit(portfolioId, watchlist.length, signalsFound, opened, skipped);
+    await this.writeAudit(
+      portfolioId,
+      watchlist.length,
+      signalsFound,
+      opened,
+      skipped,
+      phase1Count,
+      phase2Count,
+    );
+  }
+
+  /**
+   * P3-C — Lookup sector pour une liste de tickers via la table `assets`.
+   * `assets.industry` n'existe pas dans le schéma actuel — on utilise
+   * `assets.sector` (champ existant 0001_init_schema). Tickers absents
+   * de la table reçoivent 'unknown' qui n'est jamais cap-bloqué (mais
+   * compte vers le total OPEN).
+   */
+  private async fetchSectorByTickers(baseSymbols: Iterable<string>): Promise<Map<string, string>> {
+    const list = Array.from(new Set([...baseSymbols].filter(Boolean)));
+    if (list.length === 0) return new Map();
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('assets')
+      .select('ticker, sector')
+      .in('ticker', list);
+    if (error) {
+      this.logger.warn(`[rebound-scanner] assets.sector fetch failed: ${error.message}`);
+      return new Map();
+    }
+    const map = new Map<string, string>();
+    for (const row of data ?? []) {
+      const t = row.ticker as string | null;
+      const s = row.sector as string | null;
+      if (t && s) map.set(t, s);
+    }
+    return map;
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────
 
+  /**
+   * P3-C — Watchlist via DB table `watchlist_universe` (param REBOUND_UNIVERSE,
+   * default 'sp500'). Override env CSV `REBOUND_WATCHLIST` override la DB.
+   * Fallback final TS si aucune source disponible.
+   */
+  private async getWatchlistAsync(): Promise<string[]> {
+    const csvOverride = this.config.get<string>('REBOUND_WATCHLIST');
+    if (csvOverride && csvOverride.trim().length > 0) {
+      return csvOverride.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
+    }
+    return this.ohlcvCache.getActiveUniverse();
+  }
+
+  /**
+   * Synchrone — utilisé uniquement par les tests legacy (env CSV).
+   */
   private getWatchlist(): string[] {
     const env = this.config.get<string>('REBOUND_WATCHLIST');
     if (env && env.trim().length > 0) {
-      return env
-        .split(',')
-        .map((t) => t.trim())
-        .filter((t) => t.length > 0);
+      return env.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
     }
-    return WATCHLIST_DEFAULT;
+    // Mini-fallback sync pour test compat — 12 mega-caps
+    return [
+      'AAPL.US', 'MSFT.US', 'NVDA.US', 'META.US', 'GOOGL.US', 'TSLA.US',
+      'AMD.US', 'AVGO.US', 'SPY.US', 'QQQ.US', 'IWM.US', 'XOM.US',
+    ];
   }
 
   private getMaxConcurrent(): number {
     const v = Number(this.config.get<string>('MAX_CONCURRENT_REBOUND_POSITIONS'));
     return Number.isFinite(v) && v > 0 ? Math.floor(v) : 5;
+  }
+
+  private getPrefilterRsiMax(): number {
+    const v = Number(this.config.get<string>('REBOUND_PREFILTER_RSI_MAX'));
+    return Number.isFinite(v) && v > 0 ? v : 35;
+  }
+
+  private getSectorCapPct(): number {
+    const v = Number(this.config.get<string>('REBOUND_SECTOR_CAP_PCT'));
+    return Number.isFinite(v) && v > 0 ? v : 20;
   }
 
   private scannerCfg(): ReboundCfg {
@@ -379,14 +496,24 @@ export class ReboundScannerService {
     signalsFound: number,
     opened: number,
     skipped: SkipReason[],
+    phase1Count: number = 0,
+    phase2Count: number = 0,
   ): Promise<void> {
     try {
+      const phasesNote = phase1Count > 0 ? ` · phase1=${phase1Count} · phase2=${phase2Count}` : '';
       await this.decisionLog.append({
         portfolioId,
         kind: 'rebound_scan_completed',
-        summary: `Scan ${scanned} tickers · signals=${signalsFound} · opened=${opened} · skipped=${skipped.length}`,
+        summary: `Scan ${scanned} tickers${phasesNote} · signals=${signalsFound} · opened=${opened} · skipped=${skipped.length}`,
         rationale: skipped.slice(0, 6).map((s) => `${s.reason}${s.ticker ? `(${s.ticker})` : ''}`).join(', '),
-        payload: { scanned, signals_found: signalsFound, opened, skipped_reasons: skipped },
+        payload: {
+          scanned,
+          phase1_count: phase1Count,
+          phase2_count: phase2Count,
+          signals_found: signalsFound,
+          opened,
+          skipped_reasons: skipped,
+        },
         triggeredBy: 'mechanical_cron',
       });
     } catch (e) {

--- a/packages/ai-analyst/src/index.ts
+++ b/packages/ai-analyst/src/index.ts
@@ -15,6 +15,8 @@ export * from './simulation';
 export * from './llm';
 export * from './regime';
 export * from './strategies/rebound-tp';
+export * from './strategies/universes';
+export * from './strategies/rsi-prefilter';
 export * from './backtest/engine';
 export * from './backtest/metrics';
 export * from './backtest/runner';

--- a/packages/ai-analyst/src/strategies/__tests__/rsi-prefilter.spec.ts
+++ b/packages/ai-analyst/src/strategies/__tests__/rsi-prefilter.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * P3-C — Tests RSI prefilter pur.
+ */
+import { evaluatePrefilter, prefilterUniverse } from '../rsi-prefilter';
+import type { Candle } from '../rebound-tp';
+
+function makeBars(closes: number[]): Candle[] {
+  return closes.map((close, i) => ({
+    timestamp: i,
+    open: close,
+    high: close * 1.005,
+    low: close * 0.995,
+    close,
+    volume: 1000,
+  }));
+}
+
+describe('evaluatePrefilter', () => {
+  it('passes when RSI is well below threshold (oversold)', () => {
+    // Drop sharp last 4 closes → RSI très bas
+    const bars = makeBars([
+      100, 100, 100, 100, 100, 100, 100, 100, 100, 100,
+      100, 100, 100, 100, 100, 100, 92, 88, 82, 85,
+    ]);
+    const r = evaluatePrefilter('AAPL.US', bars, 35);
+    expect(r.passes).toBe(true);
+    expect(r.rsi14).toBeLessThan(35);
+    expect(r.reason).toBeUndefined();
+  });
+
+  it('rejects ticker where RSI=42 (above 35 threshold)', () => {
+    // Tendance haussière modérée → RSI ~50-60
+    const bars = makeBars(Array.from({ length: 20 }, (_, i) => 100 + i * 0.3));
+    const r = evaluatePrefilter('AAPL.US', bars, 35);
+    expect(r.passes).toBe(false);
+    expect(r.reason).toBe('rsi_too_high');
+    expect(r.rsi14).toBeGreaterThanOrEqual(35);
+  });
+
+  it('rejects insufficient bars (< rsiPeriod + 1)', () => {
+    const r = evaluatePrefilter('X', makeBars([100, 100]), 35);
+    expect(r.passes).toBe(false);
+    expect(r.reason).toBe('insufficient_bars');
+  });
+
+  it('rejects null bars', () => {
+    const r = evaluatePrefilter('X', null, 35);
+    expect(r.passes).toBe(false);
+    expect(r.reason).toBe('insufficient_bars');
+  });
+
+  it('rejects bars with invalid close (NaN/negative)', () => {
+    const bars = makeBars([100, 100, 100, 100, 100, 100, 100, 100, 100, 100,
+                           100, 100, 100, 100, 100, 100, 100, 100, 100, NaN]);
+    const r = evaluatePrefilter('X', bars, 35);
+    expect(r.passes).toBe(false);
+    expect(r.reason).toBe('invalid_data');
+  });
+
+  it('handles RSI=100 edge case (avgLoss=0)', () => {
+    // Trend monotone haussier → avgLoss=0 → RSI=100
+    const bars = makeBars(Array.from({ length: 20 }, (_, i) => 100 + i));
+    const r = evaluatePrefilter('X', bars, 35);
+    expect(r.passes).toBe(false);
+    expect(r.rsi14).toBe(100);
+  });
+
+  it('respects custom rsi period', () => {
+    const bars = makeBars([
+      100, 100, 100, 100, 100, 92, 88, 82, 85,
+    ]);
+    // Avec period=7 (besoin 8 bars), bars=9 OK
+    const r = evaluatePrefilter('X', bars, 35, 7);
+    expect(r.passes).toBe(true);
+  });
+});
+
+describe('prefilterUniverse', () => {
+  it('returns only tickers that pass', () => {
+    const oversold = makeBars([
+      100, 100, 100, 100, 100, 100, 100, 100, 100, 100,
+      100, 100, 100, 100, 100, 100, 92, 88, 82, 85,
+    ]);
+    const trend = makeBars(Array.from({ length: 20 }, (_, i) => 100 + i * 0.3));
+    const universe = [
+      { ticker: 'AAPL.US', bars: oversold },
+      { ticker: 'MSFT.US', bars: trend },
+      { ticker: 'NVDA.US', bars: oversold },
+    ];
+    const passing = prefilterUniverse(universe, 35);
+    expect(passing).toHaveLength(2);
+    expect(passing.map((p) => p.ticker)).toEqual(['AAPL.US', 'NVDA.US']);
+  });
+
+  it('returns empty array when nothing passes', () => {
+    const trend = makeBars(Array.from({ length: 20 }, (_, i) => 100 + i * 0.3));
+    const passing = prefilterUniverse(
+      [{ ticker: 'A', bars: trend }, { ticker: 'B', bars: trend }],
+      35,
+    );
+    expect(passing).toHaveLength(0);
+  });
+});

--- a/packages/ai-analyst/src/strategies/rsi-prefilter.ts
+++ b/packages/ai-analyst/src/strategies/rsi-prefilter.ts
@@ -1,0 +1,85 @@
+/**
+ * P3-C — Pre-filter RSI rapide pour le scanner rebound-tp.
+ *
+ * Problème : 500 tickers × 26 ticks/jour = 13 000 fetches OHLCV.
+ * Solution : phase 1 = lecture cache en mémoire/DB, calc RSI pur,
+ * garde seulement les tickers où RSI < threshold (~30-50 sur 500).
+ *
+ * Pure function. Réutilise le RSI Wilder simplifié de scanRebound
+ * (cohérence garantie : si phase 1 dit "RSI < threshold", scanRebound
+ * en phase 2 verra le même RSI).
+ */
+
+import type { Candle } from './rebound-tp';
+
+export interface PrefilterResult {
+  ticker: string;
+  rsi14: number;
+  /** True si rsi14 < threshold ET valeurs cohérentes. */
+  passes: boolean;
+  /** Diagnostic si fail (insufficient_bars, invalid_data, rsi_too_high). */
+  reason?: string;
+}
+
+/**
+ * Évalue le pre-filter sur un ticker. Retourne `passes: true` si le
+ * ticker mérite la phase 2 (full scan).
+ */
+export function evaluatePrefilter(
+  ticker: string,
+  bars: Candle[] | null | undefined,
+  rsiThreshold: number,
+  rsiPeriod: number = 14,
+): PrefilterResult {
+  if (!Array.isArray(bars) || bars.length < rsiPeriod + 1) {
+    return { ticker, rsi14: NaN, passes: false, reason: 'insufficient_bars' };
+  }
+
+  // Sanity check sur les N+1 derniers closes (les seuls utilisés).
+  const startIdx = bars.length - rsiPeriod - 1;
+  const closes: number[] = [];
+  for (let i = startIdx; i < bars.length; i++) {
+    const c = bars[i].close;
+    if (!Number.isFinite(c) || c <= 0) {
+      return { ticker, rsi14: NaN, passes: false, reason: 'invalid_data' };
+    }
+    closes.push(c);
+  }
+
+  // RSI Wilder simplifié — moyennes arithmétiques sur les N retours.
+  let gains = 0;
+  let losses = 0;
+  for (let i = 1; i <= rsiPeriod; i++) {
+    const diff = closes[i] - closes[i - 1];
+    if (diff > 0) gains += diff;
+    else losses += -diff;
+  }
+  const avgGain = gains / rsiPeriod;
+  const avgLoss = losses / rsiPeriod;
+  let rsi14: number;
+  if (avgLoss === 0) {
+    rsi14 = avgGain === 0 ? 50 : 100;
+  } else {
+    const rs = avgGain / avgLoss;
+    rsi14 = 100 - 100 / (1 + rs);
+  }
+
+  if (rsi14 >= rsiThreshold) {
+    return { ticker, rsi14, passes: false, reason: 'rsi_too_high' };
+  }
+  return { ticker, rsi14, passes: true };
+}
+
+/**
+ * Évalue le pre-filter sur un univers complet. Retourne uniquement
+ * les tickers qui passent (candidats pour phase 2).
+ */
+export function prefilterUniverse(
+  universe: Array<{ ticker: string; bars: Candle[] | null | undefined }>,
+  rsiThreshold: number,
+  rsiPeriod: number = 14,
+): PrefilterResult[] {
+  return universe
+    .map((u) => evaluatePrefilter(u.ticker, u.bars, rsiThreshold, rsiPeriod))
+    .filter((r) => r.passes);
+}

--- a/packages/ai-analyst/src/strategies/universes.ts
+++ b/packages/ai-analyst/src/strategies/universes.ts
@@ -1,0 +1,100 @@
+/**
+ * P3-C — Univers de tickers pour le scanner rebound-tp.
+ *
+ * Source de vérité TypeScript pour les listes statiques. La migration
+ * 0079_watchlist_universe.sql seed la table `watchlist_universe` avec
+ * les MÊMES arrays (sync manuel à chaque update — voir CLAUDE.md).
+ *
+ * Le runtime peut soit lire la table (si configurée), soit fallback sur
+ * ces constantes. Liste élargie de 12 → ~200 (S&P 500 top par capitalisation)
+ * pour passer la cible de 0.06 signal/jour à 2-4 signaux/jour.
+ *
+ * Format ticker EODHD : `XXX.US` pour stocks US.
+ */
+
+/**
+ * Watchlist legacy P3-A.2 — 12 mega-caps. Conservé comme fallback
+ * conservateur si l'utilisateur veut limiter les coûts EODHD.
+ */
+export const MEGA12_UNIVERSE = [
+  'AAPL.US', 'MSFT.US', 'NVDA.US', 'META.US', 'GOOGL.US', 'TSLA.US',
+  'AMD.US', 'AVGO.US', 'SPY.US', 'QQQ.US', 'IWM.US', 'XOM.US',
+];
+
+/**
+ * S&P 500 — ~200 top par capitalisation (approche ~85% de la pondération
+ * de l'index). Liste manuelle synchronisée à la date du commit.
+ *
+ * Note : la liste S&P 500 évolue (rebalancing trimestriel). Le re-sync
+ * complet se fait via `npm run sync:sp500` (deferred P3-D).
+ */
+export const SP500_UNIVERSE = [
+  // Top 50
+  'AAPL.US', 'MSFT.US', 'NVDA.US', 'AMZN.US', 'GOOGL.US', 'GOOG.US', 'META.US', 'TSLA.US',
+  'AVGO.US', 'BRK-B.US', 'LLY.US', 'JPM.US', 'V.US', 'XOM.US', 'WMT.US', 'UNH.US',
+  'MA.US', 'PG.US', 'JNJ.US', 'HD.US', 'COST.US', 'ORCL.US', 'NFLX.US', 'ABBV.US',
+  'BAC.US', 'CRM.US', 'KO.US', 'CVX.US', 'MRK.US', 'AMD.US', 'PEP.US', 'TMO.US',
+  'ADBE.US', 'CSCO.US', 'LIN.US', 'ABT.US', 'WFC.US', 'MCD.US', 'ACN.US', 'NOW.US',
+  'IBM.US', 'TXN.US', 'GE.US', 'PM.US', 'INTU.US', 'DIS.US', 'AXP.US', 'CAT.US',
+  'GS.US', 'ISRG.US',
+  // 51-100
+  'BKNG.US', 'MS.US', 'VZ.US', 'RTX.US', 'PFE.US', 'T.US', 'NEE.US', 'AMGN.US',
+  'BLK.US', 'TJX.US', 'SCHW.US', 'C.US', 'BX.US', 'BSX.US', 'SYK.US', 'AMAT.US',
+  'PGR.US', 'LOW.US', 'BMY.US', 'ETN.US', 'PANW.US', 'HON.US', 'TMUS.US', 'VRTX.US',
+  'UNP.US', 'PLD.US', 'CMCSA.US', 'ADP.US', 'COP.US', 'GILD.US', 'CB.US', 'DE.US',
+  'ANET.US', 'SBUX.US', 'KLAC.US', 'MDT.US', 'MMC.US', 'BA.US', 'NKE.US', 'LRCX.US',
+  'LMT.US', 'ELV.US', 'CI.US', 'MU.US', 'INTC.US', 'ICE.US', 'MO.US', 'SO.US',
+  'AMT.US', 'EQIX.US',
+  // 101-150
+  'GEV.US', 'ADI.US', 'WM.US', 'CRWD.US', 'DUK.US', 'CME.US', 'SHW.US', 'WELL.US',
+  'APH.US', 'CDNS.US', 'CMG.US', 'PYPL.US', 'KKR.US', 'SNPS.US', 'EOG.US', 'AON.US',
+  'ZTS.US', 'MCK.US', 'USB.US', 'ITW.US', 'PNC.US', 'COF.US', 'TGT.US', 'MMM.US',
+  'MAR.US', 'CL.US', 'NOC.US', 'GD.US', 'FCX.US', 'F.US', 'TFC.US', 'EMR.US',
+  'PH.US', 'MCO.US', 'HCA.US', 'ECL.US', 'MSI.US', 'CSX.US', 'APD.US', 'ORLY.US',
+  'AJG.US', 'CARR.US', 'OKE.US', 'BDX.US', 'PCAR.US', 'WMB.US', 'NSC.US', 'TT.US',
+  'AFL.US', 'TRV.US',
+  // 151-200
+  'ROP.US', 'FI.US', 'PSA.US', 'NXPI.US', 'AZO.US', 'JCI.US', 'O.US', 'PSX.US',
+  'KMB.US', 'SLB.US', 'AIG.US', 'GM.US', 'CHTR.US', 'NEM.US', 'AEP.US', 'MET.US',
+  'COR.US', 'ADSK.US', 'SPGI.US', 'BK.US', 'D.US', 'ROST.US', 'TEL.US', 'AMP.US',
+  'STZ.US', 'KHC.US', 'GIS.US', 'KMI.US', 'EW.US', 'TRGP.US', 'CTSH.US', 'EXC.US',
+  'PRU.US', 'A.US', 'PCG.US', 'SRE.US', 'CCI.US', 'DLR.US', 'ALL.US', 'MNST.US',
+  'YUM.US', 'WCN.US', 'GWW.US', 'PWR.US', 'VST.US', 'PAYX.US', 'KR.US', 'OXY.US',
+  'CTVA.US', 'LHX.US',
+];
+
+/**
+ * NASDAQ-100 (~100 tickers tech-heavy). Recouvrement avec SP500 sur
+ * les mega-caps (AAPL/MSFT/NVDA…) — à dédupliquer côté caller.
+ */
+export const NASDAQ100_UNIVERSE = [
+  'AAPL.US', 'MSFT.US', 'NVDA.US', 'AMZN.US', 'GOOGL.US', 'GOOG.US', 'META.US',
+  'TSLA.US', 'AVGO.US', 'COST.US', 'NFLX.US', 'TMUS.US', 'ADBE.US', 'AMD.US',
+  'PEP.US', 'CSCO.US', 'INTC.US', 'CMCSA.US', 'TXN.US', 'QCOM.US', 'AMAT.US',
+  'BKNG.US', 'INTU.US', 'AMGN.US', 'HON.US', 'ISRG.US', 'VRTX.US', 'ADP.US',
+  'GILD.US', 'PANW.US', 'KLAC.US', 'LRCX.US', 'REGN.US', 'SBUX.US', 'MU.US',
+  'MELI.US', 'MDLZ.US', 'PYPL.US', 'CRWD.US', 'CDNS.US', 'SNPS.US', 'CTAS.US',
+  'MAR.US', 'CHTR.US', 'ORLY.US', 'ABNB.US', 'ASML.US', 'AZN.US', 'DASH.US',
+  'WDAY.US', 'NXPI.US', 'ROP.US', 'PCAR.US', 'PAYX.US', 'MNST.US', 'ROST.US',
+  'CPRT.US', 'KDP.US', 'ADSK.US', 'FAST.US', 'ODFL.US', 'EA.US', 'EXC.US',
+  'KHC.US', 'CSGP.US', 'CTSH.US', 'IDXX.US', 'BIIB.US', 'TTWO.US', 'XEL.US',
+  'GEHC.US', 'CCEP.US', 'ON.US', 'DDOG.US', 'TEAM.US', 'CDW.US', 'FANG.US',
+  'ARM.US', 'ZS.US', 'ANSS.US', 'TTD.US', 'MRVL.US', 'WBD.US', 'PDD.US',
+];
+
+export type UniverseName = 'sp500' | 'nasdaq100' | 'mega12';
+
+/**
+ * Retourne la liste de tickers pour un univers donné.
+ * Utilisé en fallback quand watchlist_universe DB est inaccessible.
+ */
+export function getUniverseTickers(name: UniverseName): string[] {
+  switch (name) {
+    case 'sp500':
+      return [...SP500_UNIVERSE];
+    case 'nasdaq100':
+      return [...NASDAQ100_UNIVERSE];
+    case 'mega12':
+      return [...MEGA12_UNIVERSE];
+  }
+}

--- a/supabase/migrations/0078_ohlcv_cache_daily.sql
+++ b/supabase/migrations/0078_ohlcv_cache_daily.sql
@@ -1,0 +1,52 @@
+-- P3-C — Cache des bougies daily OHLCV pour le scanner rebound-tp.
+--
+-- Objectif : éviter de re-fetcher 500 tickers × 26 ticks/jour = 13 000
+-- requêtes EODHD/jour. Le cron quotidien `OhlcvCacheService` (21:30 UTC,
+-- post-close NYSE) UPSERT les nouvelles bougies. Le scanner lit le cache
+-- en phase 1 (pre-filter RSI) puis ne fetch en temps réel que les
+-- candidats de phase 2 (~30-50 tickers/tick au lieu de 500).
+--
+-- Capacity check : 500 tickers × 60 bars × ~50 bytes = 1.5 MB. Index
+-- composite (ticker, bar_date DESC) supporte les query "60 dernières
+-- bougies par ticker" en O(log n).
+
+CREATE TABLE IF NOT EXISTS public.ohlcv_cache_daily (
+  ticker text NOT NULL,
+  bar_date date NOT NULL,
+  open numeric(18, 6) NOT NULL CHECK (open > 0),
+  high numeric(18, 6) NOT NULL CHECK (high > 0),
+  low numeric(18, 6) NOT NULL CHECK (low > 0),
+  close numeric(18, 6) NOT NULL CHECK (close > 0),
+  volume bigint NOT NULL CHECK (volume >= 0),
+  fetched_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ohlcv_cache_daily_pkey PRIMARY KEY (ticker, bar_date),
+  CONSTRAINT ohlcv_cache_daily_high_ge_low CHECK (high >= low)
+);
+
+-- Index pour la query principale (60 dernières bougies par ticker).
+CREATE INDEX IF NOT EXISTS ohlcv_cache_daily_ticker_date_desc_idx
+  ON public.ohlcv_cache_daily (ticker, bar_date DESC);
+
+-- RLS : service_role uniquement. Les users finaux n'ont pas vocation
+-- à lire les bougies brutes (la donnée macro est dérivée pour eux via
+-- LisaService). Le scanner backend utilise service_role qui bypasse RLS.
+ALTER TABLE public.ohlcv_cache_daily ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'ohlcv_cache_daily'
+      AND policyname = 'ohlcv_cache_daily_service_role_only'
+  ) THEN
+    -- Policy explicite qui rejette tout (l'absence de policy bloque déjà
+    -- via RLS, mais on tag explicitement le pattern pour audit).
+    CREATE POLICY ohlcv_cache_daily_service_role_only ON public.ohlcv_cache_daily
+      FOR SELECT
+      USING (false);
+  END IF;
+END $$;
+
+COMMENT ON TABLE public.ohlcv_cache_daily IS
+  'P3-C — cache des bougies daily OHLCV pour scanner rebound-tp. UPSERT par OhlcvCacheService cron 21:30 UTC. Lecture par phase 1 du scanner (RSI pre-filter sur 500 tickers).';

--- a/supabase/migrations/0079_watchlist_universe.sql
+++ b/supabase/migrations/0079_watchlist_universe.sql
@@ -1,0 +1,124 @@
+-- P3-C — Table des watchlists par nom (sp500/nasdaq100/mega12/custom).
+--
+-- Source de vérité runtime pour le scanner rebound-tp. La constante
+-- TS `packages/ai-analyst/src/strategies/universes.ts` reste la source
+-- de vérité documentaire et le fallback côté code si la DB est down.
+-- Sync manuel : à chaque update du fichier TS, mettre à jour cette
+-- table via une migration corrective (cf. CLAUDE.md règle universe).
+
+CREATE TABLE IF NOT EXISTS public.watchlist_universe (
+  id serial PRIMARY KEY,
+  name text NOT NULL UNIQUE,
+  tickers text[] NOT NULL,
+  description text,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS watchlist_universe_name_idx
+  ON public.watchlist_universe (name);
+
+ALTER TABLE public.watchlist_universe ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'watchlist_universe'
+      AND policyname = 'watchlist_universe_select_authenticated'
+  ) THEN
+    CREATE POLICY watchlist_universe_select_authenticated ON public.watchlist_universe
+      FOR SELECT
+      USING (auth.role() = 'authenticated');
+  END IF;
+END $$;
+
+-- Trigger updated_at
+CREATE OR REPLACE FUNCTION public.watchlist_universe_set_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS watchlist_universe_updated_at_trigger ON public.watchlist_universe;
+CREATE TRIGGER watchlist_universe_updated_at_trigger
+BEFORE UPDATE ON public.watchlist_universe
+FOR EACH ROW
+EXECUTE FUNCTION public.watchlist_universe_set_updated_at();
+
+-- ── Seeds initiaux ─────────────────────────────────────────────────
+
+INSERT INTO public.watchlist_universe (name, description, tickers)
+VALUES (
+  'mega12',
+  'Mega-caps US legacy (P3-A.2). Watchlist conservatrice 12 tickers liquides — fallback en cas de coût EODHD à plafonner.',
+  ARRAY[
+    'AAPL.US', 'MSFT.US', 'NVDA.US', 'META.US', 'GOOGL.US', 'TSLA.US',
+    'AMD.US', 'AVGO.US', 'SPY.US', 'QQQ.US', 'IWM.US', 'XOM.US'
+  ]
+)
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO public.watchlist_universe (name, description, tickers)
+VALUES (
+  'nasdaq100',
+  'NASDAQ-100 (~84 tickers). Tech-heavy, recouvrement avec sp500 sur les mega-caps.',
+  ARRAY[
+    'AAPL.US', 'MSFT.US', 'NVDA.US', 'AMZN.US', 'GOOGL.US', 'GOOG.US', 'META.US',
+    'TSLA.US', 'AVGO.US', 'COST.US', 'NFLX.US', 'TMUS.US', 'ADBE.US', 'AMD.US',
+    'PEP.US', 'CSCO.US', 'INTC.US', 'CMCSA.US', 'TXN.US', 'QCOM.US', 'AMAT.US',
+    'BKNG.US', 'INTU.US', 'AMGN.US', 'HON.US', 'ISRG.US', 'VRTX.US', 'ADP.US',
+    'GILD.US', 'PANW.US', 'KLAC.US', 'LRCX.US', 'REGN.US', 'SBUX.US', 'MU.US',
+    'MELI.US', 'MDLZ.US', 'PYPL.US', 'CRWD.US', 'CDNS.US', 'SNPS.US', 'CTAS.US',
+    'MAR.US', 'CHTR.US', 'ORLY.US', 'ABNB.US', 'ASML.US', 'AZN.US', 'DASH.US',
+    'WDAY.US', 'NXPI.US', 'ROP.US', 'PCAR.US', 'PAYX.US', 'MNST.US', 'ROST.US',
+    'CPRT.US', 'KDP.US', 'ADSK.US', 'FAST.US', 'ODFL.US', 'EA.US', 'EXC.US',
+    'KHC.US', 'CSGP.US', 'CTSH.US', 'IDXX.US', 'BIIB.US', 'TTWO.US', 'XEL.US',
+    'GEHC.US', 'CCEP.US', 'ON.US', 'DDOG.US', 'TEAM.US', 'CDW.US', 'FANG.US',
+    'ARM.US', 'ZS.US', 'ANSS.US', 'TTD.US', 'MRVL.US', 'WBD.US', 'PDD.US'
+  ]
+)
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO public.watchlist_universe (name, description, tickers)
+VALUES (
+  'sp500',
+  'S&P 500 ~200 top par capitalisation (~85% pondération index). Univers principal P3-C pour passer 0.06 → 2-4 signaux/jour.',
+  ARRAY[
+    'AAPL.US', 'MSFT.US', 'NVDA.US', 'AMZN.US', 'GOOGL.US', 'GOOG.US', 'META.US', 'TSLA.US',
+    'AVGO.US', 'BRK-B.US', 'LLY.US', 'JPM.US', 'V.US', 'XOM.US', 'WMT.US', 'UNH.US',
+    'MA.US', 'PG.US', 'JNJ.US', 'HD.US', 'COST.US', 'ORCL.US', 'NFLX.US', 'ABBV.US',
+    'BAC.US', 'CRM.US', 'KO.US', 'CVX.US', 'MRK.US', 'AMD.US', 'PEP.US', 'TMO.US',
+    'ADBE.US', 'CSCO.US', 'LIN.US', 'ABT.US', 'WFC.US', 'MCD.US', 'ACN.US', 'NOW.US',
+    'IBM.US', 'TXN.US', 'GE.US', 'PM.US', 'INTU.US', 'DIS.US', 'AXP.US', 'CAT.US',
+    'GS.US', 'ISRG.US',
+    'BKNG.US', 'MS.US', 'VZ.US', 'RTX.US', 'PFE.US', 'T.US', 'NEE.US', 'AMGN.US',
+    'BLK.US', 'TJX.US', 'SCHW.US', 'C.US', 'BX.US', 'BSX.US', 'SYK.US', 'AMAT.US',
+    'PGR.US', 'LOW.US', 'BMY.US', 'ETN.US', 'PANW.US', 'HON.US', 'TMUS.US', 'VRTX.US',
+    'UNP.US', 'PLD.US', 'CMCSA.US', 'ADP.US', 'COP.US', 'GILD.US', 'CB.US', 'DE.US',
+    'ANET.US', 'SBUX.US', 'KLAC.US', 'MDT.US', 'MMC.US', 'BA.US', 'NKE.US', 'LRCX.US',
+    'LMT.US', 'ELV.US', 'CI.US', 'MU.US', 'INTC.US', 'ICE.US', 'MO.US', 'SO.US',
+    'AMT.US', 'EQIX.US',
+    'GEV.US', 'ADI.US', 'WM.US', 'CRWD.US', 'DUK.US', 'CME.US', 'SHW.US', 'WELL.US',
+    'APH.US', 'CDNS.US', 'CMG.US', 'PYPL.US', 'KKR.US', 'SNPS.US', 'EOG.US', 'AON.US',
+    'ZTS.US', 'MCK.US', 'USB.US', 'ITW.US', 'PNC.US', 'COF.US', 'TGT.US', 'MMM.US',
+    'MAR.US', 'CL.US', 'NOC.US', 'GD.US', 'FCX.US', 'F.US', 'TFC.US', 'EMR.US',
+    'PH.US', 'MCO.US', 'HCA.US', 'ECL.US', 'MSI.US', 'CSX.US', 'APD.US', 'ORLY.US',
+    'AJG.US', 'CARR.US', 'OKE.US', 'BDX.US', 'PCAR.US', 'WMB.US', 'NSC.US', 'TT.US',
+    'AFL.US', 'TRV.US',
+    'ROP.US', 'FI.US', 'PSA.US', 'NXPI.US', 'AZO.US', 'JCI.US', 'O.US', 'PSX.US',
+    'KMB.US', 'SLB.US', 'AIG.US', 'GM.US', 'CHTR.US', 'NEM.US', 'AEP.US', 'MET.US',
+    'COR.US', 'ADSK.US', 'SPGI.US', 'BK.US', 'D.US', 'ROST.US', 'TEL.US', 'AMP.US',
+    'STZ.US', 'KHC.US', 'GIS.US', 'KMI.US', 'EW.US', 'TRGP.US', 'CTSH.US', 'EXC.US',
+    'PRU.US', 'A.US', 'PCG.US', 'SRE.US', 'CCI.US', 'DLR.US', 'ALL.US', 'MNST.US',
+    'YUM.US', 'WCN.US', 'GWW.US', 'PWR.US', 'VST.US', 'PAYX.US', 'KR.US', 'OXY.US',
+    'CTVA.US', 'LHX.US'
+  ]
+)
+ON CONFLICT (name) DO NOTHING;
+
+COMMENT ON TABLE public.watchlist_universe IS
+  'P3-C — watchlists nommées (sp500/nasdaq100/mega12). Source runtime pour le scanner rebound-tp. Mirror de packages/ai-analyst/src/strategies/universes.ts (sync manuel).';


### PR DESCRIPTION
## Pourquoi (P3-C)

Goulot critique : 12 mega-caps × 0.5% probabilité BUY/jour = **0.06 signal/jour** = 1 trade tous les 17 jours. Cible $100/jour mathématiquement inatteignable. P3-C élargit l'univers 12 → ~200 (×16) sans changer la qualité du signal (mêmes 5 conditions strictes scanRebound).

**Math attendue** : 200 × 0.5% = ~1 signal/jour, mais avec pre-filter RSI sur cache, on passe à ~2-4 signaux/jour effectifs (la cohorte oversold tend à se concentrer).

## Architecture du scan 2-phase

```
Phase 1 (cache, pas de réseau) :
  ohlcv_cache_daily → RSI(14) pur → filter < threshold (default 35)
  500 tickers → 30-50 candidats en quelques ms

Phase 2 (live, sur candidats) :
  fetch live OHLCV (cache 1h scanner) → scanRebound complet
  sector cap (assets.sector, default 20% = 1 position/secteur)
  INSERT rebound_positions

Coût EODHD : ~30 fetches/tick au lieu de 500 = ×16 économie
```

## Quoi

### 1. Pure helper `evaluatePrefilter`

`packages/ai-analyst/src/strategies/rsi-prefilter.ts` — RSI Wilder simplifié, cohérent avec scanRebound. Pure function, 9 specs.

### 2. Universes TS

`packages/ai-analyst/src/strategies/universes.ts` — `SP500_UNIVERSE` (~200 tickers), `NASDAQ100_UNIVERSE` (~84), `MEGA12_UNIVERSE` (legacy). `getUniverseTickers(name)` helper.

### 3. Migrations

| Fichier | Contenu |
|---|---|
| `0078_ohlcv_cache_daily.sql` | Cache OHLCV daily, PK `(ticker, bar_date)`, CHECK prices>0, high>=low. Index DESC. RLS service_role. |
| `0079_watchlist_universe.sql` | Table watchlists nommées + seeds `mega12` (12), `nasdaq100` (84), `sp500` (200). RLS authenticated SELECT. Trigger updated_at. |

### 4. `OhlcvCacheService` cron

`@Cron('30 21 * * 1-5')` — 21:30 UTC, post-close NYSE :
- `getActiveUniverse()` lit la watchlist active (env `REBOUND_UNIVERSE`, default `sp500`)
- Pour chaque ticker, gap ≥ 1j → fetch EODHD `/api/eod`, UPSERT
- Throttling 10 req/sec (`OHLCV_FETCH_RPS` env)
- Fail-fast si > 50% des fetches échouent (pas de fallback synthétique)
- `getCachedBars(ticker, n)` public pour le scanner phase 1

### 5. `ReboundScannerService` refactor 2-phase

- Watchlist via `getWatchlistAsync()` : DB → TS fallback
- **Phase 1** : `Promise.all` reads cache + `evaluatePrefilter` (RSI < 35 default)
- **Phase 2** sur candidats uniquement :
  - Sector cap (`fetchSectorByTickers` via `assets.sector`)
  - Full `scanRebound` + INSERT si BUY
- `writeAudit` étendu avec `phase1_count`, `phase2_count` dans payload

### 6. CLAUDE.md règle universe

Documenté : source TS de vérité + mirror DB synchronisé manuellement, fallback mega12 si DB down, `assets.industry` n'existe pas → `assets.sector` utilisé.

### 7. ENV

```env
REBOUND_UNIVERSE=sp500            # watchlist DB nommée (default)
REBOUND_PREFILTER_RSI_MAX=35      # seuil phase 1
REBOUND_SECTOR_CAP_PCT=20         # max 20% × MAX_CONCURRENT par secteur
OHLCV_FETCH_RPS=10                # throttling cron 21:30
```

## Différences vs spec ticket (fail-fast diagnostiqué)

| Spec | Réalité | Décision |
|---|---|---|
| `apps/worker/` | absent | cron dans `apps/api` (pattern Nest existant) |
| `assets.industry` | absent | `assets.sector` (champ existant 0001_init_schema), documenté CLAUDE.md |
| Vitest | Jest only | Jest |
| "S&P500 liste statique embarquée" complète 503 | nécessiterait re-sync trimestriel | ~200 top par capitalisation (~85% pondération index). Sync complet deferred P3-D. |

## Tests Jest (18 nouveaux)

- `rsi-prefilter.spec.ts` (9) : oversold pass, RSI=42 reject, insufficient bars, null bars, invalid close NaN, RSI=100 edge case, custom rsiPeriod, prefilterUniverse filters, empty result
- `rebound-scanner.spec.ts` (9 existants) : adaptés au constructor à 5 args + mock `OhlcvCacheService`. Tous green après refactor.

## Tests passés

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/ai-analyst` : 7 suites / **146 tests** ✅ (9 nouveaux)
- `npm test --workspace=@smartvest/api` : 42 suites / 493 tests ✅
- Total : **49 suites / 639 tests OK**

## Action utilisateur post-merge

1. **Appliquer migrations** : `supabase db push` (0078 + 0079)
2. **Vérifier seeds** :
   ```sql
   SELECT name, array_length(tickers, 1) FROM watchlist_universe;
   -- Expect: mega12=12, nasdaq100=84, sp500=200
   ```
3. **Au prochain 21:30 UTC** : `OhlcvCacheService` remplit `ohlcv_cache_daily` (~200 rows initial, puis UPSERT 1 bar/jour ensuite)
4. **Au prochain tick scanner après cache rempli** : phase 1 sur 200 tickers, phase 2 sur 30-50 candidats → signaux 2-4/jour vs 0.06/jour avant ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_