### PR TITLE
feat(watchlist): couverture H24 multi-bourses CAC40+DAX+FTSE+Nikkei+HSI (P4-A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,34 @@ P3-D — correctifs config issus de l'analyse logs 27-28/04 :
 
 ---
 
+## RÈGLE OPÉRATIONNELLE — COUVERTURE H24 MULTI-BOURSES (P4-A)
+
+P4-A — Le scanner rebound-tp couvre 5 bourses pour atteindre la couverture H24 :
+
+| Bourse | Code | Suffixe | Session UTC | CEST été |
+|---|---|---|---|---|
+| Nikkei 225 | TSE | `.T` | 00:00-06:00 | 02:00-08:00 |
+| Hang Seng | HKEX | `.HK` | 01:30-08:00 | 03:30-10:00 |
+| CAC 40 | EURONEXT | `.PA` | 07:00-15:30 | 09:00-17:30 |
+| DAX 40 | XETRA | `.DE` | 07:00-15:30 | 09:00-17:30 |
+| FTSE 100 | LSE | `.L` | 08:00-16:30 | 10:00-18:30 |
+| S&P 500 | NYSE | `.US` | 14:30-21:00 | 16:30-23:00 |
+
+**Mode H24** (`OhlcvCacheService.getActiveUniverse(now)`) :
+- Si `REBOUND_UNIVERSE` env set : behaviour P3-C (single watchlist par nom)
+- Sinon : aggrège TOUTES les watchlists dont `[session_open_utc, session_close_utc]` inclut `now` UTC
+- Fallback `sp500` (after-hours US) si rien actif
+
+**Source de vérité TS** : `packages/ai-analyst/src/strategies/universes.ts` pour US, mais les watchlists multi-exchange sont **uniquement en DB** (table `watchlist_universe` + migration 0081). Sync manuel TS à éviter pour ces univers — la table est l'autorité.
+
+**Crypto exclu** : aucune watchlist multi-exchange ne contient de crypto. Lisa peut toujours proposer BTC/ETH en thesis classique.
+
+**Coût EODHD** : EODHD plan US-only ne couvre PAS `.PA/.DE/.L/.T/.HK`. Vérifier l'abonnement (« All World » ou « Fundamentals + EOD All World ») avant d'activer le mode H24 en prod. Sans ce plan, le fetch retourne 404 et le scanner skip silencieusement → pas de crash mais pas de signaux non-US.
+
+**Sector cap** : actuellement global (`assets.sector` lookup). Cap par exchange = follow-up P4-B (assets.sector ne distingue pas la bourse).
+
+---
+
 ## RÈGLE OPÉRATIONNELLE — UNIVERS WATCHLIST PAR DÉFAUT
 
 P3-C — Le scanner rebound-tp scanne par défaut **`sp500`** (~200 mega-caps US, table `watchlist_universe`). Override possible :

--- a/README.md
+++ b/README.md
@@ -370,6 +370,23 @@ EODHD_API_KEY=... SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
 - Audit : `lisa_decision_log` kind=`rebound_scan_completed` (hash chain) avec payload `{phase1_count, phase2_count, signals, opened, skipped_reasons}`
 - Lisa pipeline : `MarketSnapshot.reboundSignals` injecté dans le prompt sous `## Positions rebound ouvertes`
 
+### Couverture H24 multi-bourses (P4-A)
+
+Pour passer de 100% US (~7h/jour) à couverture H24, le scanner agrège dynamiquement les watchlists actives selon l'heure UTC :
+
+| Heure CEST | Heure UTC | Bourses actives |
+|---|---|---|
+| 02-04h | 00-02h | Nikkei (Asie nuit) |
+| 04-08h | 02-06h | Nikkei + HSI |
+| 08-10h | 06-08h | HSI + CAC + DAX |
+| 10-17h | 08-15h | CAC + DAX + FTSE (+ US dès 16:30 CEST) |
+| 17-23h | 15-21h | FTSE + US |
+| 23-02h | 21-00h | US-afterhours fallback puis Nikkei reprend |
+
+**Activation** : retirer l'env `REBOUND_UNIVERSE` → `OhlcvCacheService.getActiveUniverse(now)` aggrège les watchlists où `now ∈ [session_open_utc, session_close_utc]` (~5 bourses simultanées en pic 17h UTC).
+
+Pré-requis EODHD plan : « All World » pour `.PA / .DE / .L / .T / .HK`. Sans ça, fetch 404 silencieux → seul `sp500` produira des signaux. Vérifier `EODHD_PLAN_TIER` ou test manuel sur un ticker non-US.
+
 ### OHLCV cache daily (P3-C)
 
 `OhlcvCacheService` cron `'30 21 * * 1-5'` (21:30 UTC, post-close NYSE) :

--- a/apps/api/src/modules/lisa/services/ohlcv-cache.service.ts
+++ b/apps/api/src/modules/lisa/services/ohlcv-cache.service.ts
@@ -18,6 +18,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
+import { aggregateActiveWatchlists } from '@smartvest/ai-analyst';
 
 interface EodhdEodBar {
   date: string;
@@ -218,25 +219,71 @@ export class OhlcvCacheService {
   }
 
   /**
-   * Récupère la liste de tickers de la watchlist active.
-   * Lit `watchlist_universe` table via le nom env `REBOUND_UNIVERSE`
-   * (default 'sp500'). Fallback TS constants si DB inaccessible.
+   * P3-C → P4-A — Récupère la liste de tickers actifs.
+   *
+   * Modes :
+   *   - Si env `REBOUND_UNIVERSE` set à un nom unique : behaviour P3-C
+   *     (lit la row correspondante, ignore les session_window).
+   *   - Sinon (mode P4-A H24) : aggrège TOUTES les watchlists dont la
+   *     fenêtre session_open_utc/session_close_utc inclut `now`.
+   *     Permet la couverture multi-bourses (Asie nuit, Europe matin,
+   *     US après-midi) sur un seul cron tick.
+   *
+   * Fallback TS si DB inaccessible.
    */
-  async getActiveUniverse(): Promise<string[]> {
-    const name = this.config.get<string>('REBOUND_UNIVERSE') ?? 'sp500';
-    const { data, error } = await this.supabase
+  async getActiveUniverse(now: Date = new Date()): Promise<string[]> {
+    const explicitName = this.config.get<string>('REBOUND_UNIVERSE');
+
+    // Mode legacy : single watchlist par nom (P3-C compat).
+    if (explicitName && explicitName.length > 0) {
+      const { data, error } = await this.supabase
+        .getClient()
+        .from('watchlist_universe')
+        .select('tickers')
+        .eq('name', explicitName)
+        .maybeSingle();
+      if (error) {
+        this.logger.warn(`watchlist_universe ${explicitName} fetch failed: ${error.message}`);
+      }
+      const tickers = (data?.tickers as string[] | undefined) ?? null;
+      if (tickers && tickers.length > 0) return tickers;
+      return fallbackTsUniverse(explicitName);
+    }
+
+    // Mode P4-A : aggrège watchlists actives.
+    const { data: rows, error } = await this.supabase
       .getClient()
       .from('watchlist_universe')
-      .select('tickers')
-      .eq('name', name)
-      .maybeSingle();
+      .select('name, exchange, session_open_utc, session_close_utc, tickers');
+
     if (error) {
-      this.logger.warn(`watchlist_universe ${name} fetch failed: ${error.message}`);
+      this.logger.warn(`watchlist_universe fetch all failed: ${error.message}`);
+      return fallbackTsUniverse('sp500');
     }
-    const tickers = (data?.tickers as string[] | undefined) ?? null;
-    if (tickers && tickers.length > 0) return tickers;
-    // Fallback TS constant
-    return fallbackTsUniverse(name);
+
+    const watchlists = (rows ?? []).map((r) => ({
+      name: r.name as string,
+      exchange: (r.exchange as string | null) ?? 'US',
+      sessionOpenUtc: r.session_open_utc as string | null,
+      sessionCloseUtc: r.session_close_utc as string | null,
+      tickers: (r.tickers as string[] | null) ?? [],
+    }));
+
+    // Fallback US si aucun row n'a de session window définie (DB pas encore migrée 0081)
+    const usFallback = watchlists.find((w) => w.name === 'sp500')?.tickers
+      ?? fallbackTsUniverse('sp500');
+
+    const { active, activeExchanges } = aggregateActiveWatchlists(
+      watchlists,
+      now,
+      usFallback,
+    );
+    if (activeExchanges.length > 0) {
+      this.logger.debug(
+        `[ohlcv-cache] active exchanges @${now.toISOString()}: ${activeExchanges.join(', ')} (${active.length} tickers)`,
+      );
+    }
+    return active;
   }
 
   private async getLastCachedDate(ticker: string): Promise<string | null> {

--- a/packages/ai-analyst/src/index.ts
+++ b/packages/ai-analyst/src/index.ts
@@ -17,6 +17,7 @@ export * from './regime';
 export * from './strategies/rebound-tp';
 export * from './strategies/universes';
 export * from './strategies/rsi-prefilter';
+export * from './strategies/session-windows';
 export * from './backtest/engine';
 export * from './backtest/metrics';
 export * from './backtest/runner';

--- a/packages/ai-analyst/src/strategies/__tests__/session-windows.spec.ts
+++ b/packages/ai-analyst/src/strategies/__tests__/session-windows.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * P4-A — Tests session-windows pure.
+ *
+ * Vérifie les transitions à 4 timestamps de référence (CEST = UTC+2 été) :
+ *   - 02h CEST = 00h UTC → Nikkei (00-06 UTC) actif
+ *   - 10h CEST = 08h UTC → DAX/CAC (07-15:30) + FTSE (08-16:30) + HSI (01:30-08:00 fini)
+ *   - 16h CEST = 14h UTC → CAC/DAX fini, FTSE actif, US (14:30-21:00) qq min
+ *   - 23h CEST = 21h UTC → US fini, après-hours, fallback
+ */
+import { isWithinSession, aggregateActiveWatchlists } from '../session-windows';
+
+const CAC = {
+  name: 'cac40',
+  exchange: 'EURONEXT',
+  sessionOpenUtc: '07:00',
+  sessionCloseUtc: '15:30',
+  tickers: ['MC.PA', 'BNP.PA'],
+};
+const DAX = {
+  name: 'dax40',
+  exchange: 'XETRA',
+  sessionOpenUtc: '07:00',
+  sessionCloseUtc: '15:30',
+  tickers: ['SAP.DE', 'SIE.DE'],
+};
+const FTSE = {
+  name: 'ftse100',
+  exchange: 'LSE',
+  sessionOpenUtc: '08:00',
+  sessionCloseUtc: '16:30',
+  tickers: ['HSBA.L', 'BP.L'],
+};
+const NIKKEI = {
+  name: 'nikkei225',
+  exchange: 'TSE',
+  sessionOpenUtc: '00:00',
+  sessionCloseUtc: '06:00',
+  tickers: ['7203.T', '6758.T'],
+};
+const HSI = {
+  name: 'hsi50',
+  exchange: 'HKEX',
+  sessionOpenUtc: '01:30',
+  sessionCloseUtc: '08:00',
+  tickers: ['0700.HK', '9988.HK'],
+};
+const SP500 = {
+  name: 'sp500',
+  exchange: 'US',
+  sessionOpenUtc: '14:30',
+  sessionCloseUtc: '21:00',
+  tickers: ['AAPL.US', 'MSFT.US'],
+};
+const ALL = [CAC, DAX, FTSE, NIKKEI, HSI, SP500];
+
+const at = (h: number, m: number = 0) => new Date(Date.UTC(2026, 3, 28, h, m, 0));
+
+describe('isWithinSession', () => {
+  it('returns true at exact open time', () => {
+    expect(isWithinSession(at(7, 0), { openUtc: '07:00', closeUtc: '15:30' })).toBe(true);
+  });
+
+  it('returns true at exact close time', () => {
+    expect(isWithinSession(at(15, 30), { openUtc: '07:00', closeUtc: '15:30' })).toBe(true);
+  });
+
+  it('returns false 1 min before open', () => {
+    expect(isWithinSession(at(6, 59), { openUtc: '07:00', closeUtc: '15:30' })).toBe(false);
+  });
+
+  it('returns false 1 min after close', () => {
+    expect(isWithinSession(at(15, 31), { openUtc: '07:00', closeUtc: '15:30' })).toBe(false);
+  });
+
+  it('handles 30-min open like 14:30 NYSE', () => {
+    expect(isWithinSession(at(14, 29), { openUtc: '14:30', closeUtc: '21:00' })).toBe(false);
+    expect(isWithinSession(at(14, 30), { openUtc: '14:30', closeUtc: '21:00' })).toBe(true);
+    expect(isWithinSession(at(21, 0), { openUtc: '14:30', closeUtc: '21:00' })).toBe(true);
+    expect(isWithinSession(at(21, 1), { openUtc: '14:30', closeUtc: '21:00' })).toBe(false);
+  });
+
+  it('returns false on invalid window strings', () => {
+    expect(isWithinSession(at(10), { openUtc: 'invalid', closeUtc: '15:30' })).toBe(false);
+    expect(isWithinSession(at(10), { openUtc: '07:00', closeUtc: '99:00' })).toBe(false);
+  });
+
+  it('rejects cross-midnight (open >= close)', () => {
+    expect(isWithinSession(at(10), { openUtc: '15:00', closeUtc: '07:00' })).toBe(false);
+  });
+});
+
+describe('aggregateActiveWatchlists transitions', () => {
+  it('02h CEST (00h UTC) → only Nikkei active', () => {
+    const r = aggregateActiveWatchlists(ALL, at(0, 0));
+    expect(r.activeExchanges).toEqual(['TSE']);
+    expect(new Set(r.active)).toEqual(new Set(['7203.T', '6758.T']));
+  });
+
+  it('03h CEST (01h UTC) → Nikkei still active, HSI not yet (HSI opens 01:30)', () => {
+    const r = aggregateActiveWatchlists(ALL, at(1, 0));
+    expect(r.activeExchanges).toEqual(['TSE']);
+  });
+
+  it('04h CEST (02h UTC) → Nikkei + HSI overlap', () => {
+    const r = aggregateActiveWatchlists(ALL, at(2, 0));
+    expect(new Set(r.activeExchanges)).toEqual(new Set(['TSE', 'HKEX']));
+    expect(r.active).toContain('7203.T');
+    expect(r.active).toContain('0700.HK');
+  });
+
+  it('10h CEST (08h UTC) → DAX/CAC + FTSE + HSI fini-juste-fini', () => {
+    const r = aggregateActiveWatchlists(ALL, at(8, 0));
+    // HSI close 08:00 inclus → encore actif
+    // DAX/CAC actif (07:00-15:30)
+    // FTSE actif (08:00-16:30)
+    expect(new Set(r.activeExchanges)).toEqual(new Set(['EURONEXT', 'XETRA', 'LSE', 'HKEX']));
+  });
+
+  it('11h CEST (09h UTC) → DAX/CAC + FTSE only', () => {
+    const r = aggregateActiveWatchlists(ALL, at(9, 0));
+    expect(new Set(r.activeExchanges)).toEqual(new Set(['EURONEXT', 'XETRA', 'LSE']));
+  });
+
+  it('16h CEST (14h UTC) → Europe (CAC/DAX/FTSE) actif, US pas encore (US 14:30)', () => {
+    const r = aggregateActiveWatchlists(ALL, at(14, 0));
+    // CAC/DAX 07-15:30 still active. FTSE 08-16:30 active. US not yet.
+    expect(new Set(r.activeExchanges)).toEqual(new Set(['EURONEXT', 'XETRA', 'LSE']));
+  });
+
+  it('17h CEST (15h UTC) → CAC/DAX/FTSE/US all overlap', () => {
+    const r = aggregateActiveWatchlists(ALL, at(15, 0));
+    expect(new Set(r.activeExchanges)).toEqual(new Set(['EURONEXT', 'XETRA', 'LSE', 'US']));
+  });
+
+  it('19h CEST (17h UTC) → CAC/DAX/FTSE fini, US only', () => {
+    const r = aggregateActiveWatchlists(ALL, at(17, 0));
+    expect(new Set(r.activeExchanges)).toEqual(new Set(['US']));
+  });
+
+  it('23h CEST (21h UTC) → US close inclusive, after-hours pas encore', () => {
+    const r = aggregateActiveWatchlists(ALL, at(21, 0));
+    expect(new Set(r.activeExchanges)).toEqual(new Set(['US']));
+  });
+
+  it('23h01 CEST (21h01 UTC) → US-after-hours fallback déclenché', () => {
+    const r = aggregateActiveWatchlists(ALL, at(21, 1));
+    expect(r.active.length).toBe(0); // pas de fallback fourni
+    expect(r.activeExchanges).toEqual([]);
+  });
+
+  it('returns empty when no fallback provided and no active session', () => {
+    const r = aggregateActiveWatchlists(ALL, at(22, 0));
+    expect(r.active.length).toBe(0);
+  });
+
+  it('falls back to provided US tickers when nothing active (22h UTC)', () => {
+    // 22h UTC : US fini (21:00), Asie pas encore (00:00).
+    const r = aggregateActiveWatchlists(
+      [CAC, NIKKEI],
+      at(22, 0),
+      ['AAPL.US', 'MSFT.US'],
+    );
+    expect(r.active).toEqual(['AAPL.US', 'MSFT.US']);
+    expect(r.activeExchanges).toEqual(['US_AFTERHOURS']);
+  });
+
+  it('dedups tickers across cross-listed watchlists', () => {
+    const customWl = { ...SP500, tickers: ['AAPL.US', 'AAPL.US', 'MSFT.US'] };
+    const r = aggregateActiveWatchlists([customWl], at(15, 0));
+    expect(new Set(r.active)).toEqual(new Set(['AAPL.US', 'MSFT.US']));
+  });
+
+  it('skips watchlists without session_open_utc set', () => {
+    const noWindow = { ...SP500, sessionOpenUtc: null, sessionCloseUtc: null };
+    const r = aggregateActiveWatchlists([noWindow], at(15, 0));
+    expect(r.active).toEqual([]);
+  });
+});

--- a/packages/ai-analyst/src/strategies/session-windows.ts
+++ b/packages/ai-analyst/src/strategies/session-windows.ts
@@ -1,0 +1,78 @@
+/**
+ * P4-A — Helpers session-window pure.
+ *
+ * Check si une heure UTC tombe dans la fenêtre [open, close] d'une bourse.
+ * Pure function, testable sans I/O.
+ */
+
+export interface SessionWindow {
+  /** Heure ouverture UTC, format "HH:MM". */
+  openUtc: string;
+  /** Heure clôture UTC, format "HH:MM". */
+  closeUtc: string;
+}
+
+/**
+ * Vérifie si `now` (Date) tombe dans la fenêtre. Compare en minutes UTC.
+ * Si openUtc > closeUtc (cas pathologique cross-midnight), retourne false
+ * — les bourses utilisées ne traversent jamais minuit UTC.
+ */
+export function isWithinSession(now: Date, win: SessionWindow): boolean {
+  const o = parseHm(win.openUtc);
+  const c = parseHm(win.closeUtc);
+  if (o === null || c === null) return false;
+  if (o >= c) return false; // cross-midnight non supporté
+  const m = now.getUTCHours() * 60 + now.getUTCMinutes();
+  return m >= o && m <= c;
+}
+
+/**
+ * Concatène les tickers de toutes les watchlists actives à `now`.
+ * Tickers dédupliqués — un même ticker dans plusieurs bourses (théorique,
+ * surtout pour les ADR cross-listés) compte une seule fois.
+ *
+ * Si aucune watchlist active : fallback sur la liste US fournie pour
+ * couvrir les heures hors-marché US (after-hours, pre-market) où le cron
+ * peut quand même calculer les RSI sur les bars cached.
+ */
+export function aggregateActiveWatchlists(
+  watchlists: Array<{
+    name: string;
+    exchange: string;
+    sessionOpenUtc: string | null;
+    sessionCloseUtc: string | null;
+    tickers: string[];
+  }>,
+  now: Date,
+  fallbackUsTickers?: string[],
+): { active: string[]; activeExchanges: string[] } {
+  const dedup = new Set<string>();
+  const exchanges = new Set<string>();
+  for (const wl of watchlists) {
+    if (!wl.sessionOpenUtc || !wl.sessionCloseUtc) continue;
+    if (!isWithinSession(now, { openUtc: wl.sessionOpenUtc, closeUtc: wl.sessionCloseUtc })) {
+      continue;
+    }
+    for (const t of wl.tickers) dedup.add(t);
+    exchanges.add(wl.exchange);
+  }
+  if (dedup.size === 0 && fallbackUsTickers) {
+    for (const t of fallbackUsTickers) dedup.add(t);
+    exchanges.add('US_AFTERHOURS');
+  }
+  return {
+    active: Array.from(dedup),
+    activeExchanges: Array.from(exchanges),
+  };
+}
+
+function parseHm(s: string): number | null {
+  if (typeof s !== 'string') return null;
+  const m = s.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/);
+  if (!m) return null;
+  const h = parseInt(m[1], 10);
+  const min = parseInt(m[2], 10);
+  if (!Number.isFinite(h) || !Number.isFinite(min)) return null;
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null;
+  return h * 60 + min;
+}

--- a/supabase/migrations/0081_watchlist_universe_multi_exchange.sql
+++ b/supabase/migrations/0081_watchlist_universe_multi_exchange.sql
@@ -1,0 +1,140 @@
+-- P4-A — Couverture H24 watchlist multi-bourses.
+--
+-- Ajoute exchange + session_window à `watchlist_universe` pour permettre au
+-- scanner de filtrer dynamiquement les watchlists actives selon l'heure UTC.
+-- Sans cette dimension, Lisa scanne 100% US et est aveugle 17h/jour entre
+-- close NYSE 21:00 UTC et open NYSE 14:30 UTC.
+--
+-- Bourses ajoutées :
+--   CAC40    .PA  Euronext Paris    07:00-15:30 UTC  (09:00-17:30 CEST)
+--   DAX40    .DE  Xetra Frankfurt   07:00-15:30 UTC
+--   FTSE100  .L   London Stock Exch 08:00-16:30 UTC
+--   Nikkei225 .T  Tokyo Stock Exch  00:00-06:00 UTC
+--   HSI50    .HK  Hong Kong Exch    01:30-08:00 UTC
+
+-- ── Schema additions ─────────────────────────────────────────────────
+
+ALTER TABLE public.watchlist_universe
+  ADD COLUMN IF NOT EXISTS exchange text NOT NULL DEFAULT 'US';
+
+ALTER TABLE public.watchlist_universe
+  ADD COLUMN IF NOT EXISTS session_open_utc time;
+
+ALTER TABLE public.watchlist_universe
+  ADD COLUMN IF NOT EXISTS session_close_utc time;
+
+ALTER TABLE public.watchlist_universe
+  ADD COLUMN IF NOT EXISTS ticker_suffix text;
+
+CREATE INDEX IF NOT EXISTS watchlist_universe_exchange_session_idx
+  ON public.watchlist_universe (exchange, session_open_utc);
+
+-- ── Patch des watchlists US existantes ───────────────────────────────
+
+UPDATE public.watchlist_universe
+SET
+  exchange = 'US',
+  session_open_utc = '14:30',
+  session_close_utc = '21:00',
+  ticker_suffix = '.US'
+WHERE name IN ('mega12', 'nasdaq100', 'sp500');
+
+-- ── Seeds nouveaux univers ───────────────────────────────────────────
+
+-- CAC 40 (Paris) — ~40 large-caps français
+INSERT INTO public.watchlist_universe (name, exchange, session_open_utc, session_close_utc, ticker_suffix, description, tickers)
+VALUES (
+  'cac40',
+  'EURONEXT',
+  '07:00',
+  '15:30',
+  '.PA',
+  'CAC 40 (Euronext Paris) — 40 large-caps français. Session 07:00-15:30 UTC = 09:00-17:30 CEST.',
+  ARRAY[
+    'AIR.PA','AI.PA','MC.PA','OR.PA','BNP.PA','SAN.PA','SU.PA','TTE.PA','SGO.PA','VIV.PA',
+    'CS.PA','BN.PA','EN.PA','RI.PA','RNO.PA','ENGI.PA','VIE.PA','GLE.PA','ML.PA','HO.PA',
+    'CAP.PA','DG.PA','EL.PA','KER.PA','LR.PA','PUB.PA','SAF.PA','STM.PA','SW.PA','TEP.PA',
+    'URW.PA','VK.PA','WLN.PA','ACA.PA','CA.PA','DSY.PA','FR.PA','LI.PA','POM.PA','RMS.PA'
+  ]
+)
+ON CONFLICT (name) DO NOTHING;
+
+-- DAX 40 (Xetra Frankfurt)
+INSERT INTO public.watchlist_universe (name, exchange, session_open_utc, session_close_utc, ticker_suffix, description, tickers)
+VALUES (
+  'dax40',
+  'XETRA',
+  '07:00',
+  '15:30',
+  '.DE',
+  'DAX 40 (Xetra Frankfurt) — 40 large-caps allemands. Session 07:00-15:30 UTC.',
+  ARRAY[
+    'SAP.DE','SIE.DE','ALV.DE','DTE.DE','BAYN.DE','MBG.DE','BMW.DE','VOW3.DE','MUV2.DE','ADS.DE',
+    'BAS.DE','DBK.DE','IFX.DE','HEN3.DE','VNA.DE','EOAN.DE','RWE.DE','BEI.DE','PUM.DE','DHL.DE',
+    'AIR.DE','DTG.DE','MTX.DE','SHL.DE','CON.DE','FRE.DE','HEI.DE','SY1.DE','MRK.DE','RHM.DE',
+    'P911.DE','PAH3.DE','QIA.DE','SRT3.DE','HNR1.DE','CBK.DE','ZAL.DE','ENR.DE','BRN3.DE','LIN.DE'
+  ]
+)
+ON CONFLICT (name) DO NOTHING;
+
+-- FTSE 100 (London Stock Exchange) — top 50 par capitalisation
+INSERT INTO public.watchlist_universe (name, exchange, session_open_utc, session_close_utc, ticker_suffix, description, tickers)
+VALUES (
+  'ftse100',
+  'LSE',
+  '08:00',
+  '16:30',
+  '.L',
+  'FTSE 100 top 50 (London Stock Exchange). Session 08:00-16:30 UTC. Chevauchement US 13:30-16:30 UTC = double signal.',
+  ARRAY[
+    'AZN.L','SHEL.L','HSBA.L','ULVR.L','BP.L','RIO.L','GSK.L','BATS.L','REL.L','LSEG.L',
+    'CPG.L','GLEN.L','VOD.L','BARC.L','LLOY.L','NWG.L','PRU.L','TSCO.L','III.L','AAL.L',
+    'AHT.L','ANTO.L','BA.L','CRDA.L','DGE.L','EXPN.L','FLTR.L','GLPG.L','HLN.L','IMB.L',
+    'INF.L','LGEN.L','LON.L','MNG.L','MRO.L','NG.L','PHNX.L','RKT.L','RTO.L','SBRY.L',
+    'SDR.L','SGE.L','SGRO.L','SMDS.L','SMIN.L','SN.L','SVT.L','TW.L','UU.L','WTB.L'
+  ]
+)
+ON CONFLICT (name) DO NOTHING;
+
+-- Nikkei 225 (Tokyo Stock Exchange) — top 30 par capitalisation
+INSERT INTO public.watchlist_universe (name, exchange, session_open_utc, session_close_utc, ticker_suffix, description, tickers)
+VALUES (
+  'nikkei225',
+  'TSE',
+  '00:00',
+  '06:00',
+  '.T',
+  'Nikkei 225 top 30 (Tokyo Stock Exchange). Session 00:00-06:00 UTC = couverture nuit Asie.',
+  ARRAY[
+    '7203.T','6758.T','9984.T','8306.T','6861.T','9433.T','8035.T','6098.T','4063.T','8316.T',
+    '9432.T','6594.T','7974.T','4502.T','6367.T','6981.T','4661.T','7267.T','8058.T','7741.T',
+    '6273.T','6857.T','9434.T','8001.T','8031.T','4543.T','6902.T','6526.T','3382.T','4519.T'
+  ]
+)
+ON CONFLICT (name) DO NOTHING;
+
+-- Hang Seng (Hong Kong Exchange) — top 30
+INSERT INTO public.watchlist_universe (name, exchange, session_open_utc, session_close_utc, ticker_suffix, description, tickers)
+VALUES (
+  'hsi50',
+  'HKEX',
+  '01:30',
+  '08:00',
+  '.HK',
+  'Hang Seng top 30 (Hong Kong Exchange). Session 01:30-08:00 UTC. Chevauchement Europe 07:00-08:00 UTC.',
+  ARRAY[
+    '0700.HK','0941.HK','1299.HK','3690.HK','9988.HK','0005.HK','0939.HK','1398.HK','3988.HK','2318.HK',
+    '0388.HK','0001.HK','0066.HK','1810.HK','9618.HK','0883.HK','0386.HK','1113.HK','2628.HK','1109.HK',
+    '0857.HK','0027.HK','0011.HK','0016.HK','0002.HK','0006.HK','0288.HK','0322.HK','1928.HK','0823.HK'
+  ]
+)
+ON CONFLICT (name) DO NOTHING;
+
+COMMENT ON COLUMN public.watchlist_universe.exchange IS
+  'P4-A — Code bourse (US/EURONEXT/XETRA/LSE/TSE/HKEX). Permet routing fetcher EODHD via le suffixe.';
+COMMENT ON COLUMN public.watchlist_universe.session_open_utc IS
+  'P4-A — Heure ouverture session UTC (TIME). Le scanner active la watchlist seulement pendant cette fenêtre.';
+COMMENT ON COLUMN public.watchlist_universe.session_close_utc IS
+  'P4-A — Heure clôture session UTC. Idem.';
+COMMENT ON COLUMN public.watchlist_universe.ticker_suffix IS
+  'P4-A — Suffixe ticker EODHD (.US/.PA/.DE/.L/.T/.HK). Informatif — les tickers stockés contiennent déjà le suffixe.';


### PR DESCRIPTION
## Pourquoi (P4-A)

Goulot critique : Watchlist 100% US = ~7h marché actif/jour. Lisa aveugle ~17h/jour entre close NYSE 21:00 UTC et open 14:30 UTC. Cible $100/jour structurellement bloquée → ouvrir Europe matin + Asie nuit + chevauchements.

## Quoi

### 1. Migration `0081_watchlist_universe_multi_exchange.sql`

```sql
ALTER TABLE watchlist_universe
  ADD exchange text DEFAULT 'US',
  ADD session_open_utc time,
  ADD session_close_utc time,
  ADD ticker_suffix text;
```

UPDATE des rows existantes (mega12/nasdaq100/sp500) avec exchange='US' + session 14:30-21:00 UTC.

INSERT 5 nouvelles watchlists :

| Bourse | Code | Session UTC | Tickers |
|---|---|---|---|
| Nikkei 225 | TSE | 00:00-06:00 | 30 .T |
| Hang Seng | HKEX | 01:30-08:00 | 30 .HK |
| CAC 40 | EURONEXT | 07:00-15:30 | 40 .PA |
| DAX 40 | XETRA | 07:00-15:30 | 40 .DE |
| FTSE 100 | LSE | 08:00-16:30 | 50 .L |

Idempotent (`ON CONFLICT name DO NOTHING`).

### 2. Pure helper `session-windows.ts`

```ts
isWithinSession(now, { openUtc, closeUtc }) → boolean
aggregateActiveWatchlists(watchlists, now, fallbackUsTickers?)
  → { active: string[], activeExchanges: string[] }
```

### 3. `OhlcvCacheService.getActiveUniverse(now)` refactor

- **Mode legacy** (env `REBOUND_UNIVERSE` set) : single watchlist par nom — **P3-C compat**
- **Mode H24** (env absent) : aggrège watchlists dont fenêtre inclut `now` UTC. Fallback sp500 si rien actif.
- Log structuré `[ohlcv-cache] active exchanges @<iso>: TSE, HKEX (60 tickers)` côté observabilité.

### 4. Tests Jest — 21 specs

`isWithinSession` (7) : open/close exacts, ±1 min, NYSE 14:30, invalid strings, cross-midnight reject.

`aggregateActiveWatchlists` (14) : transitions horaires aux 4 timestamps clés (02h/10h/16h/23h CEST) + edge cases (dedup cross-listed, no-window skip, fallback after-hours).

## Différences vs spec ticket (fail-fast diagnostiqué)

| Spec | Réalité | Décision |
|---|---|---|
| "EODHD client suffix routing" | déjà supporté nativement (`/api/eod/{TICKER}.{SUFFIX}`) | Pas de refactor — tickers stockés contiennent déjà le suffixe |
| "scanner per-exchange parallel + sector cap per exchange" | `assets.sector` global, pas per-exchange | Sector cap reste global ce PR ; per-exchange = follow-up P4-B |
| "rate-limit per-exchange" | throttling global 10rps en place | Pas splitté ce PR — à faire si saturation observée |
| "Migration 0082 multi-session harvest" | refactor profond DailySessionService nécessaire | Deferred P4-B dédié |
| "UI badge Marchés actifs" | nécessite endpoint API + composant React | Out of scope ; les logs exposent déjà `activeExchanges` |
| Vitest | Jest only | Jest |

## Pré-requis EODHD plan

Plan **« All World »** nécessaire pour `.PA/.DE/.L/.T/.HK`. Sans ce plan, EODHD retourne 404 silencieusement → seul `sp500` produira des signaux. **Vérifier abonnement avant deploy prod.**

## Tests

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/ai-analyst` : 8 suites / **167 tests** ✅ (21 nouveaux)
- `npm test --workspace=@smartvest/api` : 43 suites / 501 tests ✅
- Total : **51 suites / 668 tests OK**

## Action utilisateur post-merge

```bash
# 1. Test plan EODHD non-US
curl "https://eodhd.com/api/eod/MC.PA?api_token=$EODHD_API_KEY&fmt=json" | head

# 2. Apply migration
supabase db push

# 3. Vérifier seeds
psql -c "SELECT name, exchange, session_open_utc, array_length(tickers, 1) AS n
         FROM watchlist_universe ORDER BY session_open_utc;"

# 4. Désactiver env REBOUND_UNIVERSE pour activer mode H24
fly secrets unset REBOUND_UNIVERSE -a <app>
```

## Out of scope (P4-B)

- Sector cap par exchange (nécessite ticker_metadata table)
- Rate-limit EODHD splitté par exchange
- Migration 0082 multi-window daily harvest sweep
- UI badge "Marchés actifs"
- Backtest CI run (P3-B workflow_dispatch déjà disponible — l'utilisateur le déclenche)

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_