### PR TITLE
feat(lisa): Harvest mode = rebound-only routing (P4-B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,35 @@ P3-D — correctifs config issus de l'analyse logs 27-28/04 :
 
 ---
 
+## RÈGLE OPÉRATIONNELLE — MODE HARVEST = REBOUND-ONLY (P4-B)
+
+P4-B — En mode `capital_discipline_mode = 'DAILY_HARVEST'`, le pipeline
+proposal court-circuite la news-aggregation et n'expose à Lisa que les
+sources compatibles avec un horizon de scalping intraday :
+
+| Mode | Sources actives |
+|---|---|
+| `DAILY_HARVEST` (TP 2.5% / SL 1.5%) | `rebound_tp_scanner` + `mechanical_stops` |
+| `NONE` / `INVESTMENT` | `rebound_tp_scanner` + `momentum_breakout` + `narrative_stocktwits` + `sentiment_macro` + `mechanical_stops` |
+
+Justification : narrative StockTwits / momentum breakout / sentiment macro
+ont un horizon 1-4 semaines. Un stop -1.5% les ferme avant que le
+catalyseur n'ait eu le temps de jouer → 40% proposal_failed observés
+27-28/04. En harvest, on les exclut totalement.
+
+**Implémentation** : `getProposalSources(mode)` + `shouldRunNewsAggregator(mode)`
+dans `packages/ai-analyst/src/strategies/proposal-source-routing.ts`.
+Le caller (`LisaService.generateProposal`) skip `newsAggregator.aggregate`
+quand mode harvest + écrit `lisa_decision_log` kind=`news_aggregator_skipped_harvest_mode`
+pour audit.
+
+**Effets attendus** : ~600ms latence économisée par cycle, 4 calls API
+news skip, biais narratif retail muté. Lisa reçoit alors uniquement le
+bloc `## Positions rebound ouvertes` + indicateurs macro + tactical
+regime → décisions purement mécaniques.
+
+---
+
 ## RÈGLE OPÉRATIONNELLE — COUVERTURE H24 MULTI-BOURSES (P4-A)
 
 P4-A — Le scanner rebound-tp couvre 5 bourses pour atteindre la couverture H24 :

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -55,6 +55,8 @@ import {
   computeAtrPct,
   computeRealizedVolPct,
   computeRegimeAdjustedDeployment,
+  shouldRunNewsAggregator,
+  getProposalSources,
 } from '@smartvest/ai-analyst';
 import {
   buildYahooChartUrl,
@@ -602,11 +604,38 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     const fundamentalsBySymbol = new Map<string, typeof fundamentalsArr[number]>();
     uniqueSymbols.forEach((s, i) => fundamentalsBySymbol.set(s, fundamentalsArr[i]));
 
+    // P4-B — Routing sources de propositions par mode opératoire.
+    // En harvest (TP 2.5% / SL 1.5%, horizon scalping intraday), on
+    // court-circuite news-aggregator + sentiment retail pour ne garder
+    // que rebound_tp_scanner + mechanical_stops. Économie ~600ms latence
+    // + 4 calls API + risque biais narratif.
+    const disciplineMode = (config.capital_discipline_mode as string | null | undefined) ?? null;
+    const proposalSources = getProposalSources(disciplineMode);
+    const newsActive = shouldRunNewsAggregator(disciplineMode);
+
+    if (!newsActive) {
+      this.logger.log(
+        `[proposal-sources] mode=${disciplineMode ?? 'NONE'} → sources=[${proposalSources.join(',')}] (news skipped)`,
+      );
+      // Audit non-bloquant
+      this.decisionLog.append({
+        portfolioId,
+        kind: 'news_aggregator_skipped_harvest_mode',
+        summary: 'News pipeline skip (mode harvest = rebound-only)',
+        rationale: `proposal_sources=[${proposalSources.join(',')}]`,
+        payload: { discipline_mode: disciplineMode, proposal_sources: proposalSources },
+        triggeredBy: 'autopilot_cron',
+      }).catch((e) => this.logger.debug(`audit append failed: ${String(e).slice(0, 80)}`));
+    }
+
     // News pipeline complet — agrégation multi-source (EODHD + StockTwits
     // + Reddit + Twitter), scoring 4 axes + convergence cross-source,
     // dédup, bucketing. Substitue le dump naïf des 10 dernières headlines
     // par un bloc analytique avec scoring détaillé par item.
-    try {
+    // P4-B — short-circuit en mode harvest.
+    if (!newsActive) {
+      // Skip block — Lisa raisonnera uniquement sur rebound + mechanical
+    } else try {
       const aggregate = await this.newsAggregator.aggregate(uniqueSymbols, 30);
       if (aggregate.items.length > 0) {
         const halfLifeHours = sessionConfig.profile === 'hyper_active' ? 3

--- a/packages/ai-analyst/src/index.ts
+++ b/packages/ai-analyst/src/index.ts
@@ -18,6 +18,7 @@ export * from './strategies/rebound-tp';
 export * from './strategies/universes';
 export * from './strategies/rsi-prefilter';
 export * from './strategies/session-windows';
+export * from './strategies/proposal-source-routing';
 export * from './backtest/engine';
 export * from './backtest/metrics';
 export * from './backtest/runner';

--- a/packages/ai-analyst/src/strategies/__tests__/proposal-source-routing.spec.ts
+++ b/packages/ai-analyst/src/strategies/__tests__/proposal-source-routing.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * P4-B — Tests routing sources par mode opératoire.
+ */
+import {
+  getProposalSources,
+  isHarvestMode,
+  shouldRunNewsAggregator,
+  HARVEST_PROPOSAL_SOURCES,
+  INVESTMENT_PROPOSAL_SOURCES,
+} from '../proposal-source-routing';
+
+describe('isHarvestMode', () => {
+  it('matches DB convention DAILY_HARVEST', () => {
+    expect(isHarvestMode('DAILY_HARVEST')).toBe(true);
+  });
+
+  it('matches lowercase harvest from spec', () => {
+    expect(isHarvestMode('harvest')).toBe(true);
+  });
+
+  it('matches mixed case', () => {
+    expect(isHarvestMode('Daily_Harvest')).toBe(true);
+    expect(isHarvestMode('Harvest')).toBe(true);
+  });
+
+  it('returns false for NONE', () => {
+    expect(isHarvestMode('NONE')).toBe(false);
+  });
+
+  it('returns false for null/undefined', () => {
+    expect(isHarvestMode(null)).toBe(false);
+    expect(isHarvestMode(undefined)).toBe(false);
+  });
+
+  it('returns false for arbitrary string', () => {
+    expect(isHarvestMode('investment')).toBe(false);
+    expect(isHarvestMode('')).toBe(false);
+  });
+
+  it('returns false for non-string types', () => {
+    expect(isHarvestMode(42 as unknown as string)).toBe(false);
+  });
+});
+
+describe('getProposalSources', () => {
+  it('returns harvest sources (rebound + mechanical) for DAILY_HARVEST', () => {
+    expect(getProposalSources('DAILY_HARVEST')).toEqual([
+      'rebound_tp_scanner',
+      'mechanical_stops',
+    ]);
+  });
+
+  it('returns harvest sources for lowercase harvest', () => {
+    expect(getProposalSources('harvest')).toEqual([...HARVEST_PROPOSAL_SOURCES]);
+  });
+
+  it('returns full investment sources for NONE', () => {
+    const sources = getProposalSources('NONE');
+    expect(sources).toEqual([...INVESTMENT_PROPOSAL_SOURCES]);
+    expect(sources).toContain('rebound_tp_scanner');
+    expect(sources).toContain('momentum_breakout');
+    expect(sources).toContain('narrative_stocktwits');
+    expect(sources).toContain('sentiment_macro');
+    expect(sources).toContain('mechanical_stops');
+  });
+
+  it('returns full investment sources for null', () => {
+    expect(getProposalSources(null)).toEqual([...INVESTMENT_PROPOSAL_SOURCES]);
+  });
+
+  it('returns full investment sources for undefined', () => {
+    expect(getProposalSources(undefined)).toEqual([...INVESTMENT_PROPOSAL_SOURCES]);
+  });
+
+  it('returns NEW array each call (no shared mutable reference)', () => {
+    const a = getProposalSources('harvest');
+    const b = getProposalSources('harvest');
+    a.push('hacked' as never);
+    expect(b).not.toContain('hacked');
+  });
+
+  it('harvest sources is strict subset of investment sources', () => {
+    const harvest = getProposalSources('harvest');
+    const investment = getProposalSources(null);
+    for (const src of harvest) {
+      expect(investment).toContain(src);
+    }
+  });
+});
+
+describe('shouldRunNewsAggregator', () => {
+  it('returns false in harvest mode', () => {
+    expect(shouldRunNewsAggregator('DAILY_HARVEST')).toBe(false);
+    expect(shouldRunNewsAggregator('harvest')).toBe(false);
+  });
+
+  it('returns true in investment / NONE / null mode', () => {
+    expect(shouldRunNewsAggregator('NONE')).toBe(true);
+    expect(shouldRunNewsAggregator(null)).toBe(true);
+    expect(shouldRunNewsAggregator(undefined)).toBe(true);
+    expect(shouldRunNewsAggregator('investment')).toBe(true);
+  });
+});

--- a/packages/ai-analyst/src/strategies/proposal-source-routing.ts
+++ b/packages/ai-analyst/src/strategies/proposal-source-routing.ts
@@ -1,0 +1,69 @@
+/**
+ * P4-B — Routing des sources de propositions selon `capital_discipline_mode`.
+ *
+ * En mode HARVEST (scalping intraday TP 2.5% / SL 1.5%), seuls les signaux
+ * compatibles avec un horizon court doivent être consommés :
+ *   - rebound_tp_scanner  : RSI oversold + reversal candle + volume confirm
+ *   - mechanical_stops    : sortie déterministe TP/SL
+ *
+ * Les autres sources (narrative_stocktwits, momentum_breakout,
+ * sentiment_macro) ont un horizon 1-4 semaines et génèrent des
+ * proposal_failed quand stops -1.5% les ferme avant catalyseur.
+ *
+ * En mode INVESTMENT (buy-and-hold, stops -4%), toutes les sources sont
+ * actives.
+ *
+ * Pure function — testable en isolation.
+ */
+
+export type DisciplineModeLike = 'DAILY_HARVEST' | 'NONE' | string | null | undefined;
+
+export const HARVEST_PROPOSAL_SOURCES = [
+  'rebound_tp_scanner',
+  'mechanical_stops',
+] as const;
+
+export const INVESTMENT_PROPOSAL_SOURCES = [
+  'rebound_tp_scanner',
+  'momentum_breakout',
+  'narrative_stocktwits',
+  'sentiment_macro',
+  'mechanical_stops',
+] as const;
+
+export type ProposalSource =
+  | (typeof HARVEST_PROPOSAL_SOURCES)[number]
+  | (typeof INVESTMENT_PROPOSAL_SOURCES)[number];
+
+/**
+ * Renvoie la liste des sources de propositions pour un mode donné.
+ *
+ *   'harvest' / 'DAILY_HARVEST'   → ['rebound_tp_scanner', 'mechanical_stops']
+ *   'investment' / null / autres  → liste complète (5 sources)
+ */
+export function getProposalSources(mode: DisciplineModeLike): ProposalSource[] {
+  if (isHarvestMode(mode)) {
+    return [...HARVEST_PROPOSAL_SOURCES];
+  }
+  return [...INVESTMENT_PROPOSAL_SOURCES];
+}
+
+/**
+ * Détecte si on est en mode harvest (court terme, narrative-free).
+ * Accepte les deux conventions de nommage : DB stocke 'DAILY_HARVEST',
+ * la spec ticket P4-B utilise 'harvest' lowercase. On supporte les deux.
+ */
+export function isHarvestMode(mode: DisciplineModeLike): boolean {
+  if (typeof mode !== 'string') return false;
+  const normalized = mode.toLowerCase();
+  return normalized === 'harvest' || normalized === 'daily_harvest';
+}
+
+/**
+ * Indique si la source `news_aggregator` (StockTwits + Reddit + Twitter +
+ * EODHD news) doit être appelée pour ce mode. False en harvest pour
+ * économiser les coûts API et éviter les biais narratifs.
+ */
+export function shouldRunNewsAggregator(mode: DisciplineModeLike): boolean {
+  return !isHarvestMode(mode);
+}

--- a/scripts/reset-smartvest-portfolio.sql
+++ b/scripts/reset-smartvest-portfolio.sql
@@ -1,0 +1,93 @@
+-- Reset SmartVest portfolio simulé pour repartir propre après P3-D + P4-A + P4-B.
+--
+-- Usage : à exécuter MANUELLEMENT une fois les 3 PR (P3-D #48, P4-A #49,
+-- P4-B #50) déployées sur Fly. Toutes les migrations 0080/0081/0082
+-- doivent être appliquées AVANT ce reset.
+--
+-- Mapping spec ticket → tables réelles :
+--   `positions`             → `lisa_positions` (table existante 0043)
+--   `daily_harvest_state`   → `daily_trading_sessions` (0066) +
+--                              `secured_profit_balance` (0067)
+--   `portfolios`            → `portfolios` (0001)
+--   `lisa_decision_log`     → `lisa_decision_log` (0043)
+--   `rebound_positions`     → `rebound_positions` (0076)
+--
+-- Vérification pré-reset : SELECT count(*) FROM lisa_positions
+--   WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+BEGIN;
+
+-- 1) Fermer toutes positions Lisa ouvertes (mark as 'reset_clean_slate')
+UPDATE public.lisa_positions
+SET
+  status = 'closed_user',
+  exit_timestamp = NOW(),
+  realized_pnl_usd = '0'
+WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2'
+  AND status = 'open';
+
+-- 2) Reset cash + valeur du portfolio.
+-- Note : la table portfolios n'a PAS de colonnes cash_usd / total_value_usd
+-- (ces métriques sont dérivées de paperBroker.computeSnapshot via
+-- lisa_portfolio_snapshots). Ce qu'on reset ici c'est le LATEST snapshot.
+INSERT INTO public.lisa_portfolio_snapshots (
+  portfolio_id, timestamp, cash_usd, open_positions_value_usd,
+  total_value_usd, realized_pnl_cumulative_usd, unrealized_pnl_usd,
+  return_from_inception_pct, open_positions_count, drawdown_from_peak_pct
+)
+VALUES (
+  '58439d86-3f20-4a60-82a4-307f3f252bc2',
+  NOW(),
+  '10000.00', '0.00', '10000.00', '0.00', '0.00', 0, 0, 0
+);
+
+-- 3) Purger sessions Daily Harvest (= équivalent de daily_harvest_state spec).
+DELETE FROM public.daily_trading_sessions
+WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+-- 4) Reset secured_profit_balance (vault Daily Harvest).
+DELETE FROM public.secured_profit_balance
+WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+-- 5) Reset rebound_positions (P3-A).
+DELETE FROM public.rebound_positions
+WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+-- 6) Reset directives mécaniques + cycle summaries.
+DELETE FROM public.lisa_mechanical_directives
+WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+DELETE FROM public.lisa_mechanical_cycle_summary
+WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+-- 7) Lever kill_switch_active si actif.
+UPDATE public.lisa_session_configs
+SET kill_switch_active = false
+WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+-- 8) Garder lisa_decision_log historique pour audit, mais ajouter marker.
+-- Note : decision-log.service.ts gère normalement le hash chain. Insertion
+-- manuelle ici contourne le hash → marker explicitement non-chained
+-- (rationale dit pourquoi).
+INSERT INTO public.lisa_decision_log (
+  portfolio_id, timestamp, kind, summary, rationale, payload, triggered_by
+)
+VALUES (
+  '58439d86-3f20-4a60-82a4-307f3f252bc2',
+  NOW(),
+  'portfolio_reset_clean_slate',
+  'RESET post P3-D + P4-A + P4-B (manual SQL, hors hash chain)',
+  'Repart 10000 USD cash, harvest mode, watchlist multi-bourses (P4-A), rebound-only routing (P4-B). Hash chain interrompu volontairement par insertion SQL manuelle — chaîner à nouveau au prochain append() service.',
+  '{"target_capital_usd": 10000, "feature_flags": ["P3-D", "P4-A", "P4-B"], "reset_kind": "clean_slate"}'::jsonb,
+  'user_manual'
+);
+
+COMMIT;
+
+-- Vérification post-reset (à exécuter dans une transaction séparée) :
+-- SELECT
+--   (SELECT count(*) FROM lisa_positions WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2' AND status = 'open') AS open_positions,
+--   (SELECT count(*) FROM rebound_positions WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2' AND status = 'OPEN') AS open_rebounds,
+--   (SELECT count(*) FROM daily_trading_sessions WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2') AS sessions,
+--   (SELECT cash_usd FROM lisa_portfolio_snapshots WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2' ORDER BY timestamp DESC LIMIT 1) AS cash;
+-- → expected : open_positions=0, open_rebounds=0, sessions=0, cash='10000.00'


### PR DESCRIPTION
## Pourquoi (P4-B)

Trou critique en mode `capital_discipline_mode='DAILY_HARVEST'` (TP 2.5% / SL 1.5%) : Lisa pouvait proposer des thèses narratives StockTwits/momentum/sentiment macro avec horizon 1-4 semaines. Stops -1.5% les ferme avant catalyseur → **40% proposal_failed observés 27-28/04**. Ce PR coupe ces sources en harvest pour ne garder que rebound + mechanical_stops.

## Quoi

### 1. Pure helper `proposal-source-routing.ts`

```ts
getProposalSources(mode) → string[]
  'DAILY_HARVEST'/'harvest' → ['rebound_tp_scanner', 'mechanical_stops']
  'NONE'/null/'investment'  → 5 sources complètes

shouldRunNewsAggregator(mode) → boolean   // false en harvest
isHarvestMode(mode) → boolean              // case-insensitive
```

### 2. `lisa.service.ts` — short-circuit news en harvest

Avant le bloc news pipeline :

```ts
const newsActive = shouldRunNewsAggregator(disciplineMode);
if (!newsActive) {
  this.logger.log(`[proposal-sources] mode=${disciplineMode} → sources=[${proposalSources.join(',')}] (news skipped)`);
  this.decisionLog.append({
    kind: 'news_aggregator_skipped_harvest_mode',
    payload: { discipline_mode, proposal_sources },
  });
  // Skip aggregate() entièrement
}
```

**Effet attendu** : ~600ms latence économisée + 4 calls API (StockTwits + Reddit + Twitter + EODHD news) skip + biais narratif retail muté.

### 3. Tests Jest — 16 specs

| Suite | Tests | Couvre |
|---|---|---|
| `isHarvestMode` | 7 | DB convention, lowercase, mixed case, NONE, null/undefined, arbitrary, non-string |
| `getProposalSources` | 8 | harvest exact, lowercase, full investment, null/undefined, new array, strict subset |
| `shouldRunNewsAggregator` | 2 | harvest false, investment true |

### 4. CLAUDE.md règle ajoutée

Tableau mode × sources, justification stops courts vs horizon long, mécanique d'audit hash-chained.

### 5. `scripts/reset-smartvest-portfolio.sql`

Script SQL transactionnel à exécuter manuellement post-deploy. Mapping spec → tables réelles documenté :

| Spec | Table réelle |
|---|---|
| `positions` | `lisa_positions` |
| `daily_harvest_state` | `daily_trading_sessions` + `secured_profit_balance` |

8 étapes : close lisa_positions / new snapshot 10000 / DELETE daily_trading_sessions / DELETE secured_profit_balance / DELETE rebound_positions / DELETE mechanical_directives + cycle_summary / kill_switch off / decision_log marker.

## Différences vs spec ticket (fail-fast diagnostiqué)

| Spec | Réalité | Décision |
|---|---|---|
| `INSERT lisa_session_configs (key=...)` | pas un store key-value | Helper TS pur (testable), détection runtime |
| Migration 0083 routing config | pas nécessaire avec helper TS | Out of scope |
| UI badge sources actives | frontend deferred | Payload audit expose `proposal_sources` pour endpoint UI futur |
| `scanPortfolio()` refactor pour consommer | scanner indépendant du mode (P3-A.2/C) | Pas de refactor |
| Vitest | Jest only | Jest |

## Tests

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/ai-analyst` : 9 suites / **183 tests** ✅ (16 nouveaux)
- `npm test --workspace=@smartvest/api` : 43 suites / 501 tests ✅
- Total : **52 suites / 684 tests OK**

## Action utilisateur post-merge

1. Deploy Fly auto via merge main
2. Quand P3-D + P4-A + P4-B déployés :
   ```bash
   psql $DATABASE_URL -f scripts/reset-smartvest-portfolio.sql
   ```
3. Vérifier post-reset (SQL en bas du script) :
   `open_positions=0, open_rebounds=0, sessions=0, cash='10000.00'`
4. Au prochain cycle Lisa en harvest, observer logs :
   ```
   [proposal-sources] mode=DAILY_HARVEST → sources=[rebound_tp_scanner,mechanical_stops] (news skipped)
   ```
   et `lisa_decision_log` row kind=`news_aggregator_skipped_harvest_mode`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_