### PR TITLE
hotfix(migrations): add 0082 + 0083 schemas (deferred from P4-A/B)

### DIFF
--- a/supabase/migrations/0082_lisa_multi_session_harvest.sql
+++ b/supabase/migrations/0082_lisa_multi_session_harvest.sql
@@ -1,0 +1,27 @@
+-- P4-A — Schema multi-session harvest sweep windows.
+--
+-- ⚠️ Cette migration ne fait QUE le schéma. La logique de sweep
+-- multi-fenêtre (DailySessionService refactor) est deferred — le runtime
+-- continue d'opérer sur 1 sweep/jour tant que `harvest_sweep_windows_utc`
+-- n'est pas consommé par DailySessionService (follow-up P4-C).
+--
+-- Justification spec ticket P4-A : "daily_harvest_reset doit devenir
+-- multi-window: matin Europe (09h CEST), après-midi US (15h30 CEST),
+-- nuit Asie (01h CEST)". Cette migration prépare la DB ; le code suit.
+--
+-- Idempotente (ADD COLUMN IF NOT EXISTS).
+
+-- Colonnes : array de fenêtres "HH:MM" UTC pendant lesquelles un sweep
+-- PER_TRADE est autorisé. Format identique à session_open_utc dans
+-- watchlist_universe (P4-A migration 0081).
+ALTER TABLE public.lisa_session_configs
+  ADD COLUMN IF NOT EXISTS harvest_sweep_windows_utc text[]
+    DEFAULT ARRAY['07:00', '13:30', '23:00']::text[];
+
+-- Override per-portfolio possible. NULL = utilise default.
+COMMENT ON COLUMN public.lisa_session_configs.harvest_sweep_windows_utc IS
+  'P4-A — fenêtres horaires UTC où le sweep PER_TRADE Daily Harvest est autorisé. Default 3 fenêtres (Europe matin / US PM / Asie nuit). Consommé par DailySessionService (refactor P4-C).';
+
+-- Index utile pour debug ("quels portfolios ont une config sweep custom ?")
+CREATE INDEX IF NOT EXISTS lisa_session_configs_harvest_sweep_idx
+  ON public.lisa_session_configs USING gin (harvest_sweep_windows_utc);

--- a/supabase/migrations/0083_lisa_harvest_source_routing.sql
+++ b/supabase/migrations/0083_lisa_harvest_source_routing.sql
@@ -1,0 +1,33 @@
+-- P4-B — Schema routing sources de propositions par mode opératoire.
+--
+-- ⚠️ Schema-only. Le routing runtime est en pure helper TS
+-- (`packages/ai-analyst/src/strategies/proposal-source-routing.ts`,
+-- `getProposalSources(mode)`) et fonctionne SANS cette migration.
+--
+-- Cette migration ajoute des colonnes per-portfolio pour permettre
+-- l'override admin/UI (futur). Tant que ces colonnes sont NULL, le
+-- helper TS retourne ses defaults hardcodés ; quand renseignées, le
+-- caller (LisaService.generateProposal) pourra les lire en priorité
+-- (follow-up wiring).
+--
+-- Justification spec ticket P4-B : "INSERT lisa_session_configs
+-- (key='harvest_proposal_sources', value=...)". lisa_session_configs
+-- n'est pas key-value → on stocke comme colonnes text[] structurées.
+--
+-- Idempotente (ADD COLUMN IF NOT EXISTS).
+
+-- Sources actives en mode DAILY_HARVEST. NULL = défaut helper TS
+-- (rebound_tp_scanner + mechanical_stops).
+ALTER TABLE public.lisa_session_configs
+  ADD COLUMN IF NOT EXISTS harvest_proposal_sources text[];
+
+-- Sources actives en mode INVESTMENT/NONE. NULL = défaut helper TS
+-- (5 sources : rebound + momentum + narrative_stocktwits + sentiment_macro + mechanical_stops).
+ALTER TABLE public.lisa_session_configs
+  ADD COLUMN IF NOT EXISTS investment_proposal_sources text[];
+
+COMMENT ON COLUMN public.lisa_session_configs.harvest_proposal_sources IS
+  'P4-B — Override des sources de propositions actives en mode DAILY_HARVEST. NULL = défaut TS helper getProposalSources(harvest) = [rebound_tp_scanner, mechanical_stops].';
+
+COMMENT ON COLUMN public.lisa_session_configs.investment_proposal_sources IS
+  'P4-B — Override des sources actives en mode INVESTMENT/NONE. NULL = défaut TS helper [rebound_tp_scanner, momentum_breakout, narrative_stocktwits, sentiment_macro, mechanical_stops].';


### PR DESCRIPTION
## Pourquoi (hotfix)

Honest hotfix : ces 2 migrations étaient spec'd dans P4-A et P4-B mais j'ai sciemment **deferred** leur création (documenté en "Out of scope" dans les PR bodies #49 et #50). L'utilisateur a raison de bloquer le reset prod tant que la séquence migrations n'est pas contiguë.

## État avant ce PR

- ✅ `0080_p3d_lisa_config_fixes.sql` (P3-D #48)
- ✅ `0081_watchlist_universe_multi_exchange.sql` (P4-A #49)
- ❌ `0082_lisa_multi_session_harvest.sql` — **MANQUANTE**
- ❌ `0083_lisa_harvest_source_routing.sql` — **MANQUANTE**

## Quoi

### `0082_lisa_multi_session_harvest.sql`

```sql
ALTER TABLE lisa_session_configs
  ADD COLUMN harvest_sweep_windows_utc text[]
    DEFAULT ARRAY['07:00', '13:30', '23:00']::text[];
CREATE INDEX ... USING gin (harvest_sweep_windows_utc);
```

Prépare le sweep multi-window Daily Harvest (Europe matin / US PM / Asie nuit). Consommé par DailySessionService refactor follow-up P4-C.

### `0083_lisa_harvest_source_routing.sql`

```sql
ALTER TABLE lisa_session_configs
  ADD COLUMN harvest_proposal_sources text[],
  ADD COLUMN investment_proposal_sources text[];
```

Override per-portfolio des sources actives. NULL = défaut helper TS `getProposalSources(mode)` (P4-B helper toujours source de vérité).

Spec ticket P4-B disait `INSERT lisa_session_configs (key=..., value=...)` mais `lisa_session_configs` n'est pas key-value → colonnes structurées text[]. Sémantique préservée.

Les deux sont **idempotentes** (`ADD COLUMN IF NOT EXISTS`).

## Vérification fly.toml

`fly.toml` **n'a PAS de `release_command`** — les migrations ne sont **PAS** auto-appliquées au deploy. Workflow manuel :

```bash
SUPABASE_ACCESS_TOKEN=sbp_xxx npm run -w @smartvest/api migrate
```

(`scripts/apply-migrations.mjs` lit `supabase/migrations/*.sql` et applique les nouvelles via Supabase Management API, tracking dans `_smartvest_migrations`.)

## Action utilisateur post-merge

```bash
# 1. Apply migrations (no auto-deploy hook)
SUPABASE_ACCESS_TOKEN=sbp_xxx npm run -w @smartvest/api migrate

# 2. Vérifier
psql $DATABASE_URL -c "SELECT name FROM _smartvest_migrations WHERE name LIKE '008%' ORDER BY name;"
# → expected : 0080, 0081, 0082, 0083 (4 rows)

# 3. Une fois les 4 visibles → exécuter le reset
psql $DATABASE_URL -f scripts/reset-smartvest-portfolio.sql
```

## Tests

- `npx tsc -b` ✅ (pas d'impact TS, SQL only)
- 52 suites / 684 tests inchangés

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_