### PR TITLE
hotfix(p0): /lisa client crash — coerce snapshot numerics (post-reset)

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1917,7 +1917,18 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       .gte('timestamp', since)
       .order('timestamp', { ascending: true });
     if (error) throw new BadRequestException(error.message);
-    return data ?? [];
+    // P0 hotfix — Postgres numeric() columns are serialized as STRINGS by
+    // supabase-js (precision-preserving). The frontend `LisaSnapshot` type
+    // expects `return_from_inception_pct: number` and `drawdown_from_peak_pct: number`
+    // and components call `.toFixed()` on them → crash if string.
+    // We coerce to numbers here for these two fields, while keeping money
+    // columns (cash_usd, total_value_usd, etc.) as strings (Decimal-safe).
+    return (data ?? []).map((row) => ({
+      ...row,
+      return_from_inception_pct: parseFloat(String(row.return_from_inception_pct ?? 0)) || 0,
+      drawdown_from_peak_pct: parseFloat(String(row.drawdown_from_peak_pct ?? 0)) || 0,
+      open_positions_count: parseInt(String(row.open_positions_count ?? 0), 10) || 0,
+    }));
   }
 
   async getDecisionLog(userId: string, portfolioId: string, limit = 50) {

--- a/apps/web/src/components/lisa/portfolio-chart.tsx
+++ b/apps/web/src/components/lisa/portfolio-chart.tsx
@@ -105,10 +105,13 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
         hour: '2-digit',
         minute: '2-digit',
       }),
-      value: parseFloat(s.total_value_usd),
-      realized: parseFloat(s.realized_pnl_cumulative_usd),
-      returnPct: s.return_from_inception_pct,
-      drawdown: s.drawdown_from_peak_pct,
+      // P0 hotfix — defensive coercion : Postgres numeric() columns are
+      // serialized as strings by supabase-js. parseFloat est idempotent
+      // sur un number JS, donc safe même quand le backend a déjà coercé.
+      value: parseFloat(String(s.total_value_usd ?? '0')) || 0,
+      realized: parseFloat(String(s.realized_pnl_cumulative_usd ?? '0')) || 0,
+      returnPct: parseFloat(String(s.return_from_inception_pct ?? 0)) || 0,
+      drawdown: parseFloat(String(s.drawdown_from_peak_pct ?? 0)) || 0,
     }));
 
     // Ajout point "live" : si la valeur live est plus récente que le
@@ -130,9 +133,9 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
             minute: '2-digit',
           }) + ' (live)',
           value: liveValue,
-          realized: parseFloat(live.realized_pnl_cumulative_usd),
-          returnPct: live.return_from_inception_pct,
-          drawdown: live.drawdown_from_peak_pct,
+          realized: parseFloat(String(live.realized_pnl_cumulative_usd ?? '0')) || 0,
+          returnPct: parseFloat(String(live.return_from_inception_pct ?? 0)) || 0,
+          drawdown: parseFloat(String(live.drawdown_from_peak_pct ?? 0)) || 0,
         });
       }
     }


### PR DESCRIPTION
## P0 incident — /lisa client crash après reset

**T0+5min** post-reset SmartVest 12:40 CEST. Symptôme : `/lisa` retourne `Application error: a client-side exception has occurred`.

## Root cause

Postgres `numeric(10,4)` colonnes sont sérialisées comme **strings** par supabase-js (precision-preserving), mais le frontend type `LisaSnapshot.return_from_inception_pct: number` et le composant PortfolioChart appelle `.toFixed(2)` directement dessus :

```ts
// apps/web/src/components/lisa/portfolio-chart.tsx:50,57,191
{point.returnPct.toFixed(2)}%   // CRASH si string
```

`getSnapshotHistory` (`lisa.service.ts:1910`) retournait les rows DB en brut via `select('*')` sans transformer — à la différence de `getCurrentSnapshot` (ligne 1786) qui mappait correctement.

**Pourquoi maintenant** : La nouvelle row insérée par `scripts/reset-smartvest-portfolio.sql` avec `return_from_inception_pct=0` (integer literal) a déclenché le path tooltip sur dataset frais.

## Fix

### Backend

`getSnapshotHistory` map les rows pour coercer :
- `return_from_inception_pct` → `parseFloat`
- `drawdown_from_peak_pct` → `parseFloat`
- `open_positions_count` → `parseInt`

Money columns (cash_usd, total_value_usd, etc.) restent strings (Decimal-safe).

### Frontend

Defensive `parseFloat` sur tous les champs numériques du `chartData` (history + live point).

## Hypothèses initiales écartées

| Suspicion | Vérifié |
|---|---|
| Migrations 0082+0083 (text[] columns) | ❌ pas consommées frontend, ignored JS |
| Badge "Sources actives" / "Marchés actifs" | ❌ deferred dans P4-A/P4-B (out of scope) |
| DailyHarvest endpoint sur session vide | ❌ retourne `mode='NONE'` propre |

## Tests

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/api` : 43 suites / 501 tests ✅

## Action utilisateur

Vercel redeploy auto sur merge main. Le crash devrait disparaître au prochain reload de `/lisa`. Surveillance live peut reprendre.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_