### PR TITLE
hotfix(p0 #2): /lisa crash 'reading description' on profile + status

### DIFF
--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -52,6 +52,22 @@ const PROFILE_LABELS: Record<SessionProfile, { label: string; description: strin
   },
 };
 
+// P0 hotfix #2 — fallback descriptor pour les profils DB inconnus du
+// frontend (ex: 'swing_active' historique avant le mapping P3-D, ou
+// nouveaux profils ajoutés côté DB sans update du PROFILE_LABELS).
+// Évite le crash `Cannot read properties of undefined (reading 'description')`
+// au render `PROFILE_LABELS[profile].description`.
+const UNKNOWN_PROFILE_LABEL = {
+  label: 'Profil personnalisé',
+  description: 'Profil DB non documenté côté UI — comportement déterminé par la config.',
+};
+const profileLabelOf = (
+  p: SessionProfile | string | undefined,
+): { label: string; description: string } => {
+  if (!p) return UNKNOWN_PROFILE_LABEL;
+  return PROFILE_LABELS[p as SessionProfile] ?? UNKNOWN_PROFILE_LABEL;
+};
+
 export default function LisaPage() {
   const portfoliosQuery = usePortfolios();
   const qc = useQueryClient();
@@ -546,7 +562,7 @@ export default function LisaPage() {
               ))}
             </select>
             <p className="text-[11px] text-muted-foreground">
-              {PROFILE_LABELS[profile].description}
+              {profileLabelOf(profile).description}
             </p>
           </div>
 

--- a/apps/web/src/components/lisa/positions-table.tsx
+++ b/apps/web/src/components/lisa/positions-table.tsx
@@ -111,8 +111,16 @@ function formatAbsolute(iso: string | null): string {
   });
 }
 
+// P0 hotfix #2 — fallback statut pour les valeurs DB inconnues du
+// PROFILE_LABELS frontend. Évite le crash `.color`/`.label` sur undefined.
+const UNKNOWN_STATUS_CFG = {
+  label: 'Statut',
+  color: 'bg-slate-50 text-slate-500 border-slate-200',
+};
+
 function PositionRow({ pos }: { pos: LisaPosition }) {
-  const statusCfg = STATUS_LABELS[pos.status];
+  const statusCfg =
+    (pos.status && STATUS_LABELS[pos.status]) ?? UNKNOWN_STATUS_CFG;
   const pnl = pos.realizedPnlUsd ? parseFloat(pos.realizedPnlUsd) : null;
   const pnlPct = pos.realizedPnlPct;
   const pnlColor = pnl === null ? '' : pnl >= 0 ? 'text-emerald-600' : 'text-red-500';


### PR DESCRIPTION
## P0 #2 — `/lisa` crash `reading 'description'` (post-hotfix #52)

**T0+10min** après merge #52. Nouveau crash, différent du précédent (qui était `.toFixed` sur numeric string) :

```
TypeError: Cannot read properties of undefined (reading 'description')
```

## Root cause

`apps/web/src/app/lisa/page.tsx:549` :

```ts
{PROFILE_LABELS[profile].description}
```

Si `profile` (issu de `config.profile` DB) ne matche aucune des 4 clés `SessionProfile`, `PROFILE_LABELS[profile]` retourne `undefined` → `.description` crashe.

**Note** : aucune référence `swing_active` dans le codebase (vérifié via grep). Le crash actuel vient d'une autre source — état stale React Query, valeur DB legacy, ou narrowing TS faux. Le fix defensive couvre toutes les sources possibles.

Même classe de bug existe dans `positions-table.tsx:115` avec `STATUS_LABELS[pos.status]`. Hotfix défensif appliqué aux deux.

## Fix

### `apps/web/src/app/lisa/page.tsx`

```ts
const UNKNOWN_PROFILE_LABEL = {
  label: 'Profil personnalisé',
  description: 'Profil DB non documenté côté UI — comportement déterminé par la config.',
};

const profileLabelOf = (p): { label: string; description: string } => {
  if (!p) return UNKNOWN_PROFILE_LABEL;
  return PROFILE_LABELS[p as SessionProfile] ?? UNKNOWN_PROFILE_LABEL;
};

// Render
{profileLabelOf(profile).description}  // jamais undefined
```

### `apps/web/src/components/lisa/positions-table.tsx`

```ts
const UNKNOWN_STATUS_CFG = { label: 'Statut', color: 'bg-slate-50 text-slate-500 border-slate-200' };
const statusCfg = (pos.status && STATUS_LABELS[pos.status]) ?? UNKNOWN_STATUS_CFG;
```

## Tests

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/api` : 43 suites / 501 tests ✅ (inchangé)

## Action utilisateur

Vercel redeploy auto. Reload `/lisa` → crash devrait disparaître. Surveillance live peut reprendre.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_