### PR TITLE
chore(fly): force redeploy trigger via fly.toml comment update

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,8 @@
 # fly.toml — SmartVest API (NestJS)
 #
+# Last forced redeploy : 2026-04-28 — sync Fly with main HEAD (P0 hotfix
+# #52 snapshot-history-types + #53 profile-label-defensive).
+#
 # auto_stop_machines = 'off' : la machine reste TOUJOURS up.
 # Indispensable pour que les crons Lisa tournent sans interruption :
 #   - autopilot (1 min)


### PR DESCRIPTION
## Pourquoi

L'utilisateur reporte que Fly worker est bloqué sur `bdd6e53` (P3-A merge ~3h ago) alors que main HEAD = `1de50f9` (P0 #52 + #53 mergés). 7 commits depuis auraient dû déclencher le workflow `.github/workflows/fly.yml` mais visiblement la chaîne push → deploy est cassée (workflow fail silencieux ou FLY_API_TOKEN expiré).

## Constraints sandbox

- ❌ `flyctl` non installé
- ❌ `gh` CLI non disponible
- ❌ Pas de MCP tool pour `workflow_dispatch` ou lister les Actions runs

Seul levier disponible : modifier un fichier dans le path filter de `fly.yml` (`apps/api/**`, `packages/**`, `Dockerfile`, `fly.toml`, `package.json`) → push → re-trigger workflow.

## Quoi

Comment-only update sur `fly.toml` avec marker date du forced redeploy. Aucun changement runtime.

## Action utilisateur post-merge

1. Surveiller GitHub Actions → "Deploy SmartVest API to Fly.io" run
2. Si fail → check logs, possible cause : `FLY_API_TOKEN` expiré
3. Si Deploy Succeeded → smoke test :
   ```bash
   curl https://smartvest.fly.dev/health
   curl -H "x-user-id: <uid>" "https://smartvest.fly.dev/api/lisa/current-snapshot/<pid>"
   ```
   Vérifier `return_from_inception_pct = number` (pas string).
4. GO reset script si `/lisa` stable post-redeploy + healthcheck 200.

## Tests

Aucun (comment-only).

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_