### PR TITLE
hotfix(p0): unblock Lisa cycles — Zod alias + Array guard

### DIFF
--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -1235,7 +1235,16 @@ Les symboles suivants sont **DÉJÀ DANS TON PORTEFEUILLE** : ${heldSymbolsList}
     // Filtre les éléments non-objets que Claude glisse parfois dans le tableau
     // (strings orphelines, null, artefacts de parsing). Sans ça, `t.id = …`
     // jette "Cannot create property 'id' on string '['" et casse le cycle.
-    const thesesRawUnfiltered = (root.theses as Array<unknown>) ?? [];
+    //
+    // P0 hotfix — Claude Opus renvoie parfois `theses: { theses: [...] }`
+    // (double wrapping) ou `theses: undefined` sur 0 result. Sans guard
+    // Array.isArray, `.filter()` jette "is not a function" et casse le cycle.
+    const rootTheses = root.theses as unknown;
+    const thesesRawUnfiltered: unknown[] = Array.isArray(rootTheses)
+      ? rootTheses
+      : (rootTheses && typeof rootTheses === 'object' && Array.isArray((rootTheses as { theses?: unknown[] }).theses))
+        ? (rootTheses as { theses: unknown[] }).theses
+        : [];
     const thesesRaw = thesesRawUnfiltered.filter(
       (t): t is Record<string, unknown> => t !== null && typeof t === 'object' && !Array.isArray(t),
     );

--- a/packages/ai-analyst/src/types/__tests__/threshold-direction-preprocess.spec.ts
+++ b/packages/ai-analyst/src/types/__tests__/threshold-direction-preprocess.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * P0 hotfix — Tests preprocess Zod sur thresholdDirection.
+ *
+ * Claude Opus utilise parfois le vocabulaire mathématique (gte/lte/gt/lt/eq)
+ * au lieu du vocabulaire produit (above/below/cross). Le preprocess
+ * normalise ces alias avant validation enum stricte.
+ */
+import { ThesisInvalidation } from '../index';
+
+const baseCondition = {
+  description: 'BTC RSI oversold',
+  metricType: 'rsi_14',
+  thresholdValue: '30',
+};
+
+function build(direction: unknown) {
+  return ThesisInvalidation.safeParse({
+    conditions: [{ ...baseCondition, thresholdDirection: direction }],
+    qualitativeConditions: [],
+  });
+}
+
+describe('ThesisInvalidation thresholdDirection preprocess', () => {
+  it('accepts canonical values without modification', () => {
+    for (const v of ['above', 'below', 'cross', 'occurs']) {
+      const r = build(v);
+      expect(r.success).toBe(true);
+      if (r.success) expect(r.data.conditions[0].thresholdDirection).toBe(v);
+    }
+  });
+
+  it('accepts null', () => {
+    const r = build(null);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.conditions[0].thresholdDirection).toBeNull();
+  });
+
+  it("maps 'gte' → 'above'", () => {
+    const r = build('gte');
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.conditions[0].thresholdDirection).toBe('above');
+  });
+
+  it("maps 'gt' → 'above'", () => {
+    const r = build('gt');
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.conditions[0].thresholdDirection).toBe('above');
+  });
+
+  it("maps 'lte' → 'below'", () => {
+    const r = build('lte');
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.conditions[0].thresholdDirection).toBe('below');
+  });
+
+  it("maps 'lt' → 'below'", () => {
+    const r = build('lt');
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.conditions[0].thresholdDirection).toBe('below');
+  });
+
+  it("maps 'eq' → 'cross'", () => {
+    const r = build('eq');
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.conditions[0].thresholdDirection).toBe('cross');
+  });
+
+  it('handles uppercase + whitespace (case insensitive + trim)', () => {
+    const r = build('  GTE  ');
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.conditions[0].thresholdDirection).toBe('above');
+  });
+
+  it('maps verbose aliases (greater_than, less_than)', () => {
+    expect((build('greater_than') as { success: true; data: { conditions: { thresholdDirection: string }[] } }).data.conditions[0].thresholdDirection).toBe('above');
+    expect((build('less_than') as { success: true; data: { conditions: { thresholdDirection: string }[] } }).data.conditions[0].thresholdDirection).toBe('below');
+    expect((build('greater_than_or_equal') as { success: true; data: { conditions: { thresholdDirection: string }[] } }).data.conditions[0].thresholdDirection).toBe('above');
+    expect((build('less_than_or_equal') as { success: true; data: { conditions: { thresholdDirection: string }[] } }).data.conditions[0].thresholdDirection).toBe('below');
+  });
+
+  it('rejects truly unknown values (preserves enum strictness)', () => {
+    const r = build('approximately');
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects non-string non-null inputs', () => {
+    const r = build(42);
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/ai-analyst/src/types/index.ts
+++ b/packages/ai-analyst/src/types/index.ts
@@ -206,7 +206,31 @@ export const ThesisInvalidation = z.object({
     description: z.string(),
     metricType: z.string().min(1).max(50),
     thresholdValue: z.string().nullable(),
-    thresholdDirection: z.enum(['above', 'below', 'cross', 'occurs']).nullable(),
+    /** P0 hotfix — Claude Opus utilise parfois le vocabulaire mathématique
+     *  (gte/lte/gt/lt/eq) au lieu du vocabulaire produit (above/below/cross).
+     *  Preprocess normalise les alias avant validation enum stricte. */
+    thresholdDirection: z.preprocess(
+      (v) => {
+        if (v == null) return v;
+        if (typeof v !== 'string') return v;
+        const normalized = v.toLowerCase().trim();
+        const aliases: Record<string, 'above' | 'below' | 'cross' | 'occurs'> = {
+          gte: 'above',
+          gt: 'above',
+          'greater_than': 'above',
+          'greater_than_or_equal': 'above',
+          lte: 'below',
+          lt: 'below',
+          'less_than': 'below',
+          'less_than_or_equal': 'below',
+          eq: 'cross',
+          equals: 'cross',
+          equal: 'cross',
+        };
+        return aliases[normalized] ?? normalized;
+      },
+      z.enum(['above', 'below', 'cross', 'occurs']).nullable(),
+    ),
   })),
   /** Conditions d'échec simples non quantifiables */
   qualitativeConditions: z.array(z.string()),


### PR DESCRIPTION
## P0 BLOQUANT — 100% des cycles Lisa fail post-reset

2 erreurs distinctes observées 14:53 et 14:58 CEST. Mode no-touch utilisateur activé, hash chain réparée, mais aucun trade ne s'ouvre.

### BUG #1 — Zod thresholdDirection enum strict

```
BadRequestException: Thesis validation failed for 'BTC tactical entry':
  invalidation.conditions.1.thresholdDirection: Invalid enum value.
  Expected 'above' | 'below' | 'cross' | 'occurs', received 'gte'
```

**Cause** : Claude Opus utilise vocabulaire mathématique (gte/lte/gt/lt/eq) au lieu du vocabulaire produit. Récurrent sur les schemas stricts.

**Fix (option b — preprocess)** : Wrapper Zod `preprocess` qui normalise les alias avant validation enum stricte :

```ts
// packages/ai-analyst/src/types/index.ts:209
thresholdDirection: z.preprocess(
  (v) => {
    if (v == null || typeof v !== 'string') return v;
    const aliases = {
      gte: 'above', gt: 'above', greater_than: 'above', greater_than_or_equal: 'above',
      lte: 'below', lt: 'below', less_than: 'below', less_than_or_equal: 'below',
      eq: 'cross', equals: 'cross', equal: 'cross',
    };
    return aliases[v.toLowerCase().trim()] ?? v.toLowerCase().trim();
  },
  z.enum(['above', 'below', 'cross', 'occurs']).nullable(),
),
```

Case-insensitive + trim. Non-string non-null toujours rejeté (préserve la strictness).

### BUG #2 — `thesesRawUnfiltered.filter is not a function`

```
BadRequestException: thesesRawUnfiltered.filter is not a function
```

**Cause** : Claude renvoie parfois `theses: { theses: [...] }` (double wrapping) ou `theses: undefined`. Le code assumait Array sans guard.

**Fix** : guard Array.isArray défensif dans `thesis-generator.service.ts:1238` :

```ts
const rootTheses = root.theses as unknown;
const thesesRawUnfiltered: unknown[] = Array.isArray(rootTheses)
  ? rootTheses
  : (rootTheses && typeof rootTheses === 'object' && Array.isArray((rootTheses as { theses?: unknown[] }).theses))
    ? (rootTheses as { theses: unknown[] }).theses
    : [];
```

## Tests

- `npx tsc -b` ✅
- 11 specs nouvelles pour le preprocess (`threshold-direction-preprocess.spec.ts`)
- ai-analyst : 10 suites / **194 tests** ✅
- apps/api : 43 suites / 501 tests ✅
- Total : **53 suites / 695 tests OK**

## Deploy auto

Le merge sur main matche `packages/**` du path filter `fly.yml` → workflow Fly auto-déclenché → Fly v218 live avec les 2 fixes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_