### PR TITLE
hotfix(p5-exec): log proposal_rejected when auto_approve=false (visibility)

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
@@ -545,6 +545,26 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
             this.logger.error(`Auto-approve failed for ${proposal.id}: ${String(e)}`);
           }
         }
+      } else if (!autoApprove && proposal.theses.length > 0) {
+        // P5-EXEC — Visibilité : log explicite quand autoApprove=false bloque
+        // l'exécution malgré des thèses générées. Sans ce log, les utilisateurs
+        // voyaient `proposal_generated` puis silence — pas de trace de pourquoi
+        // 0 position s'ouvrait. Maintenant traçable via decision_log :
+        //   kind='proposal_rejected', rationale='gate=auto_approve_disabled'
+        await this.decisionLog.append({
+          portfolioId,
+          kind: 'proposal_rejected',
+          summary: `Proposal ${proposal.id.slice(0, 8)} non-exécutée (${proposal.theses.length} thèses, auto_approve=false)`,
+          rationale: `gate=auto_approve_disabled · autopilot_auto_approve=false · Pour activer l'exécution automatique : UPDATE lisa_session_configs SET autopilot_auto_approve=true, autopilot_expires_at=now()+interval '24 hours' WHERE portfolio_id='${portfolioId}'`,
+          payload: {
+            proposal_id: proposal.id,
+            theses_count: proposal.theses.length,
+            gate: 'auto_approve_disabled',
+            autopilot_enabled: true,
+            autopilot_auto_approve: false,
+          },
+          triggeredBy: 'autopilot_cron',
+        }).catch((e) => this.logger.warn(`proposal_rejected log append failed: ${String(e).slice(0, 120)}`));
       }
 
       const momentumTag = proposal.marketMomentum === 'bullish_strong'


### PR DESCRIPTION
## Diagnostic P5-EXEC

**Symptôme** : Lisa génère des propositions valides (3 thèses au cycle 13:17), mais **0 position ouverte** dans `lisa_positions`. Aucun `decision_log` kind='position_opened'.

**Root cause confirmé** via call graph trace (`lisa-autopilot.service.ts:528`) :

```ts
if (autoApprove && proposal.theses.length > 0) {
  // approveProposal → paperBroker.openPosition → INSERT lisa_positions
}
```

Si `autopilot_auto_approve=false` (default migration 0044), tout le bloc approve+open est **silencieusement skippé**. Aucun log ne traçait ce gate → utilisateur voyait `proposal_generated` puis silence.

`paperBroker.openPosition` est **correctement câblé**. Pas de `DRY_RUN` env (vérifié grep). Le seul blocker = `autopilot_auto_approve` en DB.

## Fix : visibilité explicite

Ajout d'une branche `else if (!autoApprove && theses>0)` qui log un `proposal_rejected` avec rationale explicite :

```ts
decisionLog.append({
  kind: 'proposal_rejected',
  summary: 'Proposal X non-exécutée (N thèses, auto_approve=false)',
  rationale: 'gate=auto_approve_disabled · UPDATE SQL pour activer',
  payload: { proposal_id, theses_count, gate: 'auto_approve_disabled', ... },
  triggered_by: 'autopilot_cron',
});
```

Maintenant, plus de **silence** entre `proposal_generated` et fin de cycle.

## Action utilisateur post-merge

Activer l'exécution automatique via SQL (24h expiration safety) :

```sql
UPDATE public.lisa_session_configs
SET
  autopilot_auto_approve = true,
  autopilot_expires_at = now() + interval '24 hours'
WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2';
```

Vérification :

```sql
SELECT autopilot_auto_approve, autopilot_expires_at, autopilot_enabled
FROM lisa_session_configs
WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2';
-- expected : true, <ISO future>, true
```

Au prochain tick autopilot ≤ 7min, si thèses générées + auto_approve=true :
- `approveProposal` → `paperBroker.openPosition` → INSERT `lisa_positions`
- `decision_log` kind=`position_opened` apparaît

## Garde-fous conservés

- `maxOpenPositions=3` (anti-dilution)
- `maxLeverage=2` cap
- `maxDrawdown2DaysPct=15` hard kill (préservé override user)
- Emergency stop UI button toujours actif
- `expires_at = now()+24h` évite auto_approve permanent (re-cocher chaque jour)

## Pourquoi pas toucher aux gates hyper_active

Le call graph montre que les gates (cooldown 5min, max_pos 3, cash buffer, duplicate symbol) sont déjà appliqués DANS `approveProposal`. Ils ne sont PAS le blocker actuel — la fonction n'est même pas appelée. Toucher aux gates avant d'avoir auto_approve=true serait spéculatif et risqué.

**Décision** : fix minimal de visibilité → activer auto_approve → observer 1-2 cycles → identifier le vrai gate bloquant SI un blocage subsiste après auto_approve=true.

## Tests

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/api` : 43 suites / 501 tests ✅
- `npm test --workspace=@smartvest/ai-analyst` : 10 suites / 194 tests ✅
- Total : **53 suites / 695 tests OK**

## Out of scope (P5-EXEC.2 si nécessaire)

- Test e2e cycle autopilot avec mock thèse → dépend si auto_approve fix résout 100%
- Assouplissement gates hyper_active → idem
- Migration column `autopilot_auto_approve` default true → trop intrusif sans test live

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_