### PR TITLE
hotfix(p0): revert P5-EXEC — Fly DOWN, restore last-good v218

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
@@ -545,26 +545,6 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
             this.logger.error(`Auto-approve failed for ${proposal.id}: ${String(e)}`);
           }
         }
-      } else if (!autoApprove && proposal.theses.length > 0) {
-        // P5-EXEC — Visibilité : log explicite quand autoApprove=false bloque
-        // l'exécution malgré des thèses générées. Sans ce log, les utilisateurs
-        // voyaient `proposal_generated` puis silence — pas de trace de pourquoi
-        // 0 position s'ouvrait. Maintenant traçable via decision_log :
-        //   kind='proposal_rejected', rationale='gate=auto_approve_disabled'
-        await this.decisionLog.append({
-          portfolioId,
-          kind: 'proposal_rejected',
-          summary: `Proposal ${proposal.id.slice(0, 8)} non-exécutée (${proposal.theses.length} thèses, auto_approve=false)`,
-          rationale: `gate=auto_approve_disabled · autopilot_auto_approve=false · Pour activer l'exécution automatique : UPDATE lisa_session_configs SET autopilot_auto_approve=true, autopilot_expires_at=now()+interval '24 hours' WHERE portfolio_id='${portfolioId}'`,
-          payload: {
-            proposal_id: proposal.id,
-            theses_count: proposal.theses.length,
-            gate: 'auto_approve_disabled',
-            autopilot_enabled: true,
-            autopilot_auto_approve: false,
-          },
-          triggeredBy: 'autopilot_cron',
-        }).catch((e) => this.logger.warn(`proposal_rejected log append failed: ${String(e).slice(0, 120)}`));
       }
 
       const momentumTag = proposal.marketMomentum === 'bullish_strong'


### PR DESCRIPTION
## P0 — Fly DOWN, revert immédiat

**Symptôme** : api.fly.dev DOWN, machine `7817472cd74728` (CDG) suspended, healthchecks 0/1, frontend reçoit `Failed to fetch` sur tous boutons /lisa.

**Run #158 (commit 1a4a14d, PR #56)** = ❌ FAILURE. Run #157 (commit e24c555 = v218) = dernier OK.

**Action** : revert PR #56 → main repasse à e24c555 → fly.yml auto-redéploie la dernière version known-good.

**Diagnostic root cause** : impossible depuis cette sandbox (pas d'accès aux logs Fly run #158). Le code de #56 (20 lignes ajoutées dans `lisa-autopilot.service.ts`, `decisionLog.append` dans else-if branche) compile (CI green ✅) et a un `.catch` défensif. Possibilités :
- Healthcheck timeout post-deploy (cold start trop lent)
- Strategy `immediate` dans fly.yml a tué l'ancienne machine avant que la nouvelle soit healthy
- Issue Fly platform (autre que mon code)
- ENV var manquante apparue entre #157 et #158 ?

**Investigation post-restore** : à faire sur branche séparée avec `fly deploy --build-only` + revue logs run #158.

## Tests

- `npx tsc -b` ✅ (revert clean)
- Pas de change autre que la suppression du bloc `else if (!autoApprove ...)`

## Action utilisateur post-merge

1. Watch GH Actions Deploy run sur `fcb8e25` (revert merge SHA)
2. Si Deploy Succeeded → `/health` 200 → prod restaurée
3. Si Deploy ALSO fail → infra Fly issue, intervention Fly CLI manuelle nécessaire

## Out of scope (post-restore)

- Re-investiguer la cause #158 fail
- Reprendre P5-EXEC visibility en branche séparée AVEC `fly deploy --build-only` local AVANT push

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_