### PR TITLE
feat(p5-exec): visibility logs proposal_rejected — close silence gap

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
@@ -545,6 +545,25 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
             this.logger.error(`Auto-approve failed for ${proposal.id}: ${String(e)}`);
           }
         }
+      } else if (!autoApprove && proposal.theses.length > 0) {
+        // P5-EXEC — Visibilité critique : log explicite quand autoApprove=false
+        // bloque l'exécution malgré thèses générées. Sans ce log, "silence"
+        // entre proposal_generated et autopilot_cycle_completed (incident
+        // 13:17 → 0 position alors que 3 thèses valides).
+        await this.decisionLog.append({
+          portfolioId,
+          kind: 'proposal_rejected',
+          summary: `Proposal ${proposal.id.slice(0, 8)} non-exécutée (${proposal.theses.length} thèses, auto_approve=false)`,
+          rationale: `gate=auto_approve_disabled · autopilot_auto_approve=false · Activer via SQL : UPDATE lisa_session_configs SET autopilot_auto_approve=true, autopilot_expires_at=now()+interval '24 hours' WHERE portfolio_id='${portfolioId}'`,
+          payload: {
+            proposal_id: proposal.id,
+            theses_count: proposal.theses.length,
+            gate: 'auto_approve_disabled',
+            autopilot_enabled: true,
+            autopilot_auto_approve: false,
+          },
+          triggeredBy: 'autopilot_cron',
+        }).catch((e) => this.logger.warn(`proposal_rejected log append failed: ${String(e).slice(0, 120)}`));
       }
 
       const momentumTag = proposal.marketMomentum === 'bullish_strong'

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1688,6 +1688,28 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       }
     }
 
+    // P5-EXEC — Summary visibility : si approveProposal a été appelée avec
+    // des thèses mais 0 position ouverte (tous les gates ont rejeté), log un
+    // résumé top-level pour visibilité dashboard. Les rejets individuels
+    // sont déjà loggés (position_skipped_*, proposal_cooldown_active,
+    // proposal_capped_by_max_positions) mais sans aggregate, le user voit
+    // proposal_generated puis silence.
+    if (opened.length === 0 && allocations.length > 0) {
+      await this.logDecision(portfolioId, 'proposal_rejected', {
+        summary: `Proposal ${proposalId.slice(0, 8)} : 0 position ouverte sur ${allocations.length} allocation(s) — tous les gates ont rejeté`,
+        rationale: `Voir les decision_log précédents pour le détail par thèse : kind in (position_skipped_duplicate_symbol, position_skipped_insufficient_cash, position_skipped_fallback_price, proposal_cooldown_active, proposal_capped_by_max_positions). Si rien n'apparaît : exception silencieuse côté paperBroker.openPosition.`,
+        payload: {
+          proposal_id: proposalId,
+          allocations_count: allocations.length,
+          opened_count: 0,
+          skipped_count: skipped,
+          closed_recommended_count: closedRecommended,
+          gate: 'all_gates_rejected_or_silent_failure',
+        },
+        triggeredBy: 'user_manual',
+      }).catch(() => null);
+    }
+
     // Mark proposal as executed
     await this.supabase.getClient()
       .from('lisa_proposals')


### PR DESCRIPTION
## P5-EXEC re-do (post #57 revert)

Cause de l'incident #158 = **lease orphelin Fly Machines** (pas le code de #56). Le diff de PR #56 était sain. Cette PR ré-applique la visibility fix + ajoute un summary log aggregate.

## Diagnostic complet

**Symptôme** : Après reset SmartVest, cycle 13:17 = `proposal_generated` (3 thèses) → **SILENCE** → `autopilot_cycle_completed`. 0 row dans `lisa_positions`.

**Call graph trace** :
```
generateProposal → INSERT lisa_proposals (status='proposed')          ✓
if (autoApprove && theses>0)                                          ← LE GATE
  → approveProposal
    → loop allocations
      → gates internes (cooldown, max_pos, cash, duplicate, fallback)
      → paperBroker.openPosition → INSERT lisa_positions               ✓
      → logDecision('position_opened')                                ✓
```

Si `autoApprove=false` (default DB migration 0044), tout le bloc est **silencieusement skippé**. Les gates internes ont déjà des logs granulaires (`position_skipped_*`, `proposal_cooldown_active`, `proposal_capped_by_max_positions`) mais le bypass top-level n'avait **aucune trace**.

`paperBroker.openPosition` correctement câblé. Pas de `DRY_RUN` env. Le seul blocker = `autopilot_auto_approve` en DB.

## Fix livré (2 logs ajoutés)

### 1. `lisa-autopilot.service.ts` — bypass autoApprove logged

```ts
} else if (!autoApprove && proposal.theses.length > 0) {
  await this.decisionLog.append({
    kind: 'proposal_rejected',
    rationale: 'gate=auto_approve_disabled · UPDATE SQL pour activer',
    payload: { gate, autopilot_enabled, autopilot_auto_approve, ... },
    triggered_by: 'autopilot_cron',
  });
}
```

### 2. `lisa.service.ts approveProposal` — summary aggregate

Si `opened.length===0 && allocations.length>0` (= tous les gates ont rejeté), log summary top-level. Cible le cas exotique où aucun `position_skipped_*` n'aurait fire (silent failure dans `paperBroker.openPosition.catch()`).

```ts
if (opened.length === 0 && allocations.length > 0) {
  await this.logDecision(portfolioId, 'proposal_rejected', {
    summary: 'Proposal X : 0 position ouverte sur N allocation(s)',
    payload: { gate: 'all_gates_rejected_or_silent_failure', ... },
  });
}
```

**Aucun changement de threshold/gate.** Pas de modif behavior. Juste visibility.

## Garde-fous conservés

- `maxOpenPositions=3` (anti-dilution)
- `maxLeverage=2` cap
- `maxDrawdown2DaysPct=15` hard kill
- Emergency Stop UI button
- Cooldown 5min hyper_active

## Action utilisateur post-merge (CRITIQUE)

```sql
UPDATE public.lisa_session_configs
SET autopilot_auto_approve = true,
    autopilot_expires_at = now() + interval '24 hours'
WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2';
```

Au prochain tick autopilot ≤ 7min :
- **AVANT SQL** : `decision_log` kind=`proposal_rejected` (nouveau log visible, plus de silence)
- **APRÈS SQL** : `decision_log` kind=`position_opened` + INSERT `lisa_positions` (status='open')

## Tests

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/api` : 43 suites / 501 tests ✅
- `npm test --workspace=@smartvest/ai-analyst` : 10 suites / 194 tests ✅
- Total : **53 suites / 695 tests OK**

## ⚠️ Limitations sandbox

- `fly deploy --build-only` non exécuté (`flyctl` absent dans sandbox CI)
- Si le lease `7817472cd74728` n'est plus actif (devait expirer 13:37 UTC = NOW()-13min selon timeline user) → deploy fly.yml passera
- Si re-fail (improbable) → user libère manuellement via `fly machine restart 7817472cd74728 --force -a smartvest`

## Out of scope (P5-EXEC.2 si nécessaire)

- e2e test cycle autopilot mocké (Supabase + paperBroker + Anthropic) → coût élevé sans observation prod
- Assouplissement gates hyper_active → spéculatif tant que auto_approve=false bloque tout
- Test `position_executed` kind dédié → préfère garder kind existant `position_opened` pour compat dashboard

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_