### PR TITLE
feat(p5-llm): force ≥1 thèse + reject empty proposal approve (P5-LLM-THESES)

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -356,6 +356,22 @@ export class LisaService {
     return !!userFocus && userFocus.startsWith('WAKE-UP');
   }
 
+  /**
+   * P5-LLM-THESES — Vrai si le userFocus correspond aux focus génériques
+   * de l'autopilot cron (pas un focus explicite utilisateur). Sert au
+   * logging : quand Lisa retourne theses=[] sur un focus utilisateur
+   * EXPLICITE (scénarios concrets), c'est un signal de mauvais prompt.
+   */
+  private isAutopilotGenericFocus(userFocus?: string): boolean {
+    if (!userFocus) return true;
+    const trimmed = userFocus.trim().toLowerCase();
+    return (
+      trimmed.startsWith('autopilot agressif') ||
+      trimmed.startsWith('autopilot cycle') ||
+      trimmed.startsWith('wake-up')
+    );
+  }
+
   async generateProposal(userId: string, portfolioId: string, userFocus?: string): Promise<AllocationProposal> {
     if (!this.thesisGenerator) {
       throw new BadRequestException('Thesis generator unavailable: ANTHROPIC_API_KEY not configured on backend');
@@ -1063,6 +1079,26 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       triggeredBy: 'user_manual',
     });
 
+    // P5-LLM-THESES — Visibilité : Lisa a retourné theses=[] alors que
+    // l'utilisateur a explicité des scénarios. Indique un problème de prompt
+    // (Lisa "se protège" en regime=neutral). Persona block 05 a été
+    // renforcé pour exiger ≥1 thèse — ce log capture les cas restants
+    // pour analyse + tuning futur.
+    if (finalProposal.theses.length === 0 && userFocus && !this.isAutopilotGenericFocus(userFocus)) {
+      await this.logDecision(portfolioId, 'proposal_rejected', {
+        summary: `Empty theses despite explicit user focus (${userFocus.slice(0, 80)})`,
+        rationale: `gate=empty_theses_with_user_focus · Lisa a retourné theses=[] alors que userFocus n'est PAS le focus autopilot générique. Vérifier persona block 05-profile-overrides + tuning prompt. regime=${finalProposal.detectedRegime}.`,
+        payload: {
+          proposalId: finalProposal.id,
+          theses_count: 0,
+          regime: finalProposal.detectedRegime,
+          user_focus_excerpt: userFocus.slice(0, 200),
+          gate: 'empty_theses_with_user_focus',
+        },
+        triggeredBy: 'user_manual',
+      }).catch(() => null);
+    }
+
     // Écrire la directive mécanique — l'agent sans-LLM l'utilise pendant 35 min
     await this.writeDirective(portfolioId, finalProposal, result.closeRecommendations ?? [], trajectoryStatus, config.profile as SessionProfile).catch(
       (e) => this.logger.warn(`writeDirective failed (non-blocking): ${String(e)}`),
@@ -1301,6 +1337,22 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     }
     const theses = proposal.theses as Array<Record<string, unknown>>;
     const allocationsRaw = proposal.allocations as Array<{ thesisId: string; pctCapital: number; amountUsd: string }>;
+
+    // P5-LLM-THESES — Guard : refuser explicitement les proposals à theses=[].
+    // Avant ce guard, l'UI cliquait "Approuver" sur une proposal vide et
+    // recevait silencieusement openedPositions=[] avec un toast "positions
+    // ouvertes" trompeur. Maintenant 400 explicite + audit decision_log.
+    if (!Array.isArray(theses) || theses.length === 0) {
+      await this.logDecision(portfolioId, 'proposal_rejected', {
+        summary: `Proposal ${proposalId.slice(0, 8)} : theses=[] — aucune action`,
+        rationale: `gate=empty_theses · Lisa a généré 0 thèse tradeable. Vérifier le user focus / scénarios envoyés au LLM. UI ne devrait pas afficher "positions ouvertes" sur une proposal vide.`,
+        payload: { proposal_id: proposalId, theses_count: 0, gate: 'empty_theses' },
+        triggeredBy: 'user_manual',
+      }).catch(() => null);
+      throw new BadRequestException(
+        'Aucune thèse à exécuter dans cette proposition. Régénérer avec scénarios concrets ou attendre prochain cycle.',
+      );
+    }
     const closeRecommendations = (proposal.close_recommendations as Array<{ positionId: string; reason: string }> | null) ?? [];
     const marketMomentum = (proposal.market_momentum as 'bullish_strong' | 'neutral' | 'bearish' | null) ?? 'neutral';
 

--- a/packages/ai-analyst/src/persona/05-profile-overrides.ts
+++ b/packages/ai-analyst/src/persona/05-profile-overrides.ts
@@ -102,7 +102,21 @@ Tu es en mode hyper-active (simulation continue). Override les inclinations :
   event_driven intraday.
 - **Categories à REJETER** : tout ce qui est long-term (non compatible).
 - **Output minimaliste** : 1-3 idées max par cycle (pas 7 — overkill).
-  Si aucune idée nouvelle, renvoyer theses: [] avec sessionNotes explicatif.
+  Si aucune idée nouvelle ET userFocus = autopilot generic ("Autopilot
+  cycle —..." ou "Autopilot agressif..."), renvoyer theses: [] avec
+  sessionNotes explicatif est acceptable.
+  ⚠️ EXCEPTION P5-LLM-THESES : si userFocus contient des SCÉNARIOS
+  CONCRETS (ex: "capitulation crypto", "short squeeze", "anti-consensus
+  max", "fear & greed extrême", ou tout focus utilisateur explicite),
+  tu DOIS produire ≥ 1 thèse tradeable structurée (symbol + side + entry
+  + stop_loss + take_profit + size_pct + confidence + rationale), même
+  si conviction modérée (5-7/10). Ne te contente PAS de décrire des
+  poches favorisées ("equity_us_small RKLB LVS...", "commodities GDX...")
+  — c'est inactionnable côté exécution. Une description macro qualitative
+  sans symbole concret = thèse vide = 0 position ouverte = utilisateur
+  bloqué. Si vraiment aucun setup tradeable malgré le scénario, expliquer
+  EXPLICITEMENT dans sessionNotes pourquoi ("aucun candidat dans X bourse
+  passe RSI<30 ET volume>1.5x SMA20", etc.) avec critères mesurables.
 - **Check continuous** :
   - Positions existantes : thesis still valid ? invalidation hit ?
   - Nouveaux catalyseurs micro : options flow, unusual prints, news


### PR DESCRIPTION
## P5-LLM-THESES — Lisa retourne theses=[] malgré scénarios explicites

**Diagnostic test rebound user 16:00 UTC** :
- User /lisa → scénarios "capitulation crypto + short squeeze + anti-consensus max"
- Cliqué "Approuver & ouvrir positions" → UI toast ✅ "positions ouvertes"
- `SELECT * FROM lisa_positions` → **0 rows** ❌
- `decision_log` : `Lisa generated 0 theses, regime=neutral`

## Cause racine

Persona block `05-profile-overrides.ts` autorisait explicitement :
> "Si aucune idée nouvelle, renvoyer theses: [] avec sessionNotes explicatif."

Lisa LLM "se protège" en `regime=neutral` → reste macro qualitatif ("poches favorisées: equity_us_small RKLB LVS, commodities GDX...") sans aucune thèse structurée. **Pas de symbole concret = 0 allocation = 0 position ouvrable.**

De plus, l'UI affichait "positions ouvertes" sur proposal vide (false positive, pas d'erreur backend).

## Fix (3 changes)

### 1. Persona prompt (`05-profile-overrides.ts`)

Exception explicite ajoutée à la règle "minimaliste 1-3 idées" :

> ⚠️ **EXCEPTION P5-LLM-THESES** : si userFocus contient des SCÉNARIOS CONCRETS (ex: "capitulation crypto", "short squeeze", "anti-consensus max", "fear & greed extrême"), tu **DOIS** produire ≥ 1 thèse tradeable structurée (symbol + side + entry + sl + tp + size_pct + confidence + rationale), même si conviction modérée (5-7/10). Ne PAS te contenter de décrire des poches favorisées — c'est inactionnable côté exécution. Si vraiment aucun setup tradeable, expliquer EXPLICITEMENT dans sessionNotes pourquoi avec critères mesurables.

### 2. Backend `approveProposal` guard (`lisa.service.ts:1303`)

Avant : silently `{ openedPositions: [], skipped: 0 }` → UI false positive.
Après : `throw BadRequestException("Aucune thèse à exécuter...")` + audit log.

### 3. Backend post-generation visibility log

Si `theses.length === 0 && userFocus` est explicite (pas autopilot générique), log :

```ts
kind: 'proposal_rejected'
gate: 'empty_theses_with_user_focus'
payload: { user_focus_excerpt, regime, theses_count: 0 }
```

→ capture les cas où le persona update n'aurait pas suffi pour tuning futur.

### Helper `isAutopilotGenericFocus(userFocus)`

Détecte les focus génériques (autopilot cron, wake-up) → comportement legacy theses=[] toléré uniquement dans ce cas.

## Garde-fous conservés

- Tous les gates internes `approveProposal` inchangés (max_pos 3, cooldown 5min, cash buffer, duplicate, fallback price, kill switch)
- Aucun changement de threshold
- Pas de modif paper-broker

## Tests

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/api` : 43 suites / 501 tests ✅
- `npm test --workspace=@smartvest/ai-analyst` : 10 suites / 194 tests ✅
- Total : **53 suites / 695 tests OK**

## Validation prod post-merge

1. Vérifier `autopilot_auto_approve=true` (sinon SQL UPDATE)
2. Cliquer /lisa avec scénarios concrets → nouvelle proposal doit avoir `theses.length ≥ 1`
3. `SELECT * FROM lisa_positions` → expected **≥ 1 ligne open**
4. Si encore theses=[] : `decision_log` nouveau kind=`proposal_rejected` rationale `gate='empty_theses_with_user_focus'` → signal pour tuner persona

## Out of scope

- Stack trace `proposal_failed` 13:55:46 / 14:07:17 (besoin logs Fly, pas accessible sandbox)
- Schema validation Zod côté backend forçant min 1 thesis (les requêtes sans userFocus explicite peuvent légitiment retourner []) — preferred soft-warn via decision_log
- Retry LLM avec stricter prompt sur theses=[] détecté (coût Anthropic ×2, à débattre vs persona prompt update direct)

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_