### PR TITLE
feat(p5-llm): permissive ThesisCategory + ThesisKind preprocess

### DIFF
--- a/packages/ai-analyst/src/types/__tests__/thesis-category-preprocess.spec.ts
+++ b/packages/ai-analyst/src/types/__tests__/thesis-category-preprocess.spec.ts
@@ -102,9 +102,16 @@ describe('ThesisCategory preprocess', () => {
     if (r.ok) expect(r.data).toBe('event_driven');
   });
 
-  it('still rejects truly nonsense values (preserves enum strictness)', () => {
-    expect(parse('definitely_not_a_category').ok).toBe(false);
-    expect(parse('xyz').ok).toBe(false);
+  // P5-LLM ext — Permissive fallback : tout string inconnu → 'flow_timing'
+  // (préfère ouvrir le pipeline avec valeur safe vs throw 400 prod).
+  it("permissive fallback : 'tail_hedge' / 'capitulation' / 'dry_powder' → 'flow_timing'", () => {
+    expect((parse('tail_hedge') as { ok: true; data: string }).data).toBe('flow_timing');
+    expect((parse('capitulation') as { ok: true; data: string }).data).toBe('flow_timing');
+    expect((parse('dry_powder') as { ok: true; data: string }).data).toBe('flow_timing');
+    expect((parse('rotation') as { ok: true; data: string }).data).toBe('flow_timing');
+    expect((parse('barbell') as { ok: true; data: string }).data).toBe('flow_timing');
+    expect((parse('definitely_not_a_category') as { ok: true; data: string }).data).toBe('flow_timing');
+    expect((parse('xyz') as { ok: true; data: string }).data).toBe('flow_timing');
   });
 
   it('still rejects non-string types', () => {

--- a/packages/ai-analyst/src/types/__tests__/thesis-kind-preprocess.spec.ts
+++ b/packages/ai-analyst/src/types/__tests__/thesis-kind-preprocess.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * P5-LLM ext — Tests preprocess Zod sur ThesisKind.
+ */
+import { ThesisKind } from '../index';
+
+function parse(v: unknown): { ok: true; data: string } | { ok: false } {
+  const r = ThesisKind.safeParse(v);
+  if (r.success) return { ok: true, data: r.data };
+  return { ok: false };
+}
+
+describe('ThesisKind preprocess', () => {
+  it('accepts canonical values without modification', () => {
+    for (const v of ['momentum', 'mean_reversion', 'breakout', 'event', 'macro_hedge']) {
+      const r = parse(v);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.data).toBe(v);
+    }
+  });
+
+  it("maps 'trend' / 'directional' / 'trend_following' → 'momentum'", () => {
+    expect((parse('trend') as { ok: true; data: string }).data).toBe('momentum');
+    expect((parse('directional') as { ok: true; data: string }).data).toBe('momentum');
+    expect((parse('trend_following') as { ok: true; data: string }).data).toBe('momentum');
+  });
+
+  it("maps 'reversion' / 'reversal' / 'oversold_bounce' / 'capitulation' → 'mean_reversion'", () => {
+    expect((parse('reversion') as { ok: true; data: string }).data).toBe('mean_reversion');
+    expect((parse('reversal') as { ok: true; data: string }).data).toBe('mean_reversion');
+    expect((parse('oversold_bounce') as { ok: true; data: string }).data).toBe('mean_reversion');
+    expect((parse('capitulation') as { ok: true; data: string }).data).toBe('mean_reversion');
+    expect((parse('mean-reversion') as { ok: true; data: string }).data).toBe('mean_reversion');
+  });
+
+  it("maps 'event_driven' / 'event-driven' / 'catalyst' / 'earnings' → 'event'", () => {
+    expect((parse('event_driven') as { ok: true; data: string }).data).toBe('event');
+    expect((parse('event-driven') as { ok: true; data: string }).data).toBe('event');
+    expect((parse('catalyst') as { ok: true; data: string }).data).toBe('event');
+    expect((parse('earnings') as { ok: true; data: string }).data).toBe('event');
+    expect((parse('news') as { ok: true; data: string }).data).toBe('event');
+  });
+
+  it("maps 'hedge' / 'tail_hedge' / 'safe_haven' / 'defensive' / 'macro' → 'macro_hedge'", () => {
+    expect((parse('hedge') as { ok: true; data: string }).data).toBe('macro_hedge');
+    expect((parse('tail_hedge') as { ok: true; data: string }).data).toBe('macro_hedge');
+    expect((parse('tail-hedge') as { ok: true; data: string }).data).toBe('macro_hedge');
+    expect((parse('safe_haven') as { ok: true; data: string }).data).toBe('macro_hedge');
+    expect((parse('safe-haven') as { ok: true; data: string }).data).toBe('macro_hedge');
+    expect((parse('defensive') as { ok: true; data: string }).data).toBe('macro_hedge');
+    expect((parse('macro') as { ok: true; data: string }).data).toBe('macro_hedge');
+  });
+
+  it("maps 'break' / 'break_out' / 'range_break' → 'breakout'", () => {
+    expect((parse('break') as { ok: true; data: string }).data).toBe('breakout');
+    expect((parse('break_out') as { ok: true; data: string }).data).toBe('breakout');
+    expect((parse('break-out') as { ok: true; data: string }).data).toBe('breakout');
+    expect((parse('range_break') as { ok: true; data: string }).data).toBe('breakout');
+  });
+
+  it('handles uppercase + whitespace', () => {
+    expect((parse('  HEDGE  ') as { ok: true; data: string }).data).toBe('macro_hedge');
+    expect((parse('TREND') as { ok: true; data: string }).data).toBe('momentum');
+  });
+
+  it("permissive fallback : unknown string → 'momentum' (default safe)", () => {
+    expect((parse('completely_unknown') as { ok: true; data: string }).data).toBe('momentum');
+    expect((parse('xyz_random') as { ok: true; data: string }).data).toBe('momentum');
+  });
+
+  it('still rejects non-string types', () => {
+    expect(parse(42).ok).toBe(false);
+    expect(parse(null).ok).toBe(false);
+    expect(parse(undefined).ok).toBe(false);
+  });
+});

--- a/packages/ai-analyst/src/types/index.ts
+++ b/packages/ai-analyst/src/types/index.ts
@@ -121,10 +121,22 @@ const ASSET_CLASS_PREFIXES = [
   'options', 'option', 'derivatives', 'derivative',
 ];
 
+const THESIS_CATEGORY_CANONICAL = [
+  'hidden_gem',
+  'turnaround',
+  'flow_timing',
+  'watchlist',
+  'contrarian',
+  'mean_reversion',
+  'event_driven',
+] as const;
+
 export const ThesisCategory = z.preprocess(
   (v) => {
     if (typeof v !== 'string') return v;
     const normalized = v.trim().toLowerCase();
+    // Canonical values pass-through FIRST (avant les fallbacks)
+    if ((THESIS_CATEGORY_CANONICAL as readonly string[]).includes(normalized)) return normalized;
     if (CATEGORY_ALIASES[normalized]) return CATEGORY_ALIASES[normalized];
     // Asset class fallback : "equity_us_small", "commodities_metals_precious",
     // "crypto_bitcoin" → flow_timing (le LLM a mis l'asset class dans category,
@@ -132,7 +144,12 @@ export const ThesisCategory = z.preprocess(
     for (const prefix of ASSET_CLASS_PREFIXES) {
       if (normalized.startsWith(prefix)) return 'flow_timing';
     }
-    return normalized;
+    // P5-LLM ext — Permissive final fallback : tout autre string (hedge,
+    // tail_hedge, dry_powder, capitulation, rotation, barbell, defensive,
+    // etc.) → flow_timing. Préfère un mapping permissif vs un 400 prod
+    // qui bloque tout le cycle. Le decision_log proposal_generated capture
+    // déjà la thèse complète pour audit.
+    return 'flow_timing';
   },
   z.enum([
     'hidden_gem',       // pépite cachée, sous-couverte
@@ -167,14 +184,71 @@ export type ThesisCategory = 'hidden_gem' | 'turnaround' | 'flow_timing' | 'watc
  *
  * Cf. PATCH 5 risk-05-stop-by-thesis-kind.
  */
-export const ThesisKind = z.enum([
-  'momentum',
-  'mean_reversion',
-  'breakout',
-  'event',
-  'macro_hedge',
-]);
-export type ThesisKind = z.infer<typeof ThesisKind>;
+/**
+ * P5-LLM ext — ThesisKind preprocess : Lisa LLM utilise parfois d'autres
+ * mots clés (trend, hedge, tail_hedge, catalyst, breakout_long...) au lieu
+ * des 5 valeurs canoniques. Pattern cohérent avec ThesisCategory.
+ * Permissive fallback : 'momentum' (le moins contraignant côté ATR multiplier).
+ */
+const THESIS_KIND_ALIASES: Record<string, 'momentum' | 'mean_reversion' | 'breakout' | 'event' | 'macro_hedge'> = {
+  // momentum aliases
+  'trend': 'momentum',
+  'trend_following': 'momentum',
+  'long_momentum': 'momentum',
+  'directional': 'momentum',
+  // mean reversion aliases
+  'mean-reversion': 'mean_reversion',
+  'meanreversion': 'mean_reversion',
+  'reversion': 'mean_reversion',
+  'mean': 'mean_reversion',
+  'reversal': 'mean_reversion',
+  'oversold_bounce': 'mean_reversion',
+  'capitulation': 'mean_reversion',
+  // breakout aliases
+  'break': 'breakout',
+  'break_out': 'breakout',
+  'break-out': 'breakout',
+  'range_break': 'breakout',
+  // event-driven aliases
+  'event_driven': 'event',
+  'event-driven': 'event',
+  'eventdriven': 'event',
+  'catalyst': 'event',
+  'catalyst_driven': 'event',
+  'news': 'event',
+  'earnings': 'event',
+  // macro_hedge aliases
+  'hedge': 'macro_hedge',
+  'tail_hedge': 'macro_hedge',
+  'tail-hedge': 'macro_hedge',
+  'tailhedge': 'macro_hedge',
+  'safe_haven': 'macro_hedge',
+  'safehaven': 'macro_hedge',
+  'safe-haven': 'macro_hedge',
+  'defensive': 'macro_hedge',
+  'macro': 'macro_hedge',
+};
+
+export const ThesisKind = z.preprocess(
+  (v) => {
+    if (typeof v !== 'string') return v;
+    const normalized = v.trim().toLowerCase();
+    if (THESIS_KIND_ALIASES[normalized]) return THESIS_KIND_ALIASES[normalized];
+    // Permissive fallback : value inconnue → 'momentum' (default safe).
+    // Évite les 400 cascade post-preprocess category fix.
+    const canonical = ['momentum', 'mean_reversion', 'breakout', 'event', 'macro_hedge'];
+    if (canonical.includes(normalized)) return normalized;
+    return 'momentum';
+  },
+  z.enum([
+    'momentum',
+    'mean_reversion',
+    'breakout',
+    'event',
+    'macro_hedge',
+  ]),
+);
+export type ThesisKind = 'momentum' | 'mean_reversion' | 'breakout' | 'event' | 'macro_hedge';
 
 /**
  * PATCH 5 — Multiplicateurs ATR par type de thèse.


### PR DESCRIPTION
## Stack trace utilisateur post-PR#60 (14:31 UTC)

```
Thesis 'BTC Tail-Hedge Capitulation Opportunity':
  "category: Invalid enum value. Expected 'hidden_ge..." (truncated)
```

Le truncation `'hidden_ge'` = début de `'hidden_gem'` (1ère valeur canonique). Donc bug **toujours sur `category`**, pas `thresholdDirection`. Le LLM a renvoyé probablement `'tail_hedge'` / `'hedge'` / `'dry_powder'` / `'capitulation'` qui n'étaient pas dans `CATEGORY_ALIASES`.

## Fix (2 changes)

### 1. Permissive final fallback `ThesisCategory`

Tout string non-canonique non-aliasé non-asset-class → `'flow_timing'`. Préfère mapping permissif vs 400 prod qui bloque tout le cycle. **Ordre du preprocess corrigé** : canonical pass-through FIRST (sinon les canoniques tombaient eux aussi dans le fallback — bug attrapé par les tests).

### 2. Audit autre enum thèse-level → `ThesisKind` preprocess préventif

5 valeurs : `momentum / mean_reversion / breakout / event / macro_hedge`. Pattern préventif identique :

```ts
const THESIS_KIND_ALIASES = {
  trend / directional / trend_following → momentum,
  reversion / reversal / oversold_bounce / capitulation → mean_reversion,
  break / range_break → breakout,
  event_driven / catalyst / earnings / news → event,
  hedge / tail_hedge / safe_haven / defensive / macro → macro_hedge,
};
// Permissive fallback : unknown → 'momentum' (le moins contraignant ATR)
```

## Tests (+9 nouveaux)

`packages/ai-analyst/src/types/__tests__/thesis-kind-preprocess.spec.ts` :
- canonical pass-through
- aliases hedge/tail_hedge/catalyst/etc.
- uppercase + whitespace
- permissive fallback unknown → 'momentum'
- non-string reject

`thesis-category-preprocess.spec.ts` mis à jour : `tail_hedge / capitulation / dry_powder / rotation / barbell / xyz` → tous mappés à `flow_timing`.

## Pourquoi pas Zod `.catch()` ?

`.catch()` évalue le schéma puis substitue sur fail. Le `preprocess` **normalise avant validation** :
- `decision_log` logge la valeur NORMALISÉE (pas la raw LLM)
- Pas de divergence entre DB et runtime (`risk-enforcer`, `persona`, UI ont tous la valeur canonique typée)
- Les autres consumers (e.g. ATR multiplier qui lookup ThesisKind) reçoivent toujours une valeur connue

## Tests

- `npx tsc -b` ✅
- `npm test --workspace=@smartvest/api` : 43 suites / 501 tests ✅
- `npm test --workspace=@smartvest/ai-analyst` : 14 suites / **218 tests** ✅
- Total : **57 suites / 719 tests OK**

## Action utilisateur post-merge

Recliquer "Générer propositions" avec scénarios capitulation/squeeze/anti-cons. La thèse "BTC Tail-Hedge Capitulation Opportunity" devrait maintenant passer la validation (`category` mappé à `flow_timing`).

Si encore 400 : un nouveau champ Zod crashe (driverType / evidenceType / direction / sizingMethod...). Stack trace du nouveau message → préprocess cas par cas.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_