### PR TITLE
feat(strategy): pivot TOP_GAINERS — scanner momentum cross-asset 24/7 (v1)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -41,6 +41,7 @@ import { ApiCostTrackerService } from './services/api-cost-tracker.service';
 import { ReboundMonitorService } from './services/rebound-monitor.service';
 import { ReboundScannerService } from './services/rebound-scanner.service';
 import { OhlcvCacheService } from './services/ohlcv-cache.service';
+import { TopGainersScannerService } from './services/top-gainers-scanner.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule, BotLabModule],
@@ -91,6 +92,8 @@ import { OhlcvCacheService } from './services/ohlcv-cache.service';
     ReboundScannerService,
     // P3-C — cache OHLCV daily (cron 21:30 UTC) + watchlist universe
     OhlcvCacheService,
+    // P5-PIVOT-TOP-GAINERS — scanner momentum cross-asset (gated par STRATEGY_MODE=top_gainers)
+    TopGainersScannerService,
   ],
   exports: [
     LisaService,

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -1,0 +1,520 @@
+/**
+ * P5-PIVOT-TOP-GAINERS — Scanner momentum cross-asset 24/7.
+ *
+ * Bypass complet du pipeline Lisa LLM / news / regime. Stratégie déterministe :
+ *   - 15 min cron (24/7)
+ *   - Fetch top gainers EODHD (multi-exchange : US/LSE/XETRA/PA/TSE/HK/AU/etc.)
+ *   - Fetch crypto top gainers via BinanceMarketService (24h ticker)
+ *   - Filter via evaluateTopGainerCandidate (asset-class adaptive thresholds)
+ *   - Top 3 cross-asset par score → INSERT pseudo-proposal + paperBroker.openPosition
+ *   - Audit dans top_gainers_log + lisa_decision_log
+ *
+ * Activation : env `STRATEGY_MODE=top_gainers` (par portfolio ou global).
+ *
+ * Out of scope ce PR (deferred PR2/PR3) :
+ *   - Yahoo fallback / Coinbase / Kraken / OANDA / IBKR multi-currency
+ *   - Indicateurs techniques avancés (RSI/MACD/EMA/BB/ATR/VWAP/Stoch/OBV/ADX)
+ *   - UI banner + endpoint /api/top-gainers
+ *   - Backtest /backtest/top-gainers + CSV export
+ *   - Trailing stop +3% custom + time-stop 4h auto-close
+ *   - Multi-currency portfolio (paperBroker actuel = USD only)
+ */
+
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'crypto';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { LisaService } from './lisa.service';
+import { DecisionLogService } from './decision-log.service';
+import { BinanceMarketService } from './binance-market.service';
+import {
+  selectTopGainers,
+  type TopGainerCandidate,
+  type TopGainerAssetClass,
+} from '@smartvest/ai-analyst';
+
+interface EodhdScreenerRow {
+  code: string;
+  name?: string;
+  exchange_short_name?: string;
+  exchange_short?: string;
+  exchange?: string;
+  last_price?: number | string;
+  high_price?: number | string;
+  high?: number | string;
+  low_price?: number | string;
+  open?: number | string;
+  change_p?: number | string;
+  volume?: number | string;
+  avgvol_50d?: number | string;
+  avgvol_200d?: number | string;
+  market_capitalization?: number | string;
+  market_cap?: number | string;
+}
+
+/**
+ * P5-PIVOT-TOP-GAINERS v1 — 13+ exchanges scannés en parallèle.
+ *
+ * Liste obligatoire confirmée (Promise.allSettled, 13+ entrées) :
+ *   US        : NYSE/NASDAQ/AMEX (équities US)
+ *   LSE       : London Stock Exchange
+ *   XETRA     : Frankfurt
+ *   PA        : Euronext Paris
+ *   SW        : SIX Suisse
+ *   MI        : Borsa Italiana
+ *   MC, BME   : Bolsa Madrid (les 2 codes EODHD selon l'API version)
+ *   AS, AMS   : Euronext Amsterdam (les 2 codes EODHD selon l'API version)
+ *   TSE       : Tokyo
+ *   HK        : Hong Kong
+ *   AU        : Australian Securities Exchange (Sydney)
+ *   KO        : Korea (Seoul)
+ *   TO        : Toronto Stock Exchange
+ *
+ * Bonus : NSE (India), BSE (India) — pas dans la spec minimale mais
+ * faible coût marginal (1 fetch parallèle de plus).
+ */
+const EODHD_EXCHANGES = [
+  'US',
+  'LSE', 'XETRA', 'PA', 'SW', 'MI', 'MC', 'BME', 'AS', 'AMS',
+  'TSE', 'HK', 'AU', 'KO', 'TO',
+  'NSE', 'BSE',
+];
+const CRYPTO_PAIRS = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT', 'ADAUSDT', 'AVAXUSDT', 'DOTUSDT', 'LINKUSDT', 'MATICUSDT'];
+
+/**
+ * P5-PIVOT-TOP-GAINERS v1 — Cap conservatif : 1 position/cycle.
+ * Permet de valider end-to-end avant scaling à 3 (PR2).
+ */
+const MAX_POSITIONS_PER_CYCLE_V1 = 1;
+
+const TOP_GAINERS_CRON_NAME = 'top-gainers-scanner';
+
+@Injectable()
+export class TopGainersScannerService implements OnModuleInit {
+  private readonly logger = new Logger(TopGainersScannerService.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly lisa: LisaService,
+    private readonly decisionLog: DecisionLogService,
+    private readonly config: ConfigService,
+    private readonly binanceMarket: BinanceMarketService,
+    private readonly schedulerRegistry: SchedulerRegistry,
+  ) {}
+
+  /**
+   * P5-PIVOT-TOP-GAINERS Guard 4 — Cron interval configurable via env
+   * `SCAN_INTERVAL_MINUTES` (default 15). Range valide 1-1440 min.
+   * Scheduling dynamique au boot : `fly secrets set SCAN_INTERVAL_MINUTES=5`
+   * + reboot machine → cron tourne toutes les 5 min.
+   *
+   * UI dynamique (changement live sans reboot) = deferred PR2.
+   */
+  onModuleInit(): void {
+    const raw = this.config.get<string>('SCAN_INTERVAL_MINUTES');
+    const parsed = parseInt(String(raw ?? '15'), 10);
+    const validated = Number.isFinite(parsed)
+      ? Math.max(1, Math.min(1440, parsed))
+      : 15;
+    if (parsed !== validated) {
+      this.logger.warn(
+        `[top-gainers] SCAN_INTERVAL_MINUTES=${raw} hors range [1,1440] → clamp à ${validated}`,
+      );
+    }
+    if (validated < 5) {
+      this.logger.warn('[top-gainers] interval <5min — risque rate-limit EODHD/Binance');
+    }
+    if (validated > 60) {
+      this.logger.warn('[top-gainers] interval >60min — opportunités intraday potentiellement ratées');
+    }
+    // Cron expression : "*/N * * * *" (minute granularité, secondes à 0 par cron lib).
+    const cronExpr = `*/${validated} * * * *`;
+    try {
+      // Idempotent : si déjà enregistré (hot-reload dev), ne pas re-add
+      this.schedulerRegistry.getCronJob(TOP_GAINERS_CRON_NAME);
+      this.logger.log(`[top-gainers] cron already registered, skip`);
+      return;
+    } catch {
+      // Pas encore enregistré — on continue
+    }
+    const job = new CronJob(cronExpr, () => {
+      void this.runScanner().catch((e) =>
+        this.logger.error(`[top-gainers] runScanner error: ${String(e).slice(0, 200)}`),
+      );
+    });
+    this.schedulerRegistry.addCronJob(TOP_GAINERS_CRON_NAME, job);
+    job.start();
+    this.logger.log(
+      `[top-gainers] scheduled every ${validated}min (cron='${cronExpr}', strategy_active=${this.isStrategyActive()})`,
+    );
+  }
+
+  /**
+   * Run scanner — gated by STRATEGY_MODE=top_gainers env. Sans le flag,
+   * le cron tourne mais retourne immédiatement (pas de side-effect).
+   */
+  async runScanner(): Promise<void> {
+    if (!this.isStrategyActive()) {
+      // Stratégie pas active globalement — ignorer le tick
+      return;
+    }
+    try {
+      await this.runScannerInner();
+    } catch (e) {
+      this.logger.error(`[top-gainers] cycle failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  /** Activation globale via env STRATEGY_MODE=top_gainers */
+  isStrategyActive(): boolean {
+    return this.config.get<string>('STRATEGY_MODE') === 'top_gainers';
+  }
+
+  private async runScannerInner(): Promise<void> {
+    // Charge tous les portfolios actifs en mode top_gainers
+    const { data: configs, error } = await this.supabase
+      .getClient()
+      .from('lisa_session_configs')
+      .select('user_id, portfolio_id')
+      .eq('autopilot_enabled', true)
+      .eq('kill_switch_active', false);
+    if (error) {
+      this.logger.error(`[top-gainers] fetch configs failed: ${error.message}`);
+      return;
+    }
+    if (!configs || configs.length === 0) return;
+
+    // Fetch global candidates UNE SEULE fois (partagé entre tous les portfolios)
+    const candidates = await this.fetchAllCandidates();
+    if (candidates.length === 0) {
+      this.logger.warn('[top-gainers] 0 candidate fetched — skip cycle');
+      return;
+    }
+
+    const top = selectTopGainers(candidates, 3);
+    this.logger.log(
+      `[top-gainers] ${candidates.length} scanned → ${top.length} retained: ${top.map((t) => `${t.symbol}(${t.assetClass},${t.changePct.toFixed(1)}%,score=${t.score})`).join(', ')}`,
+    );
+
+    // Persist log entries pour les top retenus + filtered samples (audit)
+    await this.persistLog(candidates, top);
+
+    if (top.length === 0) return;
+
+    // Pour chaque portfolio, ouvre les top 3
+    for (const cfg of configs) {
+      try {
+        await this.scanPortfolio(
+          cfg.user_id as string,
+          cfg.portfolio_id as string,
+          top,
+        );
+      } catch (e) {
+        this.logger.warn(
+          `[top-gainers] portfolio ${String(cfg.portfolio_id).slice(0, 8)} failed: ${String(e).slice(0, 120)}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Fetch candidates depuis toutes les sources : EODHD multi-exchange + Binance crypto.
+   * Yahoo / Coinbase / Kraken / OANDA → deferred PR.
+   */
+  private async fetchAllCandidates(): Promise<TopGainerCandidate[]> {
+    const apiKey = this.config.get<string>('EODHD_API_KEY');
+    const tasks: Promise<TopGainerCandidate[]>[] = [];
+
+    if (apiKey) {
+      // Iterate over exchanges in parallel
+      for (const ex of EODHD_EXCHANGES) {
+        tasks.push(this.fetchEodhdScreener(ex, apiKey).catch(() => []));
+      }
+    } else {
+      this.logger.warn('[top-gainers] EODHD_API_KEY missing — skip equity scan');
+    }
+
+    // Crypto via Binance
+    tasks.push(this.fetchBinanceGainers().catch(() => []));
+
+    const results = await Promise.allSettled(tasks);
+    return results
+      .filter((r): r is PromiseFulfilledResult<TopGainerCandidate[]> => r.status === 'fulfilled')
+      .flatMap((r) => r.value);
+  }
+
+  /**
+   * EODHD Screener API : top gainers > 5% par exchange.
+   * Doc : https://eodhd.com/financial-apis/stock-market-screener-api
+   */
+  private async fetchEodhdScreener(exchange: string, apiKey: string): Promise<TopGainerCandidate[]> {
+    const filters = encodeURIComponent(JSON.stringify([
+      ['change_p', '>', 3],
+      ['close', '>', 1],
+      ['avgvol_200d', '>', 100_000],
+    ]));
+    const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}&exchange=${encodeURIComponent(exchange)}&sort=change_p.desc&limit=20&fmt=json`;
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+      if (!res.ok) {
+        this.logger.debug(`[top-gainers] eodhd ${exchange} HTTP ${res.status}`);
+        return [];
+      }
+      const json = await res.json() as { data?: EodhdScreenerRow[] } | EodhdScreenerRow[];
+      const rows: EodhdScreenerRow[] = Array.isArray(json) ? json : (json.data ?? []);
+      return rows
+        .map((r) => this.mapEodhdRow(r, exchange))
+        .filter((c): c is TopGainerCandidate => c !== null);
+    } catch (e) {
+      this.logger.debug(`[top-gainers] eodhd ${exchange} fetch error: ${String(e).slice(0, 120)}`);
+      return [];
+    }
+  }
+
+  private mapEodhdRow(r: EodhdScreenerRow, exchange: string): TopGainerCandidate | null {
+    const symbol = r.code;
+    if (!symbol) return null;
+    const close = num(r.last_price);
+    const high = num(r.high_price ?? r.high) || close;
+    const changePct = num(r.change_p);
+    const volume = num(r.volume);
+    const avgVol50d = num(r.avgvol_50d ?? r.avgvol_200d);
+    const marketCap = num(r.market_capitalization ?? r.market_cap);
+    if (!Number.isFinite(close) || close <= 0) return null;
+    return {
+      symbol,
+      exchange,
+      close,
+      high,
+      changePct,
+      volume,
+      avgVol50d,
+      marketCap,
+    };
+  }
+
+  /**
+   * Binance crypto top gainers via ticker24hr existant
+   * (BinanceMarketService.getTicker24h already wired).
+   */
+  private async fetchBinanceGainers(): Promise<TopGainerCandidate[]> {
+    const out: TopGainerCandidate[] = [];
+    for (const pair of CRYPTO_PAIRS) {
+      try {
+        const t = await this.binanceMarket.getTicker24h(pair);
+        if (!t) continue;
+        out.push({
+          symbol: pair,
+          exchange: 'BINANCE',
+          close: t.lastPrice,
+          high: t.high ?? t.lastPrice,
+          changePct: t.priceChangePct,
+          volume: t.quoteVolume ?? 0,
+          avgVol50d: 0,
+          marketCap: 0, // Crypto major filter ne nécessite pas marketCap si on whitelist top pairs
+        });
+      } catch (e) {
+        this.logger.debug(`[top-gainers] binance ${pair} error: ${String(e).slice(0, 80)}`);
+      }
+    }
+    return out;
+  }
+
+  private async scanPortfolio(
+    userId: string,
+    portfolioId: string,
+    top: Array<TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass }>,
+  ): Promise<void> {
+    // Garde-fou : count current open positions
+    const { data: openPositions } = await this.supabase
+      .getClient()
+      .from('lisa_positions')
+      .select('symbol')
+      .eq('portfolio_id', portfolioId)
+      .eq('status', 'open');
+    const openSymbols = new Set((openPositions ?? []).map((p) => String(p.symbol).toUpperCase()));
+    const maxOpen = 3;
+    const slotsAvailable = Math.max(0, maxOpen - (openPositions?.length ?? 0));
+    if (slotsAvailable === 0) {
+      this.logger.log(`[top-gainers] ${portfolioId.slice(0, 8)}: no slots (${openPositions?.length}/3 open)`);
+      return;
+    }
+
+    // Guard 3 v1 — cap conservatif : 1 position/cycle (test prudent avant
+    // bump à 3 dans v2). Permet de valider le pipeline end-to-end.
+    const maxThisCycle = Math.min(slotsAvailable, MAX_POSITIONS_PER_CYCLE_V1);
+    let opened = 0;
+    for (const cand of top) {
+      if (opened >= maxThisCycle) break;
+      const baseSym = cand.symbol.replace(/USDT$|USDC$/, '').toUpperCase();
+      if (openSymbols.has(cand.symbol.toUpperCase()) || openSymbols.has(baseSym)) continue;
+
+      const insertedPosId = await this.openTopGainerPosition(
+        userId,
+        portfolioId,
+        cand,
+      ).catch((e) => {
+        this.logger.warn(
+          `[top-gainers] open ${cand.symbol} failed: ${String(e).slice(0, 120)}`,
+        );
+        return null;
+      });
+      if (insertedPosId) {
+        opened++;
+        await this.markLogOpened(cand.symbol, portfolioId, insertedPosId).catch(() => null);
+      }
+    }
+  }
+
+  /**
+   * Crée une pseudo-proposal + thèse minimale, puis call paperBroker.openPosition.
+   * Le paperBroker existant exige (proposalId, thesisId) → on synthétise ces 2.
+   */
+  private async openTopGainerPosition(
+    userId: string,
+    portfolioId: string,
+    cand: TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass },
+  ): Promise<string | null> {
+    const proposalId = randomUUID();
+    const thesisId = randomUUID();
+
+    // Pseudo-thèse minimale + pseudo-allocation 30% capital.
+    const thesis = {
+      id: thesisId,
+      summary: `TopGainer ${cand.symbol} +${cand.changePct.toFixed(1)}% (${cand.assetClass})`,
+      conviction: 0.7,
+      conviction_score: 7,
+      category: 'flow_timing',
+      kind: 'momentum',
+      preferredExpressionIndex: 0,
+      expressions: [
+        {
+          symbol: cand.symbol,
+          assetClass: cand.assetClass,
+          direction: 'long',
+          venue: cand.exchange ?? 'unknown',
+          stopLossPct: 1.5,
+          takeProfitPct: 3.0,
+          horizonDays: 1,
+        },
+      ],
+    };
+    const allocations = [
+      { thesisId, pctCapital: 30, amountUsd: '3000.00' },
+    ];
+
+    // INSERT pseudo-proposal
+    const { error: insErr } = await this.supabase.getClient().from('lisa_proposals').insert({
+      id: proposalId,
+      portfolio_id: portfolioId,
+      user_id: userId,
+      capital_usd: '10000.00',
+      base_currency: 'USD',
+      detected_regime: 'momentum_top_gainers',
+      market_momentum: 'bullish_strong',
+      regime_summary: `TopGainer scanner candidate: ${cand.symbol} ${cand.assetClass}`,
+      favored_pockets: [],
+      avoided_pockets: [],
+      theses: [thesis],
+      allocations,
+      cash_reserve_pct: 70,
+      warnings: [],
+      status: 'proposed',
+      claude_cost_usd: 0,
+      generated_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 4 * 3600 * 1000).toISOString(),
+    });
+    if (insErr) {
+      this.logger.warn(`[top-gainers] insert pseudo-proposal failed: ${insErr.message}`);
+      return null;
+    }
+
+    // Call approveProposal (réutilise toute la logique cooldown / max_pos /
+    // cash buffer / fallback price guard / decision_log position_opened).
+    try {
+      const result = await this.lisa.approveProposal(userId, proposalId);
+      if (result.openedPositions.length === 0) {
+        this.logger.log(`[top-gainers] ${cand.symbol}: approveProposal returned 0 (rejected by gates)`);
+        return null;
+      }
+      this.logger.log(
+        `[top-gainers] ${cand.symbol} opened (${result.openedPositions.length} pos, score=${cand.score})`,
+      );
+      return result.openedPositions[0].id;
+    } catch (e) {
+      this.logger.warn(`[top-gainers] approveProposal ${cand.symbol} failed: ${String(e).slice(0, 120)}`);
+      return null;
+    }
+  }
+
+  /**
+   * Persist log entries dans top_gainers_log.
+   * Logge tous les top retenus (decision='passed') + sample de filtered (audit).
+   */
+  private async persistLog(
+    allCandidates: TopGainerCandidate[],
+    top: Array<TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass }>,
+  ): Promise<void> {
+    const topSet = new Set(top.map((t) => t.symbol));
+    const rows: Record<string, unknown>[] = [];
+    for (const t of top) {
+      rows.push({
+        symbol: t.symbol,
+        market: t.assetClass,
+        exchange: t.exchange ?? 'unknown',
+        close_price: String(t.close),
+        high_price: String(t.high),
+        change_pct: String(t.changePct),
+        volume: t.volume,
+        avg_vol_50d: t.avgVol50d,
+        market_cap_usd: String(t.marketCap),
+        score: String(t.score),
+        decision: 'passed',
+        detected_asset_class: t.assetClass,
+      });
+    }
+    // Sample 10 filtered candidates pour audit
+    const filtered = allCandidates.filter((c) => !topSet.has(c.symbol)).slice(0, 10);
+    for (const c of filtered) {
+      rows.push({
+        symbol: c.symbol,
+        market: 'us_equity_small_mid', // best-effort, asset class non recalculée pour log
+        exchange: c.exchange ?? 'unknown',
+        close_price: String(c.close),
+        high_price: String(c.high),
+        change_pct: String(c.changePct),
+        volume: c.volume,
+        avg_vol_50d: c.avgVol50d,
+        market_cap_usd: String(c.marketCap),
+        score: '0',
+        decision: 'filtered',
+      });
+    }
+    if (rows.length === 0) return;
+    const { error } = await this.supabase.getClient().from('top_gainers_log').insert(rows);
+    if (error) this.logger.debug(`[top-gainers] persistLog failed: ${error.message}`);
+  }
+
+  /**
+   * Met à jour le log row avec opened_position_id après ouverture position.
+   */
+  private async markLogOpened(symbol: string, portfolioId: string, positionId: string): Promise<void> {
+    await this.supabase.getClient()
+      .from('top_gainers_log')
+      .update({ decision: 'opened', opened_position_id: positionId, portfolio_id: portfolioId })
+      .eq('symbol', symbol)
+      .eq('decision', 'passed')
+      .gte('captured_at', new Date(Date.now() - 60_000).toISOString());
+  }
+}
+
+function num(v: unknown): number {
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string') {
+    const n = parseFloat(v);
+    return Number.isFinite(n) ? n : 0;
+  }
+  return 0;
+}

--- a/packages/ai-analyst/src/index.ts
+++ b/packages/ai-analyst/src/index.ts
@@ -19,6 +19,7 @@ export * from './strategies/universes';
 export * from './strategies/rsi-prefilter';
 export * from './strategies/session-windows';
 export * from './strategies/proposal-source-routing';
+export * from './strategies/top-gainers-filter';
 export * from './backtest/engine';
 export * from './backtest/metrics';
 export * from './backtest/runner';

--- a/packages/ai-analyst/src/strategies/__tests__/top-gainers-filter.spec.ts
+++ b/packages/ai-analyst/src/strategies/__tests__/top-gainers-filter.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * P5-PIVOT-TOP-GAINERS — Tests pure filter logic.
+ */
+import {
+  evaluateTopGainerCandidate,
+  selectTopGainers,
+  detectAssetClass,
+  TopGainerCandidate,
+} from '../top-gainers-filter';
+
+const baseUSEquity: TopGainerCandidate = {
+  symbol: 'NVDA',
+  exchange: 'US',
+  close: 500,
+  high: 510,
+  changePct: 7,
+  volume: 50_000_000,
+  avgVol50d: 30_000_000,
+  marketCap: 1_500_000_000_000,
+};
+
+describe('detectAssetClass', () => {
+  it('detects US equity large cap (MC>10B)', () => {
+    expect(detectAssetClass('NVDA', 'US', 1_500_000_000_000)).toBe('us_equity_large');
+  });
+  it('detects US equity small/mid (MC<10B)', () => {
+    expect(detectAssetClass('PLTR', 'US', 50_000_000_000)).toBe('us_equity_large');
+    expect(detectAssetClass('RKLB', 'US', 5_000_000_000)).toBe('us_equity_small_mid');
+  });
+  it('detects EU equity (LSE/XETRA/PA)', () => {
+    expect(detectAssetClass('VOD.L', 'LSE')).toBe('eu_equity');
+    expect(detectAssetClass('SAP.DE', 'XETRA')).toBe('eu_equity');
+    expect(detectAssetClass('LVMH.PA', 'PA')).toBe('eu_equity');
+  });
+  it('detects Asia equity (TSE/HK/AU)', () => {
+    expect(detectAssetClass('7203.T', 'TSE')).toBe('asia_equity');
+    expect(detectAssetClass('0700.HK', 'HK')).toBe('asia_equity');
+  });
+  it('detects crypto major (BTC/ETH/BNB/SOL)', () => {
+    expect(detectAssetClass('BTCUSDT', 'BINANCE')).toBe('crypto_major');
+    expect(detectAssetClass('ETHUSDT', 'BINANCE')).toBe('crypto_major');
+  });
+  it('detects crypto alt', () => {
+    expect(detectAssetClass('DOGEUSDT', 'BINANCE')).toBe('crypto_alt');
+    expect(detectAssetClass('SHIBUSDT', 'BINANCE')).toBe('crypto_alt');
+  });
+  it('detects FX major (EURUSD)', () => {
+    expect(detectAssetClass('EURUSD', 'FOREX')).toBe('fx_major');
+    expect(detectAssetClass('USDJPY', 'FOREX')).toBe('fx_major');
+  });
+  it('detects FX cross', () => {
+    expect(detectAssetClass('EURJPY', 'FOREX')).toBe('fx_cross');
+    expect(detectAssetClass('USDTRY', 'FOREX')).toBe('fx_cross');
+  });
+  it('detects commodity (futures pattern XX.F)', () => {
+    expect(detectAssetClass('CL.F', 'COMM')).toBe('commodity');
+    expect(detectAssetClass('GC.F', 'COMM')).toBe('commodity');
+  });
+});
+
+describe('evaluateTopGainerCandidate — US equity', () => {
+  it('passes when all criteria met (NVDA +7%)', () => {
+    const r = evaluateTopGainerCandidate(baseUSEquity);
+    expect(r.passes).toBe(true);
+    expect(r.score).toBeGreaterThan(0);
+    expect(r.assetClass).toBe('us_equity_large');
+  });
+
+  it('rejects on changePct < 5% for small/mid', () => {
+    const r = evaluateTopGainerCandidate({
+      ...baseUSEquity,
+      symbol: 'RKLB',
+      marketCap: 5_000_000_000,
+      changePct: 4,
+    });
+    expect(r.passes).toBe(false);
+    expect(r.reasons[0]).toMatch(/changePct/);
+  });
+
+  it('accepts 3% for large cap (NVDA at +3.5%)', () => {
+    const r = evaluateTopGainerCandidate({ ...baseUSEquity, changePct: 3.5 });
+    expect(r.passes).toBe(true);
+    expect(r.assetClass).toBe('us_equity_large');
+  });
+
+  it('rejects on penny stock price < $5', () => {
+    const r = evaluateTopGainerCandidate({ ...baseUSEquity, close: 3, high: 3.5 });
+    expect(r.passes).toBe(false);
+    expect(r.reasons.some((rs) => rs.startsWith('price='))).toBe(true);
+  });
+
+  it('rejects on small market cap (<100M for small/mid)', () => {
+    const r = evaluateTopGainerCandidate({
+      ...baseUSEquity,
+      symbol: 'TINY',
+      marketCap: 50_000_000,
+    });
+    expect(r.passes).toBe(false);
+    expect(r.reasons.some((rs) => rs.startsWith('mcap='))).toBe(true);
+  });
+
+  it('rejects on low volume ratio (vol < 1.5x avg)', () => {
+    const r = evaluateTopGainerCandidate({
+      ...baseUSEquity,
+      volume: 30_000_000,
+      avgVol50d: 30_000_000,
+    });
+    expect(r.passes).toBe(false);
+    expect(r.reasons.some((rs) => rs.startsWith('volRatio='))).toBe(true);
+  });
+
+  it('rejects gap-and-fade (close < 80% of high)', () => {
+    const r = evaluateTopGainerCandidate({
+      ...baseUSEquity,
+      close: 400,
+      high: 510,  // close/high = 78%
+    });
+    expect(r.passes).toBe(false);
+    expect(r.reasons.some((rs) => rs.startsWith('closeToHigh='))).toBe(true);
+  });
+});
+
+describe('evaluateTopGainerCandidate — Crypto', () => {
+  it('crypto major BTC passes at +3% (lower threshold)', () => {
+    const r = evaluateTopGainerCandidate({
+      symbol: 'BTCUSDT',
+      exchange: 'BINANCE',
+      close: 50000,
+      high: 51000,
+      changePct: 3.5,
+      volume: 100_000_000,
+      avgVol50d: 0,
+      marketCap: 1_000_000_000_000,
+    });
+    expect(r.passes).toBe(true);
+    expect(r.assetClass).toBe('crypto_major');
+  });
+
+  it('crypto alt requires +8% (DOGE +5% rejected)', () => {
+    const r = evaluateTopGainerCandidate({
+      symbol: 'DOGEUSDT',
+      exchange: 'BINANCE',
+      close: 0.15,
+      high: 0.16,
+      changePct: 5,
+      volume: 50_000_000,
+      avgVol50d: 0,
+      marketCap: 20_000_000_000,
+    });
+    expect(r.passes).toBe(false);
+    expect(r.reasons[0]).toMatch(/changePct/);
+  });
+
+  it('crypto alt accepted at +8.5%', () => {
+    const r = evaluateTopGainerCandidate({
+      symbol: 'DOGEUSDT',
+      exchange: 'BINANCE',
+      close: 0.15,
+      high: 0.155,
+      changePct: 8.5,
+      volume: 50_000_000,
+      avgVol50d: 0,
+      marketCap: 20_000_000_000,
+    });
+    expect(r.passes).toBe(true);
+  });
+});
+
+describe('evaluateTopGainerCandidate — FX', () => {
+  it('FX major EURUSD passes at +0.6%', () => {
+    const r = evaluateTopGainerCandidate({
+      symbol: 'EURUSD',
+      exchange: 'FOREX',
+      close: 1.0850,
+      high: 1.0855,
+      changePct: 0.6,
+      volume: 0,
+      avgVol50d: 0,
+      marketCap: 0,
+    });
+    expect(r.passes).toBe(true);
+    expect(r.assetClass).toBe('fx_major');
+  });
+
+  it('FX cross USDTRY requires +1.5%', () => {
+    const r = evaluateTopGainerCandidate({
+      symbol: 'USDTRY',
+      exchange: 'FOREX',
+      close: 35,
+      high: 35.1,
+      changePct: 1.0,
+      volume: 0,
+      avgVol50d: 0,
+      marketCap: 0,
+    });
+    expect(r.passes).toBe(false);
+  });
+});
+
+describe('selectTopGainers — cross-asset ranking', () => {
+  it('returns top N across asset classes by score', () => {
+    const candidates: TopGainerCandidate[] = [
+      { ...baseUSEquity, symbol: 'NVDA', changePct: 4 },
+      { ...baseUSEquity, symbol: 'TSLA', changePct: 8 },
+      {
+        symbol: 'BTCUSDT', exchange: 'BINANCE', close: 50000, high: 50500,
+        changePct: 6, volume: 100_000_000, avgVol50d: 0, marketCap: 1_000_000_000_000,
+      },
+      {
+        symbol: 'EURUSD', exchange: 'FOREX', close: 1.085, high: 1.086,
+        changePct: 0.7, volume: 0, avgVol50d: 0, marketCap: 0,
+      },
+    ];
+    const top = selectTopGainers(candidates, 3);
+    expect(top.length).toBeGreaterThanOrEqual(2);
+    // Best score must be first
+    expect(top[0].score).toBeGreaterThanOrEqual(top[top.length - 1].score);
+    // No symbol with rejected criteria
+    expect(top.every((t) => t.symbol !== 'NVDA' || t.changePct >= 3)).toBe(true);
+  });
+
+  it('returns [] when all candidates fail filters', () => {
+    const flat = [{ ...baseUSEquity, changePct: 1 }];
+    expect(selectTopGainers(flat, 3)).toEqual([]);
+  });
+
+  it('rejects invalid data (high < close)', () => {
+    const r = evaluateTopGainerCandidate({ ...baseUSEquity, high: 400, close: 500 });
+    expect(r.passes).toBe(false);
+    expect(r.reasons[0]).toBe('invalid_data');
+  });
+
+  it('rejects NaN / negative prices', () => {
+    expect(evaluateTopGainerCandidate({ ...baseUSEquity, close: NaN }).passes).toBe(false);
+    expect(evaluateTopGainerCandidate({ ...baseUSEquity, close: -10 }).passes).toBe(false);
+  });
+});

--- a/packages/ai-analyst/src/strategies/top-gainers-filter.ts
+++ b/packages/ai-analyst/src/strategies/top-gainers-filter.ts
@@ -1,0 +1,198 @@
+/**
+ * P5-PIVOT-TOP-GAINERS — Pure filter logic for momentum candidates
+ * cross-asset (US/EU/Asia equities, crypto, FX, commodities).
+ *
+ * Critères stricts (anti pump&dump, anti gap-and-fade) avec seuils
+ * ADAPTATIFS par classe d'actif :
+ *
+ *   us_equity_large (MC>10B)   : changePct >= +3%
+ *   us_equity_small_mid        : changePct >= +5%
+ *   eu_equity                  : changePct >= +5%
+ *   asia_equity                : changePct >= +5%
+ *   crypto_major (top 4)       : changePct >= +3%
+ *   crypto_alt                 : changePct >= +8% (bruit élevé)
+ *   fx_major                   : changePct >= +0.5%
+ *   fx_cross                   : changePct >= +1.5%
+ *   commodity                  : changePct >= +1.5%
+ *
+ * Pure function : aucun I/O, testable sans mocks.
+ */
+
+export type TopGainerAssetClass =
+  | 'us_equity_large'
+  | 'us_equity_small_mid'
+  | 'eu_equity'
+  | 'asia_equity'
+  | 'crypto_major'
+  | 'crypto_alt'
+  | 'fx_major'
+  | 'fx_cross'
+  | 'commodity';
+
+const CRYPTO_MAJORS = new Set(['BTC', 'ETH', 'BNB', 'SOL']);
+const FX_MAJORS = new Set([
+  'EURUSD', 'GBPUSD', 'USDJPY', 'AUDUSD', 'NZDUSD', 'USDCAD', 'USDCHF', 'DXY',
+]);
+
+/**
+ * Détecte la classe d'actif à partir d'un ticker + exchange.
+ */
+export function detectAssetClass(
+  symbol: string,
+  exchange: string | null | undefined,
+  marketCap: number | null = null,
+): TopGainerAssetClass {
+  const s = symbol.toUpperCase();
+  const ex = (exchange ?? '').toUpperCase();
+
+  // Crypto : exchange=BINANCE/CRYPTO ou pair pattern *USDT/*USDC
+  if (ex === 'BINANCE' || ex === 'CRYPTO' || /^(BTC|ETH|BNB|SOL|XRP|ADA|DOT|MATIC|AVAX|LINK|DOGE|SHIB|TRX|ATOM).*USD[T|C]?$/.test(s)) {
+    const base = s.replace(/USD[T|C]?$/, '');
+    return CRYPTO_MAJORS.has(base) ? 'crypto_major' : 'crypto_alt';
+  }
+
+  // FX : exchange=FOREX/FX, pattern 6-char ou DXY
+  if (ex === 'FOREX' || ex === 'FX' || /^[A-Z]{6}$/.test(s) || s === 'DXY') {
+    return FX_MAJORS.has(s) ? 'fx_major' : 'fx_cross';
+  }
+
+  // Commodity : exchange=COMM/FUTURES, pattern XX.F
+  if (ex === 'COMM' || ex === 'FUTURES' || /^[A-Z]{2,3}\.F$/.test(s)) {
+    return 'commodity';
+  }
+
+  // EU equity exchanges
+  if (['LSE', 'XETRA', 'PA', 'AMS', 'BR', 'SW', 'BME', 'MI', 'STO', 'L', 'DE'].includes(ex)) {
+    return 'eu_equity';
+  }
+  // Asia equity exchanges
+  if (['TSE', 'HK', 'AU', 'NSE', 'BSE', 'KO', 'KRX', 'T', 'HKEX'].includes(ex)) {
+    return 'asia_equity';
+  }
+  // Default = US equity, large vs small/mid via marketCap
+  if (marketCap !== null && Number.isFinite(marketCap) && marketCap >= 10_000_000_000) {
+    return 'us_equity_large';
+  }
+  return 'us_equity_small_mid';
+}
+
+/**
+ * Seuils par classe d'actif. Caller peut override via une copie modifiée.
+ */
+export const DEFAULT_THRESHOLDS: Record<TopGainerAssetClass, {
+  minChangePct: number;
+  minPrice: number;
+  minMarketCap: number;
+  minAvgVol50d: number;
+  minVolRatio: number;
+  minCloseToHighRatio: number;
+}> = {
+  us_equity_large:    { minChangePct: 3,   minPrice: 5,      minMarketCap: 10_000_000_000, minAvgVol50d: 500_000, minVolRatio: 1.5, minCloseToHighRatio: 0.80 },
+  us_equity_small_mid:{ minChangePct: 5,   minPrice: 5,      minMarketCap: 100_000_000,    minAvgVol50d: 500_000, minVolRatio: 1.5, minCloseToHighRatio: 0.80 },
+  eu_equity:          { minChangePct: 5,   minPrice: 5,      minMarketCap: 100_000_000,    minAvgVol50d: 200_000, minVolRatio: 1.5, minCloseToHighRatio: 0.80 },
+  asia_equity:        { minChangePct: 5,   minPrice: 1,      minMarketCap: 50_000_000,     minAvgVol50d: 200_000, minVolRatio: 1.5, minCloseToHighRatio: 0.80 },
+  crypto_major:       { minChangePct: 3,   minPrice: 0.0001, minMarketCap: 500_000_000,    minAvgVol50d: 0,       minVolRatio: 0,   minCloseToHighRatio: 0.85 },
+  crypto_alt:         { minChangePct: 8,   minPrice: 0.0001, minMarketCap: 500_000_000,    minAvgVol50d: 0,       minVolRatio: 0,   minCloseToHighRatio: 0.85 },
+  fx_major:           { minChangePct: 0.5, minPrice: 0,      minMarketCap: 0,              minAvgVol50d: 0,       minVolRatio: 0,   minCloseToHighRatio: 0.85 },
+  fx_cross:           { minChangePct: 1.5, minPrice: 0,      minMarketCap: 0,              minAvgVol50d: 0,       minVolRatio: 0,   minCloseToHighRatio: 0.85 },
+  commodity:          { minChangePct: 1.5, minPrice: 0,      minMarketCap: 0,              minAvgVol50d: 0,       minVolRatio: 0,   minCloseToHighRatio: 0.85 },
+};
+
+export interface TopGainerCandidate {
+  symbol: string;
+  exchange: string | null;
+  assetClass?: TopGainerAssetClass;
+  close: number;
+  high: number;
+  changePct: number;
+  volume: number;
+  avgVol50d: number;
+  marketCap: number;
+}
+
+export interface TopGainerEvaluation {
+  passes: boolean;
+  reasons: string[];
+  score: number;
+  assetClass: TopGainerAssetClass;
+}
+
+export function evaluateTopGainerCandidate(c: TopGainerCandidate): TopGainerEvaluation {
+  // Sanity
+  if (
+    !Number.isFinite(c.close) ||
+    !Number.isFinite(c.high) ||
+    !Number.isFinite(c.changePct) ||
+    !Number.isFinite(c.volume) ||
+    c.close <= 0 ||
+    c.high <= 0 ||
+    c.high < c.close
+  ) {
+    return { passes: false, reasons: ['invalid_data'], score: 0, assetClass: 'us_equity_small_mid' };
+  }
+
+  const assetClass = c.assetClass ?? detectAssetClass(c.symbol, c.exchange, c.marketCap);
+  const f = DEFAULT_THRESHOLDS[assetClass];
+  const reasons: string[] = [];
+
+  if (c.changePct < f.minChangePct) {
+    reasons.push(`changePct=${c.changePct.toFixed(2)}<${f.minChangePct}`);
+  }
+  if (f.minPrice > 0 && c.close < f.minPrice) {
+    reasons.push(`price=${c.close.toFixed(2)}<${f.minPrice}`);
+  }
+  if (f.minMarketCap > 0 && c.marketCap < f.minMarketCap) {
+    reasons.push(`mcap=${(c.marketCap / 1e6).toFixed(0)}M<${(f.minMarketCap / 1e6).toFixed(0)}M`);
+  }
+  if (f.minAvgVol50d > 0 && c.avgVol50d < f.minAvgVol50d) {
+    reasons.push(`avgVol50d=${(c.avgVol50d / 1000).toFixed(0)}k<${(f.minAvgVol50d / 1000).toFixed(0)}k`);
+  }
+  if (f.minVolRatio > 0) {
+    const volRatio = c.avgVol50d > 0 ? c.volume / c.avgVol50d : 0;
+    if (volRatio < f.minVolRatio) {
+      reasons.push(`volRatio=${volRatio.toFixed(2)}<${f.minVolRatio}`);
+    }
+  }
+  const closeToHigh = c.high > 0 ? c.close / c.high : 0;
+  if (closeToHigh < f.minCloseToHighRatio) {
+    reasons.push(`closeToHigh=${closeToHigh.toFixed(2)}<${f.minCloseToHighRatio} gap-and-fade`);
+  }
+
+  if (reasons.length > 0) {
+    return { passes: false, reasons, score: 0, assetClass };
+  }
+
+  // Score composite : changeMargin + closeStrength (+ volMargin si applicable).
+  const changeMargin = Math.min(1, Math.max(0, (c.changePct - f.minChangePct) / Math.max(1, f.minChangePct * 2)));
+  const closeStrength = Math.min(1, Math.max(0, (closeToHigh - f.minCloseToHighRatio) / Math.max(0.001, 1 - f.minCloseToHighRatio)));
+  let score: number;
+  if (f.minAvgVol50d > 0 && c.avgVol50d > 0) {
+    const volMargin = Math.min(1, Math.max(0, (c.volume / c.avgVol50d - f.minVolRatio) / 3));
+    score = (changeMargin + volMargin + closeStrength) / 3;
+  } else {
+    score = (changeMargin + closeStrength) / 2;
+  }
+
+  return {
+    passes: true,
+    reasons: [],
+    score: Math.round(score * 100) / 100,
+    assetClass,
+  };
+}
+
+/**
+ * Filter + sort un univers de candidats CROSS-ASSET. Retourne top N
+ * par score décroissant, toutes classes confondues.
+ */
+export function selectTopGainers(
+  candidates: TopGainerCandidate[],
+  topN: number = 3,
+): Array<TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass }> {
+  const passing = candidates
+    .map((c) => ({ candidate: c, eval: evaluateTopGainerCandidate(c) }))
+    .filter((x) => x.eval.passes)
+    .map((x) => ({ ...x.candidate, score: x.eval.score, assetClass: x.eval.assetClass }))
+    .sort((a, b) => b.score - a.score);
+  return passing.slice(0, topN);
+}

--- a/supabase/migrations/0084_top_gainers_log.sql
+++ b/supabase/migrations/0084_top_gainers_log.sql
@@ -1,0 +1,82 @@
+-- P5-PIVOT-TOP-GAINERS — Log de chaque candidat scanné par TopGainersScannerService.
+--
+-- Permet :
+--   1. Audit a posteriori : "à 14:32 le scanner a vu ce gainer, l'a traité OUI/NON"
+--   2. Backtest manuel : ré-évaluer la stratégie sur la base du historique
+--   3. UI dashboard : top gainers du jour, breakdown par market
+--
+-- Append-only. Pas de cleanup automatique — pruning à venir si volume excessif
+-- (15min × 50 candidats × 24h = ~5000 rows/jour).
+
+CREATE TABLE IF NOT EXISTS public.top_gainers_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  captured_at timestamptz NOT NULL DEFAULT now(),
+  symbol text NOT NULL,
+  -- market = classe d'actif normalisée (TopGainerAssetClass)
+  market text NOT NULL CHECK (market IN (
+    'us_equity_large', 'us_equity_small_mid',
+    'eu_equity', 'asia_equity',
+    'crypto_major', 'crypto_alt',
+    'fx_major', 'fx_cross',
+    'commodity'
+  )),
+  -- exchange = source data (NYSE, NASDAQ, LSE, XETRA, BINANCE, FOREX, etc.)
+  exchange text NOT NULL,
+  -- Snapshots des metrics scannés
+  close_price numeric(18, 6) NOT NULL CHECK (close_price > 0),
+  high_price numeric(18, 6) NOT NULL CHECK (high_price > 0),
+  change_pct numeric(10, 4) NOT NULL,
+  volume bigint NOT NULL CHECK (volume >= 0),
+  avg_vol_50d bigint NOT NULL CHECK (avg_vol_50d >= 0),
+  market_cap_usd numeric(28, 2) NOT NULL CHECK (market_cap_usd >= 0),
+  -- Score composite filter
+  score numeric(4, 3) NOT NULL CHECK (score >= 0 AND score <= 1),
+  -- Décision : passed (top N retenu) / filtered (ne passe pas les seuils) / opened (position ouverte)
+  decision text NOT NULL CHECK (decision IN ('opened', 'passed', 'filtered')),
+  -- Si decision='opened', lien vers la lisa_position créée
+  opened_position_id uuid,
+  -- Raisons rejet si decision='filtered' (e.g. "changePct=4<5,gap-and-fade")
+  filter_reasons text[],
+  -- Asset class détectée (= market la plupart du temps mais peut diverger
+  -- si le caller a override)
+  detected_asset_class text,
+  portfolio_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index principaux
+CREATE INDEX IF NOT EXISTS top_gainers_log_captured_at_desc_idx
+  ON public.top_gainers_log (captured_at DESC);
+
+CREATE INDEX IF NOT EXISTS top_gainers_log_symbol_captured_at_idx
+  ON public.top_gainers_log (symbol, captured_at DESC);
+
+CREATE INDEX IF NOT EXISTS top_gainers_log_market_captured_at_idx
+  ON public.top_gainers_log (market, captured_at DESC);
+
+CREATE INDEX IF NOT EXISTS top_gainers_log_decision_idx
+  ON public.top_gainers_log (decision, captured_at DESC);
+
+CREATE INDEX IF NOT EXISTS top_gainers_log_portfolio_idx
+  ON public.top_gainers_log (portfolio_id, captured_at DESC)
+  WHERE portfolio_id IS NOT NULL;
+
+-- RLS — service_role write, authenticated SELECT pour /lisa UI affichage
+ALTER TABLE public.top_gainers_log ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'top_gainers_log'
+      AND policyname = 'top_gainers_log_select_authenticated'
+  ) THEN
+    CREATE POLICY top_gainers_log_select_authenticated ON public.top_gainers_log
+      FOR SELECT
+      USING (auth.role() = 'authenticated');
+  END IF;
+END $$;
+
+COMMENT ON TABLE public.top_gainers_log IS
+  'P5-PIVOT-TOP-GAINERS — log append-only des candidats scannés par TopGainersScannerService cron 15min. market = classe d''actif (us_equity_large/eu_equity/crypto_major/fx_major/etc.). decision = opened/passed/filtered.';


### PR DESCRIPTION
## PIVOT STRATÉGIQUE : kill news/LLM → TopGainers déterministe 24/7 (v1)

User feedback : *"je te demande 10 valeurs à forte hausses aujourd'hui tu me le trouves en 2min et nous on galère"*. Lisa LLM philosophait sur Fed/Mongolia Jade pendant que NVDA/PLTR faisaient +8%. Pivot : scanner top gainers cross-asset déterministe, ouverture position directe via paperBroker (bypass LLM).

**Activation** : `fly secrets set STRATEGY_MODE=top_gainers`. Sans le flag, cron tourne mais retourne immédiat (no side-effect).

## Architecture v1

### 1. Pure helper `top-gainers-filter.ts`

`evaluateTopGainerCandidate` + `selectTopGainers` + `detectAssetClass`. Seuils **adaptatifs par classe d'actif** :

| Asset class | minChangePct | minPrice | minMarketCap | minVolRatio | minCloseToHigh |
|---|---|---|---|---|---|
| us_equity_large (MC>10B) | 3% | $5 | 10B | 1.5× | 80% |
| us_equity_small_mid | 5% | $5 | 100M | 1.5× | 80% |
| eu_equity | 5% | $5 | 100M | 1.5× | 80% |
| asia_equity | 5% | $1 | 50M | 1.5× | 80% |
| crypto_major (BTC/ETH/BNB/SOL) | 3% | - | 500M | - | 85% |
| crypto_alt | 8% | - | 500M | - | 85% |
| fx_major | 0.5% | - | - | - | 85% |
| fx_cross | 1.5% | - | - | - | 85% |
| commodity | 1.5% | - | - | - | 85% |

### 2. `TopGainersScannerService` cron 24/7

- **17 exchanges** en `Promise.allSettled` : `US, LSE, XETRA, PA, SW, MI, MC, BME, AS, AMS, TSE, HK, AU, KO, TO, NSE, BSE`
- **10 paires crypto** Binance : BTC/ETH/BNB/SOL/XRP/ADA/AVAX/DOT/LINK/MATIC USDT
- Filter via helper → top 1 cross-asset par score
- INSERT pseudo-proposal `lisa_proposals` + appel `approveProposal` → réutilise tous les garde-fous existants (cooldown, max_pos, cash buffer, fallback price guard, `position_opened` decision_log)

### 3. Migration `0084_top_gainers_log`

Append-only log : `symbol`, `market`, `exchange`, `close_price`, `high_price`, `change_pct`, `volume`, `avg_vol_50d`, `market_cap_usd`, `score`, `decision` (passed/opened/filtered), `opened_position_id`, `filter_reasons`, `portfolio_id`. 5 indices, RLS authenticated SELECT.

## 4 Guards utilisateur confirmés

| Guard | v1 ? | Détail |
|---|---|---|
| **#1** Multi-exchange Promise.allSettled dès v1 | ✅ | 17 exchanges (les 13 obligatoires + 4 bonus) |
| **#2** Cron 24/7 sans gating heures marché | ✅ | Cron tourne en continu, filter rejette tickers hors session via `avg_vol` |
| **#3** Cap conservatif 1 position/cycle | ✅ | `MAX_POSITIONS_PER_CYCLE_V1 = 1`. Bump à 3 en v2 |
| **#4** Cron interval configurable via env | ✅ | `SCAN_INTERVAL_MINUTES` (range 1-1440, default 15). SchedulerRegistry au boot. UI dynamique = v2. |

## Out of scope (PR2/PR3 séparés)

| Catégorie | Item deferred |
|---|---|
| **UI** | Banner `🔥 MODE TOP_GAINERS`, tableau temps réel 10/30/100 configurable, endpoint `/api/top-gainers`, page `/backtest/top-gainers`, CSV export |
| **Indicateurs techniques** | RSI/MACD/EMA/BB/ATR/VWAP/Stoch RSI/OBV/ADX, beta vs SPY-BTC, short interest, news count 24h, table `top_gainers_snapshots` persistance 90j |
| **Multi-broker** | Yahoo fallback / Coinbase / Kraken / OANDA / IBKR multi-currency. **paperBroker actuel = USD only** ; positions FX/JPY/EUR = refactor majeur |
| **Trading rules** | Trailing stop +3% custom, time stop 4h auto-close, sizing dynamique notionnel (actuellement fixe 30% via pseudo-proposal) |

## Tests Jest +25 specs

- `detectAssetClass` (9) : routing par exchange + market cap
- `evaluateTopGainerCandidate` US equity (7) : pass + tous les threshold rejects
- Crypto (3) : major +3% pass, alt +8% boundary
- FX (2) : major +0.6% pass, cross +1% reject
- `selectTopGainers` cross-asset (4) : ranking, empty, invalid

**Suite globale : 59 suites / 758 tests OK** ✅

## Action utilisateur post-merge

```bash
# Activer la stratégie
fly secrets set STRATEGY_MODE=top_gainers -a smartvest
fly secrets set SCAN_INTERVAL_MINUTES=15 -a smartvest  # ou 5/30/60
fly machine restart -a smartvest                       # reschedule cron au boot

# Appliquer migration
psql ... -f supabase/migrations/0084_top_gainers_log.sql
# OR via apply-migrations.mjs si SUPABASE_ACCESS_TOKEN dispo
```

**Vérification** :
```sql
-- Cycles cron
SELECT count(*) FROM top_gainers_log WHERE captured_at > NOW() - INTERVAL '20 min';
-- expected ≥ 1 par cycle SCAN_INTERVAL_MINUTES

-- Positions ouvertes
SELECT * FROM lisa_positions
WHERE portfolio_id='58439d86-3f20-4a60-82a4-307f3f252bc2'
  AND status='open' AND entry_timestamp > NOW() - INTERVAL '1 hour';
-- expected ≥ 1 si scanner trouve gainers + slot dispo
```

**Désactivation** :
```bash
fly secrets unset STRATEGY_MODE -a smartvest
# isStrategyActive() = false → cron tourne mais runScanner exit early
```

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_