### PR TITLE
fix(p13): defensive parsing in normalizeProposal — guard non-objects

### DIFF
--- a/packages/ai-analyst/src/thesis/__tests__/normalize-proposal-defensive.spec.ts
+++ b/packages/ai-analyst/src/thesis/__tests__/normalize-proposal-defensive.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * P13 hotfix — regression test for "Cannot create property 'assetClass' on string"
+ *
+ * Bug : quand Claude retourne expressions/poolsScan.favored/avoided comme
+ * array de strings (au lieu d'array d'objets), le code de normalisation
+ * essayait `e.assetClass = ...` sur une string et crashait.
+ *
+ * Le fix : guard runtime `typeof e === 'object' && !Array.isArray(e)` avant
+ * d'écrire la propriété.
+ */
+import { ThesisGeneratorService } from '../thesis-generator.service';
+
+// Accède à la méthode privée normalizeProposal via cast pour tester en isolation.
+// Pas idéal côté style mais évite un refactor intrusif sur un hotfix.
+type NormalizeProposalFn = (
+  parsed: unknown,
+  config: unknown,
+  claudeResult: { model: string; usage: { inputTokens: number; outputTokens: number } },
+) => unknown;
+
+function getNormalize(): NormalizeProposalFn {
+  // Constructor needs claudeClient + corpus, mais normalizeProposal n'utilise
+  // ni l'un ni l'autre — on passe des stubs vides.
+  const svc = new ThesisGeneratorService({} as never, {} as never);
+  return ((svc as unknown as { normalizeProposal: NormalizeProposalFn }).normalizeProposal).bind(svc);
+}
+
+const baseConfig = {
+  capitalUsd: '10000',
+  baseCurrency: 'USD',
+  profile: 'active_trading',
+  antiConsensusStrength: 5,
+  maxTheses: 3,
+  enableCrypto: true,
+  enableDerivatives: false,
+  enableLeverage: false,
+  riskConstraints: {
+    maxDrawdown2DaysPct: 5,
+    maxDrawdown7DaysPct: 10,
+    maxOpenPositions: 3,
+    maxExposurePerAssetClassPct: 40,
+  },
+};
+
+const claudeMeta = { model: 'claude-opus-4-7', usage: { inputTokens: 1, outputTokens: 1 } };
+
+describe('normalizeProposal — defensive parsing of malformed Claude output (P13 hotfix)', () => {
+  it('does NOT crash when expressions is array of strings (the bug)', () => {
+    const normalize = getNormalize();
+    const malformed = {
+      theses: [
+        {
+          id: 't1',
+          title: 'Stagflation hedge',
+          expressions: ['confidenceScore', 'assetClass'], // strings au lieu d'objets
+        },
+      ],
+      poolsScan: { favored: [], avoided: [] },
+      allocationSuggestion: { perThesis: [], cashReservePct: 100 },
+      marketContext: { regime: 'stagflation' },
+    };
+    expect(() => normalize(malformed, baseConfig, claudeMeta)).not.toThrow(
+      /Cannot create property/,
+    );
+  });
+
+  it('does NOT crash when poolsScan.favored is array of strings', () => {
+    const normalize = getNormalize();
+    const malformed = {
+      theses: [],
+      poolsScan: {
+        favored: ['confidenceScore', 'rationale'], // strings au lieu d'objets
+        avoided: [],
+      },
+      allocationSuggestion: { perThesis: [], cashReservePct: 100 },
+      marketContext: { regime: 'stagflation' },
+    };
+    expect(() => normalize(malformed, baseConfig, claudeMeta)).not.toThrow(
+      /Cannot create property/,
+    );
+  });
+
+  it('does NOT crash when poolsScan.avoided is array of strings', () => {
+    const normalize = getNormalize();
+    const malformed = {
+      theses: [],
+      poolsScan: {
+        favored: [],
+        avoided: ['rationale'],
+      },
+      allocationSuggestion: { perThesis: [], cashReservePct: 100 },
+      marketContext: { regime: 'stagflation' },
+    };
+    expect(() => normalize(malformed, baseConfig, claudeMeta)).not.toThrow(
+      /Cannot create property/,
+    );
+  });
+
+  it('does NOT crash when expressions contains a mix of objects and strings', () => {
+    const normalize = getNormalize();
+    const malformed = {
+      theses: [
+        {
+          id: 't1',
+          title: 'Mixed',
+          expressions: [
+            { symbol: 'GLD', assetClass: 'gold' },
+            'confidenceScore', // intrus
+            { symbol: 'TLT', assetClass: 'bonds' },
+          ],
+        },
+      ],
+      poolsScan: { favored: [], avoided: [] },
+      allocationSuggestion: { perThesis: [], cashReservePct: 100 },
+      marketContext: { regime: 'stagflation' },
+    };
+    expect(() => normalize(malformed, baseConfig, claudeMeta)).not.toThrow(
+      /Cannot create property/,
+    );
+  });
+
+  it('does NOT crash with TypeError when expressions contains null', () => {
+    const normalize = getNormalize();
+    const malformed = {
+      theses: [
+        {
+          id: 't1',
+          title: 'Null guard',
+          expressions: [null, { symbol: 'GLD', assetClass: 'gold' }],
+        },
+      ],
+      poolsScan: { favored: [null, null], avoided: [] },
+      allocationSuggestion: { perThesis: [], cashReservePct: 100 },
+      marketContext: { regime: 'stagflation' },
+    };
+    // Le bug original (Cannot create property) ne doit PAS apparaître.
+    // Une éventuelle Zod failure downstream sur la thèse incomplète est OK.
+    expect(() => normalize(malformed, baseConfig, claudeMeta)).not.toThrow(
+      /Cannot create property/,
+    );
+  });
+
+  it('filters out non-object pools from favoredPockets/avoidedPockets', () => {
+    const normalize = getNormalize();
+    const malformed = {
+      theses: [], // pas de thèses → pas de Zod validation à passer
+      poolsScan: {
+        favored: [
+          { assetClass: 'commodities_metals_precious', rationale: 'gold' },
+          'confidenceScore', // string filtrée (le bug)
+          null,
+          { assetClass: 'govt_bonds_us', rationale: 'flight to safety' },
+        ],
+        avoided: ['rationale', { assetClass: 'crypto_altcoins', rationale: 'avoid' }],
+      },
+      allocationSuggestion: { perThesis: [], cashReservePct: 100 },
+      marketContext: { regime: 'stagflation' },
+    };
+    const result = normalize(malformed, baseConfig, claudeMeta) as {
+      favoredPockets: Array<{ assetClass: string }>;
+      avoidedPockets: Array<{ assetClass: string }>;
+    };
+    expect(result.favoredPockets).toHaveLength(2);
+    expect(result.favoredPockets[0].assetClass).toBe('commodities_metals_precious');
+    expect(result.favoredPockets[1].assetClass).toBe('govt_bonds_us');
+    expect(result.avoidedPockets).toHaveLength(1);
+    expect(result.avoidedPockets[0].assetClass).toBe('crypto_altcoins');
+  });
+});

--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -1265,20 +1265,30 @@ Les symboles suivants sont **DÉJÀ DANS TON PORTEFEUILLE** : ${heldSymbolsList}
         t.id = newId;
       }
       positionMap.set(i, newId);
-      // Normalize common assetClass aliases Claude invents despite the prompt
-      const exprs = t.expressions as Array<Record<string, unknown>> | undefined;
+      // Normalize common assetClass aliases Claude invents despite the prompt.
+      // Defense-in-depth : Claude peut retourner expressions comme array de
+      // strings (ex: ["confidenceScore"]) au lieu d'array d'objets sous le
+      // forced regime thesis (P13). Le cast TS ne valide rien à l'exécution —
+      // on filtre explicitement les non-objets avant d'écrire .assetClass.
+      const exprs = t.expressions as unknown;
       if (Array.isArray(exprs)) {
         for (const e of exprs) {
-          e.assetClass = this.normalizeAssetClass(e.assetClass, e.symbol);
+          if (e !== null && typeof e === 'object' && !Array.isArray(e)) {
+            const obj = e as Record<string, unknown>;
+            obj.assetClass = this.normalizeAssetClass(obj.assetClass, obj.symbol);
+          }
         }
       }
     }
-    // Also normalize pools scan asset classes
+    // Also normalize pools scan asset classes — même garde-fou.
     for (const key of ['favored', 'avoided'] as const) {
-      const pools = ((root.poolsScan as Record<string, unknown>)?.[key]) as Array<Record<string, unknown>> | undefined;
+      const pools = (root.poolsScan as Record<string, unknown> | undefined)?.[key];
       if (Array.isArray(pools)) {
         for (const p of pools) {
-          p.assetClass = this.normalizeAssetClass(p.assetClass);
+          if (p !== null && typeof p === 'object' && !Array.isArray(p)) {
+            const obj = p as Record<string, unknown>;
+            obj.assetClass = this.normalizeAssetClass(obj.assetClass);
+          }
         }
       }
     }
@@ -1357,14 +1367,18 @@ Les symboles suivants sont **DÉJÀ DANS TON PORTEFEUILLE** : ${heldSymbolsList}
       detectedRegime: (mc.regime as MarketRegime) ?? 'fragmented_no_consensus',
       marketMomentum,
       regimeSummary: (mc.regimeSummary as string) ?? '',
-      favoredPockets: ((poolsScan.favored as Array<Record<string, unknown>>) ?? []).map((p) => ({
-        assetClass: p.assetClass as AllocationProposal['favoredPockets'][number]['assetClass'],
-        rationale: p.rationale as string,
-      })),
-      avoidedPockets: ((poolsScan.avoided as Array<Record<string, unknown>>) ?? []).map((p) => ({
-        assetClass: p.assetClass as AllocationProposal['avoidedPockets'][number]['assetClass'],
-        rationale: p.rationale as string,
-      })),
+      favoredPockets: (Array.isArray(poolsScan.favored) ? poolsScan.favored : [])
+        .filter((p): p is Record<string, unknown> => p !== null && typeof p === 'object' && !Array.isArray(p))
+        .map((p) => ({
+          assetClass: p.assetClass as AllocationProposal['favoredPockets'][number]['assetClass'],
+          rationale: p.rationale as string,
+        })),
+      avoidedPockets: (Array.isArray(poolsScan.avoided) ? poolsScan.avoided : [])
+        .filter((p): p is Record<string, unknown> => p !== null && typeof p === 'object' && !Array.isArray(p))
+        .map((p) => ({
+          assetClass: p.assetClass as AllocationProposal['avoidedPockets'][number]['assetClass'],
+          rationale: p.rationale as string,
+        })),
       theses,
       allocations,
       cashReservePct,


### PR DESCRIPTION
## 🚨 Hotfix urgent post-deploy v247

**Erreur prod observée** (decision_log /lisa) :
```
BadRequestException: Lisa n'a pas pu produire une proposition exploitable
(Cannot create property 'assetClass' on string 'confidenceScore')
```

**Diagnostic** : Lisa GÉNÈRE bien des thèses (le `[FORCED_REGIME_THESIS]` P13 fonctionne ✅), mais le post-traitement crash sur le `normalizeProposal`. Probable que Claude renvoie occasionnellement `expressions`/`poolsScan.favored`/`avoided` comme **array de strings** (noms de propriétés du schéma) au lieu d'array d'objets sous le forced thesis avec conviction réduite.

## Cause racine

`thesis-generator.service.ts:1268-1284` castait `t.expressions as Array<Record<string, unknown>>` **sans vérification runtime**. Le cast TS ne valide rien — quand Claude retourne `["confidenceScore"]` au lieu de `[{symbol, assetClass, ...}]`, l'assignation `e.assetClass = ...` crash avec `TypeError: Cannot create property 'assetClass' on string 'confidenceScore'`.

## Fix

- Guard `typeof e === 'object' && !Array.isArray(e)` AVANT chaque assignation `.assetClass = ...` dans les 3 boucles concernées (`expressions`, `poolsScan.favored`, `poolsScan.avoided`).
- Filtrage défensif aussi en aval lors du build de `favoredPockets` / `avoidedPockets` dans le proposal final pour éviter les undefined leaks.

## Tests

6 cas de régression — `packages/ai-analyst/src/thesis/__tests__/normalize-proposal-defensive.spec.ts` :
- ✅ does NOT crash when `expressions` is array of strings (the bug)
- ✅ does NOT crash when `poolsScan.favored` is array of strings
- ✅ does NOT crash when `poolsScan.avoided` is array of strings
- ✅ does NOT crash with mix of objects and strings
- ✅ does NOT crash with null
- ✅ filters out non-object pools from final `favoredPockets`/`avoidedPockets`

Typecheck ✅. Tests 6/6 ✅.

## Suivi attendu

Au prochain cycle Lisa post-merge, le decision_log doit montrer une proposition complète (potentiellement avec un thèse FORCED_REGIME_THESIS sur GLD/TLT/XLE) sans erreur de parsing.

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_