### PR TITLE
chore(ci): add bench-scanner-eu workflow on main for workflow_dispatch

### DIFF
--- a/.github/workflows/bench-scanner-eu.yml
+++ b/.github/workflows/bench-scanner-eu.yml
@@ -1,0 +1,57 @@
+name: Bench Scanner LLM EU Providers
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: bench/p16-llm-eu-providers
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run bench
+        env:
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          SCALEWAY_API_KEY: ${{ secrets.SCALEWAY_API_KEY }}
+          SCALEWAY_BASE_URL: ${{ secrets.SCALEWAY_BASE_URL }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: npm run bench:scanner-eu
+
+      - name: Commit REPORT
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add -f bench/scanner-llm/REPORT.md
+          if git diff --cached --quiet; then
+            echo "No REPORT changes to commit"
+          else
+            git commit -m "chore(bench/p16): auto-update REPORT after CI run"
+            git push origin bench/p16-llm-eu-providers
+          fi
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-results-${{ github.run_id }}
+          path: |
+            bench/scanner-llm/results/*.jsonl
+            bench/scanner-llm/REPORT.md
+          retention-days: 30


### PR DESCRIPTION
## Summary

- Ajoute `.github/workflows/bench-scanner-eu.yml` sur `main` (requis pour `workflow_dispatch`)
- Aucun code bench dans `main` — uniquement la définition CI
- Le workflow pointe sur `bench/p16-llm-eu-providers` pour le checkout

## Pourquoi main ?

GitHub n'affiche `workflow_dispatch` dans l'UI Actions que si le fichier YAML existe sur la branche par défaut. Le code bench reste isolé sur `bench/p16-llm-eu-providers`.

## Usage après merge

GitHub UI → Actions → **Bench Scanner LLM EU Providers** → Run workflow

Secrets requis (Settings → Secrets) : `MISTRAL_API_KEY`, `SCALEWAY_API_KEY`, `SCALEWAY_BASE_URL`, `GEMINI_API_KEY`, `OPENAI_API_KEY`

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_