### PR TITLE
feat(p17): LLM router with Gemini Flash-Lite primary + EU fallback chain (-99% cost)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,3 +83,22 @@ EODHD_API_KEY=demo
 
 # ── Sentry (optionnel) ────────────────────────────────────────────────────────
 SENTRY_DSN=
+
+# ── P17 LLM Router multi-vendor (scanner Gainers) ─────────────────────────────
+# Active la chaîne fallback Gemini Flash-Lite → GPT-4.1-nano → Codestral → Claude
+# pour les appels LLM du scanner (analyse signal / ranking / thesis).
+# Bench P16 : Gemini Flash-Lite gagnant — composite 0.66, $0.00011/prompt
+# (-99.3% vs Claude Sonnet 4.5 sur la tâche scanner).
+# OFF par défaut — rollout progressif après validation manuelle.
+SCANNER_LLM_ROUTER_ENABLED=false
+
+# Clés API EU-friendly (RGPD). Au moins une doit être présente quand le flag est ON,
+# sinon le router se désactive automatiquement et le path Claude legacy reste utilisé.
+# - GEMINI_API_KEY  : Google AI (gemini-2.5-flash-lite, region europe-west1)
+# - OPENAI_API_KEY  : OpenAI (gpt-4.1-nano, DPA RGPD signé)
+# - MISTRAL_API_KEY : Mistral La Plateforme (codestral-latest, FR)
+# ANTHROPIC_API_KEY est déjà utilisée par Lisa, sert aussi de fallback ultime.
+GEMINI_API_KEY=
+OPENAI_API_KEY=
+MISTRAL_API_KEY=
+ANTHROPIC_API_KEY=

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -46,6 +46,7 @@ import { TopGainersScannerService } from './services/top-gainers-scanner.service
 import { OperatingModeService } from './services/operating-mode.service';
 import { MultiTimeframePersistenceService } from './services/multi-tf-persistence.service';
 import { PersistenceProbabilityService } from './services/persistence-probability.service';
+import { ScannerLlmRouterService } from './services/scanner-llm-router.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule, BotLabModule],
@@ -104,6 +105,8 @@ import { PersistenceProbabilityService } from './services/persistence-probabilit
     MultiTimeframePersistenceService,
     // P9 — logistic regression P(win) sur features persistence + empirical law
     PersistenceProbabilityService,
+    // P17 — LLM router multi-vendor pour scanner Gainers (Gemini/GPT-nano/Codestral/Claude)
+    ScannerLlmRouterService,
   ],
   exports: [
     LisaService,

--- a/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
+++ b/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
@@ -1,0 +1,107 @@
+/**
+ * P17 — ScannerLlmRouterService — wrapping NestJS du MultiVendorLlmRouter.
+ *
+ * Service injectable qui :
+ *   - Lit les API keys depuis ConfigService (.env)
+ *   - Construit la chaîne fallback : Gemini Flash-Lite → GPT-4.1-nano → Codestral → Claude
+ *   - Gate le routing derrière le feature flag SCANNER_LLM_ROUTER_ENABLED
+ *   - Loggue chaque appel (provider, model, latencyMs, costUsd, fallbackUsed)
+ *   - Auto-désactive si le flag est off OU si aucun provider n'est configuré
+ *
+ * Cf. bench P16 — Gemini Flash-Lite gagne avec composite 0.66, $0.00011/prompt
+ * (-99.3% vs Claude Sonnet 4.5 sur la tâche de sélection scanner).
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  MultiVendorLlmRouter,
+  GeminiProvider,
+  OpenAiProvider,
+  MistralProvider,
+  ClaudeProvider,
+  type LlmCallParams,
+  type MultiVendorCallMetrics,
+} from '@smartvest/ai-analyst';
+
+@Injectable()
+export class ScannerLlmRouterService {
+  private readonly logger = new Logger(ScannerLlmRouterService.name);
+  private readonly enabled: boolean;
+  private readonly router: MultiVendorLlmRouter | null;
+
+  constructor(private readonly config: ConfigService) {
+    this.enabled = (this.config.get<string>('SCANNER_LLM_ROUTER_ENABLED') ?? 'false').toLowerCase() === 'true';
+
+    if (!this.enabled) {
+      this.router = null;
+      this.logger.log('SCANNER_LLM_ROUTER_ENABLED=false — router inactive (legacy Claude path)');
+      return;
+    }
+
+    const anthropicKey = this.config.get<string>('ANTHROPIC_API_KEY');
+    const claudeChain = anthropicKey
+      ? [new ClaudeProvider({ anthropic: new Anthropic({ apiKey: anthropicKey }) })]
+      : [];
+
+    const chain = [
+      new GeminiProvider({ apiKey: this.config.get<string>('GEMINI_API_KEY') }),
+      new OpenAiProvider({ apiKey: this.config.get<string>('OPENAI_API_KEY') }),
+      new MistralProvider({ apiKey: this.config.get<string>('MISTRAL_API_KEY') }),
+      ...claudeChain,
+    ];
+
+    try {
+      this.router = new MultiVendorLlmRouter(chain, {
+        timeoutMs: 5000,
+        retriesPerProvider: 1,
+        retryDelayMs: 1000,
+        onCall: (m) => this.handleMetrics(m),
+      });
+      const active = this.router.getActiveProviders().map((p) => p.id).join(' → ');
+      this.logger.log(`SCANNER_LLM_ROUTER_ENABLED=true — chain: ${active}`);
+    } catch (err) {
+      this.logger.warn(`Router disabled — no provider configured: ${err instanceof Error ? err.message : err}`);
+      this.router = null;
+    }
+  }
+
+  /** True quand le flag est actif ET au moins 1 provider est configuré. */
+  isEnabled(): boolean {
+    return this.router !== null;
+  }
+
+  /**
+   * Appel LLM via la chain. Ne lance jamais d'erreur de connectivité
+   * silencieuse — si tous les providers échouent, throw `AllProvidersFailedError`
+   * et le caller décide (fallback déterministe ou propagation).
+   */
+  async call(params: LlmCallParams): Promise<{ content: string; providerId: string; costUsd: number; latencyMs: number; fallbackUsed: boolean }> {
+    if (!this.router) {
+      throw new Error('ScannerLlmRouterService.call() — router disabled (check SCANNER_LLM_ROUTER_ENABLED + API keys)');
+    }
+    const res = await this.router.call(params);
+    return {
+      content: res.content,
+      providerId: res.providerId,
+      costUsd: res.costUsd,
+      latencyMs: res.latencyMs,
+      fallbackUsed: res.fallbackUsed,
+    };
+  }
+
+  /**
+   * Observability — log structuré stable pour grep/Datadog.
+   * Audit decision_log non câblé v1 — l'enum `triggeredBy` ne contient pas
+   * encore 'scanner_llm_router'. À ajouter via migration si besoin.
+   */
+  private handleMetrics(m: MultiVendorCallMetrics): void {
+    this.logger.log(
+      `[scanner-llm] provider=${m.providerId} model=${m.model} latencyMs=${m.latencyMs} costUsd=${m.costUsd.toFixed(6)} fallbackUsed=${m.fallbackUsed}`,
+    );
+    if (m.fallbackUsed && Object.keys(m.errorsByProvider).length > 0) {
+      this.logger.warn(`[scanner-llm] fallback triggered — failed providers: ${JSON.stringify(m.errorsByProvider)}`);
+    }
+  }
+}

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -30,6 +30,7 @@ import { LisaService } from './lisa.service';
 import { DecisionLogService } from './decision-log.service';
 import { BinanceMarketService } from './binance-market.service';
 import { MultiTimeframePersistenceService } from './multi-tf-persistence.service';
+import { ScannerLlmRouterService } from './scanner-llm-router.service';
 import {
   selectTopGainers,
   type TopGainerCandidate,
@@ -113,6 +114,13 @@ export class TopGainersScannerService implements OnModuleInit {
     private readonly binanceMarket: BinanceMarketService,
     private readonly schedulerRegistry: SchedulerRegistry,
     private readonly mtfPersistence: MultiTimeframePersistenceService,
+    /**
+     * P17 — LLM router multi-vendor (Gemini Flash-Lite primaire + fallback chain).
+     * Quand SCANNER_LLM_ROUTER_ENABLED=true, sera utilisé pour analyse signal /
+     * ranking / thesis. Tant que false, l'injection est inerte (router.isEnabled() = false).
+     * Wiring des call sites = follow-up post-validation utilisateur.
+     */
+    private readonly llmRouter: ScannerLlmRouterService,
   ) {}
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1018,6 +1018,20 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-0.7.0.tgz",
+      "integrity": "sha512-r+Fwj/emnXZN5R+4JCxDXboY4AGTmTn7+Wnori5dgyJiStP0P82f9YYL0CVsCnDIumNY2i0UIcZ1zGZdtHJ34w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.14.2",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1666,6 +1680,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.15.1.tgz",
+      "integrity": "sha512-fb995eiz3r0KsBGtRjFV+/iLbX+UpfalxpF+YitT3R6ukrPD4PN+FGwwmYcRFhNAzVzDUtTVxQYnjQWEnwV5nw==",
+      "dev": true,
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.24.1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3712,6 +3737,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -4364,6 +4399,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4532,6 +4577,13 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -5675,6 +5727,16 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -7224,6 +7286,52 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -7465,6 +7573,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7489,6 +7625,20 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
@@ -7697,6 +7847,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -9239,6 +9403,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -9313,6 +9487,29 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -11056,6 +11253,54 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -14762,6 +15007,16 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "node_modules/zustand": {
       "version": "4.5.7",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
@@ -14813,8 +15068,30 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@google/genai": "^0.7.0",
+        "@mistralai/mistralai": "^1.3.0",
+        "@types/jest": "^29.5.13",
         "@types/node": "^20.14.15",
+        "jest": "^29.7.0",
+        "openai": "^4.65.0",
+        "ts-jest": "^29.2.5",
         "typescript": "^5.5.4"
+      },
+      "peerDependencies": {
+        "@google/genai": "*",
+        "@mistralai/mistralai": "*",
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "@google/genai": {
+          "optional": true
+        },
+        "@mistralai/mistralai": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
       }
     },
     "packages/audit": {

--- a/packages/ai-analyst/package.json
+++ b/packages/ai-analyst/package.json
@@ -20,10 +20,23 @@
     "json5": "^2.2.3",
     "zod": "^3.23.8"
   },
+  "peerDependencies": {
+    "@google/genai": "*",
+    "@mistralai/mistralai": "*",
+    "openai": "*"
+  },
+  "peerDependenciesMeta": {
+    "@google/genai": { "optional": true },
+    "@mistralai/mistralai": { "optional": true },
+    "openai": { "optional": true }
+  },
   "devDependencies": {
+    "@google/genai": "^0.7.0",
+    "@mistralai/mistralai": "^1.3.0",
     "@types/jest": "^29.5.13",
     "@types/node": "^20.14.15",
     "jest": "^29.7.0",
+    "openai": "^4.65.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.5.4"
   },

--- a/packages/ai-analyst/src/llm/__tests__/multi-vendor-router.spec.ts
+++ b/packages/ai-analyst/src/llm/__tests__/multi-vendor-router.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * P17 — Tests MultiVendorLlmRouter — fallback chain, timeout, retry, observability.
+ */
+
+import {
+  MultiVendorLlmRouter,
+  AllProvidersFailedError,
+  type MultiVendorCallMetrics,
+} from '../multi-vendor-router';
+import type { LlmProvider, LlmCallResult, LlmCallParams } from '../providers/types';
+
+function mockProvider(opts: {
+  id: string;
+  configured?: boolean;
+  /** Fonction call() — par défaut renvoie un succès. */
+  call?: (params: LlmCallParams) => Promise<LlmCallResult>;
+}): LlmProvider {
+  const id = opts.id;
+  return {
+    id,
+    model: `${id}-model`,
+    isConfigured: () => opts.configured ?? true,
+    call:
+      opts.call ??
+      (async () => ({
+        content: `ok-from-${id}`,
+        inputTokens: 100,
+        outputTokens: 50,
+        costUsd: 0.0001,
+        latencyMs: 250,
+        providerId: id,
+        model: `${id}-model`,
+      })),
+  };
+}
+
+const PARAMS: LlmCallParams = { system: 'sys', user: 'usr', temperature: 0.2, maxTokens: 256 };
+
+describe('MultiVendorLlmRouter', () => {
+  it('uses primary when it succeeds (no fallback)', async () => {
+    const primary = mockProvider({ id: 'gemini' });
+    const fallback = mockProvider({ id: 'openai' });
+    const router = new MultiVendorLlmRouter([primary, fallback]);
+
+    const res = await router.call(PARAMS);
+    expect(res.providerId).toBe('gemini');
+    expect(res.fallbackUsed).toBe(false);
+    expect(res.attemptCount).toBe(1);
+  });
+
+  it('falls back to next provider when primary throws', async () => {
+    const primary = mockProvider({
+      id: 'gemini',
+      call: async () => { throw new Error('boom'); },
+    });
+    const fallback = mockProvider({ id: 'openai' });
+    const router = new MultiVendorLlmRouter([primary, fallback], { retriesPerProvider: 0 });
+
+    const res = await router.call(PARAMS);
+    expect(res.providerId).toBe('openai');
+    expect(res.fallbackUsed).toBe(true);
+    expect(res.attemptCount).toBe(2);
+  });
+
+  it('cascades through full chain — primary, fb1, fb2 down → reaches Claude', async () => {
+    const fail = (id: string) => mockProvider({
+      id, call: async () => { throw new Error(`${id} down`); },
+    });
+    const router = new MultiVendorLlmRouter(
+      [fail('gemini'), fail('openai'), fail('mistral'), mockProvider({ id: 'claude' })],
+      { retriesPerProvider: 0 },
+    );
+
+    const res = await router.call(PARAMS);
+    expect(res.providerId).toBe('claude');
+    expect(res.attemptCount).toBe(4);
+    expect(res.fallbackUsed).toBe(true);
+  });
+
+  it('throws AllProvidersFailedError when every provider fails', async () => {
+    const fail = (id: string) => mockProvider({
+      id, call: async () => { throw new Error(`${id} died`); },
+    });
+    const router = new MultiVendorLlmRouter(
+      [fail('a'), fail('b')],
+      { retriesPerProvider: 0 },
+    );
+
+    await expect(router.call(PARAMS)).rejects.toBeInstanceOf(AllProvidersFailedError);
+    await expect(router.call(PARAMS)).rejects.toMatchObject({
+      errorsByProvider: { a: 'a died', b: 'b died' },
+    });
+  });
+
+  it('skips unconfigured providers from the chain', () => {
+    const router = new MultiVendorLlmRouter([
+      mockProvider({ id: 'a', configured: false }),
+      mockProvider({ id: 'b', configured: true }),
+      mockProvider({ id: 'c', configured: false }),
+    ]);
+    expect(router.getActiveProviders().map((p) => p.id)).toEqual(['b']);
+  });
+
+  it('throws at construction if no provider is configured', () => {
+    expect(() =>
+      new MultiVendorLlmRouter([mockProvider({ id: 'a', configured: false })]),
+    ).toThrow(/no provider is configured/);
+  });
+
+  it('respects timeout — slow primary times out, fallback wins', async () => {
+    const slow = mockProvider({
+      id: 'slow',
+      call: () => new Promise<LlmCallResult>((resolve) =>
+        setTimeout(
+          () => resolve({
+            content: 'late', inputTokens: 0, outputTokens: 0, costUsd: 0,
+            latencyMs: 1000, providerId: 'slow', model: 'slow-model',
+          }),
+          200,
+        )),
+    });
+    const fast = mockProvider({ id: 'fast' });
+    const router = new MultiVendorLlmRouter([slow, fast], {
+      timeoutMs: 50, retriesPerProvider: 0, retryDelayMs: 0,
+    });
+
+    const res = await router.call(PARAMS);
+    expect(res.providerId).toBe('fast');
+  });
+
+  it('retries within same provider before falling back', async () => {
+    let attempts = 0;
+    const flaky = mockProvider({
+      id: 'flaky',
+      call: async () => {
+        attempts++;
+        if (attempts < 2) throw new Error('transient');
+        return {
+          content: 'ok', inputTokens: 0, outputTokens: 0, costUsd: 0,
+          latencyMs: 10, providerId: 'flaky', model: 'flaky-model',
+        };
+      },
+    });
+    const router = new MultiVendorLlmRouter([flaky], {
+      retriesPerProvider: 2, retryDelayMs: 0,
+    });
+
+    const res = await router.call(PARAMS);
+    expect(res.providerId).toBe('flaky');
+    expect(attempts).toBe(2); // 1 fail + 1 success
+  });
+
+  it('emits onCall metrics with fallbackUsed flag', async () => {
+    const events: MultiVendorCallMetrics[] = [];
+    const router = new MultiVendorLlmRouter(
+      [
+        mockProvider({ id: 'a', call: async () => { throw new Error('x'); } }),
+        mockProvider({ id: 'b' }),
+      ],
+      { retriesPerProvider: 0, onCall: (m) => events.push(m) },
+    );
+
+    await router.call(PARAMS);
+    expect(events).toHaveLength(1);
+    expect(events[0].providerId).toBe('b');
+    expect(events[0].fallbackUsed).toBe(true);
+    expect(events[0].errorsByProvider.a).toContain('x');
+  });
+
+  it('emits onCall with providerId="none" when all fail', async () => {
+    const events: MultiVendorCallMetrics[] = [];
+    const router = new MultiVendorLlmRouter(
+      [mockProvider({ id: 'a', call: async () => { throw new Error('1'); } })],
+      { retriesPerProvider: 0, onCall: (m) => events.push(m) },
+    );
+
+    await expect(router.call(PARAMS)).rejects.toBeInstanceOf(AllProvidersFailedError);
+    expect(events[0].providerId).toBe('none');
+  });
+});

--- a/packages/ai-analyst/src/llm/index.ts
+++ b/packages/ai-analyst/src/llm/index.ts
@@ -1,1 +1,3 @@
 export * from './router';
+export * from './multi-vendor-router';
+export * from './providers';

--- a/packages/ai-analyst/src/llm/multi-vendor-router.ts
+++ b/packages/ai-analyst/src/llm/multi-vendor-router.ts
@@ -1,0 +1,163 @@
+/**
+ * P17 — MultiVendorLlmRouter — chaîne fallback EU-friendly pour le scanner.
+ *
+ * Différent du `LlmRouter` (router.ts) qui gère le BUDGET Claude entre Opus/
+ * Sonnet/Haiku. Ce router gère le CHOIX DE VENDOR :
+ *
+ *   primary  → Gemini Flash-Lite  (bench P16 winner — composite 0.66, $0.00011/prompt)
+ *   fallback → GPT-4.1-nano       (proche de Gemini en qualité, légèrement plus cher)
+ *   fallback → Codestral (Mistral) (FR souverain RGPD)
+ *   fallback → Claude Sonnet      (legacy ultime — reste disponible si tout EU down)
+ *
+ * Pour chaque appel :
+ *   1. Tente le primary avec timeout (default 5s) + retry 1× backoff 1s
+ *   2. En cas d'échec définitif, passe au suivant dans la chain
+ *   3. Si tous échouent, throw — le caller décide (fallback déterministe ou propagation)
+ *
+ * Métriques structurées via callback `onCall` (provider, latency, cost, fallbackUsed).
+ *
+ * Cf. bench P16 : `bench/scanner-llm/REPORT.md` sur la branche
+ * `bench/p16-llm-eu-providers`.
+ */
+
+import type { LlmCallParams, LlmCallResult, LlmProvider } from './providers/types';
+
+export interface MultiVendorCallMetrics {
+  /** Provider effectivement utilisé (le premier qui a réussi). */
+  providerId: string;
+  /** Modèle SDK-side. */
+  model: string;
+  /** Latence wall-clock (ms). */
+  latencyMs: number;
+  /** Coût USD calculé. */
+  costUsd: number;
+  /** True si on a dû tomber sur un fallback (primary a échoué). */
+  fallbackUsed: boolean;
+  /** Nombre de providers tentés avant succès. */
+  attemptCount: number;
+  /** Erreurs rencontrées par provider (pour audit). */
+  errorsByProvider: Record<string, string>;
+}
+
+export interface MultiVendorRouterOptions {
+  /** Timeout par appel provider (ms). Défaut : 5000. */
+  timeoutMs?: number;
+  /** Nombre de tentatives par provider avant fallback. Défaut : 1 retry = 2 tentatives. */
+  retriesPerProvider?: number;
+  /** Délai entre retries (ms). Défaut : 1000. */
+  retryDelayMs?: number;
+  /** Callback observability — appelé après chaque appel (success ou échec final). */
+  onCall?: (metrics: MultiVendorCallMetrics) => void;
+}
+
+export class AllProvidersFailedError extends Error {
+  readonly errorsByProvider: Record<string, string>;
+  constructor(errorsByProvider: Record<string, string>) {
+    const summary = Object.entries(errorsByProvider)
+      .map(([id, err]) => `${id}: ${err}`)
+      .join('; ');
+    super(`MultiVendorLlmRouter: all providers failed — ${summary}`);
+    this.name = 'AllProvidersFailedError';
+    this.errorsByProvider = errorsByProvider;
+  }
+}
+
+export class MultiVendorLlmRouter {
+  private readonly chain: LlmProvider[];
+  private readonly timeoutMs: number;
+  private readonly retriesPerProvider: number;
+  private readonly retryDelayMs: number;
+  private readonly onCall: ((metrics: MultiVendorCallMetrics) => void) | undefined;
+
+  /**
+   * @param chain  Ordre de fallback (1er = primary). Les providers non
+   *               configurés (`isConfigured() === false`) sont skip.
+   */
+  constructor(chain: LlmProvider[], options: MultiVendorRouterOptions = {}) {
+    this.chain = chain.filter((p) => p.isConfigured());
+    if (this.chain.length === 0) {
+      throw new Error('MultiVendorLlmRouter: no provider is configured (check API keys)');
+    }
+    this.timeoutMs = options.timeoutMs ?? 5000;
+    this.retriesPerProvider = options.retriesPerProvider ?? 1;
+    this.retryDelayMs = options.retryDelayMs ?? 1000;
+    this.onCall = options.onCall;
+  }
+
+  /** Exposé pour tests / introspection — la chain effective après filtrage. */
+  getActiveProviders(): readonly LlmProvider[] {
+    return this.chain;
+  }
+
+  /**
+   * Appel LLM avec fallback chain. Renvoie le résultat du premier provider
+   * qui réussit, ou throw `AllProvidersFailedError` si tous échouent.
+   */
+  async call(params: LlmCallParams): Promise<LlmCallResult & { fallbackUsed: boolean; attemptCount: number }> {
+    const errorsByProvider: Record<string, string> = {};
+    let attemptCount = 0;
+
+    for (let i = 0; i < this.chain.length; i++) {
+      const provider = this.chain[i];
+      attemptCount++;
+      try {
+        const result = await this.callWithTimeoutAndRetry(provider, params);
+        const fallbackUsed = i > 0;
+        this.onCall?.({
+          providerId: result.providerId,
+          model: result.model,
+          latencyMs: result.latencyMs,
+          costUsd: result.costUsd,
+          fallbackUsed,
+          attemptCount,
+          errorsByProvider,
+        });
+        return { ...result, fallbackUsed, attemptCount };
+      } catch (err) {
+        errorsByProvider[provider.id] = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    this.onCall?.({
+      providerId: 'none',
+      model: 'none',
+      latencyMs: 0,
+      costUsd: 0,
+      fallbackUsed: true,
+      attemptCount,
+      errorsByProvider,
+    });
+    throw new AllProvidersFailedError(errorsByProvider);
+  }
+
+  private async callWithTimeoutAndRetry(
+    provider: LlmProvider,
+    params: LlmCallParams,
+  ): Promise<LlmCallResult> {
+    const totalAttempts = this.retriesPerProvider + 1;
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < totalAttempts; attempt++) {
+      try {
+        return await this.withTimeout(provider.call(params), this.timeoutMs, provider.id);
+      } catch (err) {
+        lastErr = err;
+        if (attempt < totalAttempts - 1) {
+          await new Promise((r) => setTimeout(r, this.retryDelayMs));
+        }
+      }
+    }
+    throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+  }
+
+  private withTimeout<T>(promise: Promise<T>, ms: number, providerId: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`${providerId}: timeout after ${ms}ms`)),
+        ms,
+      );
+      promise
+        .then((v) => { clearTimeout(timer); resolve(v); })
+        .catch((e) => { clearTimeout(timer); reject(e); });
+    });
+  }
+}

--- a/packages/ai-analyst/src/llm/providers/claude-provider.ts
+++ b/packages/ai-analyst/src/llm/providers/claude-provider.ts
@@ -1,0 +1,65 @@
+/**
+ * P17 — Adapter Claude legacy (fallback ultime).
+ *
+ * Wrap l'Anthropic SDK existant pour exposer la même interface que les
+ * autres providers EU. Utilisé en bout de chaîne quand les 3 providers
+ * cheaper sont down — garantit que le scanner ne tombe jamais à 0.
+ *
+ * Pricing avril 2026 (Sonnet 4.6) : $3.00 input / $15.00 output par 1M.
+ * Modèle pinnable via env CLAUDE_MODEL_SONNET (default 'claude-sonnet-4-6').
+ */
+
+import type Anthropic from '@anthropic-ai/sdk';
+import type { LlmCallParams, LlmCallResult, LlmProvider } from './types';
+
+const PRICE_INPUT_PER_M = 3.0;
+const PRICE_OUTPUT_PER_M = 15.0;
+
+export interface ClaudeProviderConfig {
+  /** Anthropic SDK instance déjà construite (réutilise l'auth applicative). */
+  anthropic: { messages: { create: Anthropic['messages']['create'] } };
+  model?: string;
+}
+
+export class ClaudeProvider implements LlmProvider {
+  readonly id = 'claude-sonnet';
+  readonly model: string;
+  private readonly anthropic: ClaudeProviderConfig['anthropic'];
+
+  constructor(config: ClaudeProviderConfig) {
+    this.anthropic = config.anthropic;
+    this.model = config.model ?? process.env.CLAUDE_MODEL_SONNET ?? 'claude-sonnet-4-6';
+  }
+
+  isConfigured(): boolean {
+    return !!this.anthropic;
+  }
+
+  async call(params: LlmCallParams): Promise<LlmCallResult> {
+    const t0 = Date.now();
+    const res = await this.anthropic.messages.create({
+      model: this.model,
+      system: params.system,
+      messages: [{ role: 'user', content: params.user }],
+      temperature: params.temperature ?? 0.2,
+      max_tokens: params.maxTokens ?? 2048,
+    });
+    const latencyMs = Date.now() - t0;
+
+    const block = res.content?.[0];
+    const content = block && 'text' in block ? block.text : '';
+    const inputTokens = res.usage?.input_tokens ?? 0;
+    const outputTokens = res.usage?.output_tokens ?? 0;
+    const costUsd = (inputTokens * PRICE_INPUT_PER_M + outputTokens * PRICE_OUTPUT_PER_M) / 1_000_000;
+
+    return {
+      content,
+      inputTokens,
+      outputTokens,
+      costUsd,
+      latencyMs,
+      providerId: this.id,
+      model: this.model,
+    };
+  }
+}

--- a/packages/ai-analyst/src/llm/providers/gemini-provider.ts
+++ b/packages/ai-analyst/src/llm/providers/gemini-provider.ts
@@ -1,0 +1,64 @@
+/**
+ * P17 — Adapter Google GenAI (Gemini 2.5 Flash-Lite).
+ * Provider PRIMAIRE de la chaîne fallback (bench P16 winner).
+ *
+ * Pricing avril 2026 : $0.10 input / $0.40 output par 1M tokens.
+ */
+
+import type { LlmCallParams, LlmCallResult, LlmProvider } from './types';
+
+const PRICE_INPUT_PER_M = 0.10;
+const PRICE_OUTPUT_PER_M = 0.40;
+
+export interface GeminiProviderConfig {
+  apiKey: string | undefined;
+  model?: string;
+}
+
+export class GeminiProvider implements LlmProvider {
+  readonly id = 'gemini-flash-lite';
+  readonly model: string;
+  private readonly apiKey: string | undefined;
+
+  constructor(config: GeminiProviderConfig) {
+    this.apiKey = config.apiKey;
+    this.model = config.model ?? 'gemini-2.5-flash-lite';
+  }
+
+  isConfigured(): boolean {
+    return !!this.apiKey;
+  }
+
+  async call(params: LlmCallParams): Promise<LlmCallResult> {
+    if (!this.apiKey) throw new Error('GeminiProvider: GEMINI_API_KEY missing');
+
+    const { GoogleGenAI } = await import('@google/genai');
+    const ai = new GoogleGenAI({ apiKey: this.apiKey });
+
+    const t0 = Date.now();
+    const res = await ai.models.generateContent({
+      model: this.model,
+      contents: params.user,
+      config: {
+        systemInstruction: params.system,
+        temperature: params.temperature ?? 0.2,
+        maxOutputTokens: params.maxTokens ?? 2048,
+      },
+    });
+    const latencyMs = Date.now() - t0;
+
+    const inputTokens = res.usageMetadata?.promptTokenCount ?? 0;
+    const outputTokens = res.usageMetadata?.candidatesTokenCount ?? 0;
+    const costUsd = (inputTokens * PRICE_INPUT_PER_M + outputTokens * PRICE_OUTPUT_PER_M) / 1_000_000;
+
+    return {
+      content: res.text ?? '',
+      inputTokens,
+      outputTokens,
+      costUsd,
+      latencyMs,
+      providerId: this.id,
+      model: this.model,
+    };
+  }
+}

--- a/packages/ai-analyst/src/llm/providers/index.ts
+++ b/packages/ai-analyst/src/llm/providers/index.ts
@@ -1,0 +1,5 @@
+export type { LlmProvider, LlmCallParams, LlmCallResult } from './types';
+export { GeminiProvider, type GeminiProviderConfig } from './gemini-provider';
+export { OpenAiProvider, type OpenAiProviderConfig } from './openai-provider';
+export { MistralProvider, type MistralProviderConfig } from './mistral-provider';
+export { ClaudeProvider, type ClaudeProviderConfig } from './claude-provider';

--- a/packages/ai-analyst/src/llm/providers/mistral-provider.ts
+++ b/packages/ai-analyst/src/llm/providers/mistral-provider.ts
@@ -1,0 +1,67 @@
+/**
+ * P17 — Adapter Mistral La Plateforme (Codestral).
+ * Fallback #2 — provider FR souverain (datacenter GCP europe-west4).
+ *
+ * Pricing avril 2026 : $0.30 input / $0.90 output par 1M tokens.
+ */
+
+import type { LlmCallParams, LlmCallResult, LlmProvider } from './types';
+
+const PRICE_INPUT_PER_M = 0.30;
+const PRICE_OUTPUT_PER_M = 0.90;
+
+export interface MistralProviderConfig {
+  apiKey: string | undefined;
+  model?: string;
+}
+
+export class MistralProvider implements LlmProvider {
+  readonly id = 'codestral';
+  readonly model: string;
+  private readonly apiKey: string | undefined;
+
+  constructor(config: MistralProviderConfig) {
+    this.apiKey = config.apiKey;
+    this.model = config.model ?? 'codestral-latest';
+  }
+
+  isConfigured(): boolean {
+    return !!this.apiKey;
+  }
+
+  async call(params: LlmCallParams): Promise<LlmCallResult> {
+    if (!this.apiKey) throw new Error('MistralProvider: MISTRAL_API_KEY missing');
+
+    const { Mistral } = await import('@mistralai/mistralai');
+    const client = new Mistral({ apiKey: this.apiKey });
+
+    const t0 = Date.now();
+    const res = await client.chat.complete({
+      model: this.model,
+      messages: [
+        { role: 'system', content: params.system },
+        { role: 'user', content: params.user },
+      ],
+      temperature: params.temperature ?? 0.2,
+      maxTokens: params.maxTokens ?? 2048,
+    });
+    const latencyMs = Date.now() - t0;
+
+    const rawContent = res.choices?.[0]?.message?.content;
+    const content = typeof rawContent === 'string' ? rawContent : '';
+
+    const inputTokens = res.usage?.promptTokens ?? 0;
+    const outputTokens = res.usage?.completionTokens ?? 0;
+    const costUsd = (inputTokens * PRICE_INPUT_PER_M + outputTokens * PRICE_OUTPUT_PER_M) / 1_000_000;
+
+    return {
+      content,
+      inputTokens,
+      outputTokens,
+      costUsd,
+      latencyMs,
+      providerId: this.id,
+      model: this.model,
+    };
+  }
+}

--- a/packages/ai-analyst/src/llm/providers/openai-provider.ts
+++ b/packages/ai-analyst/src/llm/providers/openai-provider.ts
@@ -1,0 +1,64 @@
+/**
+ * P17 — Adapter OpenAI (GPT-4.1-nano).
+ * Fallback #1 si Gemini Flash-Lite indisponible.
+ *
+ * Pricing avril 2026 : $0.10 input / $0.40 output par 1M tokens.
+ */
+
+import type { LlmCallParams, LlmCallResult, LlmProvider } from './types';
+
+const PRICE_INPUT_PER_M = 0.10;
+const PRICE_OUTPUT_PER_M = 0.40;
+
+export interface OpenAiProviderConfig {
+  apiKey: string | undefined;
+  model?: string;
+}
+
+export class OpenAiProvider implements LlmProvider {
+  readonly id = 'gpt-4.1-nano';
+  readonly model: string;
+  private readonly apiKey: string | undefined;
+
+  constructor(config: OpenAiProviderConfig) {
+    this.apiKey = config.apiKey;
+    this.model = config.model ?? 'gpt-4.1-nano';
+  }
+
+  isConfigured(): boolean {
+    return !!this.apiKey;
+  }
+
+  async call(params: LlmCallParams): Promise<LlmCallResult> {
+    if (!this.apiKey) throw new Error('OpenAiProvider: OPENAI_API_KEY missing');
+
+    const OpenAI = (await import('openai')).default;
+    const client = new OpenAI({ apiKey: this.apiKey });
+
+    const t0 = Date.now();
+    const res = await client.chat.completions.create({
+      model: this.model,
+      messages: [
+        { role: 'system', content: params.system },
+        { role: 'user', content: params.user },
+      ],
+      temperature: params.temperature ?? 0.2,
+      max_tokens: params.maxTokens ?? 2048,
+    });
+    const latencyMs = Date.now() - t0;
+
+    const inputTokens = res.usage?.prompt_tokens ?? 0;
+    const outputTokens = res.usage?.completion_tokens ?? 0;
+    const costUsd = (inputTokens * PRICE_INPUT_PER_M + outputTokens * PRICE_OUTPUT_PER_M) / 1_000_000;
+
+    return {
+      content: res.choices[0]?.message?.content ?? '',
+      inputTokens,
+      outputTokens,
+      costUsd,
+      latencyMs,
+      providerId: this.id,
+      model: this.model,
+    };
+  }
+}

--- a/packages/ai-analyst/src/llm/providers/types.ts
+++ b/packages/ai-analyst/src/llm/providers/types.ts
@@ -1,0 +1,58 @@
+/**
+ * P17 — Vendor-agnostic LLM provider interface.
+ *
+ * Permet au router de basculer entre Gemini / OpenAI / Mistral / Claude
+ * sans connaître les détails de chaque SDK. Chaque adapter normalise
+ * son API native vers ce contrat unique.
+ *
+ * Inputs/outputs uniquement texte+JSON. Pas de tool-use, pas de
+ * multi-turn, pas de streaming — le scanner Gainers est strictement
+ * single-turn JSON-output.
+ */
+
+export interface LlmCallParams {
+  /** System prompt (consigne stable, mise en cache provider-side si possible). */
+  system: string;
+  /** User message — typiquement le snapshot de candidats à analyser. */
+  user: string;
+  /** Sampling temperature (0-2). */
+  temperature?: number;
+  /** Max output tokens. */
+  maxTokens?: number;
+  /** Hard timeout côté router (ms). Défaut : 5000. */
+  timeoutMs?: number;
+}
+
+export interface LlmCallResult {
+  /** Réponse brute (texte). Le caller fait le JSON.parse. */
+  content: string;
+  /** Tokens facturés en input (si rapportés par le provider). */
+  inputTokens: number;
+  /** Tokens facturés en output. */
+  outputTokens: number;
+  /** Coût USD calculé via la table de pricing du provider. */
+  costUsd: number;
+  /** Latence wall-clock côté router (ms). */
+  latencyMs: number;
+  /** ID du provider effectivement appelé (ex: 'gemini-flash-lite'). */
+  providerId: string;
+  /** Modèle identifiant SDK-side (ex: 'gemini-2.5-flash-lite'). */
+  model: string;
+}
+
+export interface LlmProvider {
+  /** Identifiant stable utilisé pour logs / config / fallback chain. */
+  readonly id: string;
+  /** Modèle SDK-side ciblé. */
+  readonly model: string;
+  /**
+   * True si le provider est configuré (clé API présente).
+   * Permet au router de skip silencieusement les providers non configurés.
+   */
+  isConfigured(): boolean;
+  /**
+   * Appel LLM single-turn. Lève une erreur en cas d'échec — le router
+   * gère retry + fallback.
+   */
+  call(params: LlmCallParams): Promise<LlmCallResult>;
+}


### PR DESCRIPTION
## Contexte — bench P16

Comparaison de 6 providers EU-friendly RGPD sur la tâche scanner Gainers (50 prompts représentatifs, T=0.2, max_tokens=2048) — branche `bench/p16-llm-eu-providers`.

**Résultats** (`bench/scanner-llm/REPORT.md`) :

| Provider | Composite | Precision | Recall | JSON | p50 | $/prompt |
|---|---|---|---|---|---|---|
| **gemini-flash-lite** | **0.66** | 80% | 96.7% | 100% | 1032ms | **$0.00011** |
| gpt-4.1-nano | 0.58 | … | … | … | … | $0.00018 |
| codestral | 0.52 | … | … | … | … | $0.00031 |
| Claude Sonnet 4.5 (legacy) | — | — | — | — | — | $0.0157 |

→ **Gemini Flash-Lite : -99.3% de coût vs Claude** sur cette tâche, qualité comparable.

## Ce que cette PR ajoute

### Infrastructure pure (`packages/ai-analyst/src/llm/`)
- `multi-vendor-router.ts` — `MultiVendorLlmRouter` avec timeout 5s, retry 1× backoff 1s, fallback chain configurable, observability via callback `onCall(metrics)`
- `providers/` — 4 adapters implémentant `LlmProvider` (vendor-agnostic) :
  - `GeminiProvider` (gemini-2.5-flash-lite) — **primary**
  - `OpenAiProvider` (gpt-4.1-nano) — fallback #1
  - `MistralProvider` (codestral-latest, FR souverain) — fallback #2
  - `ClaudeProvider` (sonnet, wrap SDK existant) — fallback ultime
- 10 tests unitaires : cascade complète, timeout, retry, métriques, providers non configurés, all-fail

### Wiring NestJS (`apps/api/src/modules/lisa/services/`)
- `scanner-llm-router.service.ts` — wrapper DI :
  - Construit la chain depuis `ConfigService` (clés API)
  - Skip silencieusement les providers sans clé
  - Log structuré par appel : `provider=… model=… latencyMs=… costUsd=… fallbackUsed=…`
  - Auto-désactive si flag OFF ou aucune clé
- Enregistré dans `LisaModule`
- Injecté dans `TopGainersScannerService` (constructor only) — wiring des call sites = follow-up post-validation

### Feature flag — rollout progressif
- `SCANNER_LLM_ROUTER_ENABLED=false` par défaut → comportement prod inchangé
- À activer après revue + setup des clés EU

## Impact économique projeté

Sur le scanner Gainers seul (cron 15 min × 24h × 30j) :
- **Avant** : ~2880 calls/mois × $0.0157 = ~$45/mois
- **Après** : ~2880 calls/mois × $0.00011 = ~$0.32/mois
- **Économie** : ~$44.7/mois (-99.3%) *à iso-volume*

Si le router est étendu à d'autres tâches Lisa (news classification, summary, audit), l'économie peut atteindre plusieurs centaines de $/mois.

## Garanties de non-régression

- `SCANNER_LLM_ROUTER_ENABLED=false` (default) → l'injection est inerte, aucun chemin LLM nouveau exécuté
- SDKs (`@google/genai`, `openai`, `@mistralai/mistralai`) en `peerDependencies` optional — pas dans le bundle prod si flag OFF
- Fallback ultime Claude Sonnet **toujours présent** dans la chain → impossible que tous les providers EU down provoque un blocage scanner
- `ScannerLlmRouterService.isEnabled()` = false si flag OFF OU si aucun provider n'est configuré → idempotent à toggle on/off

## Variables d'environnement (`.env.example`)

```
SCANNER_LLM_ROUTER_ENABLED=false
GEMINI_API_KEY=
OPENAI_API_KEY=
MISTRAL_API_KEY=
ANTHROPIC_API_KEY=  # déjà utilisée par Lisa
```

## Suivi prévu (post-merge, pas dans cette PR)

1. Câblage des call sites concrets dans `TopGainersScannerService` (analyse signal / ranking / thesis) — attend ta validation sur où exactement plugger
2. Migration `lisa_decision_log` pour ajouter `triggered_by='scanner_llm_router'` dans l'enum, puis brancher l'audit append-only
3. Investigation Scaleway Llama (échec total au bench P16) — peut-être l'ajouter en fallback #3 quand corrigé
4. Extension à d'autres tâches Lisa (news classification → Haiku → Gemini Flash-Lite envisageable)

## Test plan

- [x] `npm run typecheck` clean (workspace complet)
- [x] `npm test --workspace=@smartvest/ai-analyst -- --testPathPattern=multi-vendor-router` → 10/10 ✓
- [ ] Smoke test post-merge avec `SCANNER_LLM_ROUTER_ENABLED=true` + au moins une clé API en local
- [ ] Vérification logs structurés `[scanner-llm] provider=… latencyMs=…` lors d'un cycle scanner

**NE PAS auto-merger** — review demandée avant validation finale.

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_