### PR TITLE
feat(p18): wire LLM router into TopGainersScanner (signal/ranking/thesis)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.llm.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.llm.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * P18 — Unit tests for the 3 LLM call sites wired into TopGainersScannerService.
+ *
+ * Tests the three private helpers via (service as any) cast:
+ *   - analyzeSignal  : signal validation per candidate
+ *   - rankCandidates : LLM re-ranking of top-N batch
+ *   - generateThesis : thesis text generation for a position
+ *
+ * Each call site is tested for 3 scenarios:
+ *   A. Router disabled (SCANNER_LLM_ROUTER_ENABLED=false) → deterministic fallback
+ *   B. Router enabled, LLM succeeds → parsed LLM response used
+ *   C. Router enabled, LLM fails (throw) → deterministic fallback (resilience)
+ */
+
+import { Logger } from '@nestjs/common';
+import { TopGainersScannerService } from '../services/top-gainers-scanner.service';
+import { ScannerLlmRouterService } from '../services/scanner-llm-router.service';
+
+// ── Minimal stubs for constructor dependencies ──────────────────────────────
+
+const mockSupabase = { getClient: jest.fn() } as any;
+const mockLisa = {} as any;
+const mockDecisionLog = {} as any;
+const mockConfig = { get: jest.fn() } as any;
+const mockBinance = {} as any;
+const mockScheduler = { getCronJob: jest.fn().mockImplementation(() => { throw new Error('not found'); }), addCronJob: jest.fn() } as any;
+const mockMtf = {} as any;
+
+// Suppress logger output in tests
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeLlmRouter(isEnabled: boolean, callImpl?: jest.Mock): ScannerLlmRouterService {
+  return {
+    isEnabled: jest.fn().mockReturnValue(isEnabled),
+    call: callImpl ?? jest.fn(),
+  } as unknown as ScannerLlmRouterService;
+}
+
+function makeService(llmRouter: ScannerLlmRouterService): TopGainersScannerService {
+  mockConfig.get.mockImplementation((key: string) => {
+    if (key === 'SCAN_INTERVAL_MINUTES') return '15';
+    return undefined;
+  });
+  return new TopGainersScannerService(
+    mockSupabase,
+    mockLisa,
+    mockDecisionLog,
+    mockConfig,
+    mockBinance,
+    mockScheduler,
+    mockMtf,
+    llmRouter,
+  );
+}
+
+const baseCand = {
+  symbol: 'BTCUSDT',
+  exchange: 'BINANCE',
+  assetClass: 'crypto' as const,
+  changePct: 5.3,
+  close: 65000,
+  high: 66000,
+  volume: 1_000_000,
+  avgVol50d: 900_000,
+  marketCap: 0,
+  score: 0.82,
+};
+
+const basePersistence = {
+  symbol: 'BTCUSDT',
+  persistenceScore: 0.83,
+  persistenceCount: '5/6',
+  availableCount: 6,
+  tf1m: 0.002,
+  tf5m: 0.018,
+  tf10m: 0.031,
+  tf15m: 0.044,
+  tf30m: 0.062,
+  tf1h: 0.091,
+  pathQuality: { overallEfficiency: 0.75, overallSmoothness: 'smooth' as const },
+};
+
+// ── analyzeSignal ────────────────────────────────────────────────────────────
+
+describe('analyzeSignal', () => {
+  it('A: returns deterministic fallback when router is disabled', async () => {
+    const svc = makeService(makeLlmRouter(false));
+    const result = await (svc as any).analyzeSignal(baseCand, basePersistence);
+    expect(result.pass).toBe(true);
+    expect(result.signal_quality).toBe(1.0);
+    expect(result.reason).toBe('deterministic_fallback');
+  });
+
+  it('B: returns parsed LLM response when router is enabled and call succeeds', async () => {
+    const callMock = jest.fn().mockResolvedValue({
+      content: JSON.stringify({ pass: true, signal_quality: 0.87, reason: 'strong multi-TF persistence' }),
+      providerId: 'gemini-flash-lite',
+      costUsd: 0.00011,
+      latencyMs: 800,
+      fallbackUsed: false,
+    });
+    const svc = makeService(makeLlmRouter(true, callMock));
+    const result = await (svc as any).analyzeSignal(baseCand, basePersistence);
+    expect(result.pass).toBe(true);
+    expect(result.signal_quality).toBe(0.87);
+    expect(result.reason).toBe('strong multi-TF persistence');
+    expect(callMock).toHaveBeenCalledTimes(1);
+    const callArg = callMock.mock.calls[0][0];
+    expect(callArg.temperature).toBe(0.1);
+    expect(callArg.maxTokens).toBe(128);
+    expect(JSON.parse(callArg.user).symbol).toBe('BTCUSDT');
+    expect(JSON.parse(callArg.user).persistenceScore).toBe(0.83);
+  });
+
+  it('B: sets pass=false when LLM returns signal_quality < 0.4', async () => {
+    const callMock = jest.fn().mockResolvedValue({
+      content: JSON.stringify({ pass: false, signal_quality: 0.22, reason: 'thin volume + spike pattern' }),
+      providerId: 'gemini-flash-lite',
+      costUsd: 0.00009,
+      latencyMs: 650,
+      fallbackUsed: false,
+    });
+    const svc = makeService(makeLlmRouter(true, callMock));
+    const result = await (svc as any).analyzeSignal(baseCand, basePersistence);
+    expect(result.pass).toBe(false);
+    expect(result.signal_quality).toBe(0.22);
+  });
+
+  it('C: falls back to deterministic pass=true when LLM call throws', async () => {
+    const callMock = jest.fn().mockRejectedValue(new Error('AllProvidersFailedError'));
+    const svc = makeService(makeLlmRouter(true, callMock));
+    const result = await (svc as any).analyzeSignal(baseCand, basePersistence);
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe('deterministic_fallback');
+  });
+
+  it('C: falls back when LLM returns invalid JSON', async () => {
+    const callMock = jest.fn().mockResolvedValue({
+      content: 'not valid json !!',
+      providerId: 'gemini-flash-lite',
+      costUsd: 0.00001,
+      latencyMs: 300,
+      fallbackUsed: false,
+    });
+    const svc = makeService(makeLlmRouter(true, callMock));
+    const result = await (svc as any).analyzeSignal(baseCand, basePersistence);
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe('deterministic_fallback');
+  });
+});
+
+// ── rankCandidates ───────────────────────────────────────────────────────────
+
+const candA = { ...baseCand, symbol: 'BTCUSDT', score: 0.82 };
+const candB = { ...baseCand, symbol: 'ETHUSDT', exchange: 'BINANCE', score: 0.76 };
+const candC = { ...baseCand, symbol: 'SOLUSDT', exchange: 'BINANCE', score: 0.71 };
+
+describe('rankCandidates', () => {
+  it('A: returns same order when router is disabled', async () => {
+    const svc = makeService(makeLlmRouter(false));
+    const result = await (svc as any).rankCandidates([candA, candB, candC]);
+    expect(result.map((c: typeof candA) => c.symbol)).toEqual(['BTCUSDT', 'ETHUSDT', 'SOLUSDT']);
+  });
+
+  it('A: returns same order when only 1 candidate (no LLM needed)', async () => {
+    const callMock = jest.fn();
+    const svc = makeService(makeLlmRouter(true, callMock));
+    const result = await (svc as any).rankCandidates([candA]);
+    expect(result).toEqual([candA]);
+    expect(callMock).not.toHaveBeenCalled();
+  });
+
+  it('B: re-orders candidates according to LLM response', async () => {
+    const callMock = jest.fn().mockResolvedValue({
+      content: JSON.stringify(['SOLUSDT', 'BTCUSDT', 'ETHUSDT']),
+      providerId: 'gemini-flash-lite',
+      costUsd: 0.00013,
+      latencyMs: 900,
+      fallbackUsed: false,
+    });
+    const svc = makeService(makeLlmRouter(true, callMock));
+    const result = await (svc as any).rankCandidates([candA, candB, candC]);
+    expect(result.map((c: typeof candA) => c.symbol)).toEqual(['SOLUSDT', 'BTCUSDT', 'ETHUSDT']);
+  });
+
+  it('B: appends unknown symbols from LLM at end (graceful gap fill)', async () => {
+    const callMock = jest.fn().mockResolvedValue({
+      content: JSON.stringify(['BTCUSDT']),  // LLM omits ETHUSDT and SOLUSDT
+      providerId: 'gemini-flash-lite',
+      costUsd: 0.00010,
+      latencyMs: 700,
+      fallbackUsed: false,
+    });
+    const svc = makeService(makeLlmRouter(true, callMock));
+    const result = await (svc as any).rankCandidates([candA, candB, candC]);
+    expect(result[0].symbol).toBe('BTCUSDT');
+    // Missing symbols are appended in original order
+    const remaining = result.slice(1).map((c: typeof candA) => c.symbol);
+    expect(remaining).toContain('ETHUSDT');
+    expect(remaining).toContain('SOLUSDT');
+  });
+
+  it('C: returns deterministic order when LLM throws', async () => {
+    const callMock = jest.fn().mockRejectedValue(new Error('timeout'));
+    const svc = makeService(makeLlmRouter(true, callMock));
+    const result = await (svc as any).rankCandidates([candA, candB, candC]);
+    expect(result.map((c: typeof candA) => c.symbol)).toEqual(['BTCUSDT', 'ETHUSDT', 'SOLUSDT']);
+  });
+});
+
+// ── generateThesis ───────────────────────────────────────────────────────────
+
+describe('generateThesis', () => {
+  it('A: returns deterministic fallback when router is disabled', async () => {
+    const svc = makeService(makeLlmRouter(false));
+    const result = await (svc as any).generateThesis(baseCand);
+    expect(result.summary).toContain('BTCUSDT');
+    expect(result.summary).toContain('+5.3%');
+    expect(result.category).toBe('flow_timing');
+    expect(result.conviction_score).toBe(7);
+  });
+
+  it('B: returns parsed LLM thesis when router is enabled and call succeeds', async () => {
+    const callMock = jest.fn().mockResolvedValue({
+      content: JSON.stringify({
+        summary: 'BTCUSDT breaks ATH with 5.3% surge on high volume',
+        category: 'technical_breakout',
+        conviction_score: 9,
+      }),
+      providerId: 'gemini-flash-lite',
+      costUsd: 0.00012,
+      latencyMs: 750,
+      fallbackUsed: false,
+    });
+    const svc = makeService(makeLlmRouter(true, callMock));
+    const result = await (svc as any).generateThesis(baseCand);
+    expect(result.summary).toBe('BTCUSDT breaks ATH with 5.3% surge on high volume');
+    expect(result.category).toBe('technical_breakout');
+    expect(result.conviction_score).toBe(9);
+    const callArg = callMock.mock.calls[0][0];
+    expect(callArg.temperature).toBe(0.2);
+    expect(callArg.maxTokens).toBe(128);
+    expect(JSON.parse(callArg.user).symbol).toBe('BTCUSDT');
+  });
+
+  it('C: falls back to deterministic template when LLM throws', async () => {
+    const callMock = jest.fn().mockRejectedValue(new Error('AllProvidersFailedError'));
+    const svc = makeService(makeLlmRouter(true, callMock));
+    const result = await (svc as any).generateThesis(baseCand);
+    expect(result.summary).toContain('TopGainer BTCUSDT');
+    expect(result.category).toBe('flow_timing');
+    expect(result.conviction_score).toBe(7);
+  });
+
+  it('C: falls back when LLM returns malformed JSON', async () => {
+    const callMock = jest.fn().mockResolvedValue({
+      content: '{"summary":"incomplete',
+      providerId: 'gpt-4.1-nano',
+      costUsd: 0.00005,
+      latencyMs: 400,
+      fallbackUsed: true,
+    });
+    const svc = makeService(makeLlmRouter(true, callMock));
+    const result = await (svc as any).generateThesis(baseCand);
+    expect(result.summary).toContain('TopGainer BTCUSDT');
+    expect(result.category).toBe('flow_timing');
+  });
+});

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -321,6 +321,9 @@ export class TopGainersScannerService implements OnModuleInit {
 
     if (top.length === 0) return;
 
+    // P18 — LLM re-ranking (inert when SCANNER_LLM_ROUTER_ENABLED=false)
+    const rankedTop = await this.rankCandidates(top);
+
     // P9-UX — Pour chaque portfolio, gate par per-portfolio cycle puis scan.
     const now = Date.now();
     for (const cfg of configs) {
@@ -333,7 +336,7 @@ export class TopGainersScannerService implements OnModuleInit {
           continue;
         }
         this.lastScanByPortfolio.set(portfolioId, now);
-        await this.scanPortfolio(cfg.user_id as string, portfolioId, top);
+        await this.scanPortfolio(cfg.user_id as string, portfolioId, rankedTop);
       } catch (e) {
         this.logger.warn(
           `[top-gainers] portfolio ${portfolioId.slice(0, 8)} failed: ${String(e).slice(0, 120)}`,
@@ -540,6 +543,15 @@ export class TopGainersScannerService implements OnModuleInit {
         continue;
       }
 
+      // P18 — LLM signal validation (inert when SCANNER_LLM_ROUTER_ENABLED=false)
+      const signal = await this.analyzeSignal(cand, persistence);
+      if (!signal.pass) {
+        this.logger.log(
+          `[top-gainers:signal] ${cand.symbol} rejected (quality=${signal.signal_quality.toFixed(2)}): ${signal.reason}`,
+        );
+        continue;
+      }
+
       const insertedPosId = await this.openTopGainerPosition(
         userId,
         portfolioId,
@@ -574,13 +586,15 @@ export class TopGainersScannerService implements OnModuleInit {
     const proposalId = randomUUID();
     const thesisId = randomUUID();
 
-    // Pseudo-thèse minimale + pseudo-allocation 30% capital.
+    // P18 — LLM thesis generation (inert when SCANNER_LLM_ROUTER_ENABLED=false)
+    const llmThesis = await this.generateThesis(cand);
+
     const thesis = {
       id: thesisId,
-      summary: `TopGainer ${cand.symbol} +${cand.changePct.toFixed(1)}% (${cand.assetClass})`,
+      summary: llmThesis.summary,
       conviction: 0.7,
-      conviction_score: 7,
-      category: 'flow_timing',
+      conviction_score: llmThesis.conviction_score,
+      category: llmThesis.category,
       kind: 'momentum',
       preferredExpressionIndex: 0,
       expressions: [
@@ -694,6 +708,129 @@ export class TopGainersScannerService implements OnModuleInit {
       persistence_count_at_entry: persistence.persistenceCount,
       tf_changes_at_entry: tfChanges,
     });
+  }
+
+  /**
+   * P18 — Analyse signal LLM : valide si le top candidat est un genuine momentum signal.
+   * Fallback déterministe (pass=true) si router off ou échec LLM — comportement P17 préservé.
+   */
+  private async analyzeSignal(
+    cand: TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass },
+    persistence: PersistenceResult,
+  ): Promise<{ pass: boolean; signal_quality: number; reason: string }> {
+    const fallback = { pass: true, signal_quality: 1.0, reason: 'deterministic_fallback' };
+    if (!this.llmRouter.isEnabled()) return fallback;
+    try {
+      const user = JSON.stringify({
+        symbol: cand.symbol,
+        assetClass: cand.assetClass,
+        exchange: cand.exchange,
+        changePct: cand.changePct,
+        price: cand.close,
+        volume: cand.volume,
+        avgVol50d: cand.avgVol50d,
+        persistenceScore: persistence.persistenceScore,
+        persistenceCount: persistence.persistenceCount,
+        tf1m: persistence.tf1m,
+        tf5m: persistence.tf5m,
+        tf10m: persistence.tf10m,
+        tf15m: persistence.tf15m,
+        tf30m: persistence.tf30m,
+        tf1h: persistence.tf1h,
+      });
+      const res = await this.llmRouter.call({
+        system:
+          'You are a momentum scanner validating top market gainers. Assess if this is a genuine momentum signal or noise (pump-and-dump, thin volume, etc.). Return ONLY a JSON object: {"pass":true,"signal_quality":0.85,"reason":"brief reason max 60 chars"}. signal_quality in [0,1]. Set pass=false when signal_quality<0.4.',
+        user,
+        temperature: 0.1,
+        maxTokens: 128,
+      });
+      const parsed = JSON.parse(res.content) as { pass: boolean; signal_quality: number; reason: string };
+      this.logger.log(
+        `[scanner-llm:signal] symbol=${cand.symbol} provider=${res.providerId} latencyMs=${res.latencyMs} costUsd=${res.costUsd.toFixed(6)} pass=${parsed.pass} signal_quality=${parsed.signal_quality}`,
+      );
+      return parsed;
+    } catch (e) {
+      this.logger.warn(`[scanner-llm:signal] ${cand.symbol} failed — deterministic fallback: ${String(e).slice(0, 100)}`);
+      return fallback;
+    }
+  }
+
+  /**
+   * P18 — Re-ranking LLM : réordonne les top candidats par probabilité de continuation.
+   * Fallback : ordre déterministe si router off ou échec LLM — comportement P17 préservé.
+   */
+  private async rankCandidates(
+    top: Array<TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass }>,
+  ): Promise<Array<TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass }>> {
+    if (!this.llmRouter.isEnabled() || top.length <= 1) return top;
+    try {
+      const user = JSON.stringify(
+        top.map((c) => ({ symbol: c.symbol, assetClass: c.assetClass, changePct: c.changePct, score: c.score, exchange: c.exchange })),
+      );
+      const res = await this.llmRouter.call({
+        system:
+          'You are a momentum scanner. Re-rank these candidates by expected momentum continuation probability. Return ONLY a JSON array of symbols in rank order, most promising first. Example: ["BTCUSDT","AAPL"]. Preserve all symbols.',
+        user,
+        temperature: 0.1,
+        maxTokens: 128,
+      });
+      const ranked: string[] = JSON.parse(res.content);
+      const reordered = [
+        ...ranked
+          .map((sym) => top.find((c) => c.symbol === sym))
+          .filter((c): c is TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass } => c !== undefined),
+        ...top.filter((c) => !ranked.includes(c.symbol)),
+      ];
+      const reordering = ranked.join(',') !== top.map((c) => c.symbol).join(',');
+      this.logger.log(
+        `[scanner-llm:ranking] symbols=${top.map((c) => c.symbol).join(',')} provider=${res.providerId} latencyMs=${res.latencyMs} costUsd=${res.costUsd.toFixed(6)} reordered=${reordering}`,
+      );
+      return reordered;
+    } catch (e) {
+      this.logger.warn(`[scanner-llm:ranking] failed — deterministic order preserved: ${String(e).slice(0, 100)}`);
+      return top;
+    }
+  }
+
+  /**
+   * P18 — Génération de thèse LLM : produit un résumé descriptif pour la position.
+   * Fallback : template déterministe si router off ou échec LLM — comportement P17 préservé.
+   */
+  private async generateThesis(
+    cand: TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass },
+  ): Promise<{ summary: string; category: string; conviction_score: number }> {
+    const fallback = {
+      summary: `TopGainer ${cand.symbol} +${cand.changePct.toFixed(1)}% (${cand.assetClass})`,
+      category: 'flow_timing',
+      conviction_score: 7,
+    };
+    if (!this.llmRouter.isEnabled()) return fallback;
+    try {
+      const user = JSON.stringify({
+        symbol: cand.symbol,
+        assetClass: cand.assetClass,
+        changePct: cand.changePct,
+        exchange: cand.exchange,
+        score: cand.score,
+        volume: cand.volume,
+      });
+      const res = await this.llmRouter.call({
+        system:
+          'You are a momentum trading thesis writer. Write a concise intraday thesis for this top gainer. Return ONLY JSON: {"summary":"one-line thesis max 100 chars","category":"flow_timing|technical_breakout|momentum","conviction_score":7}. conviction_score 1-10.',
+        user,
+        temperature: 0.2,
+        maxTokens: 128,
+      });
+      const parsed = JSON.parse(res.content) as { summary: string; category: string; conviction_score: number };
+      this.logger.log(
+        `[scanner-llm:thesis] symbol=${cand.symbol} provider=${res.providerId} latencyMs=${res.latencyMs} costUsd=${res.costUsd.toFixed(6)} category=${parsed.category} conviction=${parsed.conviction_score}`,
+      );
+      return parsed;
+    } catch (e) {
+      this.logger.warn(`[scanner-llm:thesis] ${cand.symbol} failed — deterministic fallback: ${String(e).slice(0, 100)}`);
+      return fallback;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Wires `ScannerLlmRouterService` (P17) into `TopGainersScannerService` at the 3 natural call sites. All calls are gated behind `SCANNER_LLM_ROUTER_ENABLED` — **zero regression when flag is off** (current deterministic behaviour is the fallback for every call site).

### Call site 1 — `analyzeSignal()` (per candidate, after persistence gate)
Validates each top candidate before opening a position. Rejects if `signal_quality < 0.4` (pump-and-dump / thin-volume filter). Prompt asks for `{"pass", "signal_quality", "reason"}`.
**Fallback:** `pass=true` → current behaviour preserved.

### Call site 2 — `rankCandidates()` (batch, after `selectTopGainers`)
Re-orders the top-3 deterministic candidates by LLM-estimated momentum continuation probability. Symbols missing from LLM response are appended in original order (gap-fill).
**Fallback:** deterministic `selectTopGainers` order → current behaviour preserved.

### Call site 3 — `generateThesis()` (per position, inside `openTopGainerPosition`)
Generates a descriptive one-line thesis (`summary`, `category`, `conviction_score`) instead of the hardcoded template string.
**Fallback:** `TopGainer {symbol} +X% (assetClass)` template → current behaviour preserved.

### Structured logs for observability A/B
```
[scanner-llm:signal]  symbol=BTCUSDT provider=gemini-flash-lite latencyMs=800 costUsd=0.000110 pass=true signal_quality=0.87
[scanner-llm:ranking] symbols=BTCUSDT,ETHUSDT,SOLUSDT provider=gemini-flash-lite latencyMs=920 costUsd=0.000130 reordered=true
[scanner-llm:thesis]  symbol=BTCUSDT provider=gemini-flash-lite latencyMs=750 costUsd=0.000120 category=technical_breakout conviction=9
```

### Tests — 14/14 passing
Covers all 3 call sites × 3 scenarios:
- **A** — router disabled → deterministic fallback
- **B** — router enabled, LLM succeeds → parsed response used + prompt params asserted
- **C** — router enabled, LLM throws / invalid JSON → deterministic fallback (resilience)

## How to enable
```bash
fly secrets set SCANNER_LLM_ROUTER_ENABLED=true GEMINI_API_KEY=... OPENAI_API_KEY=... MISTRAL_API_KEY=...
```
Current prod has `SCANNER_LLM_ROUTER_ENABLED=false` → no change until secrets are set.

## Test plan
- [ ] Review 3 call sites and fallback logic in `top-gainers-scanner.service.ts`
- [ ] Review 14 unit tests in `__tests__/top-gainers-scanner.llm.spec.ts`
- [ ] Verify typecheck passes (CI)
- [ ] Enable flag manually on Fly staging + watch `[scanner-llm:*]` log lines
- [ ] Confirm fallback path works by revoking API keys temporarily

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_