### PR TITLE
feat(p18b): bootstrap workflow_dispatch to push scanner LLM router secrets to Fly

### DIFF
--- a/.github/workflows/fly-set-router-secrets.yml
+++ b/.github/workflows/fly-set-router-secrets.yml
@@ -1,0 +1,49 @@
+name: Fly — Set Scanner LLM Router Secrets
+
+# P18b — Bootstrap workflow_dispatch pour pousser les secrets du scanner LLM
+# router (P17/P18) vers l'app Fly `smartvest`. Manuel uniquement — pas de
+# trigger sur push pour éviter de re-staguer les secrets à chaque commit.
+#
+# Secrets requis dans GitHub repository secrets :
+#   - FLY_API_TOKEN  : token Fly avec scope deploy/secrets sur l'app smartvest
+#   - GEMINI_API_KEY : Google AI (gemini-2.5-flash-lite)
+#   - OPENAI_API_KEY : OpenAI (gpt-4.1-nano)
+#   - MISTRAL_API_KEY: Mistral La Plateforme (codestral-latest)
+#
+# `flyctl secrets set` SANS `--stage` déclenche un restart machine immédiat —
+# c'est volontaire ici (on veut activer le router sans re-déployer le binaire).
+#
+# Note : ANTHROPIC_API_KEY est déjà sur Fly (utilisé par Lisa) et sert de
+# fallback ultime dans la chain — pas besoin de le re-pousser.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: fly-set-router-secrets
+  cancel-in-progress: false
+
+jobs:
+  set-secrets:
+    name: Set router secrets on Fly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Set secrets (triggers machine restart)
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl secrets set \
+            SCANNER_LLM_ROUTER_ENABLED=true \
+            GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }} \
+            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} \
+            MISTRAL_API_KEY=${{ secrets.MISTRAL_API_KEY }} \
+            --app smartvest \
+            --stage=false
+
+      - name: Confirm secrets are set (names only, never values)
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl secrets list --app smartvest


### PR DESCRIPTION
## Summary

Bootstrap PR ahead of P18 (PR #78). Adds a manual-only `workflow_dispatch` GitHub Action that pushes the 4 scanner-LLM-router secrets to Fly using the GitHub repository secrets already configured by the user.

`flyctl secrets set --stage=false` triggers an immediate Fly machine restart, activating the router without a redeploy.

## Order of operations
1. Merge this PR (the workflow becomes available on `main`)
2. Trigger the workflow manually → Fly machine restarts with new env
3. **Then** merge PR #78 (P18 wiring) → wired code goes live with credentials already in place

Reverse order would deploy wired code in prod without credentials → router would silently fall back to deterministic path with `[scanner-llm:*]` warnings on every cycle.

## What ends up on Fly
| Secret | Value source |
|---|---|
| `SCANNER_LLM_ROUTER_ENABLED` | hardcoded `true` |
| `GEMINI_API_KEY` | `secrets.GEMINI_API_KEY` |
| `OPENAI_API_KEY` | `secrets.OPENAI_API_KEY` |
| `MISTRAL_API_KEY` | `secrets.MISTRAL_API_KEY` |

`ANTHROPIC_API_KEY` is already on Fly (used by Lisa) and serves as the ultimate fallback — not re-pushed.

## Test plan
- [x] CI typecheck + Jest stay green (workflow file only, no code touched)
- [ ] After merge: trigger `Fly — Set Scanner LLM Router Secrets` via Actions tab
- [ ] Confirm exit code 0 + `flyctl secrets list` shows the 4 secrets
- [ ] Tail `fly logs --app smartvest` and grep `scanner-llm` to see the chain log on next restart

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_