### PR TITLE
fix(p18c): EODHD screener returns HTTP 422 on every exchange (filters array + field names)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * P18c — Regression tests for the EODHD screener URL construction.
+ *
+ * Bug observed in prod (29/04/2026): every exchange returned HTTP 422
+ * because the URL had:
+ *   - `exchange` as a separate query param (must be inside `filters` array)
+ *   - `change_p` as a filter field (must be `refund_1d_p`)
+ *   - `close` as a filter field (must be `adjusted_close`)
+ *
+ * These tests intercept `global.fetch` and assert the URL contains the
+ * correct EODHD filter format so the bug cannot regress silently.
+ */
+
+import { Logger } from '@nestjs/common';
+import { TopGainersScannerService } from '../services/top-gainers-scanner.service';
+import { ScannerLlmRouterService } from '../services/scanner-llm-router.service';
+
+// ── Stubs ──────────────────────────────────────────────────────────────────
+const mockSupabase = { getClient: jest.fn() } as any;
+const mockLisa = {} as any;
+const mockDecisionLog = {} as any;
+const mockConfig = { get: jest.fn() } as any;
+const mockBinance = {} as any;
+const mockScheduler = {
+  getCronJob: jest.fn().mockImplementation(() => { throw new Error('not found'); }),
+  addCronJob: jest.fn(),
+} as any;
+const mockMtf = {} as any;
+const mockLlmRouter = { isEnabled: jest.fn().mockReturnValue(false), call: jest.fn() } as any;
+
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+function makeService(): TopGainersScannerService {
+  mockConfig.get.mockImplementation((key: string) => (key === 'SCAN_INTERVAL_MINUTES' ? '15' : undefined));
+  return new TopGainersScannerService(
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter,
+  );
+}
+
+describe('fetchEodhdScreener — URL construction (P18c regression guard)', () => {
+  const realFetch = global.fetch;
+  let capturedUrl: string | undefined;
+
+  beforeEach(() => {
+    capturedUrl = undefined;
+    global.fetch = jest.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [] }),
+        text: async () => '',
+      } as unknown as Response;
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it('passes exchange INSIDE the filters array (lowercase), not as a separate query param', async () => {
+    const svc = makeService();
+    await (svc as any).fetchEodhdScreener('US', 'test-key');
+    expect(capturedUrl).toBeDefined();
+    const decoded = decodeURIComponent(capturedUrl!);
+
+    // Must NOT have `&exchange=` query param
+    expect(decoded).not.toMatch(/[?&]exchange=/);
+    // MUST have ["exchange","=","us"] inside the filters array (lowercase)
+    expect(decoded).toContain('["exchange","=","us"]');
+  });
+
+  it('lowercases exchange code (e.g. XETRA → xetra)', async () => {
+    const svc = makeService();
+    await (svc as any).fetchEodhdScreener('XETRA', 'test-key');
+    const decoded = decodeURIComponent(capturedUrl!);
+    expect(decoded).toContain('["exchange","=","xetra"]');
+    expect(decoded).not.toContain('XETRA');
+  });
+
+  it('uses refund_1d_p (NOT change_p) as the daily-change filter field', async () => {
+    const svc = makeService();
+    await (svc as any).fetchEodhdScreener('US', 'test-key');
+    const decoded = decodeURIComponent(capturedUrl!);
+    expect(decoded).toContain('["refund_1d_p",">",3]');
+    // change_p must NOT appear as a filter field key
+    expect(decoded).not.toMatch(/\["change_p","[<>=]"/);
+  });
+
+  it('uses adjusted_close (NOT close) as the price filter field', async () => {
+    const svc = makeService();
+    await (svc as any).fetchEodhdScreener('US', 'test-key');
+    const decoded = decodeURIComponent(capturedUrl!);
+    expect(decoded).toContain('["adjusted_close",">",1]');
+    expect(decoded).not.toMatch(/\["close","[<>=]"/);
+  });
+
+  it('keeps avgvol_200d filter (still a valid EODHD filter field)', async () => {
+    const svc = makeService();
+    await (svc as any).fetchEodhdScreener('US', 'test-key');
+    const decoded = decodeURIComponent(capturedUrl!);
+    expect(decoded).toContain('["avgvol_200d",">",100000]');
+  });
+
+  it('sorts by refund_1d_p.desc (NOT change_p.desc)', async () => {
+    const svc = makeService();
+    await (svc as any).fetchEodhdScreener('US', 'test-key');
+    const decoded = decodeURIComponent(capturedUrl!);
+    expect(decoded).toContain('sort=refund_1d_p.desc');
+    expect(decoded).not.toContain('sort=change_p.desc');
+  });
+
+  it('logs HTTP error body at warn level for diagnostic (was debug, now warn)', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn');
+    warnSpy.mockClear();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: async () => '{"error":"invalid filter field: change_p"}',
+    } as unknown as Response);
+    const svc = makeService();
+    const result = await (svc as any).fetchEodhdScreener('US', 'test-key');
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalled();
+    const lastCall = warnSpy.mock.calls.find((c) => String(c[0]).includes('HTTP 422'));
+    expect(lastCall).toBeDefined();
+    expect(String(lastCall![0])).toContain('invalid filter field');
+  });
+});
+
+describe('mapEodhdRow — accepts both filter-form and legacy field names', () => {
+  it('reads refund_1d_p (preferred) when present', () => {
+    const svc = makeService();
+    const row = { code: 'AAPL', last_price: 180, refund_1d_p: 4.2, volume: 1000 } as any;
+    const result = (svc as any).mapEodhdRow(row, 'US');
+    expect(result.changePct).toBe(4.2);
+  });
+
+  it('falls back to change_p when refund_1d_p is missing (legacy response shape)', () => {
+    const svc = makeService();
+    const row = { code: 'AAPL', last_price: 180, change_p: 3.7, volume: 1000 } as any;
+    const result = (svc as any).mapEodhdRow(row, 'US');
+    expect(result.changePct).toBe(3.7);
+  });
+
+  it('reads adjusted_close (preferred) when present', () => {
+    const svc = makeService();
+    const row = { code: 'AAPL', adjusted_close: 175, refund_1d_p: 2.1 } as any;
+    const result = (svc as any).mapEodhdRow(row, 'US');
+    expect(result.close).toBe(175);
+  });
+
+  it('falls back to last_price when adjusted_close is missing', () => {
+    const svc = makeService();
+    const row = { code: 'AAPL', last_price: 178, refund_1d_p: 2.1 } as any;
+    const result = (svc as any).mapEodhdRow(row, 'US');
+    expect(result.close).toBe(178);
+  });
+});

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -45,12 +45,17 @@ interface EodhdScreenerRow {
   exchange_short?: string;
   exchange?: string;
   last_price?: number | string;
+  adjusted_close?: number | string;
   high_price?: number | string;
   high?: number | string;
   low_price?: number | string;
   open?: number | string;
+  /** Filter form (new, validated against EODHD doc). */
+  refund_1d_p?: number | string;
+  /** Legacy / response form — sometimes present alongside `refund_1d_p`. */
   change_p?: number | string;
   volume?: number | string;
+  avgvol_1d?: number | string;
   avgvol_50d?: number | string;
   avgvol_200d?: number | string;
   market_capitalization?: number | string;
@@ -375,20 +380,35 @@ export class TopGainersScannerService implements OnModuleInit {
   }
 
   /**
-   * EODHD Screener API : top gainers > 5% par exchange.
+   * EODHD Screener API : top gainers par exchange.
+   *
+   * P18c — fix HTTP 422 sur tous les marchés. Causes :
+   *   1) `exchange` doit être DANS le tableau `filters` (lowercase), pas en
+   *      query param séparé.
+   *   2) `change_p` n'est pas un filter field valide → `refund_1d_p`.
+   *   3) `close` n'est pas un filter field valide → `adjusted_close`.
+   *   4) Le sort key doit aussi être `refund_1d_p.desc`.
+   *
    * Doc : https://eodhd.com/financial-apis/stock-market-screener-api
    */
   private async fetchEodhdScreener(exchange: string, apiKey: string): Promise<TopGainerCandidate[]> {
+    const exLower = exchange.toLowerCase();
     const filters = encodeURIComponent(JSON.stringify([
-      ['change_p', '>', 3],
-      ['close', '>', 1],
+      ['exchange', '=', exLower],
+      ['refund_1d_p', '>', 3],
+      ['adjusted_close', '>', 1],
       ['avgvol_200d', '>', 100_000],
     ]));
-    const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}&exchange=${encodeURIComponent(exchange)}&sort=change_p.desc&limit=20&fmt=json`;
+    const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}&sort=refund_1d_p.desc&limit=20&offset=0&fmt=json`;
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
       if (!res.ok) {
-        this.logger.debug(`[top-gainers] eodhd ${exchange} HTTP ${res.status}`);
+        // P18c — log le body pour diagnostic (422 = champ filter invalide,
+        // 401 = token expiré, 403 = plan insuffisant). Tronqué à 200 char.
+        const body = await res.text().catch(() => '');
+        this.logger.warn(
+          `[top-gainers] eodhd ${exchange} HTTP ${res.status} — body: ${body.slice(0, 200)}`,
+        );
         return [];
       }
       const json = await res.json() as { data?: EodhdScreenerRow[] } | EodhdScreenerRow[];
@@ -405,10 +425,12 @@ export class TopGainersScannerService implements OnModuleInit {
   private mapEodhdRow(r: EodhdScreenerRow, exchange: string): TopGainerCandidate | null {
     const symbol = r.code;
     if (!symbol) return null;
-    const close = num(r.last_price);
+    // P18c — accepter les 2 conventions (filter form vs response form), la doc
+    // EODHD ne documente pas explicitement le schéma de réponse du screener.
+    const close = num(r.adjusted_close ?? r.last_price);
     const high = num(r.high_price ?? r.high) || close;
-    const changePct = num(r.change_p);
-    const volume = num(r.volume);
+    const changePct = num(r.refund_1d_p ?? r.change_p);
+    const volume = num(r.volume ?? r.avgvol_1d);
     const avgVol50d = num(r.avgvol_50d ?? r.avgvol_200d);
     const marketCap = num(r.market_capitalization ?? r.market_cap);
     if (!Number.isFinite(close) || close <= 0) return null;


### PR DESCRIPTION
## Bug en prod

Tous les cycles top-gainers loggent HTTP 422 sur **les 13 marchés** EODHD (US, LSE, XETRA, PA, TSE, HK, SW, AU, AMS, MI, NSE, MC, BSE). Conséquence : 0 candidat scanné → router LLM (P17/P18) jamais invoqué malgré flags green.

Pas un quota (14% used sur le plan All-In-One). Bug pur côté URL construction.

## Cause racine

3 erreurs dans `fetchEodhdScreener` — toutes confirmées par la doc EODHD officielle :

| # | Avant (cassé) | Après (correct) |
|---|---|---|
| 1 | `&exchange=US` query param | `["exchange","=","us"]` dans le tableau `filters`, lowercase |
| 2 | `["change_p",">",3]` filter | `["refund_1d_p",">",3]` (`change_p` n'est pas un filter field valide) |
| 3 | `["close",">",1]` filter | `["adjusted_close",">",1]` (`close` n'est pas un filter field valide) |

Le `sort=change_p.desc` est aussi corrigé en `sort=refund_1d_p.desc`.

## Bonus de robustesse

- **Logs 422/401/403 promus de `debug` à `warn`** avec le body de la réponse tronqué — la prochaine régression provider ne sera pas silencieuse.
- **`mapEodhdRow` défensif** sur les noms de champs réponse (la doc EODHD ne documente PAS le schéma de réponse du screener) : essaie `refund_1d_p` puis fallback `change_p` ; essaie `adjusted_close` puis fallback `last_price`.

## Tests

11 nouveaux tests de régression dans `top-gainers-scanner.eodhd.spec.ts` :
- URL ne contient PAS `&exchange=` query param
- URL contient `["exchange","=","us"]` (lowercase forcé : XETRA → xetra)
- Filter field = `refund_1d_p`, pas `change_p`
- Filter field = `adjusted_close`, pas `close`
- `avgvol_200d` toujours présent (filter valide)
- `sort=refund_1d_p.desc`
- 422 body loggé en `warn` avec le contenu

Combiné avec les 14 tests P18 LLM call sites = **25/25 green**.

## Effet attendu post-deploy

Au prochain cycle scanner (15 min, 24/7) :
```
[top-gainers] 200+ scanned → 3 retained: AAPL(us_equity_large_cap, +5.2%, score=0.83), ...
[scanner-llm:ranking] symbols=AAPL,NVDA,MSFT provider=gemini-flash-lite latencyMs=820 ...
[scanner-llm:signal]  symbol=AAPL provider=gemini-flash-lite pass=true signal_quality=0.88
[scanner-llm:thesis]  symbol=AAPL provider=gemini-flash-lite category=technical_breakout conviction=8
```

## Test plan
- [ ] CI typecheck + Jest 25/25 vert
- [ ] Auto-merge per CLAUDE.md rule
- [ ] Watch `fly logs --app smartvest | grep "top-gainers\|scanner-llm"` after deploy
- [ ] Confirm 422 disparaît + candidates remontent + router LLM invoqué

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_