### PR TITLE
[P18e] MTF log throttle + market pre-filter

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p18e.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p18e.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * P18e — Tests for log throttling + market pre-filter + counters.
+ *
+ * Three regression scenarios (issue from Fly logs 09:14:46–09:15:03 UTC) :
+ *   1. 50 unsupported / no-data tickers in one batch → ONE aggregated log line
+ *      (not 50 per-symbol debug lines)
+ *   2. Pre-filter unsupported equity exchange (e.g. "TO" Toronto, "NSE" India)
+ *      → no EODHD call + counter increment
+ *   3. Counters cumulatives `noIntradayCounter` and
+ *      `skippedUnsupportedMarketCounter` are correct after multiple batches
+ */
+
+import { Logger } from '@nestjs/common';
+import { MultiTimeframePersistenceService } from '../services/multi-tf-persistence.service';
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+const mockBinance = {
+  toBinanceSymbol: jest.fn().mockImplementation((s: string) => s),
+  getKlines: jest.fn(),
+} as any;
+
+const mockEodhd = {
+  getCandles: jest.fn(),
+} as any;
+
+const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+const debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+beforeEach(() => {
+  logSpy.mockClear();
+  debugSpy.mockClear();
+  warnSpy.mockClear();
+  mockBinance.getKlines.mockReset();
+  mockEodhd.getCandles.mockReset();
+});
+
+function makeService(): MultiTimeframePersistenceService {
+  return new MultiTimeframePersistenceService(mockBinance, mockEodhd);
+}
+
+// ── 1. Aggregated log — single line for N misses ─────────────────────────────
+
+describe('analyzeBatch — log throttling', () => {
+  it('emits ONE aggregated log line for 50 tickers without intraday data (was 50 debug lines)', async () => {
+    // All EODHD calls return null/empty → no data
+    mockEodhd.getCandles.mockResolvedValue(null);
+
+    const candidates = Array.from({ length: 50 }, (_, i) => ({
+      symbol: `TICK${i}`,
+      exchange: 'US',
+      currentPrice: 100,
+    }));
+
+    const svc = makeService();
+    const result = await svc.analyzeBatch(candidates);
+
+    expect(result.size).toBe(0);
+    // Find the aggregated log line
+    const aggregateLogs = logSpy.mock.calls.filter((c) =>
+      String(c[0]).includes('[mtf-persist] no intraday for'),
+    );
+    expect(aggregateLogs.length).toBe(1);
+    const logMsg = String(aggregateLogs[0][0]);
+    expect(logMsg).toContain('50 tickers');
+    expect(logMsg).toContain('sample:');
+    // Counter should reflect all 50 misses
+    expect(svc.getNoIntradayCounter()).toBe(50);
+  });
+
+  it('does not emit the aggregated log when batch has 0 misses', async () => {
+    // Return a valid candle series for every call
+    const fakeCandles = Array.from({ length: 13 }, (_, i) => ({
+      datetime: `2026-04-29 ${String(9 + Math.floor(i / 12)).padStart(2, '0')}:${String((i % 12) * 5).padStart(2, '0')}:00`,
+      open: 100 + i,
+      high: 101 + i,
+      low: 99 + i,
+      close: 100 + i,
+      volume: 1000,
+    }));
+    mockEodhd.getCandles.mockResolvedValue({ candles: fakeCandles });
+
+    const svc = makeService();
+    await svc.analyzeBatch([
+      { symbol: 'AAPL', exchange: 'US', currentPrice: 105 },
+    ]);
+
+    const aggregateLogs = logSpy.mock.calls.filter((c) =>
+      String(c[0]).includes('[mtf-persist] no intraday'),
+    );
+    expect(aggregateLogs.length).toBe(0);
+  });
+
+  it('emits no per-symbol "no eodhd intraday" debug spam (was 1 line per ticker)', async () => {
+    mockEodhd.getCandles.mockResolvedValue(null);
+
+    const svc = makeService();
+    await svc.analyzeBatch([
+      { symbol: 'AAA', exchange: 'US', currentPrice: 100 },
+      { symbol: 'BBB', exchange: 'US', currentPrice: 200 },
+      { symbol: 'CCC', exchange: 'US', currentPrice: 300 },
+    ]);
+
+    // The legacy spam pattern was: `[mtf-persist] <symbol> no eodhd intraday`
+    // It must NEVER appear (replaced by the aggregated log line).
+    const allCalls = [
+      ...logSpy.mock.calls,
+      ...debugSpy.mock.calls,
+      ...warnSpy.mock.calls,
+    ];
+    const legacySpam = allCalls.filter((c) =>
+      /\[mtf-persist\] (AAA|BBB|CCC) no eodhd intraday/.test(String(c[0])),
+    );
+    expect(legacySpam.length).toBe(0);
+
+    // The aggregate log IS expected (single line for all 3)
+    const aggregateLog = logSpy.mock.calls.filter((c) =>
+      String(c[0]).startsWith('[mtf-persist] no intraday for'),
+    );
+    expect(aggregateLog.length).toBe(1);
+  });
+});
+
+// ── 2. Market pre-filter ─────────────────────────────────────────────────────
+
+describe('analyzeBatch — market pre-filter', () => {
+  it('does NOT call EODHD for tickers from unsupported exchanges (TO, NSE, BSE)', async () => {
+    const svc = makeService();
+    await svc.analyzeBatch([
+      { symbol: 'SHOP', exchange: 'TO', currentPrice: 100 }, // Toronto — unsupported
+      { symbol: 'RELIANCE', exchange: 'NSE', currentPrice: 200 },
+      { symbol: 'TCS', exchange: 'BSE', currentPrice: 3500 },
+    ]);
+
+    expect(mockEodhd.getCandles).not.toHaveBeenCalled();
+    expect(svc.getSkippedUnsupportedMarketCounter()).toBe(3);
+  });
+
+  it('DOES call EODHD for supported equity exchanges (US, LSE, XETRA, PA, TSE, HK)', async () => {
+    mockEodhd.getCandles.mockResolvedValue(null);
+
+    const svc = makeService();
+    await svc.analyzeBatch([
+      { symbol: 'AAPL', exchange: 'US', currentPrice: 100 },
+      { symbol: 'SHEL', exchange: 'LSE', currentPrice: 25 },
+      { symbol: 'SAP', exchange: 'XETRA', currentPrice: 200 },
+      { symbol: 'AIR', exchange: 'PA', currentPrice: 150 },
+      { symbol: '7203', exchange: 'TSE', currentPrice: 2500 },
+      { symbol: '0700', exchange: 'HK', currentPrice: 350 },
+    ]);
+
+    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(6);
+    expect(svc.getSkippedUnsupportedMarketCounter()).toBe(0);
+  });
+
+  it('crypto tickers (BINANCE / *USDT) bypass the equity pre-filter', async () => {
+    mockBinance.getKlines.mockResolvedValue([]);  // no klines → no data
+
+    const svc = makeService();
+    await svc.analyzeBatch([
+      { symbol: 'BTCUSDT', exchange: 'BINANCE', currentPrice: 65000 },
+      { symbol: 'ETHUSDT', exchange: 'BINANCE', currentPrice: 3500 },
+    ]);
+
+    expect(mockBinance.getKlines).toHaveBeenCalledTimes(2);
+    // Crypto did NOT increment unsupported-market counter
+    expect(svc.getSkippedUnsupportedMarketCounter()).toBe(0);
+  });
+
+  it('mixes supported equity + unsupported equity + crypto in one batch correctly', async () => {
+    mockEodhd.getCandles.mockResolvedValue(null);
+    mockBinance.getKlines.mockResolvedValue(null);
+
+    const svc = makeService();
+    await svc.analyzeBatch([
+      { symbol: 'AAPL', exchange: 'US', currentPrice: 180 },         // supported equity
+      { symbol: 'SHOP', exchange: 'TO', currentPrice: 100 },          // unsupported
+      { symbol: 'BTCUSDT', exchange: 'BINANCE', currentPrice: 65000 }, // crypto
+      { symbol: 'TCS', exchange: 'BSE', currentPrice: 3500 },          // unsupported
+    ]);
+
+    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(1);  // only AAPL
+    expect(mockBinance.getKlines).toHaveBeenCalledTimes(1); // only BTCUSDT
+    expect(svc.getSkippedUnsupportedMarketCounter()).toBe(2); // SHOP + TCS
+    expect(svc.getNoIntradayCounter()).toBe(2);  // AAPL + BTCUSDT (both null)
+  });
+});
+
+// ── 3. Counters cumulative across batches ───────────────────────────────────
+
+describe('counters', () => {
+  it('noIntradayCounter is cumulative across multiple batches', async () => {
+    mockEodhd.getCandles.mockResolvedValue(null);
+
+    const svc = makeService();
+    await svc.analyzeBatch([{ symbol: 'A', exchange: 'US', currentPrice: 100 }]);
+    expect(svc.getNoIntradayCounter()).toBe(1);
+    await svc.analyzeBatch([
+      { symbol: 'B', exchange: 'US', currentPrice: 100 },
+      { symbol: 'C', exchange: 'US', currentPrice: 100 },
+    ]);
+    expect(svc.getNoIntradayCounter()).toBe(3);
+  });
+
+  it('skippedUnsupportedMarketCounter is cumulative across multiple batches', async () => {
+    const svc = makeService();
+    await svc.analyzeBatch([{ symbol: 'X', exchange: 'TO', currentPrice: 100 }]);
+    expect(svc.getSkippedUnsupportedMarketCounter()).toBe(1);
+    await svc.analyzeBatch([
+      { symbol: 'Y', exchange: 'NSE', currentPrice: 100 },
+      { symbol: 'Z', exchange: 'BSE', currentPrice: 100 },
+    ]);
+    expect(svc.getSkippedUnsupportedMarketCounter()).toBe(3);
+  });
+
+  it('resetCounters() clears both', async () => {
+    mockEodhd.getCandles.mockResolvedValue(null);
+
+    const svc = makeService();
+    await svc.analyzeBatch([
+      { symbol: 'A', exchange: 'US', currentPrice: 100 },
+      { symbol: 'B', exchange: 'TO', currentPrice: 100 },
+    ]);
+    expect(svc.getNoIntradayCounter()).toBe(1);
+    expect(svc.getSkippedUnsupportedMarketCounter()).toBe(1);
+    svc.resetCounters();
+    expect(svc.getNoIntradayCounter()).toBe(0);
+    expect(svc.getSkippedUnsupportedMarketCounter()).toBe(0);
+  });
+});

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18e-skip-summary.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18e-skip-summary.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * P18e — Tests for TopGainersScanner aggregated cycle skip-summary log.
+ *
+ * Bug observed in Fly logs 09:14–09:15 UTC : N lines `[top-gainers] <T> no
+ * persistence data → skip` per cycle, polluting the log stream.
+ *
+ * P18e replaces them with ONE line per cycle :
+ *   `[top-gainers] cycle skip-summary: scanned=N, retained=R, skipped_no_persistence=S (sample: A, B, C)`
+ */
+
+import { Logger } from '@nestjs/common';
+import { TopGainersScannerService } from '../services/top-gainers-scanner.service';
+import { ScannerLlmRouterService } from '../services/scanner-llm-router.service';
+import type { TopGainerCandidate, TopGainerAssetClass } from '@smartvest/ai-analyst';
+
+// ── Stubs ────────────────────────────────────────────────────────────────
+
+const supabaseFromMock = jest.fn();
+const mockSupabase = { getClient: () => ({ from: supabaseFromMock }) } as any;
+const mockLisa = {
+  approveProposal: jest.fn().mockResolvedValue({ openedPositions: [] }),
+} as any;
+const mockDecisionLog = {} as any;
+const mockConfig = { get: jest.fn() } as any;
+const mockBinance = { getTicker24h: jest.fn().mockResolvedValue(null) } as any;
+const mockScheduler = {
+  getCronJob: jest.fn().mockImplementation(() => { throw new Error('not found'); }),
+  addCronJob: jest.fn(),
+} as any;
+const mockMtf = { analyzeBatch: jest.fn() } as any;
+const mockLlmRouter = { isEnabled: jest.fn().mockReturnValue(false), call: jest.fn() } as any;
+
+const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+
+beforeEach(() => {
+  logSpy.mockClear();
+  warnSpy.mockClear();
+  supabaseFromMock.mockReset();
+  mockMtf.analyzeBatch.mockReset();
+});
+
+function makeService(): TopGainersScannerService {
+  mockConfig.get.mockImplementation((key: string) => {
+    if (key === 'SCAN_INTERVAL_MINUTES') return '15';
+    return undefined;
+  });
+  return new TopGainersScannerService(
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter,
+  );
+}
+
+/**
+ * Mock the chained Supabase calls inside scanPortfolio:
+ *   getClient().from('lisa_positions').select(...).eq(...).eq(...) → openPositions
+ *   getClient().from('lisa_session_configs').select(...).eq(...).maybeSingle() → cfgRow
+ */
+function mockScanPortfolioSupabase(openPositions: any[] = []) {
+  supabaseFromMock.mockImplementation((table: string) => {
+    if (table === 'lisa_positions') {
+      const eq2 = jest.fn().mockResolvedValue({ data: openPositions, error: null });
+      const eq1 = jest.fn().mockReturnValue({ eq: eq2 });
+      const select = jest.fn().mockReturnValue({ eq: eq1 });
+      return { select };
+    }
+    if (table === 'lisa_session_configs') {
+      const maybeSingle = jest.fn().mockResolvedValue({ data: { gainers_min_persistence_score: null, gainers_min_path_efficiency: null }, error: null });
+      const eq = jest.fn().mockReturnValue({ maybeSingle });
+      const select = jest.fn().mockReturnValue({ eq });
+      return { select };
+    }
+    return { select: jest.fn() };
+  });
+}
+
+function makeCandidate(symbol: string): TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass } {
+  return {
+    symbol,
+    exchange: 'US',
+    close: 100,
+    high: 105,
+    changePct: 5,
+    volume: 1_000_000,
+    avgVol50d: 500_000,
+    marketCap: 1e10,
+    score: 0.7,
+    assetClass: 'us_equity_large',
+  };
+}
+
+// ── 1. Aggregated cycle log replaces per-symbol spam ────────────────────────
+
+describe('TopGainersScanner — cycle skip-summary log', () => {
+  it('emits ONE aggregated log line when ALL candidates have no persistence (was N lines)', async () => {
+    mockScanPortfolioSupabase();
+    // analyzeBatch returns empty Map → no candidate has persistence
+    mockMtf.analyzeBatch.mockResolvedValue(new Map());
+
+    const top = [
+      makeCandidate('AAA'),
+      makeCandidate('BBB'),
+      makeCandidate('CCC'),
+    ];
+    const svc = makeService();
+    await (svc as any).scanPortfolio('user-1', '11111111-1111-1111-1111-111111111111', top);
+
+    // Legacy per-symbol spam must not appear
+    const legacySpam = logSpy.mock.calls.filter((c) =>
+      /no persistence data → skip/.test(String(c[0])),
+    );
+    expect(legacySpam.length).toBe(0);
+
+    // Aggregated log IS emitted, exactly once
+    const aggregate = logSpy.mock.calls.filter((c) =>
+      String(c[0]).includes('[top-gainers] cycle skip-summary:'),
+    );
+    expect(aggregate.length).toBe(1);
+    const msg = String(aggregate[0][0]);
+    expect(msg).toContain('scanned=3');
+    expect(msg).toContain('skipped_no_persistence=3');
+    expect(msg).toContain('(sample: AAA');
+  });
+
+  it('does NOT emit the aggregated log when 0 candidates were skipped for no-persistence', async () => {
+    mockScanPortfolioSupabase();
+    // All candidates have persistence
+    mockMtf.analyzeBatch.mockResolvedValue(new Map([
+      ['AAA', { persistenceScore: 0.83, persistenceCount: '5/6', availableCount: 6, tf1m: 0.01, tf5m: 0.02, tf10m: 0.03, tf15m: 0.04, tf30m: 0.05, tf1h: 0.06, pathQuality: { overallEfficiency: 0.8, overallSmoothness: 'smooth' } }],
+    ]));
+    // approveProposal returns 0 opens (rejected by gates) so we don't end up in INSERT path
+    mockLisa.approveProposal.mockResolvedValue({ openedPositions: [] });
+
+    const top = [makeCandidate('AAA')];
+    const svc = makeService();
+    await (svc as any).scanPortfolio('user-1', '11111111-1111-1111-1111-111111111111', top);
+
+    const aggregate = logSpy.mock.calls.filter((c) =>
+      String(c[0]).includes('[top-gainers] cycle skip-summary:'),
+    );
+    expect(aggregate.length).toBe(0);
+  });
+
+  it('counter `getSkippedNoPersistenceCounter` increments correctly across cycles', async () => {
+    mockScanPortfolioSupabase();
+    mockMtf.analyzeBatch.mockResolvedValue(new Map());
+
+    const svc = makeService();
+    expect(svc.getSkippedNoPersistenceCounter()).toBe(0);
+
+    // Cycle 1 — 2 skipped
+    await (svc as any).scanPortfolio('u', 'p1', [makeCandidate('A'), makeCandidate('B')]);
+    expect(svc.getSkippedNoPersistenceCounter()).toBe(2);
+
+    // Cycle 2 — 3 skipped
+    await (svc as any).scanPortfolio('u', 'p2', [makeCandidate('X'), makeCandidate('Y'), makeCandidate('Z')]);
+    expect(svc.getSkippedNoPersistenceCounter()).toBe(5);
+  });
+
+  it('truncates sample to first 5 symbols even if 50 are skipped', async () => {
+    mockScanPortfolioSupabase();
+    mockMtf.analyzeBatch.mockResolvedValue(new Map());
+
+    const top = Array.from({ length: 50 }, (_, i) => makeCandidate(`T${i}`));
+    const svc = makeService();
+    await (svc as any).scanPortfolio('u', 'p', top);
+
+    const aggregate = logSpy.mock.calls.find((c) =>
+      String(c[0]).includes('[top-gainers] cycle skip-summary:'),
+    );
+    expect(aggregate).toBeDefined();
+    const msg = String(aggregate![0]);
+    expect(msg).toContain('skipped_no_persistence=50');
+    // Sample should contain first 5 (T0..T4) and not all 50
+    expect(msg).toMatch(/sample: T0, T1, T2, T3, T4/);
+    expect(msg).not.toContain('T49');
+  });
+});

--- a/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
+++ b/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
@@ -32,6 +32,23 @@ interface Candidate {
 }
 
 /**
+ * P18e — Marchés EODHD couverts par le plan All-In-One pour intraday 5m.
+ * Tout ticker dont l'exchange n'est pas dans cette liste sera skip
+ * silencieusement (avec compteur dédié) avant l'appel EODHD — économise
+ * les calls et les 422 sur tickers Toronto/India/etc. non supportés en intraday.
+ *
+ * Source : `EU_EXCHANGES` + `NON_EU_EXCHANGES` de `top-gainers-scanner.service.ts`
+ * (P18d), filtré aux exchanges où EODHD fournit des candles 5m.
+ */
+const SUPPORTED_EQUITY_EXCHANGES = new Set([
+  'US',
+  'LSE', 'XETRA', 'PA', 'SW', 'MI', 'MC', 'BME', 'AS', 'AMS',
+  'TSE', 'HK', 'AU', 'KO',
+]);
+// TO (Toronto) / NSE / BSE intraday souvent indisponible sur le plan EODHD courant
+// → pas dans la whitelist, skip pré-filtré.
+
+/**
  * P9-UX ADDENDUM — Path quality par TF (5/10/15/30/60m), dérivé des candles
  * 1m ou 5m natifs déjà fetchés pour persistence.
  */
@@ -64,10 +81,28 @@ export class MultiTimeframePersistenceService {
   private readonly logger = new Logger(MultiTimeframePersistenceService.name);
   private cache = new Map<string, CacheEntry>();
 
+  /** P18e — Compteur cumulatif des tickers sans intraday EODHD (visibilité). */
+  private noIntradayCounter = 0;
+  /** P18e — Compteur cumulatif des tickers skip pour exchange non supporté. */
+  private skippedUnsupportedMarketCounter = 0;
+
   constructor(
     private readonly binance: BinanceMarketService,
     private readonly eodhd: EodhdIntradayService,
   ) {}
+
+  /** P18e — Métriques cumulatives pour observability. */
+  getNoIntradayCounter(): number {
+    return this.noIntradayCounter;
+  }
+  getSkippedUnsupportedMarketCounter(): number {
+    return this.skippedUnsupportedMarketCounter;
+  }
+  /** Reset utilitaire pour tests. */
+  resetCounters(): void {
+    this.noIntradayCounter = 0;
+    this.skippedUnsupportedMarketCounter = 0;
+  }
 
   /**
    * Analyse un seul candidat. Retourne null si les données ne permettent
@@ -92,31 +127,108 @@ export class MultiTimeframePersistenceService {
    * les rate-limits (Binance 1200 weight/min, EODHD plan-dependent).
    *
    * Retourne un Map symbol→result. Les symboles sans donnée sont absents.
+   *
+   * P18e — Pré-filtre les equities dont l'exchange n'est pas dans la
+   * whitelist EODHD (compteur `skippedUnsupportedMarketCounter`). Les
+   * `null` retournés par `analyze` (no intraday) sont accumulés dans une
+   * Set locale puis loggés EN UNE LIGNE en fin de batch — élimine le
+   * spam debug par-symbole observé dans les logs Fly 09:14:46–09:15:03 UTC.
    */
   async analyzeBatch(candidates: Candidate[]): Promise<Map<string, PersistenceWithPath>> {
     const out = new Map<string, PersistenceWithPath>();
     if (candidates.length === 0) return out;
 
-    // Split crypto vs equity pour respecter les caps par source
+    // Split crypto vs equity + pré-filtre exchanges non supportés (P18e)
     const crypto: Candidate[] = [];
     const equity: Candidate[] = [];
+    const skippedUnsupported: string[] = [];
     for (const c of candidates) {
-      if (this.isCrypto(c)) crypto.push(c);
-      else equity.push(c);
+      if (this.isCrypto(c)) {
+        crypto.push(c);
+        continue;
+      }
+      const ex = String(c.exchange ?? 'US').toUpperCase();
+      if (!SUPPORTED_EQUITY_EXCHANGES.has(ex)) {
+        this.skippedUnsupportedMarketCounter++;
+        skippedUnsupported.push(`${c.symbol}@${ex}`);
+        continue;
+      }
+      equity.push(c);
     }
+    if (skippedUnsupported.length > 0) {
+      this.logger.debug(
+        `[mtf-persist] skipped_unsupported_market: ${skippedUnsupported.length} (sample: ${skippedUnsupported.slice(0, 3).join(', ')})`,
+      );
+    }
+
+    // Accumule les "no data" symbols pour log agrégé en fin de batch
+    const noIntradaySymbols: string[] = [];
+    const trackNoData = (c: Candidate) => {
+      this.noIntradayCounter++;
+      noIntradaySymbols.push(c.symbol);
+    };
 
     await Promise.all([
       this.runWithCap(crypto, MAX_PARALLEL_PER_SOURCE, async (c) => {
-        const r = await this.analyze(c).catch(() => null);
+        const r = await this.analyzeQuiet(c).catch(() => null);
         if (r) out.set(c.symbol.toUpperCase(), r);
+        else trackNoData(c);
       }),
       this.runWithCap(equity, MAX_PARALLEL_PER_SOURCE, async (c) => {
-        const r = await this.analyze(c).catch(() => null);
+        const r = await this.analyzeQuiet(c).catch(() => null);
         if (r) out.set(c.symbol.toUpperCase(), r);
+        else trackNoData(c);
       }),
     ]);
 
+    if (noIntradaySymbols.length > 0) {
+      const sample = noIntradaySymbols.slice(0, 5).join(', ');
+      this.logger.log(
+        `[mtf-persist] no intraday for ${noIntradaySymbols.length} tickers (sample: ${sample})`,
+      );
+    }
+
     return out;
+  }
+
+  /**
+   * P18e — Variante "quiet" de `analyze` sans logs debug par-symbole.
+   * Utilisée par `analyzeBatch` qui aggrège les misses en une seule ligne.
+   * `analyze()` (single-symbol) reste verbose pour le path UI.
+   */
+  private async analyzeQuiet(c: Candidate): Promise<PersistenceWithPath | null> {
+    const key = c.symbol.toUpperCase();
+    const cached = this.cache.get(key);
+    if (cached && Date.now() - cached.asOf < CACHE_TTL_MS) {
+      return cached.result;
+    }
+    const result = this.isCrypto(c)
+      ? await this.fetchCryptoPersistenceQuiet(c)
+      : await this.fetchEquityPersistenceQuiet(c);
+    if (result) {
+      this.cache.set(key, { result, asOf: Date.now() });
+    }
+    return result;
+  }
+
+  private async fetchCryptoPersistenceQuiet(c: Candidate): Promise<PersistenceWithPath | null> {
+    const binSym = this.binance.toBinanceSymbol(c.symbol) ?? c.symbol.toUpperCase();
+    const candles = await this.binance.getKlines(binSym, '1m', 61);
+    if (!candles || candles.length === 0) return null;
+    const prices = extractPricesFromOneMinSeries(candles);
+    const persistence = evaluatePersistence(c.currentPrice, prices);
+    const pathQuality = computePathQualityForTfsFromOneMin(candles);
+    return { ...persistence, pathQuality };
+  }
+
+  private async fetchEquityPersistenceQuiet(c: Candidate): Promise<PersistenceWithPath | null> {
+    const eodhdTicker = this.toEodhdTicker(c);
+    const series = await this.eodhd.getCandles(eodhdTicker, '5m', 13);
+    if (!series || series.candles.length === 0) return null;
+    const prices = extractPricesFromFiveMinSeries(series.candles);
+    const persistence = evaluatePersistence(c.currentPrice, prices);
+    const pathQuality = computePathQualityForTfsFromFiveMin(series.candles);
+    return { ...persistence, pathQuality };
   }
 
   // ───────────────────────────────────────────────────────────────────

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -137,6 +137,9 @@ export class TopGainersScannerService implements OnModuleInit {
   } | null = null;
   private readonly EU_SESSIONS_CACHE_TTL_MS = 60_000;
 
+  /** P18e — Compteur cumulatif des candidats skip pour absence de persistence. */
+  private skippedNoPersistenceCounter = 0;
+
   constructor(
     private readonly supabase: SupabaseService,
     private readonly lisa: LisaService,
@@ -216,6 +219,11 @@ export class TopGainersScannerService implements OnModuleInit {
    */
   getLastScanForPortfolio(portfolioId: string): number | null {
     return this.lastScanByPortfolio.get(portfolioId) ?? null;
+  }
+
+  /** P18e — Métrique cumulative observability. */
+  getSkippedNoPersistenceCounter(): number {
+    return this.skippedNoPersistenceCounter;
   }
 
   /**
@@ -635,6 +643,9 @@ export class TopGainersScannerService implements OnModuleInit {
     // bump à 3 dans v2). Permet de valider le pipeline end-to-end.
     const maxThisCycle = Math.min(slotsAvailable, MAX_POSITIONS_PER_CYCLE_V1);
     let opened = 0;
+    // P18e — accumule les skips pour log agrégé en fin de cycle (au lieu de
+    // N lignes "no persistence data → skip" qui polluent les logs Fly).
+    const skippedNoPersistence: string[] = [];
     for (const cand of top) {
       if (opened >= maxThisCycle) break;
       const baseSym = cand.symbol.replace(/USDT$|USDC$/, '').toUpperCase();
@@ -671,9 +682,11 @@ export class TopGainersScannerService implements OnModuleInit {
           `[top-gainers] ${cand.symbol} persistence=${persistence.persistenceCount} score=${persistence.persistenceScore.toFixed(2)} pathEff=${persistence.pathQuality?.overallEfficiency?.toFixed(2) ?? 'n/a'} (${persistence.pathQuality?.overallSmoothness ?? 'n/a'}) → OPEN`,
         );
       } else {
+        // P18e — Skip silencieux ; aggregé dans le log de fin de cycle.
         // Si la donnée TF est indispo (provider down) on n'ouvre pas — gate
         // strict pour éviter d'ouvrir aveuglément.
-        this.logger.log(`[top-gainers] ${cand.symbol} no persistence data → skip`);
+        this.skippedNoPersistenceCounter++;
+        skippedNoPersistence.push(cand.symbol);
         continue;
       }
 
@@ -701,6 +714,14 @@ export class TopGainersScannerService implements OnModuleInit {
         opened++;
         await this.markLogOpened(cand.symbol, portfolioId, insertedPosId).catch(() => null);
       }
+    }
+
+    // P18e — Log agrégé une fois par cycle (au lieu de N lignes par-symbol).
+    if (skippedNoPersistence.length > 0) {
+      const sample = skippedNoPersistence.slice(0, 5).join(', ');
+      this.logger.log(
+        `[top-gainers] cycle skip-summary: scanned=${top.length}, retained=${opened}, skipped_no_persistence=${skippedNoPersistence.length} (sample: ${sample})`,
+      );
     }
   }
 


### PR DESCRIPTION
## Problème

Audit Fly logs `09:14:46–09:15:03 UTC` (machine `d8d4070a719018`, region CDG) — à chaque cycle scanner :
- **30+ lignes `DEBUG [mtf-persist] <T> no eodhd intraday`** (BIYA, ATER, KNSA, OML, 006340, ...)
- **N lignes `[top-gainers] <T> no persistence data → skip`** suivantes

Non bloquant (skipping est correct), mais ça **pollue le log stream** et masque les vrais signaux d'erreur.

## Fix

### 1. `MultiTimeframePersistenceService`

| Avant | Après |
|---|---|
| `this.logger.debug('[mtf-persist] X no eodhd intraday')` × N | 1 ligne agrégée par batch : `[mtf-persist] no intraday for N tickers (sample: ...)` |
| Aucun pré-filtre — call EODHD pour tout exchange | Pré-filtre `SUPPORTED_EQUITY_EXCHANGES` whitelist : US, LSE, XETRA, PA, SW, MI, MC, BME, AS, AMS, TSE, HK, AU, KO |
| Pas de visibilité métrique | 2 compteurs cumulatifs : `getNoIntradayCounter()`, `getSkippedUnsupportedMarketCounter()` |

`analyze()` / `fetchCryptoPersistence()` / `fetchEquityPersistence()` conservées pour les call sites single-symbol (endpoints UI). `analyzeBatch` utilise les variantes `*Quiet` qui n'émettent pas de log par-symbol — l'agrégation se fait à la sortie du batch.

### 2. `TopGainersScannerService`

| Avant | Après |
|---|---|
| `[top-gainers] X no persistence data → skip` × N | 1 ligne par cycle : `[top-gainers] cycle skip-summary: scanned=N, retained=R, skipped_no_persistence=S (sample: A, B, C)` |
| Pas de compteur | `getSkippedNoPersistenceCounter()` cumulatif |

Sample tronqué aux 5 premiers symboles (même si 50 skips).

## Tests

**14 nouveaux** dans deux fichiers spec, **51/51 green sur scanner + MTF** :

`multi-tf-persistence.p18e.spec.ts` (10 tests) :
- ✅ 50 tickers no-data → 1 ligne agrégée (was 50)
- ✅ Pas de log agrégé si 0 miss
- ✅ Pas de spam legacy `[mtf-persist] X no eodhd intraday` par-symbol
- ✅ Pré-filtre TO/NSE/BSE → 0 call EODHD
- ✅ US/LSE/XETRA/PA/TSE/HK supportés → calls effectués
- ✅ Crypto (BINANCE, *USDT) bypass pré-filtre equity
- ✅ Mix supported+unsupported+crypto correct
- ✅ Counters cumulatifs sur N batches
- ✅ `resetCounters()` clears
- ✅ Bonus : pas de log agrégé sur happy path

`top-gainers-scanner.p18e-skip-summary.spec.ts` (4 tests) :
- ✅ 1 ligne `cycle skip-summary` quand all skip (was N)
- ✅ Pas de log agrégé si 0 skip
- ✅ Compteur cumulatif sur N cycles
- ✅ Sample tronqué aux 5 premiers même si 50 skips

## Validation post-deploy

```bash
fly logs --app smartvest | grep -E "mtf-persist|skip-summary" | head -30
```

**Avant P18e** (sample 17s @ 09:14:46–09:15:03 UTC, mesuré aujourd'hui) :
- ~30 lignes `[mtf-persist] X no eodhd intraday` par cycle scanner

**Après P18e attendu** :
- ~1 ligne `[mtf-persist] no intraday for N tickers (sample: ...)` par cycle
- +1 ligne `[top-gainers] cycle skip-summary: ...` si applicable

**Réduction visée : >95% du volume de logs `mtf-persist` / cycle.**

Mini-rapport quantitatif à fournir post-deploy (avant/après/ratio sur 10 min).

## Hors scope

- ❌ Path UI single-symbol : `analyze()` reste verbose (utile pour debug ad-hoc)
- ❌ ReboundScannerService : pas touché (PR séparée)
- ❌ Persisting compteurs en DB : compteurs in-memory v1, suffisants pour observability /lisa/debug-stats endpoint à venir

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_