### PR TITLE
[P18h] Add /version endpoint for deploy visibility

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -31,6 +31,13 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to Fly
-        run: flyctl deploy --remote-only --wait-timeout 300 --strategy immediate
+        # P18h — Inject GIT_SHA + BUILD_TIME at build time so /version can
+        # report which commit/binary is actually running in prod.
+        run: |
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          flyctl deploy --remote-only \
+            --build-arg GIT_SHA=${{ github.sha }} \
+            --build-arg BUILD_TIME=$BUILD_TIME \
+            --wait-timeout 300 --strategy immediate
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ FROM node:20-alpine AS builder
 ARG CACHEBUST=11
 RUN echo "cachebust=$CACHEBUST"
 
+# P18h — Build metadata exposée via GET /version. Passées par fly.yml :
+#   --build-arg GIT_SHA=${{ github.sha }} --build-arg BUILD_TIME=$(date -u +%FT%TZ)
+ARG GIT_SHA=
+ARG BUILD_TIME=
+ENV GIT_SHA=$GIT_SHA
+ENV BUILD_TIME=$BUILD_TIME
+
 WORKDIR /repo
 
 COPY package.json package-lock.json tsconfig.base.json ./
@@ -42,6 +49,13 @@ RUN echo "✅ LisaModule present in build output"
 FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+
+# P18h — re-declare build args in runner stage (ARG doesn't cross stages)
+# and bake into runtime ENV. Runtime container reads via process.env.
+ARG GIT_SHA=
+ARG BUILD_TIME=
+ENV GIT_SHA=$GIT_SHA
+ENV BUILD_TIME=$BUILD_TIME
 
 COPY --from=builder /repo/package.json /repo/package-lock.json ./
 COPY --from=builder /repo/node_modules ./node_modules

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import { HealthModule } from './modules/health/health.module';
+import { VersionModule } from './modules/version/version.module';
 import { SupabaseModule } from './modules/supabase/supabase.module';
 import { FeatureFlagsModule } from './modules/feature-flags/feature-flags.module';
 import { PortfolioModule } from './modules/portfolio/portfolio.module';
@@ -41,6 +42,7 @@ import { MonteCarloModule } from './modules/monte-carlo/monte-carlo.module';
     SupabaseModule,
     FeatureFlagsModule,
     HealthModule,
+    VersionModule,
     PortfolioModule,
     DashboardModule,
     MarketDataModule,

--- a/apps/api/src/modules/version/__tests__/version.controller.spec.ts
+++ b/apps/api/src/modules/version/__tests__/version.controller.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * P18h — VersionController tests.
+ *
+ * Validates :
+ *   1. Reads GIT_SHA / BUILD_TIME / NODE_ENV / FLY_* from process.env
+ *   2. Returns null for missing / empty env vars (instead of empty string)
+ *   3. node_env defaults to 'development' if NODE_ENV is unset
+ *   4. Real-world Fly-injected env vars are picked up
+ */
+
+import { VersionController } from '../version.controller';
+
+describe('VersionController', () => {
+  const ORIGINAL_ENV = process.env;
+  let controller: VersionController;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    // Wipe vars we control in each test — only set what the test cares about
+    delete process.env.GIT_SHA;
+    delete process.env.BUILD_TIME;
+    delete process.env.FLY_RELEASE_VERSION;
+    delete process.env.FLY_APP_NAME;
+    delete process.env.FLY_REGION;
+    delete process.env.FLY_MACHINE_ID;
+    controller = new VersionController();
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('returns all env vars when fully populated (production-like Fly deploy)', () => {
+    process.env.GIT_SHA = '7d1f13249d2cf1e1727160d9c7d839bd2c047065';
+    process.env.BUILD_TIME = '2026-04-29T10:08:47Z';
+    process.env.NODE_ENV = 'production';
+    process.env.FLY_RELEASE_VERSION = '259';
+    process.env.FLY_APP_NAME = 'smartvest';
+    process.env.FLY_REGION = 'cdg';
+    process.env.FLY_MACHINE_ID = 'd8d4070a719018';
+
+    const result = controller.getVersion();
+
+    expect(result).toEqual({
+      git_sha: '7d1f13249d2cf1e1727160d9c7d839bd2c047065',
+      build_time: '2026-04-29T10:08:47Z',
+      node_env: 'production',
+      fly_release_id: '259',
+      fly_app_name: 'smartvest',
+      fly_region: 'cdg',
+      fly_machine_id: 'd8d4070a719018',
+    });
+  });
+
+  it('returns null for missing build-time env vars (local dev without --build-arg)', () => {
+    process.env.NODE_ENV = 'development';
+    // GIT_SHA + BUILD_TIME absent (npm run api:dev case)
+    const result = controller.getVersion();
+
+    expect(result.git_sha).toBeNull();
+    expect(result.build_time).toBeNull();
+    expect(result.node_env).toBe('development');
+  });
+
+  it('returns null for empty-string env vars (safer than returning "")', () => {
+    process.env.GIT_SHA = '';
+    process.env.BUILD_TIME = '';
+    const result = controller.getVersion();
+    expect(result.git_sha).toBeNull();
+    expect(result.build_time).toBeNull();
+  });
+
+  it('falls back to "development" when NODE_ENV is unset', () => {
+    delete process.env.NODE_ENV;
+    const result = controller.getVersion();
+    expect(result.node_env).toBe('development');
+  });
+
+  it('returns null for Fly-only vars when running outside Fly (e.g. local CI)', () => {
+    process.env.NODE_ENV = 'test';
+    // No FLY_* vars
+    const result = controller.getVersion();
+    expect(result.fly_release_id).toBeNull();
+    expect(result.fly_app_name).toBeNull();
+    expect(result.fly_region).toBeNull();
+    expect(result.fly_machine_id).toBeNull();
+  });
+});

--- a/apps/api/src/modules/version/version.controller.ts
+++ b/apps/api/src/modules/version/version.controller.ts
@@ -1,0 +1,46 @@
+/**
+ * P18h — `GET /version` exposes deploy metadata for external visibility
+ * (no flyctl/admin required).
+ *
+ * Built from env vars injected at Docker build time + Fly runtime env :
+ *   - GIT_SHA             : passed via `flyctl deploy --build-arg GIT_SHA=...`
+ *   - BUILD_TIME          : passed at build (ISO-8601 UTC)
+ *   - NODE_ENV            : runtime
+ *   - FLY_RELEASE_VERSION : injected automatically by Fly at runtime (e.g. "v259")
+ *
+ * Designed to resolve the visibility blind spot observed during the v258
+ * failed-deploy / v259 success episode (29/04/2026 ~10:03–10:12 UTC) :
+ * `/health` returned 200 from both the old and new binary indistinguishably.
+ */
+
+import { Controller, Get } from '@nestjs/common';
+
+interface VersionResponse {
+  git_sha: string | null;
+  build_time: string | null;
+  node_env: string;
+  fly_release_id: string | null;
+  fly_app_name: string | null;
+  fly_region: string | null;
+  fly_machine_id: string | null;
+}
+
+@Controller('version')
+export class VersionController {
+  @Get()
+  getVersion(): VersionResponse {
+    const env = (key: string): string | null => {
+      const v = process.env[key];
+      return v && v.length > 0 ? v : null;
+    };
+    return {
+      git_sha: env('GIT_SHA'),
+      build_time: env('BUILD_TIME'),
+      node_env: process.env['NODE_ENV'] ?? 'development',
+      fly_release_id: env('FLY_RELEASE_VERSION'),
+      fly_app_name: env('FLY_APP_NAME'),
+      fly_region: env('FLY_REGION'),
+      fly_machine_id: env('FLY_MACHINE_ID'),
+    };
+  }
+}

--- a/apps/api/src/modules/version/version.module.ts
+++ b/apps/api/src/modules/version/version.module.ts
@@ -1,0 +1,5 @@
+import { Module } from '@nestjs/common';
+import { VersionController } from './version.controller';
+
+@Module({ controllers: [VersionController] })
+export class VersionModule {}


### PR DESCRIPTION
## Problème

Pendant l'épisode `v258 failed → v259 success` (29/04/2026 10:03–10:12 UTC), `/health` retournait **200 depuis l'ancien et le nouveau binaire indistinguablement**. On a perdu ~10 min à investiguer si le déploiement P18d/P18e était live ou non, sans pouvoir le vérifier sans `flyctl` ou Fly UI.

## Fix

Nouveau endpoint `GET /version` non-authentifié exposant l'identité du binaire en cours d'exécution :

```json
{
  "git_sha": "7d1f13249d2cf1e1727160d9c7d839bd2c047065",
  "build_time": "2026-04-29T10:08:47Z",
  "node_env": "production",
  "fly_release_id": "259",
  "fly_app_name": "smartvest",
  "fly_region": "cdg",
  "fly_machine_id": "d8d4070a719018"
}
```

### Implementation

| Fichier | Rôle |
|---|---|
| `apps/api/src/modules/version/version.controller.ts` | NestJS controller, `@Controller('version')`, GET / lit process.env, normalise les empty strings → null |
| `apps/api/src/modules/version/version.module.ts` | Module wrapper |
| `apps/api/src/app.module.ts` | Wired aux côtés de `HealthModule` |
| `Dockerfile` | `ARG GIT_SHA=`, `ARG BUILD_TIME=` déclarés dans **builder ET runner** (ARG ne traverse pas les stages), promus en ENV |
| `.github/workflows/fly.yml` | `flyctl deploy --build-arg GIT_SHA=${{ github.sha }} --build-arg BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)` |

### Sources d'env

| Champ | Source |
|---|---|
| `git_sha` | `--build-arg GIT_SHA=${{ github.sha }}` (CI) |
| `build_time` | `--build-arg BUILD_TIME=$(date)` (CI) |
| `node_env` | Container `ENV NODE_ENV=production` |
| `fly_release_id` | `FLY_RELEASE_VERSION` (auto-injecté par Fly runtime) |
| `fly_app_name` / `fly_region` / `fly_machine_id` | Auto-injecté par Fly runtime |

## Tests — 5 nouveaux

`version.controller.spec.ts` :
- ✅ Tous les env populés (production-like) → JSON complet
- ✅ Build vars absents (local dev `npm run api:dev`) → `git_sha=null`, `build_time=null`
- ✅ Empty string env vars → null (plus safe que `""`)
- ✅ `NODE_ENV` absent → fallback `"development"`
- ✅ Fly-only vars absents (CI Jest local) → tous null

## Validation post-deploy

```bash
curl -s https://smartvest.fly.dev/version | jq
```

Attendu :
- `git_sha` = SHA du merge commit de cette PR (ne sera pas `7d1f1324` mais le SHA post-merge)
- `fly_release_id` = numéro de release Fly courant (v260+ probablement)
- `node_env` = `"production"`

Si l'un de ces champs est `null` : le `--build-arg` n'a pas été passé ou Fly n'injecte pas la var → debug par grep des logs build Fly.

## Hors scope

- ❌ Pas de middleware d'auth (les valeurs sont publiques : SHA visible sur GitHub, region/machine_id non-sensible)
- ❌ Pas de retour des secrets ou config (pas de SUPABASE_URL, etc.)
- ❌ Pas de healthcheck séparé : `/health` reste minimal pour load balancer

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_