### PR TITLE
[P18h.1] /version: replace fly_release_id with fly_image_ref

### DIFF
--- a/apps/api/src/modules/version/__tests__/version.controller.spec.ts
+++ b/apps/api/src/modules/version/__tests__/version.controller.spec.ts
@@ -20,7 +20,7 @@ describe('VersionController', () => {
     // Wipe vars we control in each test — only set what the test cares about
     delete process.env.GIT_SHA;
     delete process.env.BUILD_TIME;
-    delete process.env.FLY_RELEASE_VERSION;
+    delete process.env.FLY_IMAGE_REF;
     delete process.env.FLY_APP_NAME;
     delete process.env.FLY_REGION;
     delete process.env.FLY_MACHINE_ID;
@@ -35,7 +35,7 @@ describe('VersionController', () => {
     process.env.GIT_SHA = '7d1f13249d2cf1e1727160d9c7d839bd2c047065';
     process.env.BUILD_TIME = '2026-04-29T10:08:47Z';
     process.env.NODE_ENV = 'production';
-    process.env.FLY_RELEASE_VERSION = '259';
+    process.env.FLY_IMAGE_REF = 'registry.fly.io/smartvest:deployment-08c46fc7b789d8423c8b193cd1885710';
     process.env.FLY_APP_NAME = 'smartvest';
     process.env.FLY_REGION = 'cdg';
     process.env.FLY_MACHINE_ID = 'd8d4070a719018';
@@ -46,11 +46,17 @@ describe('VersionController', () => {
       git_sha: '7d1f13249d2cf1e1727160d9c7d839bd2c047065',
       build_time: '2026-04-29T10:08:47Z',
       node_env: 'production',
-      fly_release_id: '259',
+      fly_image_ref: 'registry.fly.io/smartvest:deployment-08c46fc7b789d8423c8b193cd1885710',
       fly_app_name: 'smartvest',
       fly_region: 'cdg',
       fly_machine_id: 'd8d4070a719018',
     });
+  });
+
+  it('fly_image_ref follows the registry.fly.io/<app>:deployment-<hash> format', () => {
+    process.env.FLY_IMAGE_REF = 'registry.fly.io/smartvest:deployment-08c46fc7b789d8423c8b193cd1885710';
+    const result = controller.getVersion();
+    expect(result.fly_image_ref).toMatch(/^registry\.fly\.io\/[a-z0-9-]+:deployment-[a-f0-9]+$/);
   });
 
   it('returns null for missing build-time env vars (local dev without --build-arg)', () => {
@@ -81,7 +87,7 @@ describe('VersionController', () => {
     process.env.NODE_ENV = 'test';
     // No FLY_* vars
     const result = controller.getVersion();
-    expect(result.fly_release_id).toBeNull();
+    expect(result.fly_image_ref).toBeNull();
     expect(result.fly_app_name).toBeNull();
     expect(result.fly_region).toBeNull();
     expect(result.fly_machine_id).toBeNull();

--- a/apps/api/src/modules/version/version.controller.ts
+++ b/apps/api/src/modules/version/version.controller.ts
@@ -3,10 +3,14 @@
  * (no flyctl/admin required).
  *
  * Built from env vars injected at Docker build time + Fly runtime env :
- *   - GIT_SHA             : passed via `flyctl deploy --build-arg GIT_SHA=...`
- *   - BUILD_TIME          : passed at build (ISO-8601 UTC)
- *   - NODE_ENV            : runtime
- *   - FLY_RELEASE_VERSION : injected automatically by Fly at runtime (e.g. "v259")
+ *   - GIT_SHA       : passed via `flyctl deploy --build-arg GIT_SHA=...`
+ *   - BUILD_TIME    : passed at build (ISO-8601 UTC)
+ *   - NODE_ENV      : runtime
+ *   - FLY_IMAGE_REF : injected automatically by Fly at runtime, e.g.
+ *                     "registry.fly.io/smartvest:deployment-08c46fc7b789...".
+ *                     P18h.1 — replaces FLY_RELEASE_VERSION (which is NOT
+ *                     auto-injected by Fly Machines, contrary to my earlier
+ *                     assumption — P18h shipped with that field always null).
  *
  * Designed to resolve the visibility blind spot observed during the v258
  * failed-deploy / v259 success episode (29/04/2026 ~10:03–10:12 UTC) :
@@ -19,7 +23,7 @@ interface VersionResponse {
   git_sha: string | null;
   build_time: string | null;
   node_env: string;
-  fly_release_id: string | null;
+  fly_image_ref: string | null;
   fly_app_name: string | null;
   fly_region: string | null;
   fly_machine_id: string | null;
@@ -37,7 +41,7 @@ export class VersionController {
       git_sha: env('GIT_SHA'),
       build_time: env('BUILD_TIME'),
       node_env: process.env['NODE_ENV'] ?? 'development',
-      fly_release_id: env('FLY_RELEASE_VERSION'),
+      fly_image_ref: env('FLY_IMAGE_REF'),
       fly_app_name: env('FLY_APP_NAME'),
       fly_region: env('FLY_REGION'),
       fly_machine_id: env('FLY_MACHINE_ID'),


### PR DESCRIPTION
## Pourquoi

**P18h shipped avec un bug d'assumption.** J'ai supposé que Fly Machines auto-injectait `FLY_RELEASE_VERSION` dans le container runtime. C'est faux. Validation post-deploy P18h (29/04/2026 10:35:07Z) :

```json
{
  "git_sha": "77f4c76c99ed4d18e14f371ffc23955e02fb63d5",
  "build_time": "2026-04-29T10:33:03Z",
  "node_env": "production",
  "fly_release_id": null,                                  ← TOUJOURS NULL
  "fly_app_name": "smartvest",
  "fly_region": "cdg",
  "fly_machine_id": "d8d4070a719018"
}
```

## Fix

Fly auto-injecte effectivement `FLY_IMAGE_REF` qui contient la deployment ID :

```
registry.fly.io/smartvest:deployment-08c46fc7b789d8423c8b193cd1885710
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                       Hash unique par release Fly
                                       corrélable directement à l'UI Fly
```

Remplace `fly_release_id` (toujours null, inutile) par `fly_image_ref` (toujours populé en prod, et utilisable pour identifier la release Fly).

## Implementation (3 lignes utiles)

| Fichier | Changement |
|---|---|
| `version.controller.ts` | `fly_release_id` → `fly_image_ref`, source env `FLY_IMAGE_REF` |
| `version.controller.spec.ts` | Test "production-like" updated, +1 nouveau test format regex `^registry\.fly\.io/...:deployment-[a-f0-9]+$` |

Pas de changement Dockerfile ni fly.yml — `FLY_IMAGE_REF` est injecté par Fly runtime, pas besoin de `--build-arg`.

## Tests — 6/6 green

- ✅ Tous env populés (production-like) → JSON complet avec FLY_IMAGE_REF réel
- ✅ Format regex `^registry\.fly\.io/[a-z0-9-]+:deployment-[a-f0-9]+$`
- ✅ Build vars absents (local dev) → null
- ✅ Empty string → null
- ✅ NODE_ENV absent → fallback `"development"`
- ✅ Fly-only vars absents (CI) → tous null

## Validation post-deploy attendue

```bash
curl -s https://smartvest.fly.dev/version | jq
```

Le champ `fly_image_ref` devrait être :
```
"registry.fly.io/smartvest:deployment-<hash unique de cette release>"
```

Le hash sera comparable à celui visible dans Fly UI > Activity > Latest release.

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_