### PR TITLE
[P18h.2] scripts/deploy.sh wrapper preserves /version build args

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,19 @@ P3-C — Le scanner rebound-tp scanne par défaut **`sp500`** (~200 mega-caps US
 
 ---
 
+## RÈGLE OPÉRATIONNELLE PERMANENTE — DEPLOY FLY (P18h.2)
+
+**Ne jamais utiliser `flyctl deploy` directement** — toujours :
+
+1. **Préféré** : push to `main` → workflow `.github/workflows/fly.yml` se déclenche et passe `--build-arg GIT_SHA=${{ github.sha }}` + `--build-arg BUILD_TIME=$(date -u +...)` automatiquement.
+2. **Manuel uniquement si CI cassée ou redeploy urgent** : `./scripts/deploy.sh` qui auto-extrait `git rev-parse HEAD` + `date -u +...` et appelle `flyctl deploy --build-arg ...`.
+
+`flyctl deploy` direct sans build args casse `/version` (P18h endpoint) → `git_sha:null` + `build_time:null` en prod → on perd la traçabilité du commit déployé. Cas vérifié 29/04/2026 11:04 UTC + 13:38 CEST. Ne pas répéter l'erreur.
+
+Re-trigger d'un workflow Actions Fly Deploy (workflow_dispatch sur `fly.yml`) est aussi acceptable et préserve les build args.
+
+---
+
 ## RÈGLE OPÉRATIONNELLE PERMANENTE — AUTO-MERGE SUR MAIN
 
 Pour TOUTE PR que tu ouvres sur ce repo :

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# P18h.2 — Wrapper for `flyctl deploy` that auto-injects GIT_SHA + BUILD_TIME
+# build args so /version stays populated even on manual deploys.
+#
+# WHY THIS EXISTS — root cause analysis (29/04/2026, sprint P18):
+#   Direct `flyctl deploy` (no GitHub Actions) does NOT inject GIT_SHA /
+#   BUILD_TIME because flyctl does not know them. Result : `/version`
+#   returns `git_sha:null` + `build_time:null` in prod, breaking the
+#   visibility guarantee that P18h shipped (verified 11:04 UTC, 13:38 CEST).
+#
+# THIS SCRIPT enforces the build args using:
+#   - GIT_SHA   = `git rev-parse HEAD` (current commit, must match origin/main
+#     for production deploys; warns if HEAD != origin/main)
+#   - BUILD_TIME = ISO-8601 UTC at the moment of the deploy
+#
+# USAGE :
+#   ./scripts/deploy.sh                 # deploy current HEAD
+#   ./scripts/deploy.sh --strategy immediate
+#   ./scripts/deploy.sh --help          # show flyctl deploy --help
+#
+# ANY ARGS PASSED ARE FORWARDED to `flyctl deploy` — defaults below cover the
+# common case (matches what `.github/workflows/fly.yml` does).
+
+set -euo pipefail
+
+# ── Pre-flight checks ──────────────────────────────────────────────────────
+
+if ! command -v flyctl >/dev/null 2>&1; then
+  echo "❌ flyctl not found in PATH. Install via: curl -L https://fly.io/install.sh | sh" >&2
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "❌ git not found in PATH" >&2
+  exit 1
+fi
+
+# Must run from inside the smartvest git repo
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "❌ Not in a git repo" >&2
+  exit 1
+fi
+
+# Warn if HEAD is not synced with origin/main — usually a deploy mistake
+GIT_SHA=$(git rev-parse HEAD)
+ORIGIN_MAIN=$(git rev-parse origin/main 2>/dev/null || echo "")
+if [ -n "$ORIGIN_MAIN" ] && [ "$GIT_SHA" != "$ORIGIN_MAIN" ]; then
+  echo "⚠️  HEAD ($GIT_SHA) != origin/main ($ORIGIN_MAIN)"
+  echo "   You are about to deploy a commit that is NOT on origin/main."
+  read -r -p "   Continue? [y/N] " confirm
+  case "$confirm" in
+    [yY]|[yY][eE][sS]) ;;
+    *) echo "Aborted."; exit 1 ;;
+  esac
+fi
+
+BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# ── Deploy ─────────────────────────────────────────────────────────────────
+
+echo "🚀 Deploying smartvest to Fly with build args:"
+echo "   GIT_SHA    = $GIT_SHA"
+echo "   BUILD_TIME = $BUILD_TIME"
+echo ""
+
+# Pass build args first; user-provided args override defaults below if needed
+flyctl deploy \
+  --remote-only \
+  --build-arg "GIT_SHA=$GIT_SHA" \
+  --build-arg "BUILD_TIME=$BUILD_TIME" \
+  --wait-timeout 300 \
+  --strategy immediate \
+  -a smartvest \
+  "$@"
+
+echo ""
+echo "✅ Deploy submitted. Verify with:"
+echo "   curl -s https://smartvest.fly.dev/version | jq"
+echo "   Expected git_sha=$GIT_SHA"


### PR DESCRIPTION
## Pourquoi (root cause vérifiée 29/04/2026)

**11:04 UTC** : `/version` montre `git_sha:null + build_time:null` après un `flyctl deploy` direct utilisateur.
**13:38 CEST** : confirmé reproductible — flyctl ne passe PAS les `--build-arg` que `fly.yml` injecte. Résultat : la visibilité que P18h shipped est cassée sur tout deploy hors CI.

## Fix — `scripts/deploy.sh`

Wrapper qui auto-extrait et passe les bons build args :

- `GIT_SHA = $(git rev-parse HEAD)` (avec warn si HEAD != origin/main, typique deploy par erreur)
- `BUILD_TIME = ISO-8601 UTC` à l'instant du deploy
- Forward tout arg supplémentaire à `flyctl deploy` (e.g. `--strategy bluegreen`)
- Pre-flight checks (flyctl + git installés, dans un repo)
- Print post-deploy : commande `curl /version` avec `git_sha` attendu

Usage :
```bash
./scripts/deploy.sh                       # deploy current HEAD with auto args
./scripts/deploy.sh --strategy bluegreen  # forward custom flyctl args
```

## Règle CLAUDE.md ajoutée

Section "RÈGLE OPÉRATIONNELLE PERMANENTE — DEPLOY FLY (P18h.2)" :

> **Ne jamais utiliser `flyctl deploy` directement** — toujours :
> 1. Préféré : push to main → workflow `fly.yml`
> 2. Manuel : `./scripts/deploy.sh`
>
> `flyctl deploy` direct sans build args casse `/version` → `git_sha:null` + `build_time:null` en prod. Cas vérifié 29/04/2026.

## Test

- `chmod +x scripts/deploy.sh` ✅
- `bash -n scripts/deploy.sh` syntax check ✅
- À valider live : utilisateur lance `./scripts/deploy.sh` post-merge → `curl /version` doit retourner `git_sha` + `build_time` populés (preuve définitive de fix).

## Pas

- Pas de changement code TS, juste un script bash + 1 section markdown.
- Auto-merge per CLAUDE.md auto-merge rule.

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_