### PR TITLE
[P19c] hotfix: autopilot pause reversible (not disable) on Anthropic credit exhausted

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/autopilot-budget-resume.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/autopilot-budget-resume.spec.ts
@@ -177,6 +177,59 @@ describe('LisaAutopilotService.maybeResumeOrSkip', () => {
     expect(ok).toBe(false);
   });
 
+  // ── P19c — ANTHROPIC_CREDIT_EXHAUSTED reversible pause ──────────────────
+
+  it('P19c — paused ANTHROPIC_CREDIT_EXHAUSTED → returns true (probe credit, retry cycle)', async () => {
+    const state = emptyState();
+    const service = makeService(state);
+    const cfg = {
+      portfolio_id: PORTFOLIO_ID,
+      autopilot_paused_reason: 'ANTHROPIC_CREDIT_EXHAUSTED',
+      daily_cost_budget_usd: 100,
+    };
+    const ok = await service.maybeResumeOrSkip(cfg);
+    // Returns true → cycle continues (probe). lisa.service will re-pause if
+    // credit still exhausted, OR clear paused_reason on success.
+    expect(ok).toBe(true);
+    // No automatic clear here — clear happens in lisa.service success path.
+    expect(state.configUpdates).toEqual([]);
+  });
+
+  it('P19c — clearAnthropicCreditPause clears reason when ANTHROPIC_CREDIT_EXHAUSTED is set', async () => {
+    const state = emptyState();
+    // Need a richer mock that supports `select(...).eq(...).maybeSingle()`
+    const supabaseRich = {
+      getClient: () => ({
+        from: () => {
+          const chain: Record<string, unknown> = {};
+          chain.select = () => chain;
+          chain.eq = () => chain;
+          chain.maybeSingle = () => Promise.resolve({
+            data: { autopilot_paused_reason: 'ANTHROPIC_CREDIT_EXHAUSTED', portfolio_id: PORTFOLIO_ID },
+            error: null,
+          });
+          chain.update = (values: Record<string, unknown>) => {
+            state.configUpdates.push(values);
+            return chain;
+          };
+          return chain;
+        },
+      }),
+    };
+    const decisionLog = {
+      append: jest.fn(async (entry: { kind: string }) => {
+        state.decisionLogs.push({ kind: entry.kind, portfolioId: PORTFOLIO_ID });
+      }),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const service = new (LisaAutopilotService as any)(
+      supabaseRich, null, decisionLog, null, null, null, null, null, null, null,
+    );
+    await service.clearAnthropicCreditPause(PORTFOLIO_ID);
+    expect(state.configUpdates.some((u) => u.autopilot_paused_reason === null)).toBe(true);
+    expect(state.decisionLogs.some((l) => l.kind === 'autopilot_resumed')).toBe(true);
+  });
+
   it('integration scenario: 3-cycle pause → bump budget → resume', async () => {
     const state = emptyState({ costToday: 51 });
     const service = makeService(state);

--- a/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
@@ -87,33 +87,62 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
     const pausedReason = cfg.autopilot_paused_reason as string | null | undefined;
     if (!pausedReason) return true; // pas en pause → cycle normal
 
-    if (pausedReason !== 'BUDGET_EXCEEDED') {
-      // MANUAL ou PROVIDER_OUTAGE → skip silencieux (resume manuel uniquement)
+    // P8-BR — Budget pause (cumulatif coût API journalier dépassé)
+    if (pausedReason === 'BUDGET_EXCEEDED') {
+      const budget = cfg.daily_cost_budget_usd as number | null | undefined;
+      if (budget == null || Number(budget) <= 0) {
+        // Budget retiré → reprise
+        await this.clearPausedReason(cfg, 'budget_unset');
+        return true;
+      }
+      const todayCostUsd = await this.apiCostTracker.getTodayTotalUsd().catch(() => 0);
+      const budgetNum = Number(budget);
+      if (todayCostUsd < budgetNum * 0.9) {
+        await this.clearPausedReason(cfg, `cost=$${todayCostUsd.toFixed(2)} < 90% of $${budgetNum.toFixed(2)}`);
+        return true;
+      }
+      this.logger.log(
+        `[autopilot:budget_paused] portfolio=${String(cfg.portfolio_id).slice(0, 8)} ` +
+        `cost=$${todayCostUsd.toFixed(2)} / budget=$${budgetNum.toFixed(2)} (≥90%) → skip cycle`,
+      );
       return false;
     }
 
-    const budget = cfg.daily_cost_budget_usd as number | null | undefined;
-    if (budget == null || Number(budget) <= 0) {
-      // Budget retiré → reprise
-      await this.clearPausedReason(cfg, 'budget_unset');
-      return true;
+    // P19c — Anthropic credit exhausted (réversible). On laisse passer au prochain
+    // cycle pour permettre une nouvelle tentative. Si la tentative échoue de
+    // nouveau avec credit_exhausted, le flag sera re-set par lisa.service.
+    // Si elle réussit (crédit rechargé), on clear le flag dans le path success.
+    // Cycle = 7-30 min selon profile, donc retry tolérable côté coût (1 call rate de probe).
+    if (pausedReason === 'ANTHROPIC_CREDIT_EXHAUSTED') {
+      this.logger.log(
+        `[autopilot:anthropic_paused] portfolio=${String(cfg.portfolio_id).slice(0, 8)} ` +
+        `→ retry this cycle (probe credit, will re-pause if still exhausted)`,
+      );
+      return true; // laisse le cycle Lisa s'exécuter ; clear géré côté success path
     }
 
-    const todayCostUsd = await this.apiCostTracker.getTodayTotalUsd().catch(() => 0);
-    const budgetNum = Number(budget);
-    if (todayCostUsd < budgetNum * 0.9) {
-      await this.clearPausedReason(cfg, `cost=$${todayCostUsd.toFixed(2)} < 90% of $${budgetNum.toFixed(2)}`);
-      return true;
-    }
-
-    // Toujours au-dessus du seuil → skip ce cycle, log discret toutes les
-    // ~30 min (sinon spam si cycle 7 min). Pas critique : la prochaine fois
-    // que le budget passe sous le seuil, le cycle reprend automatiquement.
-    this.logger.log(
-      `[autopilot:budget_paused] portfolio=${String(cfg.portfolio_id).slice(0, 8)} ` +
-      `cost=$${todayCostUsd.toFixed(2)} / budget=$${budgetNum.toFixed(2)} (≥90%) → skip cycle`,
-    );
+    // MANUAL ou autres → skip silencieux (resume manuel uniquement)
     return false;
+  }
+
+  /**
+   * P19c — Public helper appelé par lisa.service.ts dans le path success
+   * de generateProposal pour clear le paused_reason='ANTHROPIC_CREDIT_EXHAUSTED'
+   * dès qu'un appel réussit (= crédit rechargé).
+   */
+  async clearAnthropicCreditPause(portfolioId: string): Promise<void> {
+    const { data } = await this.supabase.getClient()
+      .from('lisa_session_configs')
+      .select('autopilot_paused_reason, portfolio_id')
+      .eq('portfolio_id', portfolioId)
+      .maybeSingle();
+    const reason = (data?.autopilot_paused_reason as string | null | undefined);
+    if (reason === 'ANTHROPIC_CREDIT_EXHAUSTED') {
+      await this.clearPausedReason(
+        { portfolio_id: portfolioId },
+        'anthropic_credit_restored_after_successful_proposal',
+      );
+    }
   }
 
   private async clearPausedReason(

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -974,27 +974,31 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         || /\b400\b.*invalid_request_error.*credit/i.test(msg);
 
       if (isCreditExhausted) {
-        // Auto-pause TOUT l'autopilot (pas juste auto_approve) pour arrêter
-        // d'essayer en boucle et empirer la facture.
+        // P19c — pause REVERSIBLE (pattern P8-BR), pas désactivation. L'autopilot
+        // reste `enabled=true` mais `autopilot_paused_reason='ANTHROPIC_CREDIT_EXHAUSTED'`
+        // → maybeResumeOrSkip skip ce cycle silencieusement. Quand le crédit est
+        // rechargé sur console.anthropic.com, l'utilisateur peut reset le paused_reason
+        // (UI badge "Anthropic indispo, reprendre") OU le prochain cycle Lisa qui
+        // réussit clear automatiquement le flag.
+        // Avant P19c (29/04/2026 12:03 UTC, observé en prod) : autopilot_enabled
+        // flipait à false → autopilot OFFLINE silencieusement, intervention manuelle
+        // requise. Cassait la promesse de continuité de service Lisa.
         await this.supabase.getClient()
           .from('lisa_session_configs')
           .update({
-            autopilot_enabled: false,
-            autopilot_auto_approve: false,
-            autopilot_aggressive: false,
-            autopilot_expires_at: null,
+            autopilot_paused_reason: 'ANTHROPIC_CREDIT_EXHAUSTED',
           })
           .eq('portfolio_id', portfolioId);
 
         await this.logDecision(portfolioId, 'anthropic_credit_exhausted', {
-          summary: '⚠️ Crédit Anthropic épuisé — autopilot désactivé automatiquement',
-          rationale: `Erreur API reçue : ${msg.slice(0, 500)}. L'autopilot a été coupé pour éviter d'autres appels qui échoueraient. Recharger le crédit sur console.anthropic.com, puis réactiver manuellement l'autopilot.`,
-          payload: { source: 'thesis_generator', errorType: 'credit_exhausted' },
-          triggeredBy: 'user_manual',
+          summary: '⚠️ Crédit Anthropic épuisé — autopilot mis en pause (réversible)',
+          rationale: `Erreur API reçue : ${msg.slice(0, 500)}. autopilot_paused_reason=ANTHROPIC_CREDIT_EXHAUSTED (autopilot_enabled reste true). Recharger le crédit sur console.anthropic.com — la pause sera levée au prochain cycle Lisa qui réussit. P19c risk-resilience.`,
+          payload: { source: 'thesis_generator', errorType: 'credit_exhausted', paused_reason: 'ANTHROPIC_CREDIT_EXHAUSTED' },
+          triggeredBy: 'risk_monitor',
         });
 
         throw new BadRequestException(
-          `⚠️ CRÉDIT ANTHROPIC ÉPUISÉ — L'autopilot a été désactivé automatiquement pour éviter d'autres tentatives coûteuses. Recharge le crédit sur console.anthropic.com, puis réactive l'autopilot depuis la page Lisa.`,
+          `⚠️ CRÉDIT ANTHROPIC ÉPUISÉ — L'autopilot a été mis en pause (réversible). Recharge le crédit sur console.anthropic.com — la pause se lèvera automatiquement au prochain cycle qui réussit.`,
         );
       }
 
@@ -1008,6 +1012,23 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         `Lisa n'a pas pu produire une proposition exploitable (${msg.slice(0, 150)}). Réessaie dans un instant — les parse failures Claude sont rares et transitoires.`,
       );
     }
+
+    // P19c — Path success : si une pause `ANTHROPIC_CREDIT_EXHAUSTED` était
+    // active, c'est que le crédit vient d'être rechargé (la nouvelle tentative
+    // a réussi). Clear silently. Pas une dépendance circulaire car on update
+    // directement la table sans passer par lisa-autopilot.service.
+    await this.supabase.getClient()
+      .from('lisa_session_configs')
+      .update({ autopilot_paused_reason: null })
+      .eq('portfolio_id', portfolioId)
+      .eq('autopilot_paused_reason', 'ANTHROPIC_CREDIT_EXHAUSTED')
+      .then(({ error, data }) => {
+        if (!error && data) {
+          this.logger.log(
+            `[autopilot:resumed] portfolio=${portfolioId.slice(0, 8)} reason=anthropic_credit_restored`,
+          );
+        }
+      });
 
     // Enforce risk constraints (structural safety net)
     // Calcule l'exposition AGRÉGÉE par classe des positions DÉJÀ TENUES


### PR DESCRIPTION
## Bug observé en prod (29/04/2026 12:03 UTC)

Autopilot Lisa **OFFLINE depuis 2h** suite à `BadRequestException 400: Your credit balance is too low to access the Anthropic API`. Le code à `lisa.service.ts:976-998` flippait `autopilot_enabled=false` en dur, cassant la promesse de continuité de service.

## Fix — Appliquer le pattern P8-BR (pause réversible) au credit_exhausted

| Avant | Après |
|---|---|
| `update({ autopilot_enabled: false, ... })` | `update({ autopilot_paused_reason: 'ANTHROPIC_CREDIT_EXHAUSTED' })` |
| Intervention manuelle requise | Auto-resume au prochain cycle qui réussit |

### Changements

1. **`lisa.service.ts:976-1000`** : remplace le flip de `enabled=false` par un `paused_reason` réversible.
2. **`lisa-autopilot.service.ts:maybeResumeOrSkip`** : étendu avec un cas `ANTHROPIC_CREDIT_EXHAUSTED` → `return true` (laisse le cycle Lisa s'exécuter pour probe le crédit). Comportement :
   - Crédit toujours épuisé → `lisa.service` re-set le flag automatiquement
   - Crédit rechargé → call réussit → success path clear le flag inline
3. **`lisa.service.ts:1014+ (success path)`** : nouvelle UPDATE inline qui clear `autopilot_paused_reason='ANTHROPIC_CREDIT_EXHAUSTED'` dès qu'une génération réussit. Pas de dépendance circulaire entre services.
4. **`lisa-autopilot.service.ts:clearAnthropicCreditPause`** : helper public pour dev tooling (test, debug).

### Logs structurés

```
[autopilot:anthropic_paused] portfolio=11111111 → retry this cycle (probe credit, will re-pause if still exhausted)
[autopilot:resumed] portfolio=11111111 reason=anthropic_credit_restored_after_successful_proposal
```

## Tests — 11/11 green

- 9 tests P8-BR existants (BUDGET_EXCEEDED, MANUAL, PROVIDER_OUTAGE, intégration) toujours green ✅
- 2 nouveaux tests P19c :
  - `paused ANTHROPIC_CREDIT_EXHAUSTED → returns true (probe credit, retry cycle)`
  - `clearAnthropicCreditPause helper clears reason when set`

## Hors scope (P19c-B follow-up — différé)

Le multi-vendor router LLM (Gemini Flash-Lite primaire, P17/P18) est wired uniquement sur `TopGainersScannerService`. La pipeline `LisaService.generateProposal` appelle Anthropic via `thesisGenerator` direct. Migrer pour zero-downtime sur credit_exhausted = refactor 4-8h avec validation manuelle de la qualité des proposals Gemini vs Claude (persona Lisa, system prompts cacheable, structured JSON output).

Différé en sprint suivant — il faut prouver que Gemini peut produire des proposals exploitables sur la persona Lisa AVANT de couper le path Anthropic principal.

## Action utilisateur requise

Recharger crédit Anthropic sur console.anthropic.com — **la pause se lèvera automatiquement** au prochain cycle Lisa qui réussit (~7-30 min selon profile).

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_