### PR TITLE
[P19d] feat: gainers univers + SSE/SZSE (China A-shares full coverage)

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -98,7 +98,12 @@ interface EodhdScreenerRow {
  * pour la Bolsa de Madrid ; `AS` et `AMS` idem pour Euronext Amsterdam.
  */
 const EU_EXCHANGES = ['LSE', 'XETRA', 'PA', 'SW', 'MI', 'MC', 'BME', 'AS', 'AMS'];
-const NON_EU_EXCHANGES = ['US', 'TSE', 'HK', 'AU', 'KO', 'TO', 'NSE', 'BSE'];
+// P19d (29/04/2026 14:30 CEST) — Ajout SSE (Shanghai) + SZSE (Shenzhen) pour
+// couverture mondiale complète. China A-shares supportées par EODHD plan
+// "All World" (à valider au runtime — 422 silencieusement skip si pas dans
+// le plan, P18c warning log). Yahoo fallback (.SS / .SZ) couvre quoi qu'il
+// arrive (P19a Yahoo intraday router).
+const NON_EU_EXCHANGES = ['US', 'TSE', 'HK', 'AU', 'KO', 'TO', 'NSE', 'BSE', 'SS', 'SZ'];
 /** Watchlists EU dont la session_open_utc / session_close_utc gate l'EODHD scan. */
 const EU_WATCHLIST_NAMES = ['cac40', 'dax40', 'ftse100'];
 const CRYPTO_PAIRS = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT', 'ADAUSDT', 'AVAXUSDT', 'DOTUSDT', 'LINKUSDT', 'MATICUSDT'];

--- a/apps/api/src/modules/lisa/services/yahoo-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/yahoo-intraday.service.ts
@@ -133,6 +133,8 @@ export class YahooIntradayService {
       case 'TO':    return `${base}.TO`;
       case 'NSE':   return `${base}.NS`;
       case 'BSE':   return `${base}.BO`;
+      case 'SS':    return `${base}.SS`;  // P19d : Shanghai Stock Exchange (China A-shares)
+      case 'SZ':    return `${base}.SZ`;  // P19d : Shenzhen Stock Exchange
       case 'CC':    return null;          // Crypto — handled by Binance
       case 'FOREX': return null;          // FX — not in scope
       case 'INDX':  return null;          // Indices — not in scope


### PR DESCRIPTION
## Audit gainers strict — directive utilisateur

> "univers international complet, AUCUN marché exclu"
> + liste explicite incluant Shanghai (SSE) + Shenzhen (SZSE)

**Findings audit** :

| Critère | État | Détail |
|---|---|---|
| `side=long` strict | ✅ | `direction: 'long'` hardcoded `openTopGainerPosition` line 767 — pas de path short |
| GAIN ONLY | ✅ | EODHD filter `refund_1d_p > 3` (excl downtrend) |
| Anti gap-and-fade | ✅ | `closeToHigh > 0.80` ratio (`evaluateTopGainerCandidate`) |
| Scoring confiance élevé | ✅ | persistence > 0.67 + path efficiency > 0.5 + LLM validation (P18) |
| Univers complet | ⚠️ → ✅ | Manquait SSE/SZSE — ajoutés cette PR |

## Diff

`top-gainers-scanner.service.ts:NON_EU_EXCHANGES`
- Avant : `['US', 'TSE', 'HK', 'AU', 'KO', 'TO', 'NSE', 'BSE']` (8)
- Après : `['US', 'TSE', 'HK', 'AU', 'KO', 'TO', 'NSE', 'BSE', 'SS', 'SZ']` (10)

`yahoo-intraday.service.ts:toYahooSymbol`
- `SS → .SS` (Shanghai)
- `SZ → .SZ` (Shenzhen)

## Univers final post-P19d

| Région | Exchanges |
|---|---|
| EU | LSE, XETRA, PA, SW, MI, MC, BME, AS, AMS (9) |
| US | US (NYSE/NASDAQ/AMEX) |
| Asia majors | TSE, HK, AU |
| Asia émergents | KO (Korea), NSE (India NSE), BSE (India BSE) |
| China A-shares | **SS (Shanghai), SZ (Shenzhen) — NOUVEAU** |
| Americas autres | TO (Toronto) |
| Crypto | 10 pairs Binance (BTC/ETH/BNB/SOL/XRP/ADA/AVAX/DOT/LINK/MATIC) |

**Total : 17 equity exchanges + 10 crypto pairs.**

## Couverture intraday

- EODHD primaire (si plan supporte SSE/SZSE)
- Yahoo Finance fallback (P19a) — `.SS` et `.SZ` toujours dispo
- Si EODHD 422 sur SSE/SZSE → log warn P18c, Yahoo prend le relais

## Tests

52/52 scanner+MTF tests green (no regression).

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_