### PR TITLE
[P18f] feat: crypto_tradable whitelist gate (option b skip+log)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18f-crypto-tradable.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18f-crypto-tradable.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * P18f — Tests pour le concept `crypto_tradable` (whitelist opt-in).
+ *
+ * Comportement attendu (option b "skip + log") :
+ *   - whitelist VIDE / non-définie → toutes les crypto sont tradables
+ *     (back-compat, pas de restriction sur le path d'open)
+ *   - whitelist SET (ex `BTCUSDT,ETHUSDT`) → seuls ces symboles passent ;
+ *     les autres sont skippés silencieusement avec log INFO + counter
+ */
+
+import { Logger } from '@nestjs/common';
+import { TopGainersScannerService } from '../services/top-gainers-scanner.service';
+
+const supabaseFromMock = jest.fn();
+const mockSupabase = { getClient: () => ({ from: supabaseFromMock }) } as any;
+const mockLisa = {} as any;
+const mockDecisionLog = {} as any;
+const mockConfig = { get: jest.fn() } as any;
+const mockBinance = { getTicker24h: jest.fn().mockResolvedValue(null) } as any;
+const mockScheduler = {
+  getCronJob: jest.fn().mockImplementation(() => { throw new Error('not found'); }),
+  addCronJob: jest.fn(),
+} as any;
+const mockMtf = {} as any;
+const mockLlmRouter = { isEnabled: jest.fn().mockReturnValue(false), call: jest.fn() } as any;
+
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+function makeService(envMap: Record<string, string | undefined> = {}): TopGainersScannerService {
+  mockConfig.get.mockImplementation((key: string) => {
+    if (key === 'SCAN_INTERVAL_MINUTES') return '15';
+    return envMap[key];
+  });
+  return new TopGainersScannerService(
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter,
+  );
+}
+
+describe('isCryptoTradable — P18f whitelist gate', () => {
+  it('returns true for ALL symbols when whitelist env var is unset (back-compat)', () => {
+    const svc = makeService({});
+    expect(svc.isCryptoTradable('BTCUSDT')).toBe(true);
+    expect(svc.isCryptoTradable('ETHUSDT')).toBe(true);
+    expect(svc.isCryptoTradable('DOGEUSDT')).toBe(true);
+    expect(svc.isCryptoTradable('SHIBUSDT')).toBe(true);
+  });
+
+  it('returns true for ALL symbols when whitelist env var is empty string', () => {
+    const svc = makeService({ CRYPTO_TRADABLE_WHITELIST: '' });
+    expect(svc.isCryptoTradable('BTCUSDT')).toBe(true);
+    expect(svc.isCryptoTradable('DOGEUSDT')).toBe(true);
+  });
+
+  it('returns true for ALL symbols when whitelist env var is whitespace-only', () => {
+    const svc = makeService({ CRYPTO_TRADABLE_WHITELIST: '   ' });
+    expect(svc.isCryptoTradable('BTCUSDT')).toBe(true);
+  });
+
+  it('returns true ONLY for whitelisted symbols when whitelist is set', () => {
+    const svc = makeService({ CRYPTO_TRADABLE_WHITELIST: 'BTCUSDT,ETHUSDT' });
+    expect(svc.isCryptoTradable('BTCUSDT')).toBe(true);
+    expect(svc.isCryptoTradable('ETHUSDT')).toBe(true);
+    // NOT in whitelist
+    expect(svc.isCryptoTradable('SOLUSDT')).toBe(false);
+    expect(svc.isCryptoTradable('DOGEUSDT')).toBe(false);
+    expect(svc.isCryptoTradable('SHIBUSDT')).toBe(false);
+  });
+
+  it('whitelist match is case-insensitive', () => {
+    const svc = makeService({ CRYPTO_TRADABLE_WHITELIST: 'btcusdt,EthUsdt' });
+    expect(svc.isCryptoTradable('BTCUSDT')).toBe(true);
+    expect(svc.isCryptoTradable('ETHUSDT')).toBe(true);
+    expect(svc.isCryptoTradable('btcusdt')).toBe(true);  // lowercase input also passes
+  });
+
+  it('handles whitespace around CSV entries', () => {
+    const svc = makeService({ CRYPTO_TRADABLE_WHITELIST: '  BTCUSDT  ,  ETHUSDT  ,SOLUSDT' });
+    expect(svc.isCryptoTradable('BTCUSDT')).toBe(true);
+    expect(svc.isCryptoTradable('ETHUSDT')).toBe(true);
+    expect(svc.isCryptoTradable('SOLUSDT')).toBe(true);
+    expect(svc.isCryptoTradable('DOGEUSDT')).toBe(false);
+  });
+
+  it('counter starts at 0', () => {
+    const svc = makeService({});
+    expect(svc.getSkippedNotCryptoTradableCounter()).toBe(0);
+  });
+});

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -109,6 +109,26 @@ const EU_WATCHLIST_NAMES = ['cac40', 'dax40', 'ftse100'];
 const CRYPTO_PAIRS = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT', 'ADAUSDT', 'AVAXUSDT', 'DOTUSDT', 'LINKUSDT', 'MATICUSDT'];
 
 /**
+ * P18f (29/04/2026, autonomous) — `crypto_tradable` concept : whitelist
+ * opt-in via env var `CRYPTO_TRADABLE_WHITELIST=BTCUSDT,ETHUSDT,...` qui
+ * RESTREINT les ouvertures de positions crypto à ces symboles.
+ *
+ * Comportement strict mode `option (b)` retenu par l'utilisateur :
+ *   - whitelist VIDE  → behavior unchanged, tous les CRYPTO_PAIRS sont
+ *                       éligibles à l'open (back-compat)
+ *   - whitelist SET   → SEULS les symboles présents sont opens. Les autres
+ *                       sont SKIPPED + LOGGED en INFO (visible mais pas
+ *                       d'effet de trade)
+ *
+ * Permet à l'utilisateur de :
+ *   - Restreindre BTC/ETH uniquement en prod (le plus safe)
+ *   - Élargir progressivement après backtest par ticker
+ *   - Garder le scan complet (UI affiche tous les CRYPTO_PAIRS dans le
+ *     Top 20) tout en ne tradant que les whitelistés
+ */
+const CRYPTO_TRADABLE_ENV_VAR = 'CRYPTO_TRADABLE_WHITELIST';
+
+/**
  * P18d — Fallback hardcodé si la query `watchlist_universe` échoue : enveloppe
  * conservatrice [07:00, 17:00] UTC qui couvre CAC40 / DAX40 (07:00-15:30) +
  * FTSE100 (08:00-16:30). Préférable au "always-on" qui re-causerait les 422.
@@ -233,6 +253,34 @@ export class TopGainersScannerService implements OnModuleInit {
   /** P18e — Métrique cumulative observability. */
   getSkippedNoPersistenceCounter(): number {
     return this.skippedNoPersistenceCounter;
+  }
+
+  /** P18f — Compteur cumulatif des crypto skip pour absence whitelist. */
+  private skippedNotCryptoTradableCounter = 0;
+  getSkippedNotCryptoTradableCounter(): number {
+    return this.skippedNotCryptoTradableCounter;
+  }
+
+  /**
+   * P18f — Vérifie si le symbole crypto est dans la whitelist opt-in
+   * définie par env `CRYPTO_TRADABLE_WHITELIST` (CSV, case-insensitive).
+   *
+   * Retourne `true` si :
+   *   - la whitelist est VIDE / non-définie (back-compat — pas de restriction)
+   *   - le symbole est présent dans la whitelist
+   *
+   * Retourne `false` SEULEMENT si la whitelist est définie ET le symbole
+   * absent. Le caller skip + log dans ce cas.
+   */
+  isCryptoTradable(symbol: string): boolean {
+    const raw = this.config.get<string>(CRYPTO_TRADABLE_ENV_VAR);
+    if (!raw || raw.trim().length === 0) return true;
+    const whitelist = raw
+      .split(',')
+      .map((s) => s.trim().toUpperCase())
+      .filter((s) => s.length > 0);
+    if (whitelist.length === 0) return true;
+    return whitelist.includes(symbol.toUpperCase());
   }
 
   /**
@@ -708,6 +756,17 @@ export class TopGainersScannerService implements OnModuleInit {
       if (!signal.pass) {
         this.logger.log(
           `[top-gainers:signal] ${cand.symbol} rejected (quality=${signal.signal_quality.toFixed(2)}): ${signal.reason}`,
+        );
+        continue;
+      }
+
+      // P18f — Crypto whitelist gate (option b "skip + log"). N'affecte que
+      // si CRYPTO_TRADABLE_WHITELIST env est définie. Sinon back-compat.
+      const isCryptoCand = cand.assetClass === 'crypto_major' || cand.assetClass === 'crypto_alt';
+      if (isCryptoCand && !this.isCryptoTradable(cand.symbol)) {
+        this.skippedNotCryptoTradableCounter++;
+        this.logger.log(
+          `[top-gainers:crypto_tradable] ${cand.symbol} not in CRYPTO_TRADABLE_WHITELIST → skip open (visible in scan, not traded)`,
         );
         continue;
       }


### PR DESCRIPTION
## Quoi

Concept opt-in `crypto_tradable` (option b "skip + log") — restreint les ouvertures de positions crypto à un sous-ensemble whitelisté via env `CRYPTO_TRADABLE_WHITELIST`.

| Env | Comportement |
|---|---|
| Non-définie / vide | back-compat : toutes les `CRYPTO_PAIRS` éligibles |
| `BTCUSDT,ETHUSDT` | seuls BTC/ETH ouvrent positions ; autres skip+log |
| `btcusdt,EthUsdt` | case-insensitive |

## Path d'invocation

`scanPortfolio()` → loop top candidats → après LLM signal validation → **avant** `openTopGainerPosition()` :

```ts
const isCryptoCand = cand.assetClass === 'crypto_major' || cand.assetClass === 'crypto_alt';
if (isCryptoCand && !this.isCryptoTradable(cand.symbol)) {
  this.skippedNotCryptoTradableCounter++;
  this.logger.log(`[top-gainers:crypto_tradable] ${cand.symbol} not in CRYPTO_TRADABLE_WHITELIST → skip open (visible in scan, not traded)`);
  continue;
}
```

## Use cases

- **Prod safety** : `CRYPTO_TRADABLE_WHITELIST=BTCUSDT,ETHUSDT` (whitelist BTC/ETH uniquement)
- **Backtest progressif** : élargir ticker par ticker
- **Disable crypto temporaire** : `CRYPTO_TRADABLE_WHITELIST=NONE` (toute valeur non-matchante = skip all crypto)

## Tests — 7/7 green

- ✅ whitelist unset → back-compat (true pour tous)
- ✅ whitelist empty/whitespace → back-compat
- ✅ whitelist set → seuls symboles présents passent
- ✅ case-insensitive match
- ✅ whitespace-tolerant CSV parsing
- ✅ counter initialisé à 0
- ✅ counter exposé via `getSkippedNotCryptoTradableCounter()`

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_