### PR TITLE
[P19e] hotfix: yahoo-finance2 ERR_PACKAGE_PATH_NOT_EXPORTED — Function-bypass dynamic import (closes #96)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/yahoo-intraday.p19e.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/yahoo-intraday.p19e.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * P19e — Regression test for ERR_PACKAGE_PATH_NOT_EXPORTED on yahoo-finance2.
+ *
+ * Issue #96 (29/04/2026 prod, machine d8d4070a719018 CDG) :
+ *   `YahooIntradayService` failed on 100% of tickers in prod with
+ *   `ERR_PACKAGE_PATH_NOT_EXPORTED: No "exports" main defined in
+ *   /app/node_modules/yahoo-finance2`.
+ *
+ * Root cause : TypeScript with `module: CommonJS` transpiles `await import(...)`
+ * to a bare `require(...)` call. yahoo-finance2 v2 publishes ESM-only with a
+ * strict `package.json` `exports.import` field (no `require` condition) →
+ * Node rejects the require with the error above.
+ *
+ * Fix : `new Function('s', 'return import(s);')` builds a dynamic ESM import
+ * that tsc cannot transform (the import() lives inside a string body of the
+ * Function constructor, parsed at runtime by V8 not by tsc). The `import()`
+ * stays as actual ESM dynamic import.
+ *
+ * NB : Jest's default CJS resolver cannot load yahoo-finance2's ESM-only
+ * package even with our Function-bypass, so we cannot test the actual import
+ * works in this test runner. The real validation is :
+ *   1. tsc compiled output preserves `new Function(...)` (verified manually)
+ *   2. Prod /version after deploy + UI Top 20 colonne Score/Path/%change
+ *      affichée (et plus '—'). Cf. issue #96 plan de validation.
+ *
+ * What we CAN test in Jest :
+ *   - Service constructor doesn't throw
+ *   - toYahooSymbol pure mapping table (no dynamic import involved)
+ *   - getCandles graceful degrade: returns null on unknown suffix without
+ *     even triggering the import (short-circuit)
+ *   - getCandles graceful degrade: returns null on import failure (catch swallows)
+ */
+
+import { Logger } from '@nestjs/common';
+import { YahooIntradayService } from '../yahoo-intraday.service';
+
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+describe('YahooIntradayService — P19e regression guard', () => {
+  it('service constructor does not throw on instantiation', () => {
+    expect(() => new YahooIntradayService()).not.toThrow();
+  });
+
+  it('getCandles returns null and does NOT throw on unknown suffix (short-circuit before dynamic import)', async () => {
+    const svc = new YahooIntradayService();
+    const result = await svc.getCandles('NOTREAL.UNKNOWNXYZ');
+    expect(result).toBeNull();
+  });
+
+  it('getCandles returns null and does NOT throw on supported suffix (catch swallows any runtime error)', async () => {
+    const svc = new YahooIntradayService();
+    // Use a suffix that toYahooSymbol maps successfully → triggers the
+    // dynamic import path. Even if the import fails (Jest CJS env, network,
+    // rate limit, etc.), the service must catch and return null without
+    // letting the error propagate to scanPortfolio.
+    const result = await svc.getCandles('AAPL.US');
+    // Result can be null (any failure) or an array (network success).
+    // Regression check : no exception escaped the try/catch.
+    expect(result === null || Array.isArray(result)).toBe(true);
+  }, 15_000);
+
+  it('toYahooSymbol pure logic — full mapping table', () => {
+    const svc = new YahooIntradayService();
+    expect(svc.toYahooSymbol('AAPL.US')).toBe('AAPL');
+    expect(svc.toYahooSymbol('199820.KO')).toBe('199820.KS');
+    expect(svc.toYahooSymbol('006340.KO')).toBe('006340.KS');
+    expect(svc.toYahooSymbol('BHP.AU')).toBe('BHP.AX');
+    expect(svc.toYahooSymbol('SHEL.LSE')).toBe('SHEL.L');
+    expect(svc.toYahooSymbol('SAP.XETRA')).toBe('SAP.DE');
+    expect(svc.toYahooSymbol('600000.SS')).toBe('600000.SS');
+    expect(svc.toYahooSymbol('000001.SZ')).toBe('000001.SZ');
+    expect(svc.toYahooSymbol('UNKNOWN.WTF')).toBeNull();
+    expect(svc.toYahooSymbol('BTC-USD.CC')).toBeNull(); // crypto handled by Binance
+    expect(svc.toYahooSymbol('EURUSD.FOREX')).toBeNull();
+    expect(svc.toYahooSymbol('')).toBeNull();
+  });
+});

--- a/apps/api/src/modules/lisa/services/yahoo-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/yahoo-intraday.service.ts
@@ -15,18 +15,31 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 /**
- * Yahoo-finance2 is published ESM-only. We can't `import` or `require`
- * it from our CJS NestJS bundle, so we lazy-load via dynamic `import()`
- * (works in CJS for ESM modules) and cache the resolved module.
+ * Yahoo-finance2 is published ESM-only (`exports.import` only, no `require`).
+ *
+ * P19e (29/04/2026, observed in prod) — TypeScript with `module: CommonJS`
+ * transpiles `await import('yahoo-finance2')` to a bare `require('yahoo-finance2')`
+ * call, which Node.js rejects with `ERR_PACKAGE_PATH_NOT_EXPORTED` because
+ * the package's `package.json` `exports` field has only an `import` condition
+ * (no `require`). Result : 100% of intraday Yahoo fallback calls failed in
+ * prod, persistance multi-TF stayed at 0/20, no positions opened.
+ *
+ * Fix : use a `Function`-constructed dynamic import. The `Function` constructor
+ * compiles its body as runtime ES code that tsc never touches → the `import()`
+ * stays as an actual ESM dynamic import, not a `require()`.
+ *
+ * Cached after first successful resolve (next calls bypass the import overhead).
  */
 let _yahooFinanceModule: any = null;
+// eslint-disable-next-line @typescript-eslint/no-implied-eval
+const _importEsm: (m: string) => Promise<any> = new Function(
+  'specifier',
+  'return import(specifier);',
+) as (m: string) => Promise<any>;
+
 async function getYahooFinance(): Promise<any> {
   if (_yahooFinanceModule) return _yahooFinanceModule;
-  // ts-ignore : yahoo-finance2 is ESM-only ; with our `node` moduleResolution
-  // tsc cannot resolve its type declarations through dynamic `import()`. The
-  // runtime resolution works fine (Node walks up `node_modules`).
-  // @ts-ignore
-  const mod: any = await import('yahoo-finance2');
+  const mod: any = await _importEsm('yahoo-finance2');
   _yahooFinanceModule = mod.default ?? mod;
   return _yahooFinanceModule;
 }


### PR DESCRIPTION
## 🚨 BLOQUANT TRADING — closes #96

Observation prod 29/04/2026 14:01 CEST :
```
[YahooIntradayService] [yahoo-intraday] QVCGP.US→QVCGP error:
  Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /app/node_modules/yahoo-finance2
```
100% des tickers échouaient → persistance multi-TF **0/20** → **0 position ouverte**.

## Root cause confirmée par sandbox

TypeScript `module: CommonJS` transpile `await import('yahoo-finance2')` en `require('yahoo-finance2')`. `yahoo-finance2` v2 est ESM-only avec `exports.import` strict (pas de condition `require`) → Node.js lance `ERR_PACKAGE_PATH_NOT_EXPORTED`.

Reproduction :
```
$ node -e "require('yahoo-finance2')"             → ERR_PACKAGE_PATH_NOT_EXPORTED
$ node -e "new Function('s','return import(s);')..." → OK
```

## Fix

```ts
const _importEsm: (m: string) => Promise<any> = new Function(
  'specifier',
  'return import(specifier);',
) as (m: string) => Promise<any>;

async function getYahooFinance(): Promise<any> {
  if (_yahooFinanceModule) return _yahooFinanceModule;
  const mod: any = await _importEsm('yahoo-finance2');
  _yahooFinanceModule = mod.default ?? mod;
  return _yahooFinanceModule;
}
```

Le `Function` constructor compile son body comme runtime code que **tsc ne touche pas**. L'`import()` reste un vrai dynamic ESM import.

**Vérifié sur la sortie compilée** `apps/api/dist/...yahoo-intraday.service.js` :
```js
const _importEsm = new Function('specifier', 'return import(specifier);');
const mod = await _importEsm('yahoo-finance2');
```
→ Plus de `require('yahoo-finance2')` dans le JS final.

## Tests — 4/4 green

`yahoo-intraday.p19e.spec.ts` :
- Service constructor n'throw pas
- `getCandles` unknown suffix → null sans throw (short-circuit avant import)
- `getCandles` supported suffix → null OR array sans throw (catch swallow)
- `toYahooSymbol` pure mapping (full table US/KO/AU/LSE/XETRA/SS/SZ/...)

> **NB** Jest's CJS resolver ne supporte pas l'ESM-only `yahoo-finance2` même via le Function-bypass. Les tests valident la robustesse du code path (service ne crash jamais), pas que le dynamic import résout en CI. La vraie validation est `/version` Fly post-deploy + UI Top 20.

## Validation post-deploy attendue

```bash
fly logs -a smartvest | grep -E "ERR_PACKAGE_PATH_NOT_EXPORTED|yahoo fallback"
```
- **ZÉRO** ligne `ERR_PACKAGE_PATH_NOT_EXPORTED`
- N lignes `[mtf-persist] yahoo fallback used for K ticker(s)`

UI `/lisa` Top 20 : colonnes Score / Path / %change peuplées (plus de '—' universel).

## Pourquoi les 48 tests P18/P19 ne l'ont pas attrapé

Tous les tests downstream **mockent** `YahooIntradayService` (cf. `multi-tf-persistence.p18e.spec.ts`). Le service réel n'était jamais instancié en CI → bug uniquement révélé en prod Node.js runtime.

Closes #96.

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_