### PR TITLE
[P19i] feat: MTF fallback chain Yahoo → EODHD → IntradayCache Supabase → null

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p18e.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p18e.spec.ts
@@ -43,9 +43,15 @@ beforeEach(() => {
 const mockYahoo = {
   getCandles: jest.fn(),
 } as any;
+// P19i — IntradayCacheService injecté en 4e arg. Tests P18e n'utilisent
+// pas le cache, donc mock no-op (read returns null, write returns false).
+const mockIntradayCache = {
+  read: jest.fn().mockResolvedValue(null),
+  write: jest.fn().mockResolvedValue(false),
+} as any;
 
 function makeService(): MultiTimeframePersistenceService {
-  return new MultiTimeframePersistenceService(mockBinance, mockEodhd, mockYahoo);
+  return new MultiTimeframePersistenceService(mockBinance, mockEodhd, mockYahoo, mockIntradayCache);
 }
 
 // ── 1. Aggregated log — single line for N misses ─────────────────────────────
@@ -154,8 +160,7 @@ describe('analyzeBatch — P19a Yahoo fallback chain', () => {
     expect(svc.getNoIntradayCounter()).toBe(3);
   });
 
-  it('uses Yahoo result with coverage="yahoo" when EODHD returns null but Yahoo succeeds', async () => {
-    mockEodhd.getCandles.mockResolvedValue(null);
+  it('P19i — uses Yahoo result with coverage="yahoo" — Yahoo PRIMAIRE (P19i reordered)', async () => {
     const baseTime = Date.parse('2026-04-29T09:00:00.000Z');
     const fakeCandles = Array.from({ length: 13 }, (_, i) => ({
       datetime: new Date(baseTime + i * 5 * 60_000).toISOString(),
@@ -168,30 +173,30 @@ describe('analyzeBatch — P19a Yahoo fallback chain', () => {
       { symbol: '199820', exchange: 'KO', currentPrice: 105 },
     ]);
 
-    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(1);
     expect(mockYahoo.getCandles).toHaveBeenCalledTimes(1);
+    expect(mockEodhd.getCandles).not.toHaveBeenCalled();
     const persist = result.get('199820');
     expect(persist).toBeDefined();
     expect(persist!.coverage).toBe('yahoo');
   });
 
-  it('does NOT call Yahoo when EODHD already provides intraday (eodhd primaire wins)', async () => {
+  it('P19i — does NOT call EODHD when Yahoo already provides intraday (yahoo primaire wins)', async () => {
     const baseTime = Date.parse('2026-04-29T09:00:00.000Z');
-    const fakeCandles = Array.from({ length: 13 }, (_, i) => ({
+    const fakeYahooCandles = Array.from({ length: 13 }, (_, i) => ({
       datetime: new Date(baseTime + i * 5 * 60_000).toISOString(),
       open: 100 + i, high: 101 + i, low: 99 + i, close: 100 + i, volume: 1000,
     }));
-    mockEodhd.getCandles.mockResolvedValue({ candles: fakeCandles });
+    mockYahoo.getCandles.mockResolvedValue(fakeYahooCandles);
 
     const svc = makeService();
     const result = await svc.analyzeBatch([
       { symbol: 'AAPL', exchange: 'US', currentPrice: 180 },
     ]);
 
-    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(1);
-    expect(mockYahoo.getCandles).not.toHaveBeenCalled();
+    expect(mockYahoo.getCandles).toHaveBeenCalledTimes(1);
+    expect(mockEodhd.getCandles).not.toHaveBeenCalled();
     const persist = result.get('AAPL');
-    expect(persist!.coverage).toBe('eodhd');
+    expect(persist!.coverage).toBe('yahoo');
   });
 
   it('crypto bypasses both EODHD and Yahoo (uses Binance with coverage="binance")', async () => {

--- a/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p19i.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p19i.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * P19i — Tests pour la nouvelle fallback chain MTF :
+ *   Yahoo (primaire) → EODHD (fallback) → IntradayCache (stale) → null
+ *
+ * Critique car l'utilisateur a observé en prod (29/04 15:30) que Yahoo
+ * retournait 429 sur 100% des tickers depuis l'IP Fly. La chain doit basculer
+ * proprement sur EODHD, puis sur le cache Supabase si EODHD aussi KO.
+ */
+
+import { Logger } from '@nestjs/common';
+import { MultiTimeframePersistenceService } from '../services/multi-tf-persistence.service';
+
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+const mockBinance = { getKlines: jest.fn(), toBinanceSymbol: jest.fn().mockImplementation((s: string) => s) } as any;
+const mockEodhd = { getCandles: jest.fn() } as any;
+const mockYahoo = { getCandles: jest.fn() } as any;
+const mockCache = { read: jest.fn(), write: jest.fn().mockResolvedValue(true) } as any;
+
+beforeEach(() => {
+  mockBinance.getKlines.mockReset();
+  mockEodhd.getCandles.mockReset();
+  mockYahoo.getCandles.mockReset();
+  mockCache.read.mockReset();
+  mockCache.write.mockReset().mockResolvedValue(true);
+});
+
+function makeService() {
+  return new MultiTimeframePersistenceService(mockBinance, mockEodhd, mockYahoo, mockCache);
+}
+
+function fakeYahooCandles(n = 13) {
+  const base = Date.parse('2026-04-29T09:00:00Z');
+  return Array.from({ length: n }, (_, i) => ({
+    datetime: new Date(base + i * 5 * 60_000).toISOString(),
+    open: 100 + i, high: 101 + i, low: 99 + i, close: 100 + i, volume: 1000,
+  }));
+}
+
+function fakeEodhdSeries(n = 13) {
+  const base = Math.floor(Date.parse('2026-04-29T09:00:00Z') / 1000);
+  return {
+    candles: Array.from({ length: n }, (_, i) => ({
+      timestamp: base + i * 300,
+      open: 200 + i, high: 201 + i, low: 199 + i, close: 200 + i, volume: 500,
+    })),
+  };
+}
+
+function fakeCachedSeries(ageMs = 5 * 60 * 1000, n = 13) {
+  const base = Math.floor(Date.parse('2026-04-29T08:30:00Z') / 1000);
+  return {
+    symbol: 'AAPL',
+    source: 'yahoo' as const,
+    fetchedAt: Date.now() - ageMs,
+    ageMs,
+    candles: Array.from({ length: n }, (_, i) => ({
+      timestamp: base + i * 300,
+      open: 50 + i, high: 51 + i, low: 49 + i, close: 50 + i, volume: 100,
+    })),
+  };
+}
+
+describe('MTF P19i — fallback chain Yahoo → EODHD → cache → null', () => {
+  it('Yahoo OK → returns coverage="yahoo", EODHD/cache NOT called, write-on-success cache', async () => {
+    mockYahoo.getCandles.mockResolvedValue(fakeYahooCandles());
+    const svc = makeService();
+    const result = await svc.analyzeBatch([
+      { symbol: 'AAPL', exchange: 'US', currentPrice: 100 },
+    ]);
+    const persist = result.get('AAPL');
+    expect(persist).toBeDefined();
+    expect(persist!.coverage).toBe('yahoo');
+    expect(mockEodhd.getCandles).not.toHaveBeenCalled();
+    expect(mockCache.read).not.toHaveBeenCalled();
+    // Write-on-success
+    expect(mockCache.write).toHaveBeenCalledTimes(1);
+    expect(mockCache.write.mock.calls[0][1]).toBe('yahoo');
+  });
+
+  it('Yahoo null → EODHD OK → returns coverage="eodhd", cache NOT read, write-on-success', async () => {
+    mockYahoo.getCandles.mockResolvedValue(null);
+    mockEodhd.getCandles.mockResolvedValue(fakeEodhdSeries());
+    const svc = makeService();
+    const result = await svc.analyzeBatch([
+      { symbol: 'AAPL', exchange: 'US', currentPrice: 100 },
+    ]);
+    const persist = result.get('AAPL');
+    expect(persist!.coverage).toBe('eodhd');
+    expect(mockYahoo.getCandles).toHaveBeenCalledTimes(1);
+    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(1);
+    expect(mockCache.read).not.toHaveBeenCalled();
+    expect(mockCache.write).toHaveBeenCalledTimes(1);
+    expect(mockCache.write.mock.calls[0][1]).toBe('eodhd');
+  });
+
+  it('Yahoo + EODHD null → cache hit < 15 min → returns coverage="cache_stale" + cacheAgeMs', async () => {
+    mockYahoo.getCandles.mockResolvedValue(null);
+    mockEodhd.getCandles.mockResolvedValue(null);
+    const cached = fakeCachedSeries(7 * 60 * 1000); // 7 min ago
+    mockCache.read.mockResolvedValue(cached);
+    const svc = makeService();
+    const result = await svc.analyzeBatch([
+      { symbol: 'AAPL', exchange: 'US', currentPrice: 100 },
+    ]);
+    const persist = result.get('AAPL');
+    expect(persist!.coverage).toBe('cache_stale');
+    expect(persist!.cacheAgeMs).toBe(7 * 60 * 1000);
+    expect(mockCache.read).toHaveBeenCalledTimes(1);
+  });
+
+  it('Yahoo + EODHD null + no cache → no entry in result map', async () => {
+    mockYahoo.getCandles.mockResolvedValue(null);
+    mockEodhd.getCandles.mockResolvedValue(null);
+    mockCache.read.mockResolvedValue(null);
+    const svc = makeService();
+    const result = await svc.analyzeBatch([
+      { symbol: 'AAPL', exchange: 'US', currentPrice: 100 },
+    ]);
+    expect(result.has('AAPL')).toBe(false);
+  });
+
+  it('Crypto BTC primary path : Binance → write cache as binance source', async () => {
+    const baseTime = Date.parse('2026-04-29T09:00:00.000Z');
+    mockBinance.getKlines.mockResolvedValue(
+      Array.from({ length: 61 }, (_, i) => ({
+        openTime: baseTime + i * 60_000,
+        closeTime: baseTime + i * 60_000 + 60_000,
+        open: 65000 + i, high: 65100 + i, low: 64900 + i, close: 65000 + i, volume: 10,
+      })),
+    );
+    const svc = makeService();
+    await svc.analyzeBatch([{ symbol: 'BTCUSDT', exchange: 'BINANCE', currentPrice: 65000 }]);
+    expect(mockCache.write).toHaveBeenCalled();
+    expect(mockCache.write.mock.calls[0][1]).toBe('binance');
+    // Yahoo + EODHD never called for crypto
+    expect(mockYahoo.getCandles).not.toHaveBeenCalled();
+    expect(mockEodhd.getCandles).not.toHaveBeenCalled();
+  });
+
+  it('Yahoo throw → caught, EODHD next', async () => {
+    mockYahoo.getCandles.mockRejectedValue(new Error('network'));
+    mockEodhd.getCandles.mockResolvedValue(fakeEodhdSeries());
+    const svc = makeService();
+    const result = await svc.analyzeBatch([{ symbol: 'AAPL', exchange: 'US', currentPrice: 100 }]);
+    expect(result.get('AAPL')!.coverage).toBe('eodhd');
+  });
+
+  it('Cache write failure does NOT block return value', async () => {
+    mockYahoo.getCandles.mockResolvedValue(fakeYahooCandles());
+    mockCache.write.mockResolvedValue(false); // simulate Supabase down
+    const svc = makeService();
+    const result = await svc.analyzeBatch([{ symbol: 'AAPL', exchange: 'US', currentPrice: 100 }]);
+    expect(result.get('AAPL')!.coverage).toBe('yahoo'); // service stays usable
+  });
+});

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -46,6 +46,7 @@ import { TopGainersScannerService } from './services/top-gainers-scanner.service
 import { OperatingModeService } from './services/operating-mode.service';
 import { MultiTimeframePersistenceService } from './services/multi-tf-persistence.service';
 import { YahooIntradayService } from './services/yahoo-intraday.service';
+import { IntradayCacheService } from './services/intraday-cache.service';
 import { PersistenceProbabilityService } from './services/persistence-probability.service';
 import { ScannerLlmRouterService } from './services/scanner-llm-router.service';
 
@@ -106,6 +107,8 @@ import { ScannerLlmRouterService } from './services/scanner-llm-router.service';
     MultiTimeframePersistenceService,
     // P19a — Yahoo Finance intraday fallback (Korea KOSPI, small-caps, etc.)
     YahooIntradayService,
+    // P19i — Intraday OHLCV cache Supabase (last_known < 15 min, fallback chain)
+    IntradayCacheService,
     // P9 — logistic regression P(win) sur features persistence + empirical law
     PersistenceProbabilityService,
     // P17 — LLM router multi-vendor pour scanner Gainers (Gemini/GPT-nano/Codestral/Claude)

--- a/apps/api/src/modules/lisa/services/__tests__/intraday-cache.p19i.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/intraday-cache.p19i.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * P19i — Tests pour IntradayCacheService (cache Supabase OHLCV intraday).
+ *
+ * Garanties :
+ *   - write() upsert proprement, failure-tolerant (Supabase down → false)
+ *   - read() retourne null si > 15 min (TTL applicatif)
+ *   - read() retourne CachedSeries avec ageMs computed à la lecture
+ *   - read()/write() ne throwent jamais (silent debug log)
+ *   - service is_ready=false → no-op
+ */
+
+import { Logger } from '@nestjs/common';
+import { IntradayCacheService } from '../intraday-cache.service';
+
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+const upsertMock = jest.fn();
+const maybeSingleMock = jest.fn();
+
+function makeSupabase(ready = true) {
+  return {
+    isReady: () => ready,
+    getClient: () => ({
+      from: () => ({
+        upsert: upsertMock,
+        select: () => ({
+          eq: () => ({
+            maybeSingle: maybeSingleMock,
+          }),
+        }),
+      }),
+    }),
+  } as any;
+}
+
+beforeEach(() => {
+  upsertMock.mockReset();
+  maybeSingleMock.mockReset();
+});
+
+describe('IntradayCacheService — P19i', () => {
+  describe('write()', () => {
+    it('upserts symbol/source/candles + fetched_at', async () => {
+      upsertMock.mockResolvedValue({ error: null });
+      const svc = new IntradayCacheService(makeSupabase());
+      const ok = await svc.write('AAPL', 'yahoo', [
+        { timestamp: 1761830400, open: 180, high: 181, low: 179, close: 180.5, volume: 1000 },
+      ]);
+      expect(ok).toBe(true);
+      expect(upsertMock).toHaveBeenCalledTimes(1);
+      const [row, opts] = upsertMock.mock.calls[0];
+      expect(row.symbol).toBe('AAPL');
+      expect(row.source).toBe('yahoo');
+      expect(row.candles).toHaveLength(1);
+      expect(row.fetched_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(opts).toEqual({ onConflict: 'symbol' });
+    });
+
+    it('returns false silently when Supabase returns an error', async () => {
+      upsertMock.mockResolvedValue({ error: { message: 'rls violation' } });
+      const svc = new IntradayCacheService(makeSupabase());
+      const ok = await svc.write('AAPL', 'yahoo', [
+        { timestamp: 1761830400, open: 180, high: 181, low: 179, close: 180.5, volume: 1000 },
+      ]);
+      expect(ok).toBe(false);
+    });
+
+    it('returns false when supabase is not ready', async () => {
+      const svc = new IntradayCacheService(makeSupabase(false));
+      const ok = await svc.write('AAPL', 'yahoo', [{ timestamp: 1, open: 1, high: 1, low: 1, close: 1, volume: 1 }]);
+      expect(ok).toBe(false);
+      expect(upsertMock).not.toHaveBeenCalled();
+    });
+
+    it('returns false on empty candles array (no-op)', async () => {
+      const svc = new IntradayCacheService(makeSupabase());
+      const ok = await svc.write('AAPL', 'yahoo', []);
+      expect(ok).toBe(false);
+      expect(upsertMock).not.toHaveBeenCalled();
+    });
+
+    it('uppercase normalization on symbol', async () => {
+      upsertMock.mockResolvedValue({ error: null });
+      const svc = new IntradayCacheService(makeSupabase());
+      await svc.write('aapl', 'yahoo', [{ timestamp: 1, open: 1, high: 1, low: 1, close: 1, volume: 1 }]);
+      expect(upsertMock.mock.calls[0][0].symbol).toBe('AAPL');
+    });
+
+    it('does NOT throw on supabase exception', async () => {
+      upsertMock.mockRejectedValue(new Error('connection refused'));
+      const svc = new IntradayCacheService(makeSupabase());
+      const ok = await svc.write('AAPL', 'yahoo', [{ timestamp: 1, open: 1, high: 1, low: 1, close: 1, volume: 1 }]);
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe('read()', () => {
+    it('returns CachedSeries with ageMs when fetched_at < 15 min ago', async () => {
+      const fetchedAt = new Date(Date.now() - 5 * 60 * 1000).toISOString(); // 5 min ago
+      maybeSingleMock.mockResolvedValue({
+        data: {
+          symbol: 'AAPL',
+          source: 'yahoo',
+          candles: [{ timestamp: 1, open: 1, high: 1, low: 1, close: 1, volume: 1 }],
+          fetched_at: fetchedAt,
+        },
+        error: null,
+      });
+      const svc = new IntradayCacheService(makeSupabase());
+      const r = await svc.read('AAPL');
+      expect(r).not.toBeNull();
+      expect(r!.symbol).toBe('AAPL');
+      expect(r!.source).toBe('yahoo');
+      expect(r!.candles).toHaveLength(1);
+      expect(r!.ageMs).toBeGreaterThan(0);
+      expect(r!.ageMs).toBeLessThan(15 * 60 * 1000);
+    });
+
+    it('returns null when fetched_at > 15 min ago (TTL expired)', async () => {
+      const fetchedAt = new Date(Date.now() - 16 * 60 * 1000).toISOString(); // 16 min ago
+      maybeSingleMock.mockResolvedValue({
+        data: {
+          symbol: 'AAPL',
+          source: 'yahoo',
+          candles: [{ timestamp: 1, open: 1, high: 1, low: 1, close: 1, volume: 1 }],
+          fetched_at: fetchedAt,
+        },
+        error: null,
+      });
+      const svc = new IntradayCacheService(makeSupabase());
+      const r = await svc.read('AAPL');
+      expect(r).toBeNull();
+    });
+
+    it('returns null when no row exists', async () => {
+      maybeSingleMock.mockResolvedValue({ data: null, error: null });
+      const svc = new IntradayCacheService(makeSupabase());
+      const r = await svc.read('UNKNOWN');
+      expect(r).toBeNull();
+    });
+
+    it('returns null when supabase is not ready', async () => {
+      const svc = new IntradayCacheService(makeSupabase(false));
+      const r = await svc.read('AAPL');
+      expect(r).toBeNull();
+      expect(maybeSingleMock).not.toHaveBeenCalled();
+    });
+
+    it('returns null and does NOT throw on supabase error', async () => {
+      maybeSingleMock.mockResolvedValue({ data: null, error: { message: 'connection refused' } });
+      const svc = new IntradayCacheService(makeSupabase());
+      const r = await svc.read('AAPL');
+      expect(r).toBeNull();
+    });
+
+    it('returns null when candles array is empty (defensive)', async () => {
+      const fetchedAt = new Date(Date.now() - 1000).toISOString();
+      maybeSingleMock.mockResolvedValue({
+        data: { symbol: 'AAPL', source: 'yahoo', candles: [], fetched_at: fetchedAt },
+        error: null,
+      });
+      const svc = new IntradayCacheService(makeSupabase());
+      const r = await svc.read('AAPL');
+      expect(r).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/intraday-cache.service.ts
+++ b/apps/api/src/modules/lisa/services/intraday-cache.service.ts
@@ -1,0 +1,118 @@
+/**
+ * P19i — Intraday OHLCV cache (Supabase persistence).
+ *
+ * Used by `MultiTimeframePersistenceService` as **last-resort fallback** :
+ *
+ *   Yahoo (P19g) → EODHD intraday → IntradayCache (15 min stale) → null
+ *
+ * Quand Yahoo ET EODHD sont KO sur un ticker (rate-limit IP Fly, quota EODHD,
+ * provider down, etc.), on lit la dernière série OHLCV connue dans
+ * `lisa_intraday_cache` (write-on-success par les providers primaires).
+ *
+ * Si la série est < 15 min (TTL configurable) → return avec flag
+ * `coverage='cache_stale'` côté UI badge dégradé orange. Sinon → null,
+ * `coverage='none'`, badge rouge.
+ *
+ * Write-on-success : à chaque fetch réussi côté provider primaire (yahoo /
+ * eodhd / binance), on upsert la série pour le prochain fallback éventuel.
+ * Failure-tolerant : si l'INSERT/UPSERT échoue (Supabase down, FK, etc.),
+ * on log debug et on continue — pas de rejet du happy path.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+export interface CachedCandle {
+  timestamp: number; // unix seconds
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export type CacheSource = 'yahoo' | 'eodhd' | 'binance';
+
+export interface CachedSeries {
+  symbol: string;
+  source: CacheSource;
+  candles: CachedCandle[];
+  fetchedAt: number; // ms epoch
+  /** Computed at read : âge en ms depuis fetched_at. */
+  ageMs: number;
+}
+
+const TTL_MS = 15 * 60 * 1000; // 15 min
+
+@Injectable()
+export class IntradayCacheService {
+  private readonly logger = new Logger(IntradayCacheService.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  /**
+   * Stocke une série de candles pour un symbole donné.
+   * Failure-tolerant : log debug et return false si Supabase échoue.
+   */
+  async write(symbol: string, source: CacheSource, candles: CachedCandle[]): Promise<boolean> {
+    if (!this.supabase.isReady() || !candles || candles.length === 0) return false;
+    try {
+      const { error } = await this.supabase
+        .getClient()
+        .from('lisa_intraday_cache')
+        .upsert({
+          symbol: symbol.toUpperCase(),
+          source,
+          candles,
+          fetched_at: new Date().toISOString(),
+        }, { onConflict: 'symbol' });
+      if (error) {
+        this.logger.debug(`[intraday-cache] write ${symbol} failed: ${error.message.slice(0, 100)}`);
+        return false;
+      }
+      return true;
+    } catch (e) {
+      this.logger.debug(`[intraday-cache] write ${symbol} threw: ${String(e).slice(0, 100)}`);
+      return false;
+    }
+  }
+
+  /**
+   * Lit la série la plus récente pour un symbole, retourne null si absente
+   * ou si plus vieille que TTL_MS (15 min). `ageMs` est calculé à la lecture.
+   */
+  async read(symbol: string): Promise<CachedSeries | null> {
+    if (!this.supabase.isReady()) return null;
+    try {
+      const { data, error } = await this.supabase
+        .getClient()
+        .from('lisa_intraday_cache')
+        .select('symbol, source, candles, fetched_at')
+        .eq('symbol', symbol.toUpperCase())
+        .maybeSingle();
+      if (error) {
+        this.logger.debug(`[intraday-cache] read ${symbol} error: ${error.message.slice(0, 100)}`);
+        return null;
+      }
+      if (!data) return null;
+
+      const fetchedAtMs = new Date(String(data.fetched_at)).getTime();
+      const ageMs = Date.now() - fetchedAtMs;
+      if (ageMs > TTL_MS) return null; // expired
+
+      const candles = (data.candles as CachedCandle[]) ?? [];
+      if (candles.length === 0) return null;
+
+      return {
+        symbol: String(data.symbol),
+        source: data.source as CacheSource,
+        candles,
+        fetchedAt: fetchedAtMs,
+        ageMs,
+      };
+    } catch (e) {
+      this.logger.debug(`[intraday-cache] read ${symbol} threw: ${String(e).slice(0, 100)}`);
+      return null;
+    }
+  }
+}

--- a/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
+++ b/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
@@ -25,6 +25,7 @@ import {
 import { BinanceMarketService } from './binance-market.service';
 import { EodhdIntradayService } from './eodhd-intraday.service';
 import { YahooIntradayService } from './yahoo-intraday.service';
+import { IntradayCacheService, CachedCandle } from './intraday-cache.service';
 
 interface Candidate {
   symbol: string;
@@ -69,11 +70,18 @@ export interface PathQualityByTf {
  *   - 'none'   → aucun vendor n'a retourné d'intraday (ticker visible mais
  *               availableCount=0, badge orange en UI)
  */
-export type CoverageSource = 'eodhd' | 'yahoo' | 'binance' | 'none';
+/**
+ * P19i — `cache_stale` ajouté pour les cas où Yahoo + EODHD sont KO sur un
+ * ticker mais qu'on a une série fraîche (<15 min) en cache Supabase.
+ * UI badge orange "stale-cache" (vs `none` rouge si vraiment rien).
+ */
+export type CoverageSource = 'eodhd' | 'yahoo' | 'binance' | 'cache_stale' | 'none';
 
 export interface PersistenceWithPath extends PersistenceResult {
   pathQuality?: PathQualityByTf;
   coverage?: CoverageSource;
+  /** P19i — Si coverage='cache_stale', âge en ms de la série cachée. */
+  cacheAgeMs?: number;
 }
 
 interface CacheEntry {
@@ -98,6 +106,7 @@ export class MultiTimeframePersistenceService {
     private readonly binance: BinanceMarketService,
     private readonly eodhd: EodhdIntradayService,
     private readonly yahoo: YahooIntradayService,
+    private readonly intradayCache: IntradayCacheService,
   ) {}
 
   /** P18e — Métriques cumulatives pour observability. */
@@ -222,43 +231,109 @@ export class MultiTimeframePersistenceService {
   private async fetchCryptoPersistenceQuiet(c: Candidate): Promise<PersistenceWithPath | null> {
     const binSym = this.binance.toBinanceSymbol(c.symbol) ?? c.symbol.toUpperCase();
     const candles = await this.binance.getKlines(binSym, '1m', 61);
-    if (!candles || candles.length === 0) return null;
+    if (!candles || candles.length === 0) {
+      // P19i — Try cache fallback (Binance WS could be down too)
+      const cached = await this.intradayCache.read(c.symbol.toUpperCase()).catch(() => null);
+      if (cached && cached.candles.length > 0) {
+        const oneMinShape = cached.candles.map((c) => ({
+          openTime: c.timestamp * 1000,
+          open: c.open, high: c.high, low: c.low, close: c.close, volume: c.volume,
+          closeTime: c.timestamp * 1000 + 60_000,
+        }));
+        const prices = extractPricesFromOneMinSeries(oneMinShape as any);
+        const persistence = evaluatePersistence(c.currentPrice, prices);
+        const pathQuality = computePathQualityForTfsFromOneMin(oneMinShape as any);
+        return { ...persistence, pathQuality, coverage: 'cache_stale', cacheAgeMs: cached.ageMs };
+      }
+      return null;
+    }
     const prices = extractPricesFromOneMinSeries(candles);
     const persistence = evaluatePersistence(c.currentPrice, prices);
     const pathQuality = computePathQualityForTfsFromOneMin(candles);
+    // P19i — Write-on-success
+    void this.intradayCache.write(
+      c.symbol.toUpperCase(),
+      'binance',
+      candles.map((k: any) => ({
+        timestamp: Math.floor((k.openTime ?? k.timestamp ?? 0) / 1000),
+        open: Number(k.open),
+        high: Number(k.high),
+        low: Number(k.low),
+        close: Number(k.close),
+        volume: Number(k.volume),
+      })),
+    );
     return { ...persistence, pathQuality, coverage: 'binance' };
   }
 
   /**
-   * P19a — Equity intraday avec fallback chain :
-   *   1. EODHD intraday (primaire — US/EU/major Asia)
-   *   2. Yahoo Finance (fallback — Korea KOSPI, small-caps obscures, etc.)
-   *   3. null (coverage='none' annoté par le caller pour UI badge dégradé)
+   * P19i — Equity intraday avec fallback chain réorganisé :
    *
-   * Annote la `coverage` source utilisée pour observability + UI.
+   *   1. Yahoo Finance (primaire — gratuit, large couverture, KOSPI/small-caps)
+   *      protégé par circuit breaker P19h — open silently si rate-limit Fly IP
+   *   2. EODHD intraday (fallback principal — US/EU large-caps, plan payant)
+   *   3. IntradayCache Supabase (last_known < 15 min, coverage='cache_stale')
+   *   4. null (coverage='none' badge dégradé)
+   *
+   * Le user (29/04 15:30 prod) a observé que Yahoo retournait 429 sur 100%
+   * des tickers depuis l'IP Fly CDG. La chain actuelle bascule rapidement
+   * sur EODHD (qui fonctionne avec EODHD_API_KEY déjà en Fly secrets).
+   *
+   * Write-on-success : à chaque fetch réussi (yahoo / eodhd), on upsert
+   * le résultat dans le cache pour le prochain fallback éventuel.
+   *
+   * Annote `coverage` (yahoo | eodhd | cache_stale | none) + `cacheAgeMs`
+   * (uniquement quand coverage='cache_stale') pour UI badge.
    */
   private async fetchEquityPersistenceQuiet(c: Candidate): Promise<PersistenceWithPath | null> {
     const eodhdTicker = this.toEodhdTicker(c);
+    const cacheKey = c.symbol.toUpperCase();
 
-    // 1. EODHD intraday (primaire)
-    const series = await this.eodhd.getCandles(eodhdTicker, '5m', 13).catch(() => null);
-    if (series && series.candles.length > 0) {
-      const prices = extractPricesFromFiveMinSeries(series.candles);
-      const persistence = evaluatePersistence(c.currentPrice, prices);
-      const pathQuality = computePathQualityForTfsFromFiveMin(series.candles);
-      return { ...persistence, pathQuality, coverage: 'eodhd' };
-    }
-
-    // 2. Yahoo Finance (fallback gratuit, no auth)
+    // 1. Yahoo Finance (primaire gratuit, P19h circuit breaker protège)
     const yahooCandles = await this.yahoo.getCandles(eodhdTicker, '5m').catch(() => null);
     if (yahooCandles && yahooCandles.length > 0) {
       const prices = extractPricesFromFiveMinSeries(yahooCandles);
       const persistence = evaluatePersistence(c.currentPrice, prices);
       const pathQuality = computePathQualityForTfsFromFiveMin(yahooCandles);
+      // Write-on-success : cache pour fallback futur
+      void this.intradayCache.write(cacheKey, 'yahoo', candlesToCached(yahooCandles, '5m'));
       return { ...persistence, pathQuality, coverage: 'yahoo' };
     }
 
-    // 3. Aucun vendor disponible
+    // 2. EODHD intraday (fallback payant, plus stable IP-side)
+    const series = await this.eodhd.getCandles(eodhdTicker, '5m', 13).catch(() => null);
+    if (series && series.candles.length > 0) {
+      const prices = extractPricesFromFiveMinSeries(series.candles);
+      const persistence = evaluatePersistence(c.currentPrice, prices);
+      const pathQuality = computePathQualityForTfsFromFiveMin(series.candles);
+      void this.intradayCache.write(cacheKey, 'eodhd', eodhdCandlesToCached(series.candles));
+      return { ...persistence, pathQuality, coverage: 'eodhd' };
+    }
+
+    // 3. Cache Supabase (last_known < 15 min)
+    const cached = await this.intradayCache.read(cacheKey).catch(() => null);
+    if (cached && cached.candles.length > 0) {
+      // Convert CachedCandle[] back to the shape expected by extractors
+      const cachedAsFiveMin = cached.candles.map((c) => ({
+        datetime: new Date(c.timestamp * 1000).toISOString(),
+        open: c.open,
+        high: c.high,
+        low: c.low,
+        close: c.close,
+        volume: c.volume,
+      }));
+      const prices = extractPricesFromFiveMinSeries(cachedAsFiveMin);
+      const persistence = evaluatePersistence(c.currentPrice, prices);
+      const pathQuality = computePathQualityForTfsFromFiveMin(cachedAsFiveMin);
+      return {
+        ...persistence,
+        pathQuality,
+        coverage: 'cache_stale',
+        cacheAgeMs: cached.ageMs,
+      };
+    }
+
+    // 4. Aucun vendor + aucun cache → null
     return null;
   }
 
@@ -393,4 +468,50 @@ function summarizePathQuality(byTf: {
     else overallSmoothness = 'mixed';
   }
   return { ...byTf, overallEfficiency, overallSmoothness };
+}
+
+/**
+ * P19i — Convert YahooCandle[] (datetime ISO) → CachedCandle[] (timestamp unix s).
+ * Filtre les candles invalides au passage.
+ */
+function candlesToCached(
+  candles: Array<{ datetime: string; open: number; high: number; low: number; close: number; volume: number }>,
+  _interval: '1m' | '5m',
+): CachedCandle[] {
+  const out: CachedCandle[] = [];
+  for (const c of candles) {
+    const ts = Math.floor(new Date(c.datetime).getTime() / 1000);
+    if (!Number.isFinite(ts) || !Number.isFinite(c.close)) continue;
+    out.push({
+      timestamp: ts,
+      open: c.open,
+      high: c.high,
+      low: c.low,
+      close: c.close,
+      volume: c.volume ?? 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * P19i — Convert EODHD intraday Candle[] (timestamp unix) → CachedCandle[].
+ * Shape déjà compatible mais on normalise pour défense.
+ */
+function eodhdCandlesToCached(
+  candles: Array<{ timestamp: number; open: number; high: number; low: number; close: number; volume: number }>,
+): CachedCandle[] {
+  const out: CachedCandle[] = [];
+  for (const c of candles) {
+    if (!Number.isFinite(c.timestamp) || !Number.isFinite(c.close)) continue;
+    out.push({
+      timestamp: c.timestamp,
+      open: c.open,
+      high: c.high,
+      low: c.low,
+      close: c.close,
+      volume: c.volume ?? 0,
+    });
+  }
+  return out;
 }

--- a/supabase/migrations/0092_lisa_intraday_cache.sql
+++ b/supabase/migrations/0092_lisa_intraday_cache.sql
@@ -1,0 +1,39 @@
+-- P19i — Intraday OHLCV cache pour fallback chain.
+--
+-- Quand Yahoo (rate-limit IP Fly) ET EODHD (rate-limit / quota) sont KO sur
+-- un ticker, on retourne le dernier candles set connu (≤15 min) avec un flag
+-- coverage='cache_stale' côté UI (badge dégradé "stale-cache" vs "live").
+--
+-- Write-on-success : à chaque fetch réussi (yahoo/eodhd/binance), on upsert
+-- la série dans cette table. Read-on-fallback : MultiTimeframePersistenceService
+-- lit cette table en dernier recours après Yahoo + EODHD.
+--
+-- TTL applicatif (15 min) — pas de constraint DB, le service filtre par
+-- fetched_at à la lecture. Cleanup périodique optionnel (cron Postgres ou
+-- side-effect au write si table > N rows).
+
+CREATE TABLE IF NOT EXISTS public.lisa_intraday_cache (
+  symbol      TEXT NOT NULL,
+  source      TEXT NOT NULL CHECK (source IN ('yahoo', 'eodhd', 'binance')),
+  candles     JSONB NOT NULL,                                  -- Array<{timestamp, open, high, low, close, volume}>
+  fetched_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (symbol)
+);
+
+CREATE INDEX IF NOT EXISTS lisa_intraday_cache_fetched_at_idx
+  ON public.lisa_intraday_cache (fetched_at DESC);
+
+ALTER TABLE public.lisa_intraday_cache ENABLE ROW LEVEL SECURITY;
+
+-- Service role (API NestJS) full access.
+DROP POLICY IF EXISTS "lisa_intraday_cache_service_role" ON public.lisa_intraday_cache;
+CREATE POLICY "lisa_intraday_cache_service_role"
+  ON public.lisa_intraday_cache
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+COMMENT ON TABLE public.lisa_intraday_cache IS
+  'P19i — Cache OHLCV intraday derniere fetch reussie par symbole. Lu en fallback quand Yahoo + EODHD sont KO. TTL applicatif 15 min.';
+COMMENT ON COLUMN public.lisa_intraday_cache.source IS
+  'Provider qui a produit cette serie : yahoo / eodhd / binance';


### PR DESCRIPTION
## Why

Observed prod 29/04/2026 15:30 (P19g live) : Yahoo HTTP 429 sur **100% des tickers** depuis l'IP Fly CDG → Top 20 UI vide. P19h circuit breaker seul ne suffit pas — il faut un **vrai fallback** EODHD + cache Supabase.

## Nouvelle chain (équités)

```
1. Yahoo Finance     (primaire, gratuit, P19h breaker protège)
2. EODHD intraday    (fallback payant, EODHD_API_KEY déjà en Fly secrets)
3. IntradayCache     (Supabase, last_known < 15 min, coverage='cache_stale')
4. null              (coverage='none', UI badge rouge)
```

Crypto : Binance primaire, fallback cache Supabase (bonus P19i).

## Composants

### Migration `0092_lisa_intraday_cache.sql`

```sql
CREATE TABLE lisa_intraday_cache (
  symbol      TEXT PRIMARY KEY,
  source      TEXT CHECK (source IN ('yahoo', 'eodhd', 'binance')),
  candles     JSONB,
  fetched_at  TIMESTAMPTZ DEFAULT NOW()
);
```
RLS service_role only, index `fetched_at DESC` pour cleanup futur.

### `IntradayCacheService` (nouveau)

- `read(symbol)` → `CachedSeries` avec `ageMs` ou `null` si > 15 min / absent
- `write(symbol, source, candles)` → upsert on conflict, failure-tolerant
- Failure-tolerant : si Supabase down → log debug + return false/null, ne crash jamais

### `MultiTimeframePersistenceService.fetchEquityPersistenceQuiet`

- **Réordonné Yahoo→EODHD** (vs EODHD→Yahoo avant) car Yahoo gratuit + plus large couverture
- Ajoute 3e étage cache read-on-double-failure
- Write-on-success à chaque fetch primaire/fallback réussi

### Coverage flag étendu

| Valeur | UI badge | Sens |
|---|---|---|
| `yahoo` | 🟢 live | primaire OK |
| `eodhd` | 🟢 live | fallback OK |
| `binance` | 🟢 live | crypto OK |
| `cache_stale` | 🟠 stale-cache | last fetch < 15 min, `cacheAgeMs` exposé |
| `none` | 🔴 dead | rien du tout |

`cacheAgeMs?: number` ajouté à `PersistenceWithPath` (uniquement si `cache_stale`).

## Tests — 30/30 green

| Suite | Count | Coverage |
|---|---|---|
| `intraday-cache.p19i.spec.ts` | 11 | TTL respect, RLS error, supabase down, empty candles, throw recovery, uppercase normalisation |
| `multi-tf-persistence.p19i.spec.ts` | 7 | Chain end-to-end Yahoo OK / Yahoo null + EODHD OK / both null + cache stale / no cache → null / crypto write binance / Yahoo throw / cache write fail tolerant |
| `multi-tf-persistence.p18e.spec.ts` | 11 | Régression P18e + reorder Yahoo→EODHD documenté |
| `yahoo-intraday.p19h.spec.ts` (existant) | 14 | Circuit breaker still green |

## Validation post-deploy attendue

```bash
fly logs -a smartvest --since 5m | grep -E "yahoo|eodhd intraday|cache_stale|coverage"
```

Au prochain cycle :
- Yahoo 429 (toujours) → bascule auto sur EODHD intraday → `coverage='eodhd'`
- Si EODHD KO aussi → `cache_stale` si < 15 min (au moins dès le 1er cycle réussi)
- Top 20 UI doit afficher Score/Path/%change peuplés sur les tickers qu'EODHD couvre (US large-caps, EU majors via .XETRA/.PA/.LSE, KOSPI grands groupes)

## Action utilisateur

**Aucune** — `EODHD_API_KEY` déjà en Fly secrets (digest `34e69855787f198b`, 7 jours).

## Migration auto-appliquée

Le script `apply-migrations.mjs` au boot Fly (cf. `Dockerfile:CMD`) applique automatiquement `0092_lisa_intraday_cache.sql` au premier deploy avec ce commit.

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_