### PR TITLE
[P19j] feat: provider-router observability — boot log + chain bascule logs

### DIFF
--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -38,7 +38,20 @@ export class EodhdIntradayService {
   constructor(
     private readonly config: ConfigService,
     private readonly supabase: SupabaseService,
-  ) {}
+  ) {
+    // P19j — Boot log to confirm key configuration in prod (essential debug
+    // signal when fallback chain doesn't seem to fire). Mask all but last 4
+    // chars to avoid leaking secrets in logs.
+    const k = this.config.get<string>('EODHD_API_KEY');
+    if (!k) {
+      this.logger.warn('[eodhd] EODHD_API_KEY env var NOT SET — intraday fetches will silently return null');
+    } else if (k === 'demo') {
+      this.logger.warn('[eodhd] EODHD_API_KEY="demo" detected — intraday fetches treated as no-op (cf. apiKey() guard)');
+    } else {
+      const tail = k.length >= 4 ? k.slice(-4) : '****';
+      this.logger.log(`[eodhd] provider initialized, key=***${tail} (length=${k.length})`);
+    }
+  }
 
   private apiKey(): string | null {
     const k = this.config.get<string>('EODHD_API_KEY');
@@ -87,7 +100,13 @@ export class EodhdIntradayService {
     }
 
     const key = this.apiKey();
-    if (!key) return null;
+    if (!key) {
+      // P19j — Promote silent skip to warn (rate-limited 1×/cycle would be
+      // ideal but ce service est appelé per-ticker, on accepte le verbatim
+      // pour le debug — peut être promu cycle-aggregated dans une PR follow-up).
+      this.logger.debug(`[eodhd] skipping fetch for ${eodhdTicker} — no API key (EODHD_API_KEY missing or 'demo')`);
+      return null;
+    }
 
     const intervalSeconds = interval === '1m' ? 60 : interval === '5m' ? 300 : 3600;
     const toUnix = Math.floor(Date.now() / 1000);
@@ -107,6 +126,10 @@ export class EodhdIntradayService {
       const latencyMs = Date.now() - tStart;
 
       if (!res.ok) {
+        // P19j — Promote silent failure to warn for visibility in Fly logs.
+        // 401 = bad key, 402 = quota, 404 = ticker not found, 429 = rate-limit
+        const body = await res.text().catch(() => '');
+        this.logger.warn(`[eodhd] ${eodhdTicker} HTTP ${res.status} (${latencyMs}ms) body=${body.slice(0, 100)}`);
         this.logCall({ ticker: eodhdTicker, success: false, statusCode: res.status, latencyMs, errorMessage: `HTTP_${res.status}` });
         return null;
       }
@@ -114,7 +137,10 @@ export class EodhdIntradayService {
       const data = await res.json() as Array<Record<string, unknown>>;
       this.logCall({ ticker: eodhdTicker, success: true, statusCode: res.status, latencyMs });
 
-      if (!Array.isArray(data)) return null;
+      if (!Array.isArray(data) || data.length === 0) {
+        this.logger.debug(`[eodhd] ${eodhdTicker} empty response (${latencyMs}ms)`);
+        return null;
+      }
 
       const candles: Candle[] = data
         .map((d) => ({

--- a/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
+++ b/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
@@ -300,6 +300,12 @@ export class MultiTimeframePersistenceService {
       return { ...persistence, pathQuality, coverage: 'yahoo' };
     }
 
+    // P19j — Log explicit bascule yahoo→eodhd pour visibilité prod.
+    // Le logger debug n'apparaît pas par défaut côté Fly (level INFO+).
+    // On utilise log() qui est INFO. Aggrégation du spam = follow-up si nécessaire,
+    // pour l'instant on veut voir TOUS les bascules.
+    this.logger.log(`[provider-router] yahoo null for ${eodhdTicker}, falling back to EODHD`);
+
     // 2. EODHD intraday (fallback payant, plus stable IP-side)
     const series = await this.eodhd.getCandles(eodhdTicker, '5m', 13).catch(() => null);
     if (series && series.candles.length > 0) {
@@ -307,8 +313,11 @@ export class MultiTimeframePersistenceService {
       const persistence = evaluatePersistence(c.currentPrice, prices);
       const pathQuality = computePathQualityForTfsFromFiveMin(series.candles);
       void this.intradayCache.write(cacheKey, 'eodhd', eodhdCandlesToCached(series.candles));
+      this.logger.log(`[provider-router] eodhd OK for ${eodhdTicker} (${series.candles.length} candles), coverage=eodhd`);
       return { ...persistence, pathQuality, coverage: 'eodhd' };
     }
+
+    this.logger.log(`[provider-router] eodhd null for ${eodhdTicker}, falling back to IntradayCache`);
 
     // 3. Cache Supabase (last_known < 15 min)
     const cached = await this.intradayCache.read(cacheKey).catch(() => null);
@@ -325,6 +334,7 @@ export class MultiTimeframePersistenceService {
       const prices = extractPricesFromFiveMinSeries(cachedAsFiveMin);
       const persistence = evaluatePersistence(c.currentPrice, prices);
       const pathQuality = computePathQualityForTfsFromFiveMin(cachedAsFiveMin);
+      this.logger.log(`[provider-router] cache hit for ${eodhdTicker} age=${Math.round(cached.ageMs / 1000)}s, coverage=cache_stale`);
       return {
         ...persistence,
         pathQuality,
@@ -334,6 +344,7 @@ export class MultiTimeframePersistenceService {
     }
 
     // 4. Aucun vendor + aucun cache → null
+    this.logger.log(`[provider-router] all paths exhausted for ${eodhdTicker}, coverage=none`);
     return null;
   }
 


### PR DESCRIPTION
## Why

Observed prod 29/04 15:51 (P19i live, sha `a231473f`) :
- ✅ Yahoo circuit breaker fonctionne (1 warn par opening)
- ❌ AUCUN log `[eodhd]` / `[provider-router]` / `[cache]` visible
- `"no intraday coverage for 20 ticker(s)"` → vol à l'aveugle

## Cause racine — silences

| Service | Silence path | Effet |
|---|---|---|
| `EodhdIntradayService.apiKey()` | retourne `null` silently si `EODHD_API_KEY` absent ou ='demo' | `getCandles()` → null sans log |
| `EodhdIntradayService.getCandles()` HTTP errors | `logCall()` vers DB seulement, **pas** de logger | Fly logs vide |
| Empty response | `null` silently | Fly logs vide |
| `MultiTimeframePersistenceService` chain | aucun log au point de bascule | Impossible de tracer où ça casse |

## Fix — logging stratégique

### `EodhdIntradayService` boot log

```ts
constructor(...) {
  if (!key) → warn "[eodhd] EODHD_API_KEY env var NOT SET — fetches will silently return null"
  if (key === 'demo') → warn "[eodhd] EODHD_API_KEY=\"demo\" detected — treated as no-op"
  if (key valid) → log "[eodhd] provider initialized, key=***XXXX (length=N)"  // last 4 only
}
```

### `EodhdIntradayService.getCandles` per-call

```
[eodhd] skipping fetch for X — no API key            (debug, key absent)
[eodhd] X HTTP {status} ({Nms}) body=...             (warn, HTTP error)
[eodhd] X empty response (Nms)                       (debug, [] response)
```

### `MultiTimeframePersistenceService` chain bascule

```
[provider-router] yahoo null for X, falling back to EODHD          (INFO)
[provider-router] eodhd OK for X (N candles), coverage=eodhd       (INFO)
[provider-router] eodhd null for X, falling back to IntradayCache  (INFO)
[provider-router] cache hit for X age=Ns, coverage=cache_stale     (INFO)
[provider-router] all paths exhausted for X, coverage=none         (INFO)
```

## Diagnostic prochain cycle

Après deploy, le user verra **UNE** des 4 hypothèses qui causent le silence actuel :

1. `[eodhd] EODHD_API_KEY env var NOT SET` au boot → secret absent en prod réelle (malgré digest visible côté Fly UI ?)
2. `[eodhd] X HTTP 401` → clé invalide
3. `[eodhd] X HTTP 402/429` → quota / rate-limit
4. `[eodhd] X HTTP 200` + `[provider-router] eodhd OK` → fix P19i marche réellement, le problème UI vient d'ailleurs

## Tests

60/60 green (Yahoo / MTF / EODHD / cache). Pure observability — pas de logique métier touchée.

## Hors scope

User a flagué 2 follow-ups (P19k) :
- `numeric field overflow` 400 sur `PATCH /lisa/config/:id` → audit migration Supabase NUMERIC width
- Chart Recharts `width(-1) height(-1)` → race CSS container

Notés pour P19k post-validation P19j.

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_