### PR TITLE
[P19k.1] hotfix: revert .KO→.KOSE — official EODHD docs say .KO is correct

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.p19k.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.p19k.spec.ts
@@ -28,30 +28,35 @@ function makeService(envMap: Record<string, string | undefined> = { EODHD_API_KE
   return new EodhdIntradayService(config, supabase);
 }
 
-describe('EodhdIntradayService — P19k symbol suffix mapping', () => {
-  it('maps KOSPI .KO → .KOSE (EODHD intraday endpoint convention)', () => {
+describe('EodhdIntradayService — P19k.1 symbol suffix mapping (corrected)', () => {
+  it('P19k.1 — Korea .KO is the CORRECT EODHD suffix, NOT remapped (revert from P19k bug)', () => {
     const svc = makeService();
     const fn = (svc as any).normalizeForEodhdIntraday.bind(svc);
-    expect(fn('199820.KO')).toBe('199820.KOSE');
-    expect(fn('006340.KO')).toBe('006340.KOSE');
-    expect(fn('005930.KO')).toBe('005930.KOSE'); // Samsung
+    // Doc officielle EODHD (eodhd-claude-skills/references/general/symbol-format.md) :
+    //   "| KO | Korea Stock Exchange | 6-digit number | 005930.KO (Samsung) |"
+    expect(fn('199820.KO')).toBe('199820.KO');
+    expect(fn('006340.KO')).toBe('006340.KO');
+    expect(fn('005930.KO')).toBe('005930.KO'); // Samsung — official example
   });
 
-  it('maps Shanghai .SS → .SHG', () => {
+  it('maps Shanghai .SS → .SHG (scanner code differs from EODHD code)', () => {
     const svc = makeService();
     const fn = (svc as any).normalizeForEodhdIntraday.bind(svc);
+    // Official: "| SHG | Shanghai | 6-digit number | 600519.SHG (Moutai) |"
     expect(fn('600000.SS')).toBe('600000.SHG');
     expect(fn('601398.SS')).toBe('601398.SHG'); // ICBC
+    expect(fn('600519.SS')).toBe('600519.SHG'); // Moutai (official example)
   });
 
   it('maps Shenzhen .SZ → .SHE', () => {
     const svc = makeService();
     const fn = (svc as any).normalizeForEodhdIntraday.bind(svc);
+    // Official: "| SHE | Shenzhen | 6-digit number | 000001.SHE |"
     expect(fn('000001.SZ')).toBe('000001.SHE');
     expect(fn('300750.SZ')).toBe('300750.SHE'); // CATL
   });
 
-  it('passes through US/LSE/XETRA/PA/HK/TO/NSE/BSE/KQ/AU unchanged', () => {
+  it('passes through US/LSE/XETRA/PA/HK/TO/NSE/BSE/KO/KQ/AU unchanged', () => {
     const svc = makeService();
     const fn = (svc as any).normalizeForEodhdIntraday.bind(svc);
     expect(fn('AAPL.US')).toBe('AAPL.US');
@@ -62,6 +67,8 @@ describe('EodhdIntradayService — P19k symbol suffix mapping', () => {
     expect(fn('SHOP.TO')).toBe('SHOP.TO');
     expect(fn('RELIANCE.NSE')).toBe('RELIANCE.NSE');
     expect(fn('TCS.BSE')).toBe('TCS.BSE');
+    // P19k.1 — Korea KOSPI .KO is the CORRECT EODHD suffix, no remapping
+    expect(fn('005930.KO')).toBe('005930.KO');
     expect(fn('035720.KQ')).toBe('035720.KQ'); // KOSDAQ already correct
     expect(fn('BHP.AU')).toBe('BHP.AU');
   });
@@ -73,11 +80,13 @@ describe('EodhdIntradayService — P19k symbol suffix mapping', () => {
     expect(fn('199820')).toBe('199820');
   });
 
-  it('case-insensitive suffix match (e.g. .ko / .ss)', () => {
+  it('case-insensitive suffix match (e.g. .ss / .sz)', () => {
     const svc = makeService();
     const fn = (svc as any).normalizeForEodhdIntraday.bind(svc);
-    expect(fn('199820.ko')).toBe('199820.KOSE');
     expect(fn('600000.ss')).toBe('600000.SHG');
+    expect(fn('000001.sz')).toBe('000001.SHE');
+    // Korea .KO doesn't need remapping ; passes through unchanged regardless of case
+    expect(fn('199820.ko')).toBe('199820.ko');
   });
 
   it('only the LAST dot is used as the suffix delimiter (multi-dot tickers)', () => {
@@ -85,15 +94,13 @@ describe('EodhdIntradayService — P19k symbol suffix mapping', () => {
     const fn = (svc as any).normalizeForEodhdIntraday.bind(svc);
     // Cas hypothétique d'un ticker avec point dans le base (rare mais défensif)
     expect(fn('BRK.B.US')).toBe('BRK.B.US');
-    expect(fn('FOO.BAR.KO')).toBe('FOO.BAR.KOSE');
+    expect(fn('FOO.BAR.SS')).toBe('FOO.BAR.SHG');
   });
 
-  it('cache key uses the normalized form (avoid duplicate cache for KO vs KOSE)', () => {
-    // We verify by checking that getCandles uses the same cache key for
-    // both inputs of the same ticker. Direct assertion impossible without
-    // exposing internals — covered indirectly by integration tests.
+  it('cache key uses the normalized form (Shanghai SS vs SHG produce same key)', () => {
     const svc = makeService();
     const fn = (svc as any).normalizeForEodhdIntraday.bind(svc);
-    expect(fn('199820.KO')).toBe(fn('199820.KOSE'));
+    // Si quelqu'un appelle avec .SS ou .SHG, on veut une seule entrée cache
+    expect(fn('600519.SS')).toBe(fn('600519.SHG'));
   });
 });

--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -89,16 +89,19 @@ export class EodhdIntradayService {
    * momentum, breakout, range.
    */
   /**
-   * P19k — EODHD intraday endpoint a des suffixes d'exchange différents du
-   * screener / Yahoo. Mapping observé via doc officielle :
-   *   - KO (KOSPI scanner code) → .KOSE (intraday endpoint required)
-   *   - SS (Shanghai scanner code) → .SHG (EODHD code)
-   *   - SZ (Shenzhen scanner code) → .SHE
-   *   - Autres exchanges (.US, .LSE, .XETRA, .PA, .HK, .TO, etc.) : pass-through
+   * P19k.1 (29/04/2026 16:15 — emergency revert) — Le mapping `.KO → .KOSE`
+   * de P19k était INCORRECT. La doc officielle EODHD (eodhd-claude-skills
+   * repo, references/general/symbol-format.md) confirme :
    *
-   * Sans cette normalisation, EODHD retournait 404 silently sur tous les
-   * tickers Korea/China → fallback chain donnait l'impression que EODHD ne
-   * fonctionnait pas alors que la clé et l'endpoint étaient OK.
+   *   | KO  | Korea Stock Exchange | 005930.KO (Samsung)  |
+   *   | SHG | Shanghai             | 600519.SHG (Moutai)  |
+   *   | SHE | Shenzhen             | 000001.SHE           |
+   *
+   * Donc `.KO` est BIEN le suffix EODHD pour Korea — pas besoin de
+   * remapper. Seul Shanghai/Shenzhen nécessitent le mapping (scanner code
+   * `.SS`/`.SZ` ≠ EODHD code `.SHG`/`.SHE`).
+   *
+   * Source initiale (comet diagnostic) erronée. P19k.1 corrige.
    */
   private normalizeForEodhdIntraday(eodhdTicker: string): string {
     if (!eodhdTicker.includes('.')) return eodhdTicker;
@@ -106,10 +109,9 @@ export class EodhdIntradayService {
     const base = eodhdTicker.slice(0, lastDot);
     const suffix = eodhdTicker.slice(lastDot + 1).toUpperCase();
     switch (suffix) {
-      case 'KO':   return `${base}.KOSE`;   // KOSPI
-      case 'SS':   return `${base}.SHG`;    // Shanghai Stock Exchange
-      case 'SZ':   return `${base}.SHE`;    // Shenzhen Stock Exchange
-      default:     return eodhdTicker;       // .US, .LSE, .XETRA, .PA, .HK, .TO, .NSE, .BSE, .KQ etc.
+      case 'SS':   return `${base}.SHG`;    // Shanghai Stock Exchange (scanner→EODHD)
+      case 'SZ':   return `${base}.SHE`;    // Shenzhen Stock Exchange (scanner→EODHD)
+      default:     return eodhdTicker;       // .US, .LSE, .XETRA, .PA, .HK, .TO, .NSE, .BSE, .KO (Korea), .KQ (KOSDAQ), .AU
     }
   }
 


### PR DESCRIPTION
## 🚨 Emergency revert — P19k introduced a regression on Korea tickers

## Source de vérité

Cloné en local le repo officiel `EodHistoricalData/eodhd-claude-skills`. Fichier `skills/eodhd-api/references/general/symbol-format.md` :

```
| KO  | Korea Stock Exchange | 6-digit number | 005930.KO (Samsung)  |
| KQ  | KOSDAQ                | 6-digit number | 035720.KQ            |
| SHG | Shanghai              | 6-digit number | 600519.SHG (Moutai)  |
| SHE | Shenzhen              | 6-digit number | 000001.SHE           |
```

→ `.KO` **EST** le suffix EODHD officiel pour Korea Stock Exchange (KOSPI). Notre scanner produisait déjà `005930.KO` qui était **correct**. Le diagnostic externe (`.KO → .KOSE`) était erroné.
→ `.SHG` et `.SHE` confirmés : scanner produit `.SS`/`.SZ`, faut bien remapper.

## Fix

`normalizeForEodhdIntraday` :
- `.KO` mapping **SUPPRIMÉ** (pass-through default branch)
- `.SS → .SHG` conservé
- `.SZ → .SHE` conservé

## Impact

| | Avant P19k | P19k (bug) | P19k.1 (fix) |
|---|---|---|---|
| Korea Samsung | `005930.KO` ✅ 200 | `005930.KOSE` ❌ 404 | `005930.KO` ✅ 200 |
| Shanghai Moutai | `600519.SS` ❌ 404 | `600519.SHG` ✅ 200 | `600519.SHG` ✅ 200 |

## Tests — 8/8 green (révisés)

- ✅ Korea `.KO` unchanged (explicit "NOT remapped" assertion)
- ✅ Shanghai `.SS → .SHG` (Moutai 600519 official example)
- ✅ Shenzhen `.SZ → .SHE` (CATL, ICBC examples)
- ✅ Pass-through US/LSE/XETRA/PA/HK/TO/NSE/BSE/**KO**/KQ/AU
- ✅ Case-insensitive (`.ss → SHG`, `.ko` stays `.ko`)
- ✅ Multi-dot delimiter
- ✅ Cache key normalisé pour SS/SHG

## Méta-leçon

Validation des sources : avant de patcher P19k, j'ai cru un diagnostic externe sans vérifier sur la source officielle. Le repo EODHD officiel était clone-able en 1 commande. Pour P19l (SDK migration) je m'appuie désormais sur ce repo + tests live avec un ticker connu (Samsung `005930.KO`).

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_