### PR TITLE
fix(P19o): micro-cap coverage — widen window 24h + tighten volume filter + real-time fallback

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
@@ -90,19 +90,32 @@ describe('fetchEodhdScreener — URL construction (P18c regression guard)', () =
     expect(decoded).not.toMatch(/\["change_p","[<>=]"/);
   });
 
-  it('uses adjusted_close (NOT close) as the price filter field', async () => {
+  it('uses adjusted_close (NOT close) as the price filter field — P19o threshold $2', async () => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('US', 'test-key');
     const decoded = decodeURIComponent(capturedUrl!);
-    expect(decoded).toContain('["adjusted_close",">",1]');
+    // P19o (29/04/2026) — bumped from $1 to $2 to exclude penny stocks
+    // that EODHD intraday returns empty for.
+    expect(decoded).toContain('["adjusted_close",">",2]');
     expect(decoded).not.toMatch(/\["close","[<>=]"/);
   });
 
-  it('keeps avgvol_200d filter (still a valid EODHD filter field)', async () => {
+  it('uses avgvol_200d > 500_000 (P19o tightened from 100k) for liquidity guarantee', async () => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('US', 'test-key');
     const decoded = decodeURIComponent(capturedUrl!);
-    expect(decoded).toContain('["avgvol_200d",">",100000]');
+    // P19o (29/04/2026) — issue #107 : avgvol > 100k laissait passer micro-caps
+    // (BIYA, ATER, SBLX...) sans coverage intraday EODHD. Bump à 500k = trades
+    // fiables.
+    expect(decoded).toContain('["avgvol_200d",">",500000]');
+    expect(decoded).not.toContain('"avgvol_200d",">",100000');
+  });
+
+  it('requires market_capitalization > 50M (P19o, exclude nano-caps OTC-style)', async () => {
+    const svc = makeService();
+    await (svc as any).fetchEodhdScreener('US', 'test-key');
+    const decoded = decodeURIComponent(capturedUrl!);
+    expect(decoded).toContain('["market_capitalization",">",50000000]');
   });
 
   it('sorts by refund_1d_p.desc (NOT change_p.desc)', async () => {

--- a/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.p19o.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.p19o.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * P19o (29/04/2026) — Tests pour la fenêtre intraday élargie + le fallback
+ * `/api/real-time` quand l'intraday retourne empty array.
+ *
+ * Issue #107 : micro-caps illiquides (BIYA, ATER, SBLX, OMCL...) renvoyaient
+ * un array vide sur `/api/intraday/{ticker}.US` car la fenêtre from/to était
+ * de 2.16h seulement (count*interval*2 avec count=13, interval=300s).
+ *
+ * Fix P19o : windowForInterval renvoie 1d / 5d / 30d selon l'interval, ce qui
+ * couvre overnight + weekends + tickers à trades sparses.
+ */
+
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EodhdIntradayService } from '../eodhd-intraday.service';
+import { SupabaseService } from '../../../supabase/supabase.service';
+
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+function makeService(envMap: Record<string, string | undefined> = { EODHD_API_KEY: 'test-key' }) {
+  const config = { get: jest.fn((k: string) => envMap[k]) } as unknown as ConfigService;
+  const supabase = {
+    isReady: () => true,
+    getClient: () => ({ from: () => ({ insert: jest.fn().mockResolvedValue({ error: null }) }) }),
+  } as unknown as SupabaseService;
+  return new EodhdIntradayService(config, supabase);
+}
+
+describe('EodhdIntradayService — P19o window widening', () => {
+  it('windowForInterval returns 1d / 5d / 30d for 1m / 5m / 1h', () => {
+    const svc = makeService();
+    const fn = (svc as any).windowForInterval.bind(svc);
+    expect(fn('1m')).toBe(24 * 3600);
+    expect(fn('5m')).toBe(5 * 24 * 3600);
+    expect(fn('1h')).toBe(30 * 24 * 3600);
+  });
+
+  it('5m getCandles uses a from/to window of ≥ 5 days (was 2.16h pre-P19o)', async () => {
+    const svc = makeService();
+    let capturedUrl = '';
+    (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [],
+        text: async () => '[]',
+      };
+    });
+
+    await svc.getCandles('ATER.US', '5m', 13);
+
+    expect(capturedUrl).toContain('https://eodhd.com/api/intraday/ATER.US');
+    const u = new URL(capturedUrl);
+    const from = Number(u.searchParams.get('from'));
+    const to = Number(u.searchParams.get('to'));
+    expect(Number.isFinite(from) && Number.isFinite(to)).toBe(true);
+    const windowSec = to - from;
+    // ≥ 5 days = 432_000s, with -1s tolerance for clock skew between Date.now() calls
+    expect(windowSec).toBeGreaterThanOrEqual(5 * 24 * 3600 - 1);
+    // And not absurdly larger (sanity)
+    expect(windowSec).toBeLessThanOrEqual(5 * 24 * 3600 + 60);
+  });
+
+  it('1m getCandles uses a 1-day window', async () => {
+    const svc = makeService();
+    let capturedUrl = '';
+    (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 200, json: async () => [], text: async () => '[]' };
+    });
+
+    await svc.getCandles('AAPL.US', '1m', 60);
+
+    const u = new URL(capturedUrl);
+    const from = Number(u.searchParams.get('from'));
+    const to = Number(u.searchParams.get('to'));
+    expect(to - from).toBeGreaterThanOrEqual(24 * 3600 - 1);
+    expect(to - from).toBeLessThanOrEqual(24 * 3600 + 60);
+  });
+
+  it('1h getCandles uses a 30-day window', async () => {
+    const svc = makeService();
+    let capturedUrl = '';
+    (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 200, json: async () => [], text: async () => '[]' };
+    });
+
+    await svc.getCandles('SHOP.TO', '1h', 24);
+
+    const u = new URL(capturedUrl);
+    const from = Number(u.searchParams.get('from'));
+    const to = Number(u.searchParams.get('to'));
+    expect(to - from).toBeGreaterThanOrEqual(30 * 24 * 3600 - 1);
+    expect(to - from).toBeLessThanOrEqual(30 * 24 * 3600 + 60);
+  });
+
+  it('still slices to the last N candles after fetching a wide window', async () => {
+    const svc = makeService();
+    // Génère 500 candles bidons sur un range de 5 jours
+    const now = Math.floor(Date.now() / 1000);
+    const fakeCandles = Array.from({ length: 500 }, (_, i) => ({
+      timestamp: now - (499 - i) * 300,
+      open: 100 + i * 0.1,
+      high: 101 + i * 0.1,
+      low: 99 + i * 0.1,
+      close: 100 + i * 0.1,
+      volume: 1000,
+    }));
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => fakeCandles,
+      text: async () => JSON.stringify(fakeCandles),
+    });
+
+    const series = await svc.getCandles('AAPL.US', '5m', 20);
+    expect(series).not.toBeNull();
+    expect(series!.candles.length).toBe(20);
+    // Les 20 dernières candles (les plus récentes)
+    expect(series!.candles[series!.candles.length - 1].timestamp).toBe(now);
+  });
+});
+
+describe('EodhdIntradayService — P19o getQuote real-time fallback', () => {
+  it('returns price + changePct from /api/real-time on 200 OK', async () => {
+    const svc = makeService();
+    let capturedUrl = '';
+    (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          code: 'ATER.US',
+          timestamp: 1735000000,
+          open: 0.95,
+          high: 1.10,
+          low: 0.92,
+          close: 1.05,
+          volume: 1_500_000,
+          change: 0.10,
+          change_p: 10.5,
+        }),
+      };
+    });
+
+    const quote = await svc.getQuote('ATER.US');
+    expect(capturedUrl).toContain('https://eodhd.com/api/real-time/ATER.US');
+    expect(capturedUrl).toContain('fmt=json');
+    expect(quote).toEqual({ price: 1.05, changePct: 10.5, timestamp: 1735000000 });
+  });
+
+  it('normalizes Shanghai .SS → .SHG in the real-time URL', async () => {
+    const svc = makeService();
+    let capturedUrl = '';
+    (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ code: '600519.SHG', close: 1800, change_p: 2.1, timestamp: 1735000000 }),
+      };
+    });
+
+    await svc.getQuote('600519.SS');
+    expect(capturedUrl).toContain('600519.SHG');
+    expect(capturedUrl).not.toContain('600519.SS?');
+  });
+
+  it('returns null when the API returns an error status', async () => {
+    const svc = makeService();
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'forbidden' }),
+    });
+
+    const quote = await svc.getQuote('ATER.US');
+    expect(quote).toBeNull();
+  });
+
+  it('returns null when no API key is configured', async () => {
+    const svc = makeService({ EODHD_API_KEY: undefined });
+    (global as any).fetch = jest.fn();
+
+    const quote = await svc.getQuote('ATER.US');
+    expect(quote).toBeNull();
+    expect((global as any).fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns null when close is missing or zero (defensive)', async () => {
+    const svc = makeService();
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ code: 'X', close: 0, change_p: 0 }),
+    });
+
+    const quote = await svc.getQuote('X.US');
+    expect(quote).toBeNull();
+  });
+});

--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -115,6 +115,24 @@ export class EodhdIntradayService {
     }
   }
 
+  /**
+   * P19o (29/04/2026) — Fenêtre from/to par interval.
+   *
+   * L'ancienne formule `count * interval * 2` donnait ~2.16h pour 5m × 13
+   * candles : trop étroit pour des micro-caps qui ne tradent pas en continu
+   * (overnight, weekends, low-volume tickers) → array vide → coverage='none'
+   * → UI Top 20 toutes lignes "—". Cf. issue #107.
+   *
+   * Ranges max EODHD intraday : 1m=120 jours, 5m=600 jours, 1h=7200 jours.
+   * On reste très large par rapport au max ; le `.slice(-count)` en aval
+   * garde uniquement les N candles les plus récentes côté client.
+   */
+  private windowForInterval(interval: '1m' | '5m' | '1h'): number {
+    if (interval === '1m') return 24 * 3600;          // 1 jour
+    if (interval === '5m') return 5 * 24 * 3600;      // 5 jours (couvre weekends)
+    return 30 * 24 * 3600;                             // 30 jours pour 1h
+  }
+
   async getCandles(
     eodhdTicker: string,
     interval: '1m' | '5m' | '1h' = '5m',
@@ -137,9 +155,8 @@ export class EodhdIntradayService {
       return null;
     }
 
-    const intervalSeconds = interval === '1m' ? 60 : interval === '5m' ? 300 : 3600;
     const toUnix = Math.floor(Date.now() / 1000);
-    const fromUnix = toUnix - count * intervalSeconds * 2; // x2 marge pour weekends/holidays
+    const fromUnix = toUnix - this.windowForInterval(interval);
 
     const tStart = Date.now();
     try {
@@ -189,6 +206,49 @@ export class EodhdIntradayService {
     } catch (e) {
       this.logger.warn(`Intraday fetch failed for ${eodhdTicker}: ${String(e).slice(0, 80)}`);
       this.logCall({ ticker: eodhdTicker, success: false, latencyMs: Date.now() - tStart, errorMessage: String(e).slice(0, 200) });
+      return null;
+    }
+  }
+
+  /**
+   * P19o (29/04/2026) — Quote ponctuel via `/api/real-time/{SYMBOL}`.
+   *
+   * Use case : quand `getCandles()` retourne une série vide (ticker à trades
+   * sparses), le scanner peut au moins peupler la colonne UI %change avec
+   * un quote unique. La persistance multi-TF reste impossible avec un seul
+   * point — pour ça il faut élargir la fenêtre intraday (cf. P19o ci-dessus).
+   *
+   * Endpoint : `GET /api/real-time/{SYMBOL}?api_token=&fmt=json`. Retourne
+   * `{ code, timestamp, open, high, low, close, volume, change, change_p }`.
+   * Ref : `vendor/eodhd-claude-skills/skills/eodhd-api/references/endpoints/live-price-data.md`
+   */
+  async getQuote(
+    eodhdTicker: string,
+  ): Promise<{ price: number; changePct: number; timestamp: number } | null> {
+    const key = this.apiKey();
+    if (!key) return null;
+    const normalized = this.normalizeForEodhdIntraday(eodhdTicker);
+    const tStart = Date.now();
+    try {
+      const url =
+        `https://eodhd.com/api/real-time/${encodeURIComponent(normalized)}` +
+        `?api_token=${encodeURIComponent(key)}&fmt=json`;
+      const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+      const latencyMs = Date.now() - tStart;
+      if (!res.ok) {
+        this.logger.debug(`[eodhd:real-time] ${normalized} HTTP ${res.status} (${latencyMs}ms)`);
+        return null;
+      }
+      const data = (await res.json()) as Record<string, unknown>;
+      const price = Number(data?.close ?? 0);
+      const changePct = Number(data?.change_p ?? 0);
+      const timestamp =
+        typeof data?.timestamp === 'number'
+          ? data.timestamp
+          : Math.floor(Date.now() / 1000);
+      if (!Number.isFinite(price) || price <= 0) return null;
+      return { price, changePct, timestamp };
+    } catch {
       return null;
     }
   }

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -574,11 +574,20 @@ export class TopGainersScannerService implements OnModuleInit {
    */
   private async fetchEodhdScreener(exchange: string, apiKey: string): Promise<TopGainerCandidate[]> {
     const exLower = exchange.toLowerCase();
+    // P19o (29/04/2026) — Resserre les filtres pour garantir la coverage
+    // EODHD intraday. L'ancien filtre laissait passer des micro-caps illiquides
+    // (BIYA, ATER, SBLX, OMCL, KNSA...) qui dominaient le Top 20 mais
+    // retournaient `[]` sur l'endpoint intraday → coverage='none' → UI "—".
+    // Cf. issue #107.
+    //   - avgvol_200d > 500_000  : 5× plus liquide → trades fiables intraday
+    //   - adjusted_close > 2     : exclut les penny stocks
+    //   - market_capitalization > 50_000_000 : exclut les nano-caps OTC-style
     const filters = encodeURIComponent(JSON.stringify([
       ['exchange', '=', exLower],
       ['refund_1d_p', '>', 3],
-      ['adjusted_close', '>', 1],
-      ['avgvol_200d', '>', 100_000],
+      ['adjusted_close', '>', 2],
+      ['avgvol_200d', '>', 500_000],
+      ['market_capitalization', '>', 50_000_000],
     ]));
     const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}&sort=refund_1d_p.desc&limit=20&offset=0&fmt=json`;
     try {


### PR DESCRIPTION
## Summary

Closes #107 — SmartVest never triggers because Top 20 dominated by micro-caps (BIYA, ATER, SBLX, OMCL, KNSA…) for which EODHD intraday returns empty arrays during overnight / sparse-trading periods.

Two compounding bugs fixed:

### 1. Intraday window too narrow (`eodhd-intraday.service.ts`)

`getCandles()` built `from/to` with `count * intervalSeconds * 2` ≈ **2.16h** for 5m × 13 candles. Far too narrow for tickers that don't trade in continuous 5m windows (overnight, weekends, low-volume).

**Fix** — new `windowForInterval()` helper:
- 1m → 1 day
- 5m → 5 days
- 1h → 30 days

EODHD max ranges allow this easily (1m=120d, 5m=600d, 1h=7200d). The existing `.slice(-N)` keeps response bounded.

### 2. Screener filter too permissive (`top-gainers-scanner.service.ts`)

Old filter let micro-caps into Top 20:
- `avgvol_200d > 100_000`
- `adjusted_close > 1`

**Fix** — tightened thresholds:
- `avgvol_200d > 500_000` (5× more liquid)
- `adjusted_close > 2` (no penny stocks)
- `market_capitalization > 50_000_000` (no nano-caps)

### 3. Bonus — `/api/real-time` quote fallback

New `EodhdIntradayService.getQuote(ticker)` returns `{ price, changePct, timestamp }` from a single `/api/real-time` call. Useful for UI %change column when intraday is empty. Not yet wired into the persistence chain (which needs multiple candles).

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` → OK
- [x] `npx jest top-gainers-scanner|eodhd|mtf|persistence` → 122 passed
- [ ] Fly deploy + verify logs show `coverage=eodhd` for ≥ 5/20 Top tickers
- [ ] UI Top 20 columns (Score / Path / %change) populated

## References

- Skill : `vendor/eodhd-claude-skills/skills/eodhd-api/references/endpoints/intraday-historical-data.md`
- Real-time : `vendor/eodhd-claude-skills/skills/eodhd-api/references/endpoints/live-price-data.md`
- Quick ref : `docs/EODHD_QUICK_REFERENCE.md`

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_