### PR TITLE
fix(P19o.4): align EODHD screener filter syntax with official spec

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
@@ -90,25 +90,25 @@ describe('fetchEodhdScreener — URL construction (P18c regression guard)', () =
     expect(decoded).not.toMatch(/\["change_p","[<>=]"/);
   });
 
-  it('uses adjusted_close (NOT close) as the price filter field — P19o threshold $2', async () => {
+  it('P19o.4 — does NOT include adjusted_close as filter field (not in EODHD spec)', async () => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('US', 'test-key');
     const decoded = decodeURIComponent(capturedUrl!);
-    // P19o (29/04/2026) — bumped from $1 to $2 to exclude penny stocks
-    // that EODHD intraday returns empty for.
-    expect(decoded).toContain('["adjusted_close",">",2]');
+    // P19o.4 (29/04/2026) — `adjusted_close` is response-only per official
+    // stock-screener-data.md ; not in Supported Filter Fields list. Le seuil
+    // price >= 2 est désormais un POST-filter dans mapEodhdRow.
+    expect(decoded).not.toMatch(/\["adjusted_close","[<>=]"/);
     expect(decoded).not.toMatch(/\["close","[<>=]"/);
   });
 
-  it('uses avgvol_200d > 500_000 (P19o tightened from 100k) for liquidity guarantee', async () => {
+  it('P19o.4 — uses avgvol_50d (NOT avgvol_200d, which is not in EODHD spec)', async () => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('US', 'test-key');
     const decoded = decodeURIComponent(capturedUrl!);
-    // P19o (29/04/2026) — issue #107 : avgvol > 100k laissait passer micro-caps
-    // (BIYA, ATER, SBLX...) sans coverage intraday EODHD. Bump à 500k = trades
-    // fiables.
-    expect(decoded).toContain('["avgvol_200d",">",500000]');
-    expect(decoded).not.toContain('"avgvol_200d",">",100000');
+    // P19o.4 — la doc officielle liste UNIQUEMENT `avgvol_50d` comme champ
+    // filter valide. `avgvol_200d` était silently ignored par EODHD.
+    expect(decoded).toContain('["avgvol_50d",">",500000]');
+    expect(decoded).not.toContain('avgvol_200d');
   });
 
   it('requires market_capitalization > 50M (P19o, exclude nano-caps OTC-style)', async () => {
@@ -118,11 +118,17 @@ describe('fetchEodhdScreener — URL construction (P18c regression guard)', () =
     expect(decoded).toContain('["market_capitalization",">",50000000]');
   });
 
-  it('sorts by refund_1d_p.desc (NOT change_p.desc)', async () => {
+  it('P19o.4 — uses canonical sort+order syntax (NOT field.desc shorthand)', async () => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('US', 'test-key');
     const decoded = decodeURIComponent(capturedUrl!);
-    expect(decoded).toContain('sort=refund_1d_p.desc');
+    // P19o.4 — Spec officielle stock-screener-data.md :
+    //   sort  : Field to sort by (e.g., market_capitalization, name)
+    //   order : Sort order: 'a' (ascending) or 'd' (descending)
+    // Notre `sort=refund_1d_p.desc` non-standard pouvait être silently ignored
+    // → top 20 par défaut alphabétique au lieu de top gainers desc.
+    expect(decoded).toContain('sort=refund_1d_p&order=d');
+    expect(decoded).not.toContain('sort=refund_1d_p.desc');
     expect(decoded).not.toContain('sort=change_p.desc');
   });
 
@@ -171,5 +177,23 @@ describe('mapEodhdRow — accepts both filter-form and legacy field names', () =
     const row = { code: 'AAPL', last_price: 178, refund_1d_p: 2.1 } as any;
     const result = (svc as any).mapEodhdRow(row, 'US');
     expect(result.close).toBe(178);
+  });
+
+  it('P19o.4 — post-filter rejects rows with adjusted_close < 2 (penny stocks)', () => {
+    const svc = makeService();
+    const pennyRow = { code: 'PENNY', adjusted_close: 1.50, refund_1d_p: 12.5, avgvol_50d: 600_000, market_capitalization: 60_000_000 } as any;
+    expect((svc as any).mapEodhdRow(pennyRow, 'US')).toBeNull();
+  });
+
+  it('P19o.4 — post-filter accepts rows with adjusted_close >= 2', () => {
+    const svc = makeService();
+    const row = { code: 'OK', adjusted_close: 2.01, refund_1d_p: 4.0, avgvol_50d: 600_000, market_capitalization: 60_000_000 } as any;
+    expect((svc as any).mapEodhdRow(row, 'US')).not.toBeNull();
+  });
+
+  it('P19o.4 — post-filter still rejects close <= 0 (defensive baseline)', () => {
+    const svc = makeService();
+    const row = { code: 'BAD', adjusted_close: 0, refund_1d_p: 5 } as any;
+    expect((svc as any).mapEodhdRow(row, 'US')).toBeNull();
   });
 });

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -574,22 +574,24 @@ export class TopGainersScannerService implements OnModuleInit {
    */
   private async fetchEodhdScreener(exchange: string, apiKey: string): Promise<TopGainerCandidate[]> {
     const exLower = exchange.toLowerCase();
-    // P19o (29/04/2026) — Resserre les filtres pour garantir la coverage
-    // EODHD intraday. L'ancien filtre laissait passer des micro-caps illiquides
-    // (BIYA, ATER, SBLX, OMCL, KNSA...) qui dominaient le Top 20 mais
-    // retournaient `[]` sur l'endpoint intraday → coverage='none' → UI "—".
-    // Cf. issue #107.
-    //   - avgvol_200d > 500_000  : 5× plus liquide → trades fiables intraday
-    //   - adjusted_close > 2     : exclut les penny stocks
-    //   - market_capitalization > 50_000_000 : exclut les nano-caps OTC-style
+    // P19o.4 (29/04/2026) — Audit vs spec officielle EODHD
+    // (`vendor/eodhd-claude-skills/.../endpoints/stock-screener-data.md`) :
+    //
+    //   1. `avgvol_200d` n'existe PAS dans la liste des Supported Filter Fields.
+    //      Seul `avgvol_50d` est documenté → patch.
+    //   2. `adjusted_close` n'est PAS documenté comme filter field non plus
+    //      (présent dans la response shape uniquement). Risk : silently ignored
+    //      par EODHD → on déplace le seuil price >= 2 EN POST-FILTRE côté
+    //      `mapEodhdRow` (sur le champ response `adjusted_close ?? last_price`).
+    //   3. Sort syntax officielle : `&sort=field&order=a|d` (2 params séparés)
+    //      vs notre `sort=field.desc` non-standard. Patch pour s'aligner.
     const filters = encodeURIComponent(JSON.stringify([
       ['exchange', '=', exLower],
       ['refund_1d_p', '>', 3],
-      ['adjusted_close', '>', 2],
-      ['avgvol_200d', '>', 500_000],
+      ['avgvol_50d', '>', 500_000],
       ['market_capitalization', '>', 50_000_000],
     ]));
-    const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}&sort=refund_1d_p.desc&limit=20&offset=0&fmt=json`;
+    const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}&sort=refund_1d_p&order=d&limit=20&offset=0&fmt=json`;
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
       if (!res.ok) {
@@ -624,6 +626,10 @@ export class TopGainersScannerService implements OnModuleInit {
     const avgVol50d = num(r.avgvol_50d ?? r.avgvol_200d);
     const marketCap = num(r.market_capitalization ?? r.market_cap);
     if (!Number.isFinite(close) || close <= 0) return null;
+    // P19o.4 — Post-filter price >= 2 (le filtre `adjusted_close > 2` côté
+    // screener n'est pas documenté comme valid filter field — risk silently
+    // ignored. On le déplace ici pour garantir l'effet : exclut les penny stocks.
+    if (close < 2) return null;
     return {
       symbol,
       exchange,


### PR DESCRIPTION
## Summary

Audit de `fetchEodhdScreener()` vs spec officielle (`vendor/eodhd-claude-skills/skills/eodhd-api/references/endpoints/stock-screener-data.md`) — 3 divergences silencieuses corrigées.

## Divergences trouvées

| # | Champ | Spec officielle | Notre code (avant) | Risk |
|---|---|---|---|---|
| 1 | `avgvol_200d` | ❌ pas dans Supported Filter Fields (seul `avgvol_50d`) | `avgvol_200d > 500_000` | Silently ignored → filter sans effet |
| 2 | `adjusted_close` | ❌ pas un filter field (response only) | `adjusted_close > 2` | Silently ignored → penny stocks passent |
| 3 | sort syntax | `sort=field` + `order=a\|d` (2 params) | `sort=field.desc` | Sort defaulte à alphabétique → rate top gainers |

## Patches appliqués

- `top-gainers-scanner.service.ts:fetchEodhdScreener()`
  - `avgvol_200d` → `avgvol_50d` (même semantique, champ officiel)
  - Drop `adjusted_close` du filtre
  - Sort syntax canonical : `&sort=refund_1d_p&order=d`
- `top-gainers-scanner.service.ts:mapEodhdRow()`
  - Ajoute post-filter `close < 2 → reject` (garantit l'effet du seuil price >= 2 sur le champ response)

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` → OK
- [x] `npx jest "top-gainers-scanner|eodhd|mtf|persistence"` → **125 passed**
- [ ] Fly logs post-deploy : `[top-gainers] eodhd US scanned N gainers` doit retourner des tickers triés par changePct desc (NOT alphabétique)

## Tests ajoutés

`top-gainers-scanner.eodhd.spec.ts` :
- filtre ne contient PAS `adjusted_close` field (P19o.4)
- filtre utilise `avgvol_50d` (NOT `avgvol_200d`)
- sort syntax canonical `sort+order`
- post-filter `mapEodhdRow` : reject `< $2` / accept `>= $2` / reject `<= 0`

## Stratégie sequential merge

Per CLAUDE.md rule : pas de merge avec P19o.3 ensemble — séquentiel pour bisect possible.
- #108 (P19o) déjà mergé
- #109 (P19o.3) merge en cours
- Cette PR (P19o.4) suit après #109 merge + Fly green

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_