### PR TITLE
fix(P19s): EODHD screener 422 on non-US exchanges — drop avgvol + sort + bump limit

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
@@ -94,42 +94,66 @@ describe('fetchEodhdScreener — URL construction (P18c regression guard)', () =
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('US', 'test-key');
     const decoded = decodeURIComponent(capturedUrl!);
-    // P19o.4 (29/04/2026) — `adjusted_close` is response-only per official
-    // stock-screener-data.md ; not in Supported Filter Fields list. Le seuil
-    // price >= 2 est désormais un POST-filter dans mapEodhdRow.
     expect(decoded).not.toMatch(/\["adjusted_close","[<>=]"/);
     expect(decoded).not.toMatch(/\["close","[<>=]"/);
   });
 
-  it('P19o.4 — uses avgvol_50d (NOT avgvol_200d, which is not in EODHD spec)', async () => {
+  it('P19s — does NOT include avgvol_50d nor avgvol_200d (rejected by EODHD validator)', async () => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('US', 'test-key');
     const decoded = decodeURIComponent(capturedUrl!);
-    // P19o.4 — la doc officielle liste UNIQUEMENT `avgvol_50d` comme champ
-    // filter valide. `avgvol_200d` était silently ignored par EODHD.
-    expect(decoded).toContain('["avgvol_50d",">",500000]');
+    // P19s (29/04/2026) — Live curl confirmed both avgvol_50d AND avgvol_200d
+    // trigger `filters.X.field invalid` 422 on EODHD screener. Doc was wrong.
+    // Volume filtering moved to post-fetch in mapEodhdRow / evaluateTopGainerCandidate.
+    expect(decoded).not.toContain('avgvol_50d');
     expect(decoded).not.toContain('avgvol_200d');
   });
 
-  it('requires market_capitalization > 50M (P19o, exclude nano-caps OTC-style)', async () => {
+  it('requires market_capitalization > 50M (still valid filter per EODHD spec)', async () => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('US', 'test-key');
     const decoded = decodeURIComponent(capturedUrl!);
     expect(decoded).toContain('["market_capitalization",">",50000000]');
   });
 
-  it('P19o.4 — uses canonical sort+order syntax (NOT field.desc shorthand)', async () => {
+  it('P19s — does NOT include sort or order param (Laravel validator rejects on non-US)', async () => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('US', 'test-key');
     const decoded = decodeURIComponent(capturedUrl!);
-    // P19o.4 — Spec officielle stock-screener-data.md :
-    //   sort  : Field to sort by (e.g., market_capitalization, name)
-    //   order : Sort order: 'a' (ascending) or 'd' (descending)
-    // Notre `sort=refund_1d_p.desc` non-standard pouvait être silently ignored
-    // → top 20 par défaut alphabétique au lieu de top gainers desc.
-    expect(decoded).toContain('sort=refund_1d_p&order=d');
-    expect(decoded).not.toContain('sort=refund_1d_p.desc');
-    expect(decoded).not.toContain('sort=change_p.desc');
+    // P19s — Live Fly logs 18:53 UTC : 100% of non-US exchanges (TSE/HK/KO/SS
+    // /SZ/TO/AS/NSE/BSE) returned HTTP 422 with `sort.0.direction required`.
+    // EODHD validator expects nested array form. Drop sort entirely — we
+    // already sort client-side in the snapshot endpoint by changePct desc.
+    expect(decoded).not.toMatch(/[?&]sort=/);
+    expect(decoded).not.toMatch(/[?&]order=/);
+  });
+
+  it('P19s — bumps limit from 20 to 100 (max per spec) to compensate dropped sort', async () => {
+    const svc = makeService();
+    await (svc as any).fetchEodhdScreener('US', 'test-key');
+    const decoded = decodeURIComponent(capturedUrl!);
+    // Limit 100 = doc max. Compensates dropped sort: even if EODHD's natural
+    // order isn't changePct desc, we capture 5x more candidates so the
+    // client-side sort still surfaces the real top gainers.
+    expect(decoded).toContain('limit=100');
+    expect(decoded).not.toContain('limit=20');
+  });
+
+  it('P19s — non-US exchanges (TSE, HK, KO, SS, SZ) build same URL pattern (no exchange-specific bug)', async () => {
+    const svc = makeService();
+    const exchanges = ['TSE', 'HK', 'KO', 'SS', 'SZ', 'TO', 'AS', 'NSE', 'BSE', 'AU'];
+    for (const ex of exchanges) {
+      capturedUrl = undefined;
+      await (svc as any).fetchEodhdScreener(ex, 'test-key');
+      expect(capturedUrl).toBeDefined();
+      const decoded = decodeURIComponent(capturedUrl!);
+      // Same canonical filter set on every exchange
+      expect(decoded).toContain(`["exchange","=","${ex.toLowerCase()}"]`);
+      expect(decoded).toContain('["refund_1d_p",">",3]');
+      expect(decoded).toContain('["market_capitalization",">",50000000]');
+      expect(decoded).not.toMatch(/[?&]sort=/);
+      expect(decoded).not.toContain('avgvol_50d');
+    }
   });
 
   it('logs HTTP error body at warn level for diagnostic (was debug, now warn)', async () => {

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -574,24 +574,33 @@ export class TopGainersScannerService implements OnModuleInit {
    */
   private async fetchEodhdScreener(exchange: string, apiKey: string): Promise<TopGainerCandidate[]> {
     const exLower = exchange.toLowerCase();
-    // P19o.4 (29/04/2026) — Audit vs spec officielle EODHD
-    // (`vendor/eodhd-claude-skills/.../endpoints/stock-screener-data.md`) :
+    // P19s (29/04/2026 18:53 UTC) — Fix 422 sur exchanges non-US.
     //
-    //   1. `avgvol_200d` n'existe PAS dans la liste des Supported Filter Fields.
-    //      Seul `avgvol_50d` est documenté → patch.
-    //   2. `adjusted_close` n'est PAS documenté comme filter field non plus
-    //      (présent dans la response shape uniquement). Risk : silently ignored
-    //      par EODHD → on déplace le seuil price >= 2 EN POST-FILTRE côté
-    //      `mapEodhdRow` (sur le champ response `adjusted_close ?? last_price`).
-    //   3. Sort syntax officielle : `&sort=field&order=a|d` (2 params séparés)
-    //      vs notre `sort=field.desc` non-standard. Patch pour s'aligner.
+    // Diagnostic via curl LIVE contre demo + observation Fly logs prod :
+    //   1. `avgvol_50d` n'est PAS un valid filter field — la doc
+    //      `stock-screener-data.md:52` est out-of-date. EODHD répond :
+    //        {"errors":{"filters.X.field":["The selected ... is invalid."]}}
+    //      → DROP du filter (post-filter volume géré côté `mapEodhdRow`).
+    //
+    //   2. Le format `&sort=field&order=d` (doc + P19o.4) déclenche le
+    //      Laravel validator EODHD :
+    //        {"errors":{"sort.0.direction":["The sort.0.direction field is required."]}}
+    //      Sur US (en prod ALL-IN-ONE) ça passe parfois silencieusement, sur
+    //      tous les autres exchanges (TSE/HK/KO/SS/SZ/TO/AS/NSE/BSE/AU) c'est
+    //      rejeté avec 422 → 0 candidats Asie/EU non-EU/Toronto.
+    //      → DROP de `sort` + `order` ; on trie client-side dans le snapshot
+    //        endpoint par changePct desc anyway.
+    //
+    //   3. Pour compenser la perte du tri EODHD-side (au cas où l'ordre
+    //      naturel ne soit pas changePct desc), on bump limit 20 → 100 (max
+    //      autorisé par la doc) pour garantir qu'on attrape les vrais top
+    //      gainers même si EODHD retourne dans un ordre arbitraire.
     const filters = encodeURIComponent(JSON.stringify([
       ['exchange', '=', exLower],
       ['refund_1d_p', '>', 3],
-      ['avgvol_50d', '>', 500_000],
       ['market_capitalization', '>', 50_000_000],
     ]));
-    const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}&sort=refund_1d_p&order=d&limit=20&offset=0&fmt=json`;
+    const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}&limit=100&offset=0&fmt=json`;
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
       if (!res.ok) {


### PR DESCRIPTION
## Root cause (Fly logs prod 18:53 UTC + live curl confirmation)

```
[top-gainers] eodhd AS HTTP 422
[top-gainers] eodhd NSE HTTP 422
[top-gainers] eodhd TO HTTP 422
[top-gainers] eodhd KO HTTP 422   (Korea — ASIE)
[top-gainers] eodhd BSE HTTP 422
[top-gainers] eodhd SS HTTP 422   (Shanghai)
[top-gainers] eodhd TSE HTTP 422  (Tokyo)
```

**EODHD response** :
```json
{"errors":{
  "filters.2.field":["The selected filters.2.field is invalid."],
  "sort.0.direction":["The sort.0.direction field is required."]
}}
```

→ Zéro candidat asiatique la nuit, zéro trade auto 24/7. UI Top 20 ne montrait que les 10 crypto majors via Binance.

## Live curl diagnostic

```bash
TEST C: filters=[exchange=us, avgvol_50d>500k]
  → {"errors":{"filters.1.field":["The selected filters.1.field is invalid."]}}

TEST D: filters=[exchange=us, market_cap>50M, refund_1d_p>3] (no avgvol)
  → {"errors":{"sort.0.direction":["The sort.0.direction field is required."]}}
```

**Both contradict** `vendor/eodhd-claude-skills/.../endpoints/stock-screener-data.md` — doc is out-of-date, EODHD API uses Laravel strict validators.

## Fixes

| # | Avant | Après | Pourquoi |
|---|---|---|---|
| 1 | `avgvol_50d > 500_000` (filter) | dropped | Validator rejette "field invalid" |
| 2 | `&sort=refund_1d_p&order=d` | dropped entirely | Laravel exige `sort.0.direction` nested array — incompatible avec doc 2-param syntax |
| 3 | `limit=20` | `limit=100` (max per spec) | Compense le drop de sort — EODHD natural order peut ne pas être changePct desc, on capture 5× plus de candidats et on trie client-side |

Sort client-side était déjà fait dans `lisa.controller.ts:gainers-persistence-snapshot:250` :
```ts
const top = [...filtered].sort((a, b) => (b.changePct ?? 0) - (a.changePct ?? 0)).slice(0, topN);
```
→ EODHD's sort est redondant. Drop = no UX impact.

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` → OK
- [x] `npx jest "top-gainers-scanner|eodhd|mtf|persistence"` → **144 passed**
- [x] **Multi-exchange regression** : 10 non-US exchanges (TSE/HK/KO/SS/SZ/TO/AS/NSE/BSE/AU) build same canonical URL with no exchange-specific bug
- [ ] Fly logs post-deploy : `[top-gainers] eodhd KO HTTP 200 — N candidates` (au lieu de 422)
- [ ] UI : Top 20 rempli avec asia_equity la nuit (pas seulement crypto)

## References

- Skill : `vendor/eodhd-claude-skills/skills/eodhd-api/references/endpoints/stock-screener-data.md`
- Diagnostic : Fly logs 18:53 UTC + curl live tests (réponse `filters.2.field invalid` + `sort.0.direction required`)

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_