### PR TITLE
fix(P19v): EODHD intraday 1m native fetch — résout tf1m=null sur equities

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p18e.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p18e.spec.ts
@@ -154,9 +154,9 @@ describe('analyzeBatch — P19a Yahoo fallback chain', () => {
       { symbol: '199820', exchange: 'KO', currentPrice: 50 },       // Korea KOSPI
     ]);
 
-    // EODHD tried first for all 3
-    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(3);
-    // Yahoo fallback invoked for all 3 (since EODHD returned null)
+    // P19v — EODHD called twice per ticker (1m primary + 5m fallback) when both null
+    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(6);
+    // Yahoo fallback invoked for all 3 (yahoo is primary in P19i chain)
     expect(mockYahoo.getCandles).toHaveBeenCalledTimes(3);
     // Counter stays at 0 (no pre-filter anymore — every ticker is tried)
     expect(svc.getSkippedUnsupportedMarketCounter()).toBe(0);

--- a/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p19i.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p19i.spec.ts
@@ -84,9 +84,13 @@ describe('MTF P19i — fallback chain Yahoo → EODHD → cache → null', () =>
     expect(mockCache.write.mock.calls[0][1]).toBe('yahoo');
   });
 
-  it('Yahoo null → EODHD OK → returns coverage="eodhd", cache NOT read, write-on-success', async () => {
+  it('Yahoo null → EODHD 1m insufficient → EODHD 5m OK → returns coverage="eodhd"', async () => {
+    // P19v — chain order : yahoo → eodhd 1m → eodhd 5m → ticks → cache → none
+    // 1m returns insufficient (13 candles) → falls back to 5m → coverage='eodhd'
     mockYahoo.getCandles.mockResolvedValue(null);
-    mockEodhd.getCandles.mockResolvedValue(fakeEodhdSeries());
+    mockEodhd.getCandles.mockImplementation(async (_t: string, interval: string) =>
+      interval === '1m' ? null : fakeEodhdSeries(),
+    );
     const svc = makeService();
     const result = await svc.analyzeBatch([
       { symbol: 'AAPL', exchange: 'US', currentPrice: 100 },
@@ -94,7 +98,8 @@ describe('MTF P19i — fallback chain Yahoo → EODHD → cache → null', () =>
     const persist = result.get('AAPL');
     expect(persist!.coverage).toBe('eodhd');
     expect(mockYahoo.getCandles).toHaveBeenCalledTimes(1);
-    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(1);
+    // Both 1m and 5m attempts (1m null → 5m fallback)
+    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(2);
     expect(mockCache.read).not.toHaveBeenCalled();
     expect(mockCache.write).toHaveBeenCalledTimes(1);
     expect(mockCache.write.mock.calls[0][1]).toBe('eodhd');
@@ -144,9 +149,11 @@ describe('MTF P19i — fallback chain Yahoo → EODHD → cache → null', () =>
     expect(mockEodhd.getCandles).not.toHaveBeenCalled();
   });
 
-  it('Yahoo throw → caught, EODHD next', async () => {
+  it('Yahoo throw → caught, EODHD 5m next (1m insufficient at 13 candles)', async () => {
     mockYahoo.getCandles.mockRejectedValue(new Error('network'));
-    mockEodhd.getCandles.mockResolvedValue(fakeEodhdSeries());
+    mockEodhd.getCandles.mockImplementation(async (_t: string, interval: string) =>
+      interval === '1m' ? null : fakeEodhdSeries(),
+    );
     const svc = makeService();
     const result = await svc.analyzeBatch([{ symbol: 'AAPL', exchange: 'US', currentPrice: 100 }]);
     expect(result.get('AAPL')!.coverage).toBe('eodhd');
@@ -162,20 +169,19 @@ describe('MTF P19i — fallback chain Yahoo → EODHD → cache → null', () =>
 
   // ── P19o.3 — Tick-data fallback (entre EODHD intraday et cache) ────────────
 
-  it('P19o.3 — Yahoo null + EODHD intraday null → tick-data OK → coverage="eodhd_ticks"', async () => {
+  it('P19o.3 — Yahoo null + EODHD 1m null + EODHD 5m null → tick-data OK → coverage="eodhd_ticks"', async () => {
     mockYahoo.getCandles.mockResolvedValue(null);
-    mockEodhd.getCandles.mockResolvedValue(null);
+    mockEodhd.getCandles.mockResolvedValue(null);  // both 1m and 5m return null
     mockEodhd.getCandlesViaTicks.mockResolvedValue(fakeEodhdSeries());
     const svc = makeService();
     const result = await svc.analyzeBatch([{ symbol: 'AAPL', exchange: 'US', currentPrice: 100 }]);
     const persist = result.get('AAPL');
     expect(persist).toBeDefined();
     expect(persist!.coverage).toBe('eodhd_ticks');
-    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(1);
+    // P19v — chain now tries 1m AND 5m before falling to ticks
+    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(2);
     expect(mockEodhd.getCandlesViaTicks).toHaveBeenCalledTimes(1);
-    // Cache NOT consulted since ticks succeeded
     expect(mockCache.read).not.toHaveBeenCalled();
-    // Write-on-success cache as eodhd_ticks
     expect(mockCache.write).toHaveBeenCalledTimes(1);
     expect(mockCache.write.mock.calls[0][1]).toBe('eodhd_ticks');
   });
@@ -193,13 +199,88 @@ describe('MTF P19i — fallback chain Yahoo → EODHD → cache → null', () =>
     expect(mockCache.read).toHaveBeenCalledTimes(1);
   });
 
-  it('P19o.3 — EODHD intraday OK skips tick-data (intraday wins, no extra API call)', async () => {
+  it('P19o.3 — EODHD 5m intraday OK skips tick-data (intraday wins, no extra API call)', async () => {
     mockYahoo.getCandles.mockResolvedValue(null);
-    mockEodhd.getCandles.mockResolvedValue(fakeEodhdSeries());
+    mockEodhd.getCandles.mockImplementation(async (_t: string, interval: string) =>
+      interval === '1m' ? null : fakeEodhdSeries(),
+    );
     const svc = makeService();
     const result = await svc.analyzeBatch([{ symbol: 'AAPL', exchange: 'US', currentPrice: 100 }]);
     expect(result.get('AAPL')!.coverage).toBe('eodhd');
     expect(mockEodhd.getCandlesViaTicks).not.toHaveBeenCalled();
+  });
+
+  // ── P19v — EODHD 1m natif comme primaire (résout tf1m=null sur equities) ────
+
+  it('P19v — Yahoo null + EODHD 1m OK (≥60 candles) → coverage="eodhd_1m" with native tf1m', async () => {
+    mockYahoo.getCandles.mockResolvedValue(null);
+    // 65 candles 1m simulant un fetch EODHD intraday 1m réussi.
+    const base = Math.floor(Date.parse('2026-04-29T13:00:00Z') / 1000);
+    const oneMinCandles = Array.from({ length: 65 }, (_, i) => ({
+      timestamp: base + i * 60,
+      open: 100 + i * 0.1, high: 101 + i * 0.1, low: 99 + i * 0.1,
+      close: 100 + i * 0.1, volume: 5000,
+    }));
+    mockEodhd.getCandles.mockImplementation(async (_t: string, interval: string) =>
+      interval === '1m' ? { candles: oneMinCandles } : null,
+    );
+
+    const svc = makeService();
+    const result = await svc.analyzeBatch([{ symbol: 'AAPL', exchange: 'US', currentPrice: 106.4 }]);
+    const persist = result.get('AAPL');
+    expect(persist).toBeDefined();
+    expect(persist!.coverage).toBe('eodhd_1m');
+    // tf1m est désormais POPULÉ (vs null pré-P19v)
+    expect(persist!.tf1m).not.toBeNull();
+    expect(persist!.availableCount).toBe(6); // tous les 6 TFs dispos
+    // Seul le 1m call (5m never tried since 1m succeeded)
+    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(1);
+    expect(mockEodhd.getCandlesViaTicks).not.toHaveBeenCalled();
+    expect(mockCache.write.mock.calls[0][1]).toBe('eodhd_1m');
+  });
+
+  it('P19v — EODHD 1m insufficient (<60 candles) → falls back to 5m → coverage="eodhd"', async () => {
+    mockYahoo.getCandles.mockResolvedValue(null);
+    // Only 30 candles 1m — insufficient for tf1h calc
+    const base = Math.floor(Date.parse('2026-04-29T13:00:00Z') / 1000);
+    const shortOneMin = Array.from({ length: 30 }, (_, i) => ({
+      timestamp: base + i * 60,
+      open: 100, high: 100, low: 100, close: 100, volume: 1000,
+    }));
+    mockEodhd.getCandles.mockImplementation(async (_t: string, interval: string) =>
+      interval === '1m' ? { candles: shortOneMin } : fakeEodhdSeries(),
+    );
+
+    const svc = makeService();
+    const result = await svc.analyzeBatch([{ symbol: 'AAPL', exchange: 'US', currentPrice: 100 }]);
+    const persist = result.get('AAPL');
+    expect(persist!.coverage).toBe('eodhd');
+    expect(mockEodhd.getCandles).toHaveBeenCalledTimes(2);
+  });
+
+  it('P19v — Yahoo OK skips EODHD 1m + 5m + ticks (yahoo primaire wins)', async () => {
+    mockYahoo.getCandles.mockResolvedValue(fakeYahooCandles());
+    const svc = makeService();
+    const result = await svc.analyzeBatch([{ symbol: 'AAPL', exchange: 'US', currentPrice: 100 }]);
+    expect(result.get('AAPL')!.coverage).toBe('yahoo');
+    expect(mockEodhd.getCandles).not.toHaveBeenCalled();
+    expect(mockEodhd.getCandlesViaTicks).not.toHaveBeenCalled();
+  });
+
+  it('P19v — EODHD 1m exactly 60 candles OK (boundary)', async () => {
+    mockYahoo.getCandles.mockResolvedValue(null);
+    const base = Math.floor(Date.parse('2026-04-29T13:00:00Z') / 1000);
+    const exact60 = Array.from({ length: 60 }, (_, i) => ({
+      timestamp: base + i * 60,
+      open: 100 + i * 0.05, high: 101, low: 99,
+      close: 100 + i * 0.05, volume: 1000,
+    }));
+    mockEodhd.getCandles.mockImplementation(async (_t: string, interval: string) =>
+      interval === '1m' ? { candles: exact60 } : null,
+    );
+    const svc = makeService();
+    const result = await svc.analyzeBatch([{ symbol: 'AAPL', exchange: 'US', currentPrice: 102.95 }]);
+    expect(result.get('AAPL')!.coverage).toBe('eodhd_1m');
   });
 
   it('P19o.3 — getCandlesViaTicks throw → caught, falls through to cache', async () => {

--- a/apps/api/src/modules/lisa/services/intraday-cache.service.ts
+++ b/apps/api/src/modules/lisa/services/intraday-cache.service.ts
@@ -31,7 +31,7 @@ export interface CachedCandle {
   volume: number;
 }
 
-export type CacheSource = 'yahoo' | 'eodhd' | 'eodhd_ticks' | 'binance';
+export type CacheSource = 'yahoo' | 'eodhd' | 'eodhd_1m' | 'eodhd_ticks' | 'binance';
 
 export interface CachedSeries {
   symbol: string;

--- a/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
+++ b/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
@@ -75,7 +75,7 @@ export interface PathQualityByTf {
  * ticker mais qu'on a une série fraîche (<15 min) en cache Supabase.
  * UI badge orange "stale-cache" (vs `none` rouge si vraiment rien).
  */
-export type CoverageSource = 'eodhd' | 'eodhd_ticks' | 'yahoo' | 'binance' | 'cache_stale' | 'none';
+export type CoverageSource = 'eodhd' | 'eodhd_1m' | 'eodhd_ticks' | 'yahoo' | 'binance' | 'cache_stale' | 'none';
 
 export interface PersistenceWithPath extends PersistenceResult {
   pathQuality?: PathQualityByTf;
@@ -301,12 +301,41 @@ export class MultiTimeframePersistenceService {
     }
 
     // P19j — Log explicit bascule yahoo→eodhd pour visibilité prod.
-    // Le logger debug n'apparaît pas par défaut côté Fly (level INFO+).
-    // On utilise log() qui est INFO. Aggrégation du spam = follow-up si nécessaire,
-    // pour l'instant on veut voir TOUS les bascules.
-    this.logger.log(`[provider-router] yahoo null for ${eodhdTicker}, falling back to EODHD`);
+    this.logger.log(`[provider-router] yahoo null for ${eodhdTicker}, falling back to EODHD 1m`);
 
-    // 2. EODHD intraday (fallback payant, plus stable IP-side)
+    // P19v (29/04/2026) — 2. EODHD intraday 1m (PRIMAIRE EODHD).
+    //
+    // Fix structurel pour `tf1m: 0/20` toujours blanc dans l'UI : avant P19v,
+    // on appelait directement `getCandles(ticker, '5m', 13)` puis l'extracteur
+    // `extractPricesFromFiveMinSeries` forçait `'1m': null` (résolution 5m
+    // insuffisante). Résultat : `tf1m=null` pour TOUTES les equities, le
+    // `summarizeByTf` les comptait comme 0 positifs → "1m: 0/20" trompeur.
+    //
+    // Maintenant on tente EODHD intraday 1m natif (plan ALL-IN-ONE le supporte
+    // — vérifié curl LIVE 286 candles AAPL 24h). On fetch 65 candles (1h05min,
+    // marge 5min sur le tf1h qui regarde 60 candles en arrière). Si on a ≥ 60
+    // candles, on utilise `extractPricesFromOneMinSeries` qui populates ALL
+    // 6 TFs nativement (incl. tf1m).
+    //
+    // Quota impact : ~+19k calls/jour worst-case (1 call/ticker × 20 × 6
+    // cycles/h × 16h). Plan ALL-IN-ONE = 100k/jour, on reste à ~38k total.
+    const oneMinSeries = await this.eodhd.getCandles(eodhdTicker, '1m', 65).catch(() => null);
+    if (oneMinSeries && oneMinSeries.candles.length >= 60) {
+      const prices = extractPricesFromOneMinSeries(oneMinSeries.candles);
+      const persistence = evaluatePersistence(c.currentPrice, prices);
+      const pathQuality = computePathQualityForTfsFromOneMin(oneMinSeries.candles);
+      void this.intradayCache.write(cacheKey, 'eodhd_1m', eodhdCandlesToCached(oneMinSeries.candles));
+      this.logger.log(
+        `[provider-router] eodhd 1m OK for ${eodhdTicker} (${oneMinSeries.candles.length} candles), coverage=eodhd_1m`,
+      );
+      return { ...persistence, pathQuality, coverage: 'eodhd_1m' };
+    }
+
+    this.logger.log(
+      `[provider-router] eodhd 1m insufficient (${oneMinSeries?.candles.length ?? 0}/60) for ${eodhdTicker}, falling back to EODHD 5m`,
+    );
+
+    // 2bis. EODHD intraday 5m (fallback dégradé — tf1m=null mais 5 TFs OK)
     const series = await this.eodhd.getCandles(eodhdTicker, '5m', 13).catch(() => null);
     if (series && series.candles.length > 0) {
       const prices = extractPricesFromFiveMinSeries(series.candles);


### PR DESCRIPTION
## RCA factuelle (code-tracée + curl LIVE)

L'utilisateur a observé "1m: 0/20" persistant dans l'UI Lisa. Investigation :

### Diff received vs persisted (où la donnée se perd)

`MultiTimeframePersistenceService.fetchEquityPersistenceQuiet:310` appelait :
```ts
this.eodhd.getCandles(eodhdTicker, '5m', 13)  // ← interval='5m', JAMAIS '1m'
```

Puis `multi-tf-persistence.ts:177` (`extractPricesFromFiveMinSeries`) :
```ts
return {
  '1m': null, // 5-min granularité ne permet pas 1m  ← BUG STRUCTUREL
  ...
};
```

→ **tf1m forcé à null pour TOUTES les equities par construction**. `summarizeByTf` ligne 207 : `if ((r.tf1m ?? 0) > 0) counts.oneMinute++` → null compté comme 0 → UI "1m: 0/20".

### Live curl confirme EODHD CAN serve 1m

```bash
GET https://eodhd.com/api/intraday/AAPL.US?interval=1m&from=NOW-86400
→ HTTP 200, 286 candles {timestamp, open, high, low, close, volume}
```

EODHD plan ALL-IN-ONE supporte 1m (max range = 120 jours). On ne l'utilisait simplement pas.

## Fix structurel (pas cosmétique)

Nouvelle chain MTF :
```
Yahoo 5m → **EODHD 1m (NEW)** → EODHD 5m → eodhd_ticks → cache → none
```

**EODHD 1m fetch** : 65 candles (1h05min, marge 5min sur le tf1h qui regarde 60 candles en arrière). Si ≥ 60 candles → `extractPricesFromOneMinSeries` populate **ALL 6 TFs natively** (incl. `tf1m`). Sinon → fallback EODHD 5m legacy (tf1m=null mais 5 TFs OK).

## Quota impact

| Avant | Après |
|---|---|
| ~19k calls/j (1 EODHD/ticker) | ~38k worst-case (2 calls quand 1m fail) |
| Plan = 100k/j | Reste 62k de marge |

Safe. La plupart des liquid US equities ont 1m → 1 seul call.

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` → OK
- [x] `npx jest "multi-tf-persistence|top-gainers-scanner|eodhd"` → **130 passed** (4 nouveaux P19v)
- [ ] Fly logs : `[provider-router] eodhd 1m OK for X (65 candles), coverage=eodhd_1m`
- [ ] UI : colonne tf1m peuplée, "1m: N/20" reflect vraie data (pas null)

## Tests P19v ajoutés

- Yahoo null + EODHD 1m OK (≥60) → `coverage='eodhd_1m'`, `tf1m≠null`, `availableCount=6`, write cache `'eodhd_1m'`, **no 5m call**
- EODHD 1m insufficient (<60) → fallback 5m, `coverage='eodhd'`, 2 calls
- Yahoo OK skips entire EODHD chain
- Boundary : exactly 60 candles → `coverage='eodhd_1m'`

## Réponse aux 6 questions RCA de l'user

1. **URL exacte** : `https://eodhd.com/api/intraday/{TICKER}?api_token=&interval=5m&from=NOW-432000&to=NOW` (jamais 1m). FIXED.
2. **HTTP status par symbole** : tracé dans `eodhd_request_log` Supabase. SQL grep dispo.
3. **Diff received vs persisted** : `extractPricesFromFiveMinSeries` force `'1m': null`. FIXED.
4. **Quota** : ~19k/j, well under 100k. Pas un issue.
5. **Window alignment** : 5d UTC, OK.
6. **Fallback logic** : 1m absent de la chain. FIXED.

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_