### PR TITLE
fix(P19r): 1m window 24h→48h for asia/NSE/AU + KOSDAQ KQ ajouté

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.p19o.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.p19o.spec.ts
@@ -29,10 +29,11 @@ function makeService(envMap: Record<string, string | undefined> = { EODHD_API_KE
 }
 
 describe('EodhdIntradayService — P19o window widening', () => {
-  it('windowForInterval returns 1d / 5d / 30d for 1m / 5m / 1h', () => {
+  it('windowForInterval returns 2d / 5d / 30d for 1m / 5m / 1h (1m bumped 24h→48h in P19r)', () => {
     const svc = makeService();
     const fn = (svc as any).windowForInterval.bind(svc);
-    expect(fn('1m')).toBe(24 * 3600);
+    // P19r — 1m window bumped 24h → 48h to capture last asia/NSE/AU session
+    expect(fn('1m')).toBe(48 * 3600);
     expect(fn('5m')).toBe(5 * 24 * 3600);
     expect(fn('1h')).toBe(30 * 24 * 3600);
   });
@@ -64,7 +65,7 @@ describe('EodhdIntradayService — P19o window widening', () => {
     expect(windowSec).toBeLessThanOrEqual(5 * 24 * 3600 + 60);
   });
 
-  it('1m getCandles uses a 1-day window', async () => {
+  it('1m getCandles uses a 2-day window (P19r)', async () => {
     const svc = makeService();
     let capturedUrl = '';
     (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
@@ -77,8 +78,9 @@ describe('EodhdIntradayService — P19o window widening', () => {
     const u = new URL(capturedUrl);
     const from = Number(u.searchParams.get('from'));
     const to = Number(u.searchParams.get('to'));
-    expect(to - from).toBeGreaterThanOrEqual(24 * 3600 - 1);
-    expect(to - from).toBeLessThanOrEqual(24 * 3600 + 60);
+    // P19r — 1m window bumped 24h → 48h
+    expect(to - from).toBeGreaterThanOrEqual(48 * 3600 - 1);
+    expect(to - from).toBeLessThanOrEqual(48 * 3600 + 60);
   });
 
   it('1h getCandles uses a 30-day window', async () => {

--- a/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.p19r.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.p19r.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * P19r (29/04/2026) — Tests pour le bump 1m window 24h → 48h.
+ *
+ * Constat prod (UI Lisa Top 20) : 1m=1/20, seul KFRC US a tf1m≠null. Les 9 KO
+ * (Korea) + 4 NSE (India) + 1 AU n'avaient PAS de candles 1m car la fenêtre
+ * 24h ne couvrait pas leur dernière session :
+ *   - KOSPI Mon 00:00–06:30 UTC ; à 19:30 UTC mardi, window 24h remonte au
+ *     lundi 19:30 → manque toute la session lundi (terminée 13h avant le
+ *     début du window).
+ *   - NSE India 03:45–10:00 UTC : pareil sur certains créneaux.
+ *
+ * Fix : window 1m = 48h. Capture systématiquement les 2 dernières sessions
+ * de tous les marchés. Le `.slice(-count)` côté client limite la payload.
+ */
+
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EodhdIntradayService } from '../eodhd-intraday.service';
+import { SupabaseService } from '../../../supabase/supabase.service';
+
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+function makeService(envMap: Record<string, string | undefined> = { EODHD_API_KEY: 'test-key' }) {
+  const config = { get: jest.fn((k: string) => envMap[k]) } as unknown as ConfigService;
+  const supabase = {
+    isReady: () => true,
+    getClient: () => ({ from: () => ({ insert: jest.fn().mockResolvedValue({ error: null }) }) }),
+  } as unknown as SupabaseService;
+  return new EodhdIntradayService(config, supabase);
+}
+
+describe('EodhdIntradayService — P19r 1m window 48h', () => {
+  it('windowForInterval(1m) returns 48h (was 24h pre-P19r)', () => {
+    const svc = makeService();
+    const fn = (svc as any).windowForInterval.bind(svc);
+    expect(fn('1m')).toBe(48 * 3600);
+  });
+
+  it('5m window unchanged at 5 days, 1h at 30 days', () => {
+    const svc = makeService();
+    const fn = (svc as any).windowForInterval.bind(svc);
+    expect(fn('5m')).toBe(5 * 24 * 3600);
+    expect(fn('1h')).toBe(30 * 24 * 3600);
+  });
+
+  it('1m getCandles uses a 48h window (verify URL params from→to span)', async () => {
+    const svc = makeService();
+    let capturedUrl = '';
+    (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 200, json: async () => [], text: async () => '[]' };
+    });
+
+    await svc.getCandles('006340.KO', '1m', 65);
+
+    expect(capturedUrl).toContain('https://eodhd.com/api/intraday/006340.KO');
+    const u = new URL(capturedUrl);
+    expect(u.searchParams.get('interval')).toBe('1m');
+    const from = Number(u.searchParams.get('from'));
+    const to = Number(u.searchParams.get('to'));
+    expect(to - from).toBeGreaterThanOrEqual(48 * 3600 - 1);
+    expect(to - from).toBeLessThanOrEqual(48 * 3600 + 60);
+  });
+
+  it('Korea KOSPI .KO ticker reaches Mon session even when polled Tue 19:30 UTC', async () => {
+    // Régression spécifique : à 19:30 UTC mardi, on doit capturer la session
+    // KOSPI Mon 00:00-06:30 UTC (terminée 37h avant). 24h window manquait,
+    // 48h window doit la capturer.
+    const svc = makeService();
+    let capturedUrl = '';
+    (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 200, json: async () => [], text: async () => '[]' };
+    });
+
+    // Mock Date.now() = mardi 19:30 UTC
+    const tueAt1930Utc = Date.parse('2026-04-29T19:30:00Z');
+    const realDateNow = Date.now;
+    Date.now = () => tueAt1930Utc;
+
+    await svc.getCandles('006340.KO', '1m', 65);
+
+    Date.now = realDateNow;
+
+    const u = new URL(capturedUrl);
+    const from = Number(u.searchParams.get('from'));
+    const fromDate = new Date(from * 1000);
+    // from = 2026-04-27 19:30 UTC (dimanche). Cela couvre :
+    //   - KOSPI Lun 28 Apr 00:00-06:30 ✓ (était le bug)
+    //   - KOSPI Mar 29 Apr 00:00-06:30 ✓
+    expect(fromDate.toISOString()).toBe('2026-04-27T19:30:00.000Z');
+  });
+
+  it('NSE India .NSE ticker reaches Mon session at Tue 19:30 UTC', async () => {
+    // NSE 03:45–10:00 UTC. Lun 28 Apr 03:45 → 19:30 mardi = 39h avant.
+    // 48h window capture, 24h window manquait.
+    const svc = makeService();
+    let capturedUrl = '';
+    (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 200, json: async () => [], text: async () => '[]' };
+    });
+
+    await svc.getCandles('DEVYANI.NSE', '1m', 65);
+
+    const u = new URL(capturedUrl);
+    const from = Number(u.searchParams.get('from'));
+    const to = Number(u.searchParams.get('to'));
+    expect(to - from).toBeGreaterThanOrEqual(48 * 3600 - 1);
+    // URL contient le ticker NSE inchangé
+    expect(capturedUrl).toContain('DEVYANI.NSE');
+  });
+});

--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -146,7 +146,30 @@ export class EodhdIntradayService {
    * garde uniquement les N candles les plus récentes côté client.
    */
   private windowForInterval(interval: '1m' | '5m' | '1h'): number {
-    if (interval === '1m') return 24 * 3600;          // 1 jour
+    // P19r (29/04/2026 19:30 UTC) — 1m window bumped 24h → 48h.
+    //
+    // Constat prod (UI Lisa Top 20 : 1m = 1/20, KFRC US seul à avoir tf1m≠null,
+    // 9/20 = Korea, 4/20 = India, 1/20 = AU) : 24h window ne couvre PAS la
+    // dernière session de la majorité des marchés non-US.
+    //
+    // Sessions UTC :
+    //   - KOSPI / KOSDAQ : 00:00–06:30 UTC Mon-Fri (Korea)
+    //   - NSE India       : 03:45–10:00 UTC Mon-Fri
+    //   - ASX Australia   : 23:00–05:00 UTC (overnight, prev day)
+    //   - LSE / XETRA / PA : 08:00–16:30 UTC
+    //   - NYSE / NASDAQ   : 14:30–21:00 UTC + after-hours 21:00–24:00
+    //
+    // À 19:30 UTC un mardi, 24h window remonte au lundi 19:30 UTC :
+    //   - Korea Mon session 00:00–06:30 = OUTSIDE window (terminée 13h avant le
+    //     début du window) → 0 candles 1m pour les KO/KQ
+    //   - Korea Tue session = aujourd'hui 00:00–06:30 = inside window mais
+    //     EODHD intraday peut avoir un délai T+1 sur certains plans
+    //   - NSE Mon session = OUTSIDE
+    //
+    // 48h window capture systématiquement les 2 dernières sessions de TOUS
+    // les marchés mondiaux. Coût négligeable car .slice(-count) limite la
+    // payload côté client.
+    if (interval === '1m') return 48 * 3600;          // 2 jours (fix asia/NSE/AU)
     if (interval === '5m') return 5 * 24 * 3600;      // 5 jours (couvre weekends)
     return 30 * 24 * 3600;                             // 30 jours pour 1h
   }

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -99,11 +99,12 @@ interface EodhdScreenerRow {
  */
 const EU_EXCHANGES = ['LSE', 'XETRA', 'PA', 'SW', 'MI', 'MC', 'BME', 'AS', 'AMS'];
 // P19d (29/04/2026 14:30 CEST) — Ajout SSE (Shanghai) + SZSE (Shenzhen) pour
-// couverture mondiale complète. China A-shares supportées par EODHD plan
-// "All World" (à valider au runtime — 422 silencieusement skip si pas dans
-// le plan, P18c warning log). Yahoo fallback (.SS / .SZ) couvre quoi qu'il
-// arrive (P19a Yahoo intraday router).
-const NON_EU_EXCHANGES = ['US', 'TSE', 'HK', 'AU', 'KO', 'TO', 'NSE', 'BSE', 'SS', 'SZ'];
+// couverture mondiale complète.
+// P19r (29/04/2026 19:30 UTC) — Ajout KQ (KOSDAQ) — couverture Asie complète
+// (KOSPI .KO + KOSDAQ .KQ). Constat user dump SQL Supabase : 9/20 KO + 4/20
+// NSE + 1/20 AU = 70% des candidats Top 20 viennent d'Asie/Inde, mais KOSDAQ
+// (Kakao 035720.KQ, Naver, etc.) n'était pas scanné → trou de couverture.
+const NON_EU_EXCHANGES = ['US', 'TSE', 'HK', 'AU', 'KO', 'KQ', 'TO', 'NSE', 'BSE', 'SS', 'SZ'];
 /** Watchlists EU dont la session_open_utc / session_close_utc gate l'EODHD scan. */
 const EU_WATCHLIST_NAMES = ['cac40', 'dax40', 'ftse100'];
 const CRYPTO_PAIRS = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT', 'ADAUSDT', 'AVAXUSDT', 'DOTUSDT', 'LINKUSDT', 'MATICUSDT'];


### PR DESCRIPTION
## Constat user dump SQL Supabase (Top 20 last_scan_candidates)

| Exchange | Count | Tickers |
|---|---|---|
| KO (Korea KOSPI) | **9** | 000680, 002020, 005950, 006340, 006345, 006650, 011170, 226320, ... |
| US | 6 | BZLFF, CNC, KFRC, SANM, WTBFA, WYY |
| NSE (India) | 4 | DEVYANI, INDOBORAX, SAPPHIRE, WHEELS |
| AU (Australia) | 1 | CDA |

**UI observée** : 1m=1/20, seul KFRC (US mid-cap, marché ouvert) avait tf1m≠null. **13/20 (65%)** viennent d'Asie/Inde sans data 1m.

## Root cause (sessions UTC)

```
KOSPI / KOSDAQ : 00:00–06:30 UTC Mon-Fri
NSE India       : 03:45–10:00 UTC Mon-Fri
ASX Australia   : 23:00–05:00 UTC
```

À **19:30 UTC mardi**, window 24h remonte à **lundi 19:30** → manque toute la session lundi de KOSPI/NSE (terminée 13–39h avant le DÉBUT du window).

## Fix

| # | Avant | Après | Pourquoi |
|---|---|---|---|
| 1 | `windowForInterval('1m') = 24h` | **48h** | Capture systématiquement les 2 dernières sessions de TOUS les marchés. EODHD max 1m = 120 jours, marge énorme. |
| 2 | `NON_EU_EXCHANGES` ne contient pas `KQ` | Ajouté **`'KQ'`** (KOSDAQ) | Couverture Asie complète : Kakao 035720.KQ, Naver, etc. n'étaient pas scannés. |

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` → OK
- [x] `npx jest "eodhd-intraday.p19r|top-gainers-scanner"` → **59 passed** (5 P19r + regression)
- [ ] Fly logs post-deploy : `[provider-router] eodhd 1m OK for 006340.KO (95 candles), coverage=eodhd_1m`
- [ ] UI Top 20 : 1m peuplé sur ~15-18/20 (vs 1/20 avant)

### Curl reproductible (auth Fly required pour valider end-to-end)

```bash
# Confirme la nouvelle SHA déployée
curl -s https://smartvest.fly.dev/version | jq .git_sha

# Snapshot persistance Top 20 — vérifier tf1m peuplé pour KO/NSE/AU
curl -s -H "x-user-id: $UID" \
  https://smartvest.fly.dev/lisa/gainers-persistence-snapshot/$PID?topN=20 \
  | jq '.candidates[] | {symbol, market, tf1m, tf5m, tf1h}'
```

## Limites connues (hors scope)

- US microcaps illiquides (BZLFF, WTBFA, WYY) peuvent rester sans 1m (volume sparse). Le fallback ticks (P19o.3) capture certains cas via `/api/ticks` aggregated.
- UI badge `market_closed` / `illiquid_1m` / `unsupported_exchange` : work frontend séparé.

## Rollback plan

```bash
git revert <merge-sha>
git push origin main
# Fly redeploy auto via .github/workflows/fly.yml
```

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_