### PR TITLE
fix(P19x.1): MIN_NET_PROFIT_USD guard avant closed_target — bloque fake TPs net négatif

### DIFF
--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -2090,6 +2090,64 @@ export class MechanicalTradingService {
       entryFeeRefund = new Decimal(0);
     }
     const realizedPnl = rawPnl.minus(exitCost).plus(entryFeeRefund);
+
+    // P19x.1 (29/04/2026) — MIN_NET_PROFIT_USD guard avant `closed_target`.
+    //
+    // Bug observé en prod ce soir : 10 trades fermés "TP hit", win rate 0%,
+    // P&L cumulé -$36.53. Cause : les exits réactifs (MACD bearish à pnl
+    // ≥ 0.5%, P19x déjà mergé) + take-profit absolu (P&L ≥ 2.5-4%) peuvent
+    // matérialiser un gain BRUT minimal sur trades à petit notional, qui
+    // devient NÉGATIF après fees IBKR ($0.35 min × 2 sides = $0.70).
+    //
+    // Garde-fou : un closed_target ne doit JAMAIS résulter en net PnL négatif.
+    // Si net < MIN = max(2$, 0.5% × notional), on REFUSE le close et la
+    // position reste ouverte. Le prochain cycle re-évaluera (price peut
+    // bouger plus, ou le trailing/stop la fermera proprement).
+    //
+    // Pourquoi seulement closed_target : closed_stop matérialise une perte
+    // par design (protection drawdown) ; closed_invalidated refund les fees.
+    if (reason === 'closed_target') {
+      const minNetProfit = Decimal.max(
+        new Decimal(2),
+        notional.mul(0.005),  // 0.5% du notional
+      );
+      if (realizedPnl.lt(minNetProfit)) {
+        this.logger.warn(
+          `[MÉCANIQUE] Skip closed_target ${pos.symbol}: net=$${realizedPnl.toFixed(2)} < min=$${minNetProfit.toFixed(2)} ` +
+          `(notional=$${notional.toFixed(0)}, gross=$${rawPnl.toFixed(2)}, fees=$${exitCost.toFixed(2)}). Position kept open.`,
+        );
+        // Audit decision_log pour tracer ce que sinon serait silencieux côté UI
+        await this.decisionLog.append({
+          portfolioId: pos.portfolio_id as string,
+          kind: 'mechanical_close_skipped_min_profit',
+          summary: `[MÉCANIQUE] Refus closed_target ${pos.symbol}: net=$${realizedPnl.toFixed(2)} < min=$${minNetProfit.toFixed(2)} → garde ouvert`,
+          rationale: `Net PnL ${realizedPnl.toFixed(2)} USD inférieur au seuil min ${minNetProfit.toFixed(2)} USD (gross ${rawPnl.toFixed(2)} - fees ${exitCost.toFixed(2)}). Position kept open pour éviter de matérialiser une perte sur fake-TP.`,
+          payload: {
+            symbol: pos.symbol,
+            entry_price: pos.entry_price,
+            attempted_exit_price: exitPrice.toFixed(4),
+            attempted_reason: rationale,
+            gross_pnl_usd: rawPnl.toFixed(2),
+            exit_cost_usd: exitCost.toFixed(2),
+            net_pnl_usd: realizedPnl.toFixed(2),
+            min_net_profit_usd: minNetProfit.toFixed(2),
+            notional_usd: notional.toFixed(2),
+          },
+          triggeredBy: 'mechanical_cron',
+        }).catch(() => { /* non-bloquant */ });
+        return; // ⚠️ Position reste ouverte, pas d'UPDATE DB
+      }
+    }
+
+    // P19x.1 — Log structuré obligatoire à chaque close effectif (req user).
+    // Permet grep Fly logs pour audit : entry, exit, qty, fees, gross, net.
+    this.logger.log(
+      `[MÉCANIQUE_CLOSE] ${pos.symbol} status=${reason} ` +
+      `entry=${entryPrice.toFixed(4)} exit=${exitPrice.toFixed(4)} qty=${qty.toFixed(4)} ` +
+      `gross=$${rawPnl.toFixed(2)} fees_out=$${exitCost.toFixed(2)} ` +
+      `net=$${realizedPnl.toFixed(2)} notional=$${notional.toFixed(2)} ` +
+      `entry_cost=$${pos.estimated_entry_cost_usd ?? '?'}`,
+    );
     const pnlPct = realizedPnl.div(notional).mul(100).toNumber();
 
     const now = new Date().toISOString();


### PR DESCRIPTION
## Bug user constat (29/04 ce soir, post-P19x merged)

10 trades fermés "TP hit", **win rate 0%**, P&L cumulé **-$36.53**.

Cause : exits réactifs (MACD bearish à pnl ≥ 0.5%, P19x) + take-profit absolu peuvent matérialiser un **gain BRUT minimal** sur trades à petit notional, qui devient **NÉGATIF après fees IBKR**.

Trade SLV exemple :
- Entry 64.4250 → exit 64.4300 (+$0.005 = +0.0078%)
- Notional $2500, qty 38.76
- Gross : $0.19
- Fees IBKR (P19u/P19x) : $0.35 entry + $0.35 exit + 5bps slip ≈ $0.95
- **Net : -$0.76** → labelled `closed_target` ❌

## Fix

**Garde-fou** : un `closed_target` ne doit **JAMAIS** résulter en net PnL négatif.
- `MIN_NET_PROFIT_USD = max($2, 0.5% × notional)`
- Si net < min → **REFUSE le close**, position reste ouverte
- Prochain cycle re-évaluera (price peut bouger plus, ou trailing/stop fermera proprement)

| Scénario | Avant P19x.1 | Après P19x.1 |
|---|---|---|
| SLV gross +$0.19, fees $0.95 | closed_target net=-$0.76 ❌ | **Skipped** — keep open ✅ |
| SLV gross +$2.50, fees $0.95 | closed_target net=$1.55 | Skipped (min=$2 sur $500 notional) |
| SLV gross +$15.50, fees $0.85 | closed_target net=$14.65 ✅ | closed_target net=$14.65 ✅ |
| SLV stop loss hit (gross -$10) | closed_stop ✅ | closed_stop ✅ (no guard sur stop) |

**Pourquoi seulement `closed_target`** :
- `closed_stop` matérialise une perte par design (protection drawdown)
- `closed_invalidated` refund les fees déjà (P19u/P19x) → net=0
- `closed_target` devrait toujours être un GAIN économique réel

## Logging obligatoire (req user)

À chaque close effectif :
```
[MÉCANIQUE_CLOSE] SLV status=closed_target entry=64.43 exit=64.50 qty=38.76 gross=$2.71 fees_out=$0.85 net=$1.86 notional=$2497 entry_cost=$0.35
```

À chaque close skipped (guard) :
```
[MÉCANIQUE] Skip closed_target SLV: net=$0.50 < min=$2.00 (notional=$2500, gross=$1.45, fees=$0.95). Position kept open.
```

Decision_log : `kind='mechanical_close_skipped_min_profit'` pour audit UI.

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` → OK
- [x] `npx jest "mechanical|paper-broker|top-gainers"` → **77 passed**
- [ ] Post-deploy : Fly logs grep `[MÉCANIQUE] Skip closed_target` apparaît
- [ ] winRatePct doit remonter sur prochaine fenêtre 5-10 trades

## Hors scope (P19x.2 à P19x.7 séparés)

- TP1=1.5% / TP2=3% / SL=-1% étagés (P19x.2)
- Cooldown 30 min same symbol/side (P19x.3)
- Watchdog expectancy E<0 → kill-switch auto (P19x.4)
- Admin endpoint Supabase 1m coverage query (P19x.5)
- Admin endpoint fly logs grep [provider-router] (P19x.6)
- Activation Gemini (workflow trigger côté user)

## Rollback

```bash
git revert <merge-sha>
git push origin main
```

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_