### PR TITLE
feat(P19x.2): TP=1.5% / SL=1.0% configurables per portfolio (DB column)

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -699,11 +699,12 @@ export class TopGainersScannerService implements OnModuleInit {
       return;
     }
 
-    // P8 — Charge le seuil min de persistance pour ce portfolio (DB > env > 0.67)
+    // P8 + P19x.2 — Charge config gainers pour ce portfolio :
+    // min persistance + path efficiency + TP/SL defaults.
     const { data: cfgRow } = await this.supabase
       .getClient()
       .from('lisa_session_configs')
-      .select('gainers_min_persistence_score, gainers_min_path_efficiency')
+      .select('gainers_min_persistence_score, gainers_min_path_efficiency, gainers_default_tp_pct, gainers_default_sl_pct')
       .eq('portfolio_id', portfolioId)
       .maybeSingle();
     const minScore = this.resolveMinPersistenceScore(
@@ -715,6 +716,15 @@ export class TopGainersScannerService implements OnModuleInit {
     const minPathEff = cfgRow?.gainers_min_path_efficiency != null
       ? Math.max(0, Math.min(1, Number(cfgRow.gainers_min_path_efficiency)))
       : null;
+    // P19x.2 — TP/SL configurables par portfolio. Defaults DB = 1.5% / 1.0%
+    // (migration 0093). Si row absent (portfolio sans config), fallback hardcoded
+    // aux mêmes defaults.
+    const tpPct = cfgRow?.gainers_default_tp_pct != null
+      ? Math.max(0.1, Math.min(50, Number(cfgRow.gainers_default_tp_pct)))
+      : 1.5;
+    const slPct = cfgRow?.gainers_default_sl_pct != null
+      ? Math.max(0.1, Math.min(20, Number(cfgRow.gainers_default_sl_pct)))
+      : 1.0;
 
     // P8 — Calcule la persistance multi-TF pour les top candidats (parallèle)
     const persistenceMap = await this.mtfPersistence.analyzeBatch(
@@ -801,6 +811,7 @@ export class TopGainersScannerService implements OnModuleInit {
         portfolioId,
         cand,
         persistence,
+        { tpPct, slPct },
       ).catch((e) => {
         this.logger.warn(
           `[top-gainers] open ${cand.symbol} failed: ${String(e).slice(0, 120)}`,
@@ -834,9 +845,14 @@ export class TopGainersScannerService implements OnModuleInit {
     portfolioId: string,
     cand: TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass },
     persistence?: PersistenceResult,
+    // P19x.2 — TP/SL config par portfolio (DB lisa_session_configs.gainers_default_*).
+    // Fallback aux nouveaux defaults P19x.2 spec : TP=1.5% / SL=1.0%.
+    overrides?: { tpPct: number; slPct: number },
   ): Promise<string | null> {
     const proposalId = randomUUID();
     const thesisId = randomUUID();
+    const effectiveTp = overrides?.tpPct ?? 1.5;
+    const effectiveSl = overrides?.slPct ?? 1.0;
 
     // P18 — LLM thesis generation (inert when SCANNER_LLM_ROUTER_ENABLED=false)
     const llmThesis = await this.generateThesis(cand);
@@ -855,8 +871,10 @@ export class TopGainersScannerService implements OnModuleInit {
           assetClass: cand.assetClass,
           direction: 'long',
           venue: cand.exchange ?? 'unknown',
-          stopLossPct: 1.5,
-          takeProfitPct: 3.0,
+          // P19x.2 — Lit DB : default 1.5% TP / 1.0% SL (vs 3.0/1.5 pré-P19x.2).
+          // User spec (29/04 02:00 UTC) : lock profits earlier + tighter stops.
+          stopLossPct: effectiveSl,
+          takeProfitPct: effectiveTp,
           horizonDays: 1,
         },
       ],

--- a/supabase/migrations/0093_gainers_tp_sl_defaults.sql
+++ b/supabase/migrations/0093_gainers_tp_sl_defaults.sql
@@ -1,0 +1,50 @@
+-- P19x.2 (29/04/2026) — TP/SL configurables par portfolio pour le scanner Gainers.
+--
+-- Bug constaté : `top-gainers-scanner.service.ts:858-859` utilisait des
+-- valeurs hardcoded `stopLossPct: 1.5` + `takeProfitPct: 3.0`. Le user
+-- a observé 10 trades fermés "TP hit" tous en perte (post-fees), preuve
+-- que le couple TP/SL n'était pas adapté aux fees IBKR + à la volatilité
+-- intraday des micro-moves.
+--
+-- Spec user (29/04 02:00 UTC) :
+--   TP = 1.5% (lock in profits plus tôt, vs 3.0% qui rate les retracements)
+--   SL = 1.0% (vs 1.5%, stop plus serré pour limiter drawdown par trade)
+--
+-- Cette migration ajoute 2 colonnes configurables par portfolio. Le scanner
+-- lit ces valeurs avec fallback aux nouveaux defaults (1.5 / 1.0).
+
+ALTER TABLE public.lisa_session_configs
+  ADD COLUMN IF NOT EXISTS gainers_default_tp_pct numeric(4, 2) NOT NULL DEFAULT 1.5,
+  ADD COLUMN IF NOT EXISTS gainers_default_sl_pct numeric(4, 2) NOT NULL DEFAULT 1.0;
+
+-- Garde-fous : TP > 0 (gain), SL > 0 (drawdown limite, exprimé en absolu).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'lisa_session_configs_gainers_tp_check'
+      AND conrelid = 'public.lisa_session_configs'::regclass
+  ) THEN
+    ALTER TABLE public.lisa_session_configs
+      ADD CONSTRAINT lisa_session_configs_gainers_tp_check
+      CHECK (gainers_default_tp_pct > 0 AND gainers_default_tp_pct <= 50);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'lisa_session_configs_gainers_sl_check'
+      AND conrelid = 'public.lisa_session_configs'::regclass
+  ) THEN
+    ALTER TABLE public.lisa_session_configs
+      ADD CONSTRAINT lisa_session_configs_gainers_sl_check
+      CHECK (gainers_default_sl_pct > 0 AND gainers_default_sl_pct <= 20);
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.lisa_session_configs.gainers_default_tp_pct IS
+  'Take-profit default % pour positions ouvertes par TopGainersScannerService. '
+  'P19x.2 (29/04/2026) : default 1.5% (vs 3.0% pré-P19x.2). Sert de fallback '
+  'quand expression.takeProfitPct n''est pas fournie.';
+
+COMMENT ON COLUMN public.lisa_session_configs.gainers_default_sl_pct IS
+  'Stop-loss default % pour positions ouvertes par TopGainersScannerService. '
+  'P19x.2 (29/04/2026) : default 1.0% (vs 1.5% pré-P19x.2).';


### PR DESCRIPTION
## User spec
> "TP1 = +1.5% (close 50% qty) / TP2 = +3% (close 50% qty restant) / SL = -1%"

## Scope ce PR (V1 simple, sans partial close)

paperBroker n'a pas de partial close support (cf. comment mechanical-trading:1965 "V2"). Implémenter staged TP requires schema migration + paperBroker fork + multi-target close logic — substantial.

**V1 ship** : **TP unique = 1.5%** (lock profits earlier vs 3.0%) + **SL = 1.0%** (vs 1.5%, tighter). Combiné avec P19x.1 (MIN_NET_PROFIT guard $2/0.5%), les fake TPs disparaissent.

**V2 staged TP** : follow-up dédié.

## Migration 0093 + runtime config

```sql
ALTER TABLE lisa_session_configs
  ADD COLUMN gainers_default_tp_pct numeric(4,2) NOT NULL DEFAULT 1.5,
  ADD COLUMN gainers_default_sl_pct numeric(4,2) NOT NULL DEFAULT 1.0;
```

`top-gainers-scanner.scanPortfolio` lit ces colonnes (DB > defaults). Clamp `[0.1, 50]` / `[0.1, 20]` defense-in-depth.

User peut override par portfolio :
```sql
UPDATE lisa_session_configs
SET gainers_default_tp_pct = 2.0, gainers_default_sl_pct = 0.8
WHERE portfolio_id = '...';
```

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` → OK
- [x] `npx jest "top-gainers"` → **54 passed**
- [ ] Post-deploy : prochain trade ouvert → `take_profit_price = entry × 1.015`, `stop_loss_price = entry × 0.99`
- [ ] Combiné P19x.1 : aucun closed_target avec net < max($2, 0.5% × notional)

## Status workstream P19x

| # | Status |
|---|---|
| P19x.1 (#118) MIN_NET_PROFIT guard | ✅ merged 8b7ff01 |
| **P19x.2 (this) TP/SL config** | ✅ shipped, awaiting CI |
| P19x.3 Cooldown 30min same symbol/side | À shipper |
| P19x.4 Watchdog expectancy E<0 | À shipper |
| P19x.5 Admin endpoint Supabase 1m coverage | À shipper |
| P19x.6 Admin endpoint logs grep | À shipper |
| P19x.7 git_sha=null régression | **NON REPRODUIT** : curl `/version` retourne `git_sha=8b7ff01...` à 02:00 UTC |
| P19x.8 Real fees per venue | Scope substantiel — à shipper |
| P19x.9 UI Path legend + tooltips | Scope frontend — à shipper |
| Staged TP1/TP2 partial close | V2 follow-up |

## Rollback

```bash
git revert <merge-sha>
git push origin main
# Migration 0093 reste appliquée (additive)
```

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_