### PR TITLE
feat(P19x.10 + P19x.5): AdminModule — apply-missing migrations + Supabase query

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -28,6 +28,7 @@ import { BotLabModule } from './modules/bot-lab/bot-lab.module';
 import { BacktestModule } from './modules/backtest/backtest.module';
 import { StrategyOptimizerModule } from './modules/strategy-optimizer/optimizer.module';
 import { MonteCarloModule } from './modules/monte-carlo/monte-carlo.module';
+import { AdminModule } from './modules/admin/admin.module';
 
 @Module({
   imports: [
@@ -66,6 +67,7 @@ import { MonteCarloModule } from './modules/monte-carlo/monte-carlo.module';
     BacktestModule,
     StrategyOptimizerModule,
     MonteCarloModule,
+    AdminModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/modules/admin/admin-migrations.controller.ts
+++ b/apps/api/src/modules/admin/admin-migrations.controller.ts
@@ -1,0 +1,284 @@
+/**
+ * P19x.10 (29/04/2026) — Admin endpoint pour appliquer les migrations Supabase
+ * manquantes en runtime.
+ *
+ * Pourquoi : audit user via Comet a révélé 2 trous DB :
+ *   - 0036_corpus_micro_5_1_svb_banking_2023.sql : NON appliquée (trou)
+ *   - 0090_p12_vault_harvest_baseline.sql        : NON appliquée (trou)
+ * Le script CI `scripts/apply-migrations.mjs` tourne au boot du container
+ * (Dockerfile CMD), MAIS si une migration plante (FK manquante, RLS, etc.)
+ * il continue à la suivante en log FAIL — DB reste désynchronisée silencieusement.
+ *
+ * Cet endpoint expose le même mécanisme manuellement, avec :
+ *   - Auth via header `x-admin-token` matchant secret Fly `ADMIN_TOKEN`
+ *   - Mode dry-run via `?dry_run=true` (liste sans appliquer)
+ *   - Retour JSON détaillé `{applied, skipped, failed}` avec checksums SHA256
+ *
+ * Usage :
+ *   curl -H "x-admin-token: $ADMIN_TOKEN" \
+ *     "https://smartvest.fly.dev/admin/migrations/apply-missing?dry_run=true"
+ *
+ * Sécurité :
+ *   - 401 si header absent
+ *   - 403 si ADMIN_TOKEN env var absent (endpoint disabled)
+ *   - 403 si token mismatch (constant-time compare)
+ *   - Aucune donnée user-supplied n'atteint le SQL — fichiers sont du repo bundlé
+ */
+
+import {
+  Controller,
+  Get,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+  Query,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface MigrationFile {
+  filename: string;
+  version: number;
+  sha256: string;
+  sql: string;
+}
+
+interface ApplyResult {
+  applied: Array<{ filename: string; sha256: string; latencyMs: number }>;
+  skipped: Array<{ filename: string; reason: 'already_applied' | 'not_in_repo' }>;
+  failed: Array<{ filename: string; error: string; status?: number }>;
+  dry_run: boolean;
+  total_files: number;
+  total_applied_db: number;
+  missing_count: number;
+}
+
+@Controller('admin/migrations')
+export class AdminMigrationsController {
+  private readonly logger = new Logger(AdminMigrationsController.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  @Get('apply-missing')
+  async applyMissing(
+    @Headers('x-admin-token') providedToken: string | undefined,
+    @Query('dry_run') dryRunRaw?: string,
+  ): Promise<ApplyResult> {
+    this.assertAdmin(providedToken);
+    const dryRun = String(dryRunRaw ?? '').toLowerCase() === 'true';
+
+    const projectRef = this.config.get<string>('SUPABASE_PROJECT_REF') ?? 'mfuutigfhrawccotinpo';
+    const supabaseToken = this.config.get<string>('SUPABASE_ACCESS_TOKEN');
+    if (!supabaseToken) {
+      throw new HttpException(
+        { message: 'SUPABASE_ACCESS_TOKEN not set on Fly — cannot reach Management API', code: 'NO_ACCESS_TOKEN' },
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+    }
+
+    // 1. Charge les fichiers du repo (bundlés dans l'image)
+    const files = this.readMigrationFiles();
+
+    // 2. Charge l'état DB
+    const apiUrl = `https://api.supabase.com/v1/projects/${projectRef}/database/query`;
+    const appliedRows = await this.runSql(
+      apiUrl,
+      supabaseToken,
+      'select filename, sha256 from _smartvest_migrations order by filename;',
+    );
+    const appliedMap = new Map<string, string>();
+    if (appliedRows.ok) {
+      try {
+        const rows = JSON.parse(appliedRows.body);
+        for (const row of Array.isArray(rows) ? rows : []) {
+          appliedMap.set(row.filename, row.sha256);
+        }
+      } catch { /* empty result */ }
+    } else if (appliedRows.status === 404 || appliedRows.body.includes('does not exist')) {
+      // Tracking table doesn't exist yet — bootstrap it
+      if (!dryRun) {
+        const init = await this.runSql(
+          apiUrl,
+          supabaseToken,
+          'create table if not exists _smartvest_migrations ( filename text primary key, sha256 text not null, applied_at timestamptz not null default now() );',
+        );
+        if (!init.ok) {
+          throw new HttpException(
+            { message: 'Failed to bootstrap _smartvest_migrations table', body: init.body },
+            HttpStatus.INTERNAL_SERVER_ERROR,
+          );
+        }
+      }
+    }
+
+    // 3. Diff
+    const result: ApplyResult = {
+      applied: [],
+      skipped: [],
+      failed: [],
+      dry_run: dryRun,
+      total_files: files.length,
+      total_applied_db: appliedMap.size,
+      missing_count: 0,
+    };
+
+    const missing = files.filter((f) => !appliedMap.has(f.filename));
+    result.missing_count = missing.length;
+
+    // Items déjà appliquées (logging)
+    for (const f of files) {
+      if (appliedMap.has(f.filename)) {
+        result.skipped.push({ filename: f.filename, reason: 'already_applied' });
+      }
+    }
+
+    // 4. Apply missing (or dry-run report)
+    for (const f of missing) {
+      if (dryRun) {
+        result.applied.push({ filename: f.filename, sha256: f.sha256, latencyMs: 0 });
+        continue;
+      }
+
+      const t0 = Date.now();
+      const r = await this.runSql(apiUrl, supabaseToken, f.sql);
+      const latencyMs = Date.now() - t0;
+
+      const alreadyExists = !r.ok && this.isAlreadyExistsError(r.body);
+      if (r.ok || alreadyExists) {
+        // Record dans tracker
+        const escaped = f.filename.replace(/'/g, "''");
+        const ins = await this.runSql(
+          apiUrl,
+          supabaseToken,
+          `insert into _smartvest_migrations (filename, sha256) values ('${escaped}', '${f.sha256}') on conflict (filename) do nothing;`,
+        );
+        if (!ins.ok) {
+          this.logger.warn(`[admin/migrations] tracker insert failed for ${f.filename}: ${ins.body.slice(0, 120)}`);
+        }
+        result.applied.push({ filename: f.filename, sha256: f.sha256, latencyMs });
+      } else {
+        const failure: { filename: string; error: string; status?: number } = {
+          filename: f.filename,
+          error: String(r.body).slice(0, 500),
+        };
+        if (typeof r.status === 'number') failure.status = r.status;
+        result.failed.push(failure);
+      }
+    }
+
+    this.logger.log(
+      `[admin/migrations] dry_run=${dryRun} files=${result.total_files} ` +
+      `applied_db=${result.total_applied_db} missing=${result.missing_count} ` +
+      `applied=${result.applied.length} failed=${result.failed.length}`,
+    );
+
+    return result;
+  }
+
+  /**
+   * Auth admin par header `x-admin-token`. Constant-time compare.
+   */
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (!providedToken) {
+      throw new HttpException(
+        { message: 'x-admin-token header required', code: 'NO_TOKEN' },
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+    // timingSafeEqual requires equal-length buffers ; pad to same length safely
+    const a = Buffer.from(expected);
+    const b = Buffer.from(providedToken);
+    if (a.length !== b.length || !timingSafeEqual(a, b)) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'BAD_TOKEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+
+  /**
+   * Lit les fichiers de migration depuis le filesystem de l'image.
+   *
+   * Path résolution :
+   *  - Container Fly : Dockerfile copie `supabase/migrations` vers `/app/supabase/migrations`.
+   *    cwd à runtime = `/app/apps/api` → fichier accessible via `/app/supabase/migrations`.
+   *  - Local dev : cwd = repo root → `supabase/migrations`.
+   * On try les 2 paths.
+   */
+  private readMigrationFiles(): MigrationFile[] {
+    const candidates = ['/app/supabase/migrations', 'supabase/migrations', '../../supabase/migrations'];
+    const dir = candidates.find((p) => existsSync(p));
+    if (!dir) {
+      throw new HttpException(
+        { message: 'Migrations directory not found on filesystem', tried: candidates },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    return readdirSync(dir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort()
+      .map((filename) => {
+        const sql = readFileSync(join(dir, filename), 'utf-8');
+        const sha256 = createHash('sha256').update(sql).digest('hex');
+        // Extract numeric version prefix (0036, 0090...)
+        const match = filename.match(/^(\d+)/);
+        const version = match ? Number(match[1]) : 0;
+        return { filename, version, sha256, sql };
+      });
+  }
+
+  private async runSql(
+    apiUrl: string,
+    token: string,
+    sql: string,
+  ): Promise<{ ok: boolean; status?: number; body: string }> {
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        const res = await fetch(apiUrl, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ query: sql }),
+          signal: AbortSignal.timeout(30_000),
+        });
+        const body = await res.text();
+        if (res.ok) return { ok: true, status: res.status, body };
+        if (res.status === 503 && attempt < 3) {
+          await new Promise((r) => setTimeout(r, 2000 * attempt));
+          continue;
+        }
+        return { ok: false, status: res.status, body };
+      } catch (e) {
+        if (attempt < 3) {
+          await new Promise((r) => setTimeout(r, 1000 * attempt));
+          continue;
+        }
+        return { ok: false, status: 0, body: String(e).slice(0, 500) };
+      }
+    }
+    return { ok: false, status: 0, body: 'exhausted' };
+  }
+
+  private isAlreadyExistsError(body: string): boolean {
+    const s = String(body).toLowerCase();
+    return (
+      s.includes('already exists') ||
+      s.includes('duplicate key') ||
+      s.includes('42p07') || // duplicate_table
+      s.includes('42710')    // duplicate_object (index, constraint)
+    );
+  }
+}

--- a/apps/api/src/modules/admin/admin-supabase-query.controller.ts
+++ b/apps/api/src/modules/admin/admin-supabase-query.controller.ts
@@ -1,0 +1,187 @@
+/**
+ * P19x.5 (29/04/2026) — Admin endpoint pour query Supabase ad-hoc (read-only).
+ *
+ * Use case primaire : audit 1m coverage table pour vérifier que les fetchs
+ * EODHD intraday 1m post-P19r/P19v marchent réellement sur les tickers
+ * asia/NSE/AU. User ne peut pas query Supabase depuis dev env (pas de
+ * service_role key) — cet endpoint expose un set de queries pré-définies
+ * avec auth admin.
+ *
+ * Pourquoi pré-défini (pas freeform SQL) :
+ *   - Sécurité : freeform SQL via endpoint = SQL injection risk même avec
+ *     auth, et expose l'entièreté de la DB
+ *   - Limite la surface d'attaque à des queries bornées + auditables
+ *   - User peut demander d'ajouter d'autres queries en patch
+ *
+ * Auth : header `x-admin-token` matchant ADMIN_TOKEN env var (constant-time
+ * compare). Sinon 401/403.
+ *
+ * Usage :
+ *   curl -H "x-admin-token: $ADMIN_TOKEN" \
+ *     "https://smartvest.fly.dev/admin/supabase-query/intraday-coverage-1m"
+ *
+ *   curl -H "x-admin-token: $ADMIN_TOKEN" \
+ *     "https://smartvest.fly.dev/admin/supabase-query/intraday-coverage-1m?since_minutes=120"
+ */
+
+import {
+  Controller,
+  Get,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+  Param,
+  Query,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { timingSafeEqual } from 'node:crypto';
+import { SupabaseService } from '../supabase/supabase.service';
+
+/**
+ * Whitelist de queries accessibles via cet endpoint. Chaque query est :
+ *  - read-only (SELECT uniquement, pas d'INSERT/UPDATE/DELETE)
+ *  - bornée par paramètres typés (pas de string interpolation user-supplied)
+ *  - documentée par sa raison d'existence
+ */
+type QueryName =
+  | 'intraday-coverage-1m'
+  | 'intraday-coverage-by-source'
+  | 'recent-positions-pnl'
+  | 'recent-decisions';
+
+@Controller('admin/supabase-query')
+export class AdminSupabaseQueryController {
+  private readonly logger = new Logger(AdminSupabaseQueryController.name);
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+  ) {}
+
+  @Get(':queryName')
+  async runQuery(
+    @Headers('x-admin-token') providedToken: string | undefined,
+    @Param('queryName') queryName: string,
+    @Query('since_minutes') sinceMinutesRaw?: string,
+    @Query('limit') limitRaw?: string,
+  ): Promise<{ query: QueryName; rows: unknown[]; count: number; params: Record<string, unknown> }> {
+    this.assertAdmin(providedToken);
+
+    const sinceMinutes = this.clampInt(sinceMinutesRaw, 1, 10080, 120); // default 2h, max 7d
+    const limit = this.clampInt(limitRaw, 1, 1000, 100);
+    const since = new Date(Date.now() - sinceMinutes * 60_000).toISOString();
+
+    const client = this.supabase.getClient();
+    let rows: unknown[] = [];
+
+    switch (queryName) {
+      case 'intraday-coverage-1m': {
+        // P19r/P19v audit : compte tickers asia/NSE/AU avec data 1m fetched
+        // dans les 2h. Confirme que le widening 48h capture les last sessions.
+        const { data, error } = await client
+          .from('lisa_intraday_cache')
+          .select('symbol, source, fetched_at')
+          .or('symbol.like.%.KO,symbol.like.%.KQ,symbol.like.%.AU,symbol.like.%.NSE,symbol.like.%.BSE,symbol.like.%.T,symbol.like.%.HK,symbol.like.%.KS,symbol.like.%.AX,symbol.like.%.NS,symbol.like.%.BO')
+          .gte('fetched_at', since)
+          .order('fetched_at', { ascending: false })
+          .limit(limit);
+        if (error) throw new HttpException({ message: error.message }, HttpStatus.INTERNAL_SERVER_ERROR);
+        rows = data ?? [];
+        break;
+      }
+      case 'intraday-coverage-by-source': {
+        // Stats agrégées par source : count des tickers en cache par source,
+        // dans la fenêtre.
+        const { data, error } = await client
+          .from('lisa_intraday_cache')
+          .select('source')
+          .gte('fetched_at', since);
+        if (error) throw new HttpException({ message: error.message }, HttpStatus.INTERNAL_SERVER_ERROR);
+        const bySource = new Map<string, number>();
+        for (const row of data ?? []) {
+          const src = String((row as { source?: string }).source ?? 'unknown');
+          bySource.set(src, (bySource.get(src) ?? 0) + 1);
+        }
+        rows = Array.from(bySource.entries()).map(([source, count]) => ({ source, count }));
+        break;
+      }
+      case 'recent-positions-pnl': {
+        // PnL des positions fermées récemment, tri desc exit_timestamp.
+        // Permet validation P19u/P19x/P19x.1 fees + MIN_NET_PROFIT guard.
+        const { data, error } = await client
+          .from('lisa_positions')
+          .select('symbol, status, entry_price, exit_price, quantity, entry_notional_usd, realized_pnl_usd, realized_pnl_pct, estimated_entry_cost_usd, exit_timestamp')
+          .neq('status', 'open')
+          .gte('exit_timestamp', since)
+          .order('exit_timestamp', { ascending: false })
+          .limit(limit);
+        if (error) throw new HttpException({ message: error.message }, HttpStatus.INTERNAL_SERVER_ERROR);
+        rows = data ?? [];
+        break;
+      }
+      case 'recent-decisions': {
+        // Derniers decision_log entries (mécanique, autopilot, watchdog).
+        // Permet d'observer les guards P19x.1, P19x.4 watchdog, etc.
+        const { data, error } = await client
+          .from('lisa_decision_log')
+          .select('kind, summary, created_at, portfolio_id, payload')
+          .gte('created_at', since)
+          .order('created_at', { ascending: false })
+          .limit(limit);
+        if (error) throw new HttpException({ message: error.message }, HttpStatus.INTERNAL_SERVER_ERROR);
+        rows = data ?? [];
+        break;
+      }
+      default:
+        throw new HttpException(
+          {
+            message: `Unknown query name`,
+            available: ['intraday-coverage-1m', 'intraday-coverage-by-source', 'recent-positions-pnl', 'recent-decisions'],
+          },
+          HttpStatus.BAD_REQUEST,
+        );
+    }
+
+    this.logger.log(
+      `[admin/supabase-query] query=${queryName} since_minutes=${sinceMinutes} limit=${limit} rows=${rows.length}`,
+    );
+    return {
+      query: queryName as QueryName,
+      rows,
+      count: rows.length,
+      params: { since_minutes: sinceMinutes, limit, since },
+    };
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (!providedToken) {
+      throw new HttpException(
+        { message: 'x-admin-token header required', code: 'NO_TOKEN' },
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+    const a = Buffer.from(expected);
+    const b = Buffer.from(providedToken);
+    if (a.length !== b.length || !timingSafeEqual(a, b)) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'BAD_TOKEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+
+  private clampInt(raw: string | undefined, min: number, max: number, def: number): number {
+    if (!raw) return def;
+    const n = parseInt(raw, 10);
+    if (!Number.isFinite(n)) return def;
+    return Math.max(min, Math.min(max, n));
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -1,0 +1,21 @@
+/**
+ * P19x.10 + P19x.5 — AdminModule
+ *
+ * Endpoints administrateurs protégés par `ADMIN_TOKEN` (header x-admin-token).
+ * Disabled si ADMIN_TOKEN env var absente (return 403).
+ *
+ * Endpoints :
+ *   - GET /admin/migrations/apply-missing[?dry_run=true]   (P19x.10)
+ *   - GET /admin/supabase-query/:queryName                  (P19x.5)
+ */
+
+import { Module } from '@nestjs/common';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { AdminMigrationsController } from './admin-migrations.controller';
+import { AdminSupabaseQueryController } from './admin-supabase-query.controller';
+
+@Module({
+  imports: [SupabaseModule],
+  controllers: [AdminMigrationsController, AdminSupabaseQueryController],
+})
+export class AdminModule {}

--- a/scripts/apply-migrations.mjs
+++ b/scripts/apply-migrations.mjs
@@ -87,7 +87,23 @@ const files = readdirSync(new URL(MIG_DIR))
   .filter((f) => f.endsWith('.sql'))
   .sort();
 
-console.log(`${files.length} migrations trouvées · ${applied.size} déjà appliquées · projet ${PROJECT_REF}\n`);
+// P19x.10 (29/04/2026) — Diff explicit repo vs DB pour éviter trous silencieux
+// (audit user via Comet : 0036 et 0090 manquaient en prod malgré être dans le
+// repo). Le script appliquait déjà tout le delta, mais sans visibilité sur
+// les gaps : failures au milieu du run laissaient des trous non visibles.
+const repoFilenames = new Set(files);
+const inDbButNotRepo = [...applied.keys()].filter((f) => !repoFilenames.has(f));
+const inRepoButNotDb = files.filter((f) => !applied.has(f));
+console.log(`${files.length} migrations dans le repo · ${applied.size} appliquées en DB · projet ${PROJECT_REF}`);
+if (inRepoButNotDb.length > 0) {
+  console.log(`  ⚠️  ${inRepoButNotDb.length} migrations MANQUANTES (gap repo→DB):`);
+  for (const f of inRepoButNotDb) console.log(`     - ${f}`);
+}
+if (inDbButNotRepo.length > 0) {
+  console.log(`  ℹ️  ${inDbButNotRepo.length} migrations en DB mais absentes du repo (legacy):`);
+  for (const f of inDbButNotRepo) console.log(`     - ${f}`);
+}
+console.log('');
 
 let successes = 0;
 let skipped = 0;


### PR DESCRIPTION
## P19x.10 — Audit Comet a révélé 2 trous DB
> 0036_corpus_micro_5_1_svb_banking_2023 + 0090_p12_vault_harvest_baseline présentes dans repo MAIS absentes de _smartvest_migrations DB.

## P19x.5 — Endpoint admin Supabase query
> User ne peut pas query Supabase depuis dev env (pas de service_role). Endpoint expose un set de queries pré-définies avec auth admin.

## Idempotency check

- **0036** : single `INSERT ... ON CONFLICT (slug) DO UPDATE` → idempotent ✓
- **0090** : 21 markers `IF NOT EXISTS / DO blocks` → idempotent ✓

Donc rejouer ces 2 migrations est SAFE.

## AdminModule (`apps/api/src/modules/admin/`)

Auth : header `x-admin-token` (constant-time compare avec `ADMIN_TOKEN` env). Disabled si `ADMIN_TOKEN` absent (return 403).

### `GET /admin/migrations/apply-missing[?dry_run=true]`
- Lit tous les fichiers `supabase/migrations/*.sql` bundlés dans l'image
- Query `_smartvest_migrations` → applied set
- Diff → liste les manquants
- Mode `dry_run=true` : retourne la liste SANS appliquer
- Mode normal : applique chaque manquant via Management API + INSERT tracker
- Tolérance "already exists" (42P07/42710)
- Retour JSON : `{ applied, skipped, failed, dry_run, total_files, total_applied_db, missing_count }`

### `GET /admin/supabase-query/:queryName`
4 queries pré-définies (whitelist, no SQL injection) :
- `intraday-coverage-1m` : tickers asia/NSE/AU dans cache 1m récent
- `intraday-coverage-by-source` : count par source
- `recent-positions-pnl` : positions fermées (validation P19u/P19x)
- `recent-decisions` : decision_log (P19x.1 guard, P19x.4 watchdog)

Params : `?since_minutes=120` (default 2h, max 7d), `?limit=100` (max 1000)

## Bonus — `scripts/apply-migrations.mjs`

Diff explicit `repo→DB` au boot : log les manquants ET les legacy DB→repo. Permet de spotter les trous AVANT d'avoir besoin de l'admin endpoint.

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` → OK
- [x] `npx jest "top-gainers|paper-broker|mechanical|version"` → **91 passed**
- [ ] Post-deploy : `fly secrets set ADMIN_TOKEN=$(openssl rand -hex 32) -a smartvest`
- [ ] `curl -H "x-admin-token: $TOKEN" .../admin/migrations/apply-missing?dry_run=true`
  → JSON liste 0036 + 0090 dans `applied`
- [ ] Run réel → vérifier `_smartvest_migrations` contient 0036 + 0090

## Rollback

```bash
git revert <merge-sha>
git push origin main
```

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_