### PR TITLE
fix(P19x.11): paper-broker MIN_NET_PROFIT guard + Dockerfile CACHEBUST force redeploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,12 @@ FROM node:20-alpine AS builder
 
 # ARG CACHEBUST invalide le cache Docker dès qu'on change sa valeur
 # (doit être passé via --build-arg CACHEBUST=X ou buildArgs dans railway.toml).
-ARG CACHEBUST=11
+# P19x.11 (29/04/2026) — bumped 11 → 12 pour forcer un rebuild complet avec
+# build args propagés. Constat : git_sha=null observé sur image
+# 539628cb..., probablement build sans --build-arg GIT_SHA (manual flyctl
+# deploy ou cache layer hit). Bump CACHEBUST = invalidation totale → nouvelle
+# build via workflow fly.yml passe tous les build args correctement.
+ARG CACHEBUST=12
 RUN echo "cachebust=$CACHEBUST"
 
 # P18h — Build metadata exposée via GET /version. Passées par fly.yml :

--- a/packages/ai-analyst/src/simulation/paper-broker.service.ts
+++ b/packages/ai-analyst/src/simulation/paper-broker.service.ts
@@ -281,6 +281,35 @@ export class PaperBrokerService {
     }
     const netPnl = grossPnl.minus(exitCost).plus(entryFeeRefund);
 
+    // P19x.11 (29/04/2026) — MIN_NET_PROFIT_USD guard avant `closed_target`.
+    //
+    // Mirror du guard P19x.1 ajouté dans mechanical-trading.service.ts.
+    // Le scanner Gainers passe par mechanical-trading donc P19x.1 couvre ces
+    // closes. MAIS Lisa LLM proposals + manual closes via paper-broker bypassed
+    // ce guard. Constat user (29/04 02:00 UTC) : "TOUTES les positions
+    // fermées affichent TP hit + closed_target avec P&L négatif" — preuve que
+    // le code path paper-broker a aussi besoin du guard.
+    //
+    // Garde-fou : un closed_target ne doit JAMAIS résulter en net PnL négatif.
+    // Min = max($2, 0.5% × notional). Si net < min → throw RetryableCloseError
+    // pour signaler au caller que la close est rejetée. Position reste ouverte.
+    if (cmd.reason === 'closed_target') {
+      const minNetProfit = Decimal.max(
+        new Decimal(2),
+        entryNotional.mul(0.005),
+      );
+      if (netPnl.lt(minNetProfit)) {
+        const err = new Error(
+          `[PAPER_BROKER] Skip closed_target ${position.symbol}: net=$${netPnl.toFixed(2)} < min=$${minNetProfit.toFixed(2)} ` +
+          `(notional=$${entryNotional.toFixed(0)}, gross=$${grossPnl.toFixed(2)}, fees=$${exitCost.toFixed(2)}). Position kept open.`,
+        );
+        (err as Error & { code?: string }).code = 'CLOSE_TARGET_BELOW_MIN_PROFIT';
+        // eslint-disable-next-line no-console
+        console.warn(err.message);
+        throw err;
+      }
+    }
+
     const pnlPct = entryNotional.isZero()
       ? 0
       : netPnl.dividedBy(entryNotional).mul(100).toNumber();


### PR DESCRIPTION
## User constat (29/04 02:30 UTC)
> "TOUTES les positions fermées affichent TP hit + closed_target avec P&L NÉGATIF (BTC -1.36$, SLV -1.66$, LMT -5.67$, XLE -6.15$, GDX -2.42$)"
> "curl /version retourne MAINTENANT git_sha=null. Le fix 8b7ff01 est écrasé"

## Investigation

`/version` : `git_sha=null`, image `539628cbece78059585ed2f78a9ae455` (différent de P19w `01KQDHA0` / P19x.1 `8b7ff01`). Conclusion : un deploy a écrasé l'image avec build args perdus → binary actuel pré-P19x.1 → MIN_NET_PROFIT guard pas actif → TP=pertes user observe.

## 2 fixes ce PR

### 1. Mirror P19x.1 guard dans paper-broker.service.ts
P19x.1 ajoutait MIN_NET_PROFIT guard dans `mechanical-trading.service.ts` mais `paper-broker.service.ts.closePosition` n'avait PAS le même guard. Lisa LLM proposals + manual closes via paper-broker bypassed ce guard.

```ts
if (cmd.reason === 'closed_target') {
  const minNetProfit = max($2, 0.5% × notional);
  if (netPnl < minNetProfit) throw RetryableCloseError;
}
```

Belt-and-braces : couvre les 2 code paths (mechanical-trading + paper-broker direct).

### 2. Dockerfile CACHEBUST 11 → 12
Force invalidation de toute la chain de layers downstream. Garantit que ce push commit re-builde avec fresh build args. Le workflow `fly.yml` sur push:main passe `--build-arg GIT_SHA=${github.sha}` + CACHEBUST_GIT_SHA + BUILD_TIME → file fallback baked correctement.

Post-deploy attendu : `/version` retourne `git_sha = SHA de ce merge`.

## KILL-SWITCH ACTIF (3ème complaint user)

> "Bannière rouge KILL-SWITCH ACTIF — Toutes les actions autonomes sont bloquées."

Trigger probable : drawdown intraday > 0.8% (P5.1) OU manuel user. Avec -36$ cumulés sur $10000 = -0.36% drawdown — pas suffisant pour seuil 0.8%. Donc soit user a manuellement pressé kill-switch via UI, soit autre trigger non-tracé.

**Désactivation via curl** :
```bash
curl -X POST https://smartvest.fly.dev/lisa/kill-switch/$PORTFOLIO_ID \
  -H "x-user-id: $UID" -H "Content-Type: application/json" \
  -d '{"action": "disable", "reason": "manual reset post-P19x.11"}'
```

Ou via UI Lisa : button "Désactiver kill-switch".

## Test plan

- [x] `npm run build --workspace=@smartvest/ai-analyst` → OK
- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` → OK
- [x] `npx jest "paper-broker|mechanical|top-gainers"` → **77 passed**
- [ ] Post-deploy : `curl /version | jq .git_sha` → SHA non-null
- [ ] Sur prochain trade fermé sur petit move : `[PAPER_BROKER] Skip closed_target ... net=$0.50 < min=$2.00` log

## Rollback

```bash
git revert <merge-sha>
git push origin main
```

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_