### PR TITLE
feat(P19x.6): admin endpoint /admin/logs/recent — grep ring buffer Nest logs

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -3,10 +3,16 @@ import { NestFactory } from '@nestjs/core';
 import { Logger } from '@nestjs/common';
 import { AppModule } from './app.module';
 import { AllExceptionsFilter } from './common/all-exceptions.filter';
+import { BufferLogger } from './modules/admin/log-buffer.service';
 
 async function bootstrap() {
+  // P19x.6 (29/04/2026) — BufferLogger capture les Nest logs dans un ring
+  // buffer in-memory (5000 lignes, rolls over). Exposé via /admin/logs/recent
+  // pour grep des logs Fly sans flyctl auth (tooling user-side).
+  const bufferLogger = new BufferLogger();
   // CORS : autorise les headers custom (x-user-id envoyé par apiFetch).
   const app = await NestFactory.create(AppModule, {
+    logger: bufferLogger,
     cors: {
       origin: true,
       credentials: true,

--- a/apps/api/src/modules/admin/admin-logs.controller.ts
+++ b/apps/api/src/modules/admin/admin-logs.controller.ts
@@ -1,0 +1,91 @@
+/**
+ * P19x.6 (29/04/2026) — Admin endpoint pour grep logs en mémoire.
+ *
+ * Use case : user veut filtrer les logs Fly récents (e.g. `[provider-router]
+ * eodhd 1m OK`, `[MÉCANIQUE] Skip closed_target`) sans flyctl auth local.
+ *
+ * Auth : header `x-admin-token` matchant ADMIN_TOKEN (constant-time compare).
+ *
+ * Usage :
+ *   curl -H "x-admin-token: $TOKEN" \
+ *     "https://smartvest.fly.dev/admin/logs/recent?pattern=provider-router&limit=100"
+ *   curl -H "x-admin-token: $TOKEN" \
+ *     "https://smartvest.fly.dev/admin/logs/recent?level=warn&pattern=closed_target"
+ */
+
+import {
+  Controller,
+  Get,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Query,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { timingSafeEqual } from 'node:crypto';
+import { logBuffer, type LogEntry } from './log-buffer.service';
+
+@Controller('admin/logs')
+export class AdminLogsController {
+  constructor(private readonly config: ConfigService) {}
+
+  @Get('recent')
+  recent(
+    @Headers('x-admin-token') providedToken: string | undefined,
+    @Query('limit') limitRaw?: string,
+    @Query('pattern') pattern?: string,
+    @Query('level') level?: string,
+  ): { entries: LogEntry[]; buffer_size: number; filtered_count: number; pattern?: string; level?: string } {
+    this.assertAdmin(providedToken);
+
+    const limit = this.clampInt(limitRaw, 1, 5000, 200);
+    const validLevels = new Set(['log', 'warn', 'error', 'debug', 'verbose']);
+    const levelOpt = level && validLevels.has(level) ? (level as 'log' | 'warn' | 'error' | 'debug' | 'verbose') : undefined;
+
+    const opts: { limit: number; pattern?: string; level?: 'log' | 'warn' | 'error' | 'debug' | 'verbose' } = { limit };
+    if (pattern) opts.pattern = pattern;
+    if (levelOpt) opts.level = levelOpt;
+
+    const entries = logBuffer.recent(opts);
+
+    const result: { entries: LogEntry[]; buffer_size: number; filtered_count: number; pattern?: string; level?: string } = {
+      entries,
+      buffer_size: logBuffer.size(),
+      filtered_count: entries.length,
+    };
+    if (pattern) result.pattern = pattern;
+    if (levelOpt) result.level = levelOpt;
+    return result;
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (!providedToken) {
+      throw new HttpException(
+        { message: 'x-admin-token header required', code: 'NO_TOKEN' },
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+    const a = Buffer.from(expected);
+    const b = Buffer.from(providedToken);
+    if (a.length !== b.length || !timingSafeEqual(a, b)) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'BAD_TOKEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+
+  private clampInt(raw: string | undefined, min: number, max: number, def: number): number {
+    if (!raw) return def;
+    const n = parseInt(raw, 10);
+    if (!Number.isFinite(n)) return def;
+    return Math.max(min, Math.min(max, n));
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -1,21 +1,23 @@
 /**
- * P19x.10 + P19x.5 — AdminModule
+ * P19x.5 + P19x.6 + P19x.10 — AdminModule
  *
  * Endpoints administrateurs protégés par `ADMIN_TOKEN` (header x-admin-token).
  * Disabled si ADMIN_TOKEN env var absente (return 403).
  *
  * Endpoints :
- *   - GET /admin/migrations/apply-missing[?dry_run=true]   (P19x.10)
- *   - GET /admin/supabase-query/:queryName                  (P19x.5)
+ *   - GET /admin/migrations/apply-missing[?dry_run=true]    (P19x.10)
+ *   - GET /admin/supabase-query/:queryName                   (P19x.5)
+ *   - GET /admin/logs/recent[?pattern=&level=&limit=]        (P19x.6)
  */
 
 import { Module } from '@nestjs/common';
 import { SupabaseModule } from '../supabase/supabase.module';
 import { AdminMigrationsController } from './admin-migrations.controller';
 import { AdminSupabaseQueryController } from './admin-supabase-query.controller';
+import { AdminLogsController } from './admin-logs.controller';
 
 @Module({
   imports: [SupabaseModule],
-  controllers: [AdminMigrationsController, AdminSupabaseQueryController],
+  controllers: [AdminMigrationsController, AdminSupabaseQueryController, AdminLogsController],
 })
 export class AdminModule {}

--- a/apps/api/src/modules/admin/log-buffer.service.ts
+++ b/apps/api/src/modules/admin/log-buffer.service.ts
@@ -1,0 +1,131 @@
+/**
+ * P19x.6 (29/04/2026) — In-memory ring buffer pour capturer les logs Nest
+ * et les exposer via admin endpoint.
+ *
+ * Use case : user veut grep les logs Fly (e.g. `[provider-router] eodhd 1m
+ * OK for ...`, `[MÉCANIQUE] Skip closed_target ...`, `[gemini] call OK...`)
+ * sans flyctl auth local. Cet endpoint expose les N derniers logs en
+ * mémoire avec filter regex.
+ *
+ * Limites volontaires :
+ *  - Buffer 5000 lignes max (rolls over) → ne grow pas indéfiniment
+ *  - Pas de persistence DB → si le container restart, buffer est vide
+ *  - Capture seulement après `app.useLogger(custom)` au bootstrap
+ *  - N'expose JAMAIS de secrets (Logger Nest ne log pas les API keys par défaut)
+ *
+ * Implémentation : étend `ConsoleLogger` pour intercepter chaque log et le
+ * pousser dans un singleton statique. Le controller lit ce singleton.
+ *
+ * Pour activer côté main.ts :
+ *   const app = await NestFactory.create(AppModule, { logger: false });
+ *   const bufferLogger = new BufferLogger();
+ *   app.useLogger(bufferLogger);
+ */
+
+import { ConsoleLogger, type LogLevel } from '@nestjs/common';
+
+export interface LogEntry {
+  timestamp: number;
+  level: LogLevel;
+  context: string | undefined;
+  message: string;
+}
+
+const MAX_BUFFER_SIZE = 5000;
+
+/**
+ * Ring buffer singleton (process-level). Toutes les instances de BufferLogger
+ * pushent dans ce buffer commun. Le AdminLogsController lit ce singleton.
+ */
+class LogRingBuffer {
+  private static instance: LogRingBuffer | null = null;
+  private buffer: LogEntry[] = [];
+
+  static getInstance(): LogRingBuffer {
+    if (!LogRingBuffer.instance) {
+      LogRingBuffer.instance = new LogRingBuffer();
+    }
+    return LogRingBuffer.instance;
+  }
+
+  push(entry: LogEntry): void {
+    this.buffer.push(entry);
+    if (this.buffer.length > MAX_BUFFER_SIZE) {
+      this.buffer.splice(0, this.buffer.length - MAX_BUFFER_SIZE);
+    }
+  }
+
+  /**
+   * Retourne les N derniers logs filtrés par regex pattern.
+   * Pattern compile-once via cache simple.
+   */
+  recent(opts: { limit?: number; pattern?: string; level?: LogLevel } = {}): LogEntry[] {
+    const limit = Math.max(1, Math.min(opts.limit ?? 200, MAX_BUFFER_SIZE));
+    let regex: RegExp | null = null;
+    if (opts.pattern) {
+      try {
+        regex = new RegExp(opts.pattern, 'i');
+      } catch {
+        regex = null; // pattern invalide → ignore filter
+      }
+    }
+    const filtered = this.buffer
+      .filter((e) => {
+        if (opts.level && e.level !== opts.level) return false;
+        if (regex && !regex.test(e.message) && !regex.test(e.context ?? '')) return false;
+        return true;
+      });
+    return filtered.slice(-limit);
+  }
+
+  size(): number {
+    return this.buffer.length;
+  }
+}
+
+export const logBuffer = LogRingBuffer.getInstance();
+
+/**
+ * BufferLogger — ConsoleLogger qui mirror chaque log dans le ring buffer.
+ *
+ * Wire au bootstrap :
+ *   app.useLogger(new BufferLogger());
+ */
+export class BufferLogger extends ConsoleLogger {
+  override log(message: unknown, context?: string): void {
+    super.log(message as string, context);
+    this.capture('log', message, context);
+  }
+
+  override warn(message: unknown, context?: string): void {
+    super.warn(message as string, context);
+    this.capture('warn', message, context);
+  }
+
+  override error(message: unknown, trace?: string, context?: string): void {
+    super.error(message as string, trace, context);
+    this.capture('error', message, context);
+    if (trace) this.capture('error', `  ${trace.slice(0, 500)}`, context);
+  }
+
+  override debug(message: unknown, context?: string): void {
+    super.debug(message as string, context);
+    this.capture('debug', message, context);
+  }
+
+  override verbose(message: unknown, context?: string): void {
+    super.verbose(message as string, context);
+    this.capture('verbose', message, context);
+  }
+
+  private capture(level: LogLevel, message: unknown, context?: string): void {
+    const text = typeof message === 'string' ? message : JSON.stringify(message);
+    logBuffer.push({
+      timestamp: Date.now(),
+      level,
+      context,
+      // Truncate to avoid huge payloads
+      message: text.length > 2000 ? text.slice(0, 2000) + '…[truncated]' : text,
+    });
+  }
+}


### PR DESCRIPTION
## Spec
> "Endpoint admin pour fly logs grep `[provider-router] gemini`" — sans flyctl auth local.

## Implémentation

- **`BufferLogger`** (extend `ConsoleLogger`) installé au bootstrap via `app.useLogger()`
- Capture chaque log Nest (`log/warn/error/debug/verbose`) dans un singleton ring buffer process-level (5000 lignes max, rolls over)
- **`AdminLogsController`** expose `GET /admin/logs/recent` avec :
  - Auth header `x-admin-token` (constant-time compare `ADMIN_TOKEN`)
  - `?pattern=regex` filter (sur message+context, case-insensitive)
  - `?level=log|warn|error|debug|verbose`
  - `?limit=N` (max 5000, default 200)

## Use cases

```bash
curl -H "x-admin-token: $TOKEN" \
  "https://smartvest.fly.dev/admin/logs/recent?pattern=provider-router&limit=100"
# → grep des bascules yahoo/eodhd/eodhd_1m/eodhd_ticks/cache_stale/none

curl -H "x-admin-token: $TOKEN" \
  "https://smartvest.fly.dev/admin/logs/recent?level=warn&pattern=closed_target"
# → tous les warn closed_target (P19x.1 + P19x.11 guards)

curl -H "x-admin-token: $TOKEN" \
  "https://smartvest.fly.dev/admin/logs/recent?pattern=scanner-llm:signal"
# → traces Gemini provider calls (post-activation SCANNER_LLM_ROUTER_ENABLED)
```

## Limites volontaires

- Buffer process-level → si container restart, buffer vide
- Pas de persistence DB (kafka/elasticsearch overkill pour debug ad-hoc)
- Capture seulement après bootstrap (pas les logs antérieurs)

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` → OK
- [x] Rebased sur main post-#122 (AdminModule combine 3 controllers)
- [ ] Post-deploy : `curl -H "x-admin-token: $TOKEN" ...recent?limit=20` → `entries[]` non-null

## Rollback

```bash
git revert <merge-sha>
git push origin main
```

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_