### PR TITLE
feat(P19x.8): real fees per venue (IBKR Pro Tiered + Binance + Asia) + breakdown JSONB persist

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/venue-fees.p19x8.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/venue-fees.p19x8.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * P19x.8 (29/04/2026) — Tests pour computeVenueFeeDetail.
+ *
+ * Snapshots calculés à la main depuis les grilles tarifaires officielles :
+ *   - IBKR Pro Tiered (US equities) : commission $0.0035/share min $0.35,
+ *     SEC fee sell $27.80/M, TAF sell $0.000166/share max $8.30,
+ *     exchange ~$0.002/share
+ *   - Binance spot crypto : 0.1% taker
+ *   - Korea KOSPI : 0.07% commission + 0.23% SST sell only
+ *   - HK : 0.04% commission + 0.10% stamp + 0.01% SFC/trading fee
+ *   - NSE India : 0.015% commission + 0.025% STT sell + 18% GST
+ */
+
+import Decimal from 'decimal.js';
+import { computeVenueFeeDetail } from '@smartvest/ai-analyst';
+
+describe('computeVenueFeeDetail — P19x.8 real fees per venue', () => {
+  describe('US equities (IBKR Pro Tiered)', () => {
+    it('BUY side: commission + exchange, no SEC/TAF', () => {
+      // 100 shares × $50 = $5000 notional
+      // Commission : max(100 × $0.0035, $0.35) = max($0.35, $0.35) = $0.35
+      // Exchange : 100 × $0.002 = $0.20
+      // Regulatory : 0 (BUY)
+      // Total : $0.55
+      const r = computeVenueFeeDetail(new Decimal(100), new Decimal(50), 'us_equity_large', 'NASDAQ', 'buy');
+      expect(r.commission).toBeCloseTo(0.35, 2);
+      expect(r.exchange).toBeCloseTo(0.20, 2);
+      expect(r.regulatory).toBeCloseTo(0, 4);
+      expect(r.fx).toBe(0);
+      expect(r.total).toBeCloseTo(0.55, 2);
+    });
+
+    it('SELL side: adds SEC fee + TAF', () => {
+      // 100 shares × $50 = $5000 notional
+      // SEC fee : $5000 × $27.80 / 1M = $0.139
+      // TAF : 100 × $0.000166 = $0.0166
+      // Regulatory : $0.156
+      const r = computeVenueFeeDetail(new Decimal(100), new Decimal(50), 'us_equity_large', 'NASDAQ', 'sell');
+      expect(r.commission).toBeCloseTo(0.35, 2);
+      expect(r.exchange).toBeCloseTo(0.20, 2);
+      expect(r.regulatory).toBeCloseTo(0.156, 2);
+      expect(r.total).toBeCloseTo(0.706, 2);
+    });
+
+    it('LMT regression : 5 shares @ $508 BUY, expected ~$0.36', () => {
+      // 5 × $0.0035 = $0.0175 → bumped to $0.35 min
+      // Exchange : 5 × $0.002 = $0.01
+      // Total BUY : $0.36
+      const r = computeVenueFeeDetail(new Decimal(5), new Decimal(508), 'us_equity_large', 'NASDAQ', 'buy');
+      expect(r.total).toBeCloseTo(0.36, 2);
+    });
+
+    it('LMT round-trip BUY+SELL ~$0.85 (vs old 20bps = $5.08)', () => {
+      const buy = computeVenueFeeDetail(new Decimal(5), new Decimal(508), 'us_equity_large', 'NASDAQ', 'buy');
+      const sell = computeVenueFeeDetail(new Decimal(5), new Decimal(508.50), 'us_equity_large', 'NASDAQ', 'sell');
+      const roundTrip = buy.total + sell.total;
+      expect(roundTrip).toBeLessThan(1.0);
+      // Compare to old 20bps round-trip (5.08)
+      const oldFee = 5 * 508.5 * 0.0020;
+      expect(roundTrip / oldFee).toBeLessThan(0.2); // <20% du legacy
+    });
+  });
+
+  describe('Binance crypto', () => {
+    it('uses 0.1% taker fee', () => {
+      // 0.1 BTC × $60000 = $6000 notional
+      // Commission : $6000 × 0.001 = $6.00
+      const r = computeVenueFeeDetail(new Decimal(0.1), new Decimal(60000), 'crypto_major', 'BINANCE', 'buy');
+      expect(r.commission).toBeCloseTo(6.0, 2);
+      expect(r.exchange).toBe(0);
+      expect(r.regulatory).toBe(0);
+      expect(r.total).toBeCloseTo(6.0, 2);
+    });
+
+    it('crypto_alt same 0.1% rate', () => {
+      const r = computeVenueFeeDetail(new Decimal(1000), new Decimal(0.5), 'crypto_alt', 'BINANCE', 'sell');
+      expect(r.total).toBeCloseTo(0.5, 2); // 1000 × 0.5 × 0.001
+    });
+  });
+
+  describe('Korea KOSPI/KOSDAQ', () => {
+    it('BUY : commission 0.07%, no regulatory', () => {
+      // 100 shares × $50 = $5000 notional
+      // Commission : $5000 × 0.0007 = $3.50
+      // FX : $5000 × 0.00002 = $0.10
+      const r = computeVenueFeeDetail(new Decimal(100), new Decimal(50), 'asia_equity', 'KO', 'buy');
+      expect(r.commission).toBeCloseTo(3.50, 2);
+      expect(r.regulatory).toBe(0);
+      expect(r.fx).toBeCloseTo(0.10, 2);
+      expect(r.total).toBeCloseTo(3.60, 2);
+    });
+
+    it('SELL : adds SST 0.23%', () => {
+      // SST sell : $5000 × 0.0023 = $11.50
+      const r = computeVenueFeeDetail(new Decimal(100), new Decimal(50), 'asia_equity', 'KQ', 'sell');
+      expect(r.regulatory).toBeCloseTo(11.50, 2);
+      expect(r.total).toBeCloseTo(15.10, 2); // 3.50 + 0 + 11.50 + 0.10
+    });
+  });
+
+  describe('Hong Kong', () => {
+    it('commission + stamp duty 0.10% both sides + SFC/trading fee', () => {
+      // 1000 × $10 = $10,000
+      // Commission : 0.04% = $4.00
+      // Exchange (SFC + trading) : 0.01% = $1.00
+      // Stamp duty : 0.10% = $10.00
+      const r = computeVenueFeeDetail(new Decimal(1000), new Decimal(10), 'asia_equity', 'HK', 'buy');
+      expect(r.commission).toBeCloseTo(4.0, 2);
+      expect(r.exchange).toBeCloseTo(1.0, 2);
+      expect(r.regulatory).toBeCloseTo(10.0, 2);
+    });
+  });
+
+  describe('NSE India', () => {
+    it('BUY : commission 0.015% + GST 18% on commission', () => {
+      // 100 × $50 = $5000
+      // Commission : 0.00015 × 5000 = $0.75
+      // GST : 0.18 × 0.75 = $0.135
+      const r = computeVenueFeeDetail(new Decimal(100), new Decimal(50), 'asia_equity', 'NSE', 'buy');
+      expect(r.commission).toBeCloseTo(0.75, 2);
+      expect(r.regulatory).toBeCloseTo(0.135, 2);
+    });
+
+    it('SELL : adds STT 0.025%', () => {
+      const r = computeVenueFeeDetail(new Decimal(100), new Decimal(50), 'asia_equity', 'NSE', 'sell');
+      // STT : $1.25 + GST $0.135 = $1.385
+      expect(r.regulatory).toBeCloseTo(1.385, 2);
+    });
+  });
+
+  describe('EU equities', () => {
+    it('all-in 5bps + 0.2bp FX', () => {
+      const r = computeVenueFeeDetail(new Decimal(100), new Decimal(50), 'eu_equity', 'PA', 'buy');
+      // Total ~ 5.2bps × 5000 = $2.60
+      expect(r.total).toBeCloseTo(2.60, 1);
+    });
+  });
+
+  describe('Defensive', () => {
+    it('returns zeros for invalid qty/price', () => {
+      const z = computeVenueFeeDetail(new Decimal(0), new Decimal(100), 'us_equity_large', 'NASDAQ', 'buy');
+      expect(z.total).toBe(0);
+    });
+
+    it('falls back to US Pro Tiered when assetClass undefined', () => {
+      const r = computeVenueFeeDetail(new Decimal(100), new Decimal(50), undefined, undefined, 'buy');
+      expect(r.commission).toBeCloseTo(0.35, 2); // min commission applied
+    });
+  });
+});

--- a/packages/ai-analyst/src/simulation/index.ts
+++ b/packages/ai-analyst/src/simulation/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './paper-broker.service';
 export * from './risk-monitor.service';
+export * from './venue-fees';

--- a/packages/ai-analyst/src/simulation/paper-broker.service.ts
+++ b/packages/ai-analyst/src/simulation/paper-broker.service.ts
@@ -19,6 +19,7 @@ import type {
   PaperPosition,
   PortfolioSnapshot,
 } from './types';
+import { computeVenueFeeDetail, type VenueFeeBreakdown } from './venue-fees';
 
 export interface PriceQuote {
   symbol: string;
@@ -149,12 +150,17 @@ export class PaperBrokerService {
 
     // P19u — Calcul fee réaliste (IBKR Pro Tiered) au lieu du modèle bps fixe
     // de l'ancien code. Two-pass : qty tentative (no fee) → fee → qty finale.
+    // P19x.8 (29/04/2026) — Capture aussi le breakdown JSON via computeVenueFeeDetail
+    // pour persist en venue_fee_detail (UI tooltip).
     const tentativeQty = notional.dividedBy(livePrice);
-    const estimatedCost = computeRealisticFee(
+    const entryFeeBreakdown = computeVenueFeeDetail(
       tentativeQty,
       livePrice,
       expression.assetClass as string | undefined,
+      expression.preferredVenue as string | undefined,
+      'buy',
     );
+    const estimatedCost = new Decimal(entryFeeBreakdown.total);
 
     // Garde-fou : si le fee dépasse la notional (cas pathologique), reject.
     if (estimatedCost.gte(notional)) {
@@ -220,6 +226,9 @@ export class PaperBrokerService {
       take_profit_price: position.takeProfitPrice,
       horizon_target_date: position.horizonTargetDate,
       estimated_entry_cost_usd: position.estimatedEntryCostUsd,
+      // P19x.8 — Real fees per venue persistence
+      fees_in_usd: position.estimatedEntryCostUsd,
+      venue_fee_detail: { entry: entryFeeBreakdown },
       created_at: position.createdAt,
       updated_at: position.updatedAt,
     });
@@ -267,6 +276,18 @@ export class PaperBrokerService {
     // closed_invalidated = trade tué par news shock / material change avant
     // que le TP/SL hit. Le PaperBroker considère ça comme "no real trade
     // happened" — refund both sides of fees, garde uniquement le price delta.
+    // P19x.8 — Capture exit fee breakdown (commission + exchange + regulatory + fx)
+    // pour persistence venue_fee_detail.exit + tooltip UI.
+    const isLong = position.direction === 'long' || position.direction === 'long_call' || position.direction === 'long_put';
+    const exitSide: 'buy' | 'sell' = isLong ? 'sell' : 'buy';
+    const exitFeeBreakdown: VenueFeeBreakdown = computeVenueFeeDetail(
+      qty,
+      exitPx,
+      position.assetClass,
+      position.venue,
+      exitSide,
+    );
+
     let exitCost: Decimal;
     let entryFeeRefund: Decimal;
     if (cmd.reason === 'closed_invalidated') {
@@ -276,7 +297,7 @@ export class PaperBrokerService {
       const entryCostStored = position.estimatedEntryCostUsd;
       entryFeeRefund = entryCostStored ? new Decimal(entryCostStored) : new Decimal(0);
     } else {
-      exitCost = computeRealisticFee(qty, exitPx, position.assetClass);
+      exitCost = new Decimal(exitFeeBreakdown.total);
       entryFeeRefund = new Decimal(0);
     }
     const netPnl = grossPnl.minus(exitCost).plus(entryFeeRefund);
@@ -323,6 +344,17 @@ export class PaperBrokerService {
     // touche 0 rows → on retourne la position fermée précédente sans
     // ré-écrire les champs (pas de double comptage P&L, pas de double
     // appel au TradeOutcomeRecorder).
+    // P19x.8 — Merge entry breakdown (déjà persisté à open) + exit breakdown
+    // pour conserver le full audit trail dans venue_fee_detail JSONB.
+    const existingDetail = (posRow as Record<string, unknown>)['venue_fee_detail'] as
+      | { entry?: VenueFeeBreakdown; exit?: VenueFeeBreakdown }
+      | null
+      | undefined;
+    const mergedFeeDetail = {
+      entry: existingDetail?.entry ?? null,
+      exit: exitFeeBreakdown,
+    };
+
     const { data: updated, error: updErr } = await this.supabase
       .from('lisa_positions')
       .update({
@@ -332,6 +364,9 @@ export class PaperBrokerService {
         exit_reason: cmd.rationale,
         realized_pnl_usd: netPnl.toFixed(2),
         realized_pnl_pct: pnlPct,
+        // P19x.8 — Persist exit fees breakdown
+        fees_out_usd: exitCost.toFixed(4),
+        venue_fee_detail: mergedFeeDetail,
         updated_at: now,
       })
       .eq('id', cmd.positionId)

--- a/packages/ai-analyst/src/simulation/venue-fees.ts
+++ b/packages/ai-analyst/src/simulation/venue-fees.ts
@@ -1,0 +1,222 @@
+/**
+ * P19x.8 (29/04/2026) — Real fees per venue avec breakdown JSON.
+ *
+ * Implémentation des grilles tarifaires officielles :
+ *
+ * IBKR Pro Tiered (US equities + ETFs)
+ *   - Commission : $0.0035/share (avec rebates) ou $0.005/share (sans), min $0.35,
+ *                  cap 1% trade value. On utilise $0.0035 (paper sim conservatif).
+ *   - SEC fee (sell side US equities) : $27.80 par million de dollar value
+ *   - TAF (FINRA Trading Activity Fee) : $0.000166/share, max $8.30 par exec (sell side)
+ *   - Exchange fees : ~$0.001-0.003/share (varie par venue NYSE/NASDAQ/ARCA — moyenne $0.002)
+ *
+ * Binance spot crypto
+ *   - Maker/taker : 0.1% (default — réduit à 0.075% si BNB pay)
+ *   - Pas de SEC/TAF, pas de FX (USDT pair par défaut)
+ *
+ * IBKR Asia
+ *   - KOSPI/KOSDAQ : 0.07% commission + 0.23% SST sell (Korea Securities Trans Tax)
+ *   - NSE India : 0.015% commission + STT 0.025% sell + GST 18% sur commission
+ *   - ASX : 0.005% commission
+ *   - Tokyo : 0.05% commission
+ *   - HK : 0.04% commission + 0.10% stamp duty + 0.005% SFC + 0.005% trading fee
+ *
+ * Note simplifiée pour paper sim : on utilise des aggregate ratios par asset class
+ * + des ajustements explicites quand venue/side font une différence majeure
+ * (e.g. SEC fee SELL US, stamp duty HK).
+ *
+ * Output schema cohérent pour persistence (JSONB lisa_positions.venue_fee_detail) :
+ *   { commission: number, exchange: number, regulatory: number, fx: number, total: number }
+ */
+
+import Decimal from 'decimal.js';
+
+export type Side = 'buy' | 'sell';
+
+export interface VenueFeeBreakdown {
+  /** Commission broker (IBKR Pro Tiered, Binance maker/taker, etc.) */
+  commission: number;
+  /** Exchange fees (NYSE/NASDAQ/ARCA + venue-specific HK stamp/SFC/trading fee) */
+  exchange: number;
+  /** Regulatory fees (SEC US sell, TAF, STT India, SST Korea sell) */
+  regulatory: number;
+  /** FX markup (cross-currency, IBKR ~0.2bp) — 0 si single-currency */
+  fx: number;
+  /** Total = commission + exchange + regulatory + fx */
+  total: number;
+}
+
+/**
+ * Calcule le breakdown des fees pour une transaction (entry ou exit).
+ *
+ * @param qty       quantité (shares / contracts / coins)
+ * @param price     prix unitaire en USD (ou converted to USD pour non-USD venues)
+ * @param assetClass  ex: 'us_equity_large', 'eu_equity', 'asia_equity', 'crypto_major', 'fx_g10'
+ * @param venue     ex: 'NASDAQ', 'BINANCE', 'KO', 'HK', 'NSE', 'PA' — utilisé pour
+ *                  les fees venue-specific (SST Korea, stamp HK, etc.)
+ * @param side      'buy' (entry long, exit short) ou 'sell' (entry short, exit long).
+ *                  Important pour SEC fee (sell only US), STT India (sell), etc.
+ */
+export function computeVenueFeeDetail(
+  qty: Decimal,
+  price: Decimal,
+  assetClass: string | undefined,
+  venue: string | undefined,
+  side: Side,
+): VenueFeeBreakdown {
+  const zero: VenueFeeBreakdown = { commission: 0, exchange: 0, regulatory: 0, fx: 0, total: 0 };
+  if (qty.lte(0) || price.lte(0)) return zero;
+
+  const ac = (assetClass ?? '').toLowerCase();
+  const v = (venue ?? '').toUpperCase();
+  const notional = qty.mul(price);
+
+  // ─── Crypto Binance ────────────────────────────────────────────────────────
+  if (ac.startsWith('crypto')) {
+    // Default taker 0.1% (aucune réduction BNB modelée — paper sim conservatif)
+    const commission = notional.mul(0.001);
+    return {
+      commission: round2(commission),
+      exchange: 0,
+      regulatory: 0,
+      fx: 0,
+      total: round2(commission),
+    };
+  }
+
+  // ─── Asia equities (KO, KQ, KS, NSE, BSE, AU, T, HK) ──────────────────────
+  if (ac === 'asia_equity' || /^(KO|KQ|KS|NSE|BSE|AU|AX|T|TSE|HK|SS|SZ)$/.test(v)) {
+    return computeAsiaFees(qty, price, v, side, notional);
+  }
+
+  // ─── EU equities ───────────────────────────────────────────────────────────
+  if (ac === 'eu_equity' || /^(LSE|L|XETRA|DE|PA|AS|AMS|MI|SW|MC|BME)$/.test(v)) {
+    // IBKR Pro EU : ~5bps moyenne all-in (commission + exchange combinés)
+    const commission = notional.mul(0.0003); // 3bps
+    const exchange = notional.mul(0.0002);   // 2bps exchange
+    // FX markup léger si NOT EUR-quoted (paper sim assume USD reporting)
+    const fx = notional.mul(0.00002); // 0.2bp
+    const total = commission.plus(exchange).plus(fx);
+    return {
+      commission: round2(commission),
+      exchange: round2(exchange),
+      regulatory: 0,
+      fx: round2(fx),
+      total: round2(total),
+    };
+  }
+
+  // ─── FX ────────────────────────────────────────────────────────────────────
+  if (ac.startsWith('fx_')) {
+    const commission = notional.mul(0.0001); // 1bp
+    return {
+      commission: round2(commission),
+      exchange: 0,
+      regulatory: 0,
+      fx: 0,
+      total: round2(commission),
+    };
+  }
+
+  // ─── US equities + ETFs (default — IBKR Pro Tiered) ────────────────────────
+  return computeUsFees(qty, price, side, notional);
+}
+
+function computeUsFees(qty: Decimal, _price: Decimal, side: Side, notional: Decimal): VenueFeeBreakdown {
+  // Commission : max($0.35, $0.0035/share), capped 1% notional
+  const perShareRate = new Decimal(0.0035);
+  const minCommission = new Decimal(0.35);
+  const maxCommission = notional.mul(0.01);
+  let commission = Decimal.max(qty.mul(perShareRate), minCommission);
+  if (commission.gt(maxCommission)) commission = maxCommission;
+
+  // Exchange fees : ~$0.002/share moyenne (NYSE/NASDAQ/ARCA mix)
+  const exchange = qty.mul(0.002);
+
+  // Regulatory fees (US):
+  //   - SEC fee (SELL only) : $27.80 per million dollar value (2024-2025 rate)
+  //   - TAF (FINRA Trading Activity Fee, SELL only) : $0.000166/share, max $8.30
+  let regulatory = new Decimal(0);
+  if (side === 'sell') {
+    const sec = notional.mul(27.80).dividedBy(1_000_000); // $27.80 / 1M
+    let taf = qty.mul(0.000166);
+    if (taf.gt(8.30)) taf = new Decimal(8.30);
+    regulatory = sec.plus(taf);
+  }
+
+  const fx = new Decimal(0); // USD-quoted, no FX markup
+  const total = commission.plus(exchange).plus(regulatory).plus(fx);
+  return {
+    commission: round4(commission),
+    exchange: round4(exchange),
+    regulatory: round4(regulatory),
+    fx: round4(fx),
+    total: round4(total),
+  };
+}
+
+function computeAsiaFees(
+  _qty: Decimal,
+  _price: Decimal,
+  v: string,
+  side: Side,
+  notional: Decimal,
+): VenueFeeBreakdown {
+  // Defaults : 5bps commission moyenne IBKR Asia + venue-specific regulatory
+  let commission = notional.mul(0.0005);
+  let exchange = new Decimal(0);
+  let regulatory = new Decimal(0);
+
+  if (v === 'KO' || v === 'KQ' || v === 'KS') {
+    // Korea KOSPI/KOSDAQ — IBKR ~0.07% commission, SST 0.23% sell side only
+    commission = notional.mul(0.0007);
+    if (side === 'sell') {
+      regulatory = notional.mul(0.0023); // KSST sell tax
+    }
+  } else if (v === 'NSE' || v === 'BSE') {
+    // India — 0.015% commission, STT 0.025% sell, GST 18% on commission
+    commission = notional.mul(0.00015);
+    const gst = commission.mul(0.18);
+    if (side === 'sell') {
+      const stt = notional.mul(0.00025);
+      regulatory = stt.plus(gst);
+    } else {
+      regulatory = gst;
+    }
+  } else if (v === 'HK') {
+    // HK — 0.04% commission, 0.10% stamp duty (both sides), 0.005% SFC + 0.005% trading fee
+    commission = notional.mul(0.0004);
+    exchange = notional.mul(0.0001); // SFC + trading fee
+    regulatory = notional.mul(0.001); // stamp duty
+  } else if (v === 'AU' || v === 'AX') {
+    commission = notional.mul(0.00005); // 0.5bp ASX
+    exchange = notional.mul(0.00005);
+  } else if (v === 'T' || v === 'TSE') {
+    // Tokyo — 0.05% commission, no transaction tax
+    commission = notional.mul(0.0005);
+  } else if (v === 'SS' || v === 'SZ') {
+    // China A-shares — 0.025% commission + 0.10% stamp duty sell only
+    commission = notional.mul(0.00025);
+    if (side === 'sell') {
+      regulatory = notional.mul(0.001);
+    }
+  }
+
+  const fx = notional.mul(0.00002); // 0.2bp FX markup (USD reporting)
+  const total = commission.plus(exchange).plus(regulatory).plus(fx);
+  return {
+    commission: round4(commission),
+    exchange: round4(exchange),
+    regulatory: round4(regulatory),
+    fx: round4(fx),
+    total: round4(total),
+  };
+}
+
+function round2(d: Decimal): number {
+  return Math.round(d.toNumber() * 100) / 100;
+}
+
+function round4(d: Decimal): number {
+  return Math.round(d.toNumber() * 10000) / 10000;
+}

--- a/supabase/migrations/0094_position_fees_breakdown.sql
+++ b/supabase/migrations/0094_position_fees_breakdown.sql
@@ -1,0 +1,38 @@
+-- P19x.8 (29/04/2026 02:30 UTC) — Persistance des fees détaillés par venue.
+--
+-- User spec : "Persister fees_in, fees_out, venue_fee_detail (JSON breakdown :
+-- commission + exchange + SEC + TAF + FX si applicable) dans la table positions.
+-- Exposer dans l'UI Lisa pour chaque position fermée : gross, fees_in, fees_out,
+-- net (tooltip détaillé au hover)."
+--
+-- Avant P19x.8 : `lisa_positions.estimated_entry_cost_usd` (numeric) stockait
+-- uniquement le total entry cost. Pas de breakdown, pas de exit cost séparé.
+--
+-- Après P19x.8 :
+--   fees_in_usd        : total fees entry (numeric, equivalent estimated_entry_cost_usd
+--                        kept for back-compat — nouveau code écrit les 2)
+--   fees_out_usd       : total fees exit (jamais NULL post-close)
+--   venue_fee_detail   : JSONB { entry: {commission, exchange, regulatory, fx, total},
+--                                exit:  {commission, exchange, regulatory, fx, total} }
+--                        Permet l'UI tooltip détaillé.
+--
+-- Idempotent : ADD COLUMN IF NOT EXISTS sur tous.
+
+ALTER TABLE public.lisa_positions
+  ADD COLUMN IF NOT EXISTS fees_in_usd       numeric(20, 4),
+  ADD COLUMN IF NOT EXISTS fees_out_usd      numeric(20, 4),
+  ADD COLUMN IF NOT EXISTS venue_fee_detail  jsonb;
+
+COMMENT ON COLUMN public.lisa_positions.fees_in_usd IS
+  'P19x.8 (29/04/2026) — Total entry fees USD (commission + exchange + regulatory + fx). '
+  'Equivalent fonctionnel à estimated_entry_cost_usd (kept for back-compat). '
+  'Calculé par computeVenueFeeDetail(qty, price, assetClass, venue, side).';
+
+COMMENT ON COLUMN public.lisa_positions.fees_out_usd IS
+  'P19x.8 (29/04/2026) — Total exit fees USD. NULL tant que position open. '
+  'Calculé au close par paper-broker.closePosition / mechanical-trading.closePosition.';
+
+COMMENT ON COLUMN public.lisa_positions.venue_fee_detail IS
+  'P19x.8 (29/04/2026) — JSONB breakdown fees par côté (entry/exit) :'
+  ' { commission, exchange, regulatory, fx, total }. '
+  'Sert au tooltip UI Lisa (cf P19x.9).';


### PR DESCRIPTION
## User spec
> "VRAIS FEES par transaction : IBKR Pro Tiered + Binance 0.1% + IBKR Asia per-venue + persist fees_in/fees_out/venue_fee_detail JSON + UI tooltip + tests snapshot."

## Migration 0094

```sql
ALTER TABLE lisa_positions ADD COLUMN IF NOT EXISTS
  fees_in_usd       numeric(20, 4),
  fees_out_usd      numeric(20, 4),
  venue_fee_detail  jsonb;
```

## `computeVenueFeeDetail(qty, price, assetClass, venue, side)` → `{commission, exchange, regulatory, fx, total}`

| Venue | Commission | Exchange | Regulatory | FX |
|---|---|---|---|---|
| **US (IBKR Pro Tiered)** | $0.0035/share min $0.35 max 1% | $0.002/share | SEC $27.80/M + TAF $0.000166/share max $8.30 (SELL only) | 0 |
| **Binance** | 0.1% taker | 0 | 0 | 0 |
| **Korea KO/KQ** | 0.07% | 0 | 0.23% SST (SELL) | 0.2bp |
| **NSE India** | 0.015% | 0 | 0.025% STT (SELL) + 18% GST | 0.2bp |
| **HK** | 0.04% | 0.01% SFC/trading | 0.10% stamp (both) | 0.2bp |
| **AU/T/SS/SZ** | 0.005-0.05% | spec-dépendant | venue-spec | 0.2bp |
| **EU** | 5bps all-in | inclus | 0 | 0.2bp |

## LMT regression evidence
- 5 shares × $508 BUY : ancien round-trip 20bps = **$5.08**, nouveau **$0.85** (-83%)
- Test `LMT round-trip BUY+SELL ~$0.85` PASS

## Persistence

**Open** :
```json
venue_fee_detail = { "entry": { commission: 0.35, exchange: 0.20, regulatory: 0, fx: 0, total: 0.55 } }
fees_in_usd = 0.55
```

**Close** :
```json
venue_fee_detail = {
  "entry": { ... },
  "exit": { commission: 0.35, exchange: 0.20, regulatory: 0.156, fx: 0, total: 0.706 }
}
fees_out_usd = 0.7060
```

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` → OK
- [x] `npm run build --workspace=@smartvest/ai-analyst` → OK
- [x] `npx jest "venue-fees.p19x8"` → **14 passed** (snapshots à la main vs grids officielles)
- [x] `npx jest "paper-broker|mechanical|top-gainers|venue-fees"` → **91 passed**
- [ ] Post-deploy : SELECT venue_fee_detail FROM lisa_positions LIMIT 5 → JSON breakdown présent

## Hors scope (P19x.9 séparé)

UI tooltip "Gross / Fees in / Fees out / Net" au hover sur position fermée — composant frontend à créer.

## Rollback

```bash
git revert <merge-sha>
git push origin main
# Migration 0094 reste appliquée (additive only)
```

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_