### PR TITLE
[P19β] Gainers 6/6 strict — shadow-logging 5/6 + 4/6 (#128)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p19beta-shadow.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p19beta-shadow.spec.ts
@@ -1,0 +1,276 @@
+/**
+ * P19β (30/04/2026) — Tests pour shadow-logging mode strict 6/6.
+ *
+ * Cf. Issue #128 "Gainers 6/6 strict operational test" + CLAUDE.md.
+ *
+ * Activation : `gainers_min_persistence_score >= 0.999` sur le portfolio.
+ * Ratios (avec tolérance float pour 5/6=0.8333 et 4/6=0.6667) :
+ *   1.00 (6/6)         → ouverture normale (pass aux gates suivants)
+ *   [0.83, 1.0)  5/6   → log `gainer_shadow_566` + skip
+ *   [0.66, 0.83) 4/6   → log `gainer_shadow_466` + skip
+ *   < 0.66             → skip silencieux
+ *
+ * Mode standard (minScore=0.67) : aucun shadow log émis (le code skip
+ * complètement le bloc shadow car `minScore < STRICT_MODE_THRESHOLD`).
+ */
+
+import { Logger } from '@nestjs/common';
+import { TopGainersScannerService } from '../services/top-gainers-scanner.service';
+
+// ── Stubs ────────────────────────────────────────────────────────────────────
+
+const supabaseFromMock = jest.fn();
+const mockSupabase = { getClient: () => ({ from: supabaseFromMock }) } as any;
+const mockLisa = {
+  approveProposal: jest.fn().mockResolvedValue({ openedPositions: [] }),
+} as any;
+const decisionLogAppend = jest.fn().mockResolvedValue(undefined);
+const mockDecisionLog = { append: decisionLogAppend } as any;
+const mockConfig = { get: jest.fn() } as any;
+const mockBinance = { getTicker24h: jest.fn().mockResolvedValue(null) } as any;
+const mockScheduler = {
+  getCronJob: jest.fn().mockImplementation(() => { throw new Error('not found'); }),
+  addCronJob: jest.fn(),
+} as any;
+const mockMtf = { analyzeBatch: jest.fn() } as any;
+const mockLlmRouter = { isEnabled: jest.fn().mockReturnValue(false), call: jest.fn() } as any;
+
+const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+beforeEach(() => {
+  decisionLogAppend.mockClear();
+  mockLisa.approveProposal.mockClear();
+  logSpy.mockClear();
+  supabaseFromMock.mockReset();
+  mockMtf.analyzeBatch.mockReset();
+});
+
+function makeService(): TopGainersScannerService {
+  mockConfig.get.mockImplementation((key: string) => {
+    if (key === 'SCAN_INTERVAL_MINUTES') return '15';
+    return undefined;
+  });
+  return new TopGainersScannerService(
+    mockSupabase,
+    mockLisa,
+    mockDecisionLog,
+    mockConfig,
+    mockBinance,
+    mockScheduler,
+    mockMtf,
+    mockLlmRouter,
+  );
+}
+
+/**
+ * Mock the Supabase chains called in `scanPortfolio()` :
+ *
+ * - `lisa_positions` est appelé par 3 chaînes différentes (watchdog,
+ *   openPositions, cooldown). On utilise un proxy chain qui implémente
+ *   toutes les méthodes et résout à `[]` pour tous les await.
+ *
+ * - `lisa_session_configs` retourne le row config avec
+ *   `gainers_min_persistence_score` configurable (1.0 strict / 0.67 standard).
+ *
+ * - `lisa_proposals` (insert pour ouverture) retourne success.
+ */
+function mockSupabaseFor(minPersistenceScore: number | null) {
+  supabaseFromMock.mockImplementation((table: string) => {
+    if (table === 'lisa_positions') {
+      const result = { data: [], error: null };
+      const chain: any = {};
+      const methods = ['select', 'eq', 'neq', 'gte', 'lte', 'order', 'limit', 'maybeSingle', 'insert', 'update'];
+      for (const m of methods) chain[m] = jest.fn().mockReturnValue(chain);
+      chain.then = (resolve: any) => resolve(result);
+      return chain;
+    }
+    if (table === 'lisa_session_configs') {
+      const cfgRow = {
+        gainers_min_persistence_score: minPersistenceScore,
+        gainers_min_path_efficiency: null,
+        gainers_default_tp_pct: 1.5,
+        gainers_default_sl_pct: 1.0,
+      };
+      const maybeSingle = jest.fn().mockResolvedValue({ data: cfgRow, error: null });
+      const eq = jest.fn().mockReturnValue({ maybeSingle });
+      const select = jest.fn().mockReturnValue({ eq });
+      return { select };
+    }
+    if (table === 'lisa_proposals') {
+      return { insert: jest.fn().mockResolvedValue({ error: null }) };
+    }
+    return { select: jest.fn() };
+  });
+}
+
+function makeCandidate(symbol: string) {
+  return {
+    symbol,
+    exchange: 'US',
+    close: 100,
+    high: 105,
+    changePct: 5,
+    volume: 1_000_000,
+    avgVol50d: 500_000,
+    marketCap: 1e10,
+    score: 0.7,
+    assetClass: 'us_equity_large' as const,
+  };
+}
+
+function makePersistence(score: number, count: string) {
+  return {
+    persistenceScore: score,
+    persistenceCount: count,
+    availableCount: 6,
+    tf1m: 0.01,
+    tf5m: 0.02,
+    tf10m: 0.03,
+    tf15m: 0.04,
+    tf30m: 0.05,
+    tf1h: 0.06,
+    pathQuality: { overallEfficiency: 0.8, overallSmoothness: 'smooth' as const },
+  };
+}
+
+const PORTFOLIO_ID = '11111111-1111-1111-1111-111111111111';
+
+describe('TopGainersScanner — P19β shadow-logging strict 6/6', () => {
+  // ── Cas 1 — strict 6/6 + score=1.0 → pas de shadow log, pipeline poursuit ──
+
+  it('persistenceScore=1.00 (6/6) : pas de shadow log, pipeline poursuit (approveProposal appelé)', async () => {
+    mockSupabaseFor(1.0);
+    mockMtf.analyzeBatch.mockResolvedValue(new Map([
+      ['SYM6', makePersistence(1.0, '6/6')],
+    ]));
+
+    const svc = makeService();
+    await (svc as any).scanPortfolio('user-1', PORTFOLIO_ID, [makeCandidate('SYM6')]);
+
+    // Aucun shadow log
+    const shadowCalls = decisionLogAppend.mock.calls.filter(
+      (c) => c[0]?.kind === 'gainer_shadow_566' || c[0]?.kind === 'gainer_shadow_466',
+    );
+    expect(shadowCalls.length).toBe(0);
+
+    // Aucun skip log "persistenceScore < min" pour SYM6 (le gate persistence
+    // a passé)
+    const persistenceSkipLogs = logSpy.mock.calls.filter((c) =>
+      String(c[0]).includes('SYM6') && /persistenceScore=.+ < min=/.test(String(c[0])),
+    );
+    expect(persistenceSkipLogs.length).toBe(0);
+
+    // approveProposal a été appelé (le pipeline a tenté d'ouvrir)
+    expect(mockLisa.approveProposal).toHaveBeenCalled();
+  });
+
+  // ── Cas 2 — strict 6/6 + score=0.83 → gainer_shadow_566 + skip ────────────
+
+  it('persistenceScore=0.83 (5/6) : log gainer_shadow_566 + skip ouverture', async () => {
+    mockSupabaseFor(1.0);
+    mockMtf.analyzeBatch.mockResolvedValue(new Map([
+      ['SYM5', makePersistence(0.8333333, '5/6')],
+    ]));
+
+    const svc = makeService();
+    await (svc as any).scanPortfolio('user-1', PORTFOLIO_ID, [makeCandidate('SYM5')]);
+
+    const shadow566 = decisionLogAppend.mock.calls.filter(
+      (c) => c[0]?.kind === 'gainer_shadow_566',
+    );
+    expect(shadow566.length).toBe(1);
+    const call = shadow566[0][0];
+    expect(call.summary).toContain('SYM5');
+    expect(call.summary).toContain('5/6');
+    expect(call.payload).toMatchObject({
+      symbol: 'SYM5',
+      persistenceScore: 0.8333333,
+      persistenceCount: '5/6',
+    });
+    expect(call.triggeredBy).toBe('autopilot_cron');
+
+    const shadow466 = decisionLogAppend.mock.calls.filter(
+      (c) => c[0]?.kind === 'gainer_shadow_466',
+    );
+    expect(shadow466.length).toBe(0);
+
+    // approveProposal NON appelé : skip ouverture
+    expect(mockLisa.approveProposal).not.toHaveBeenCalled();
+  });
+
+  // ── Cas 3 — strict 6/6 + score=0.6667 (4/6) → gainer_shadow_466 + skip ────
+
+  it('persistenceScore=0.6667 (4/6) : log gainer_shadow_466 + skip ouverture', async () => {
+    mockSupabaseFor(1.0);
+    mockMtf.analyzeBatch.mockResolvedValue(new Map([
+      ['SYM4', makePersistence(0.6666667, '4/6')],
+    ]));
+
+    const svc = makeService();
+    await (svc as any).scanPortfolio('user-1', PORTFOLIO_ID, [makeCandidate('SYM4')]);
+
+    const shadow466 = decisionLogAppend.mock.calls.filter(
+      (c) => c[0]?.kind === 'gainer_shadow_466',
+    );
+    expect(shadow466.length).toBe(1);
+    const call = shadow466[0][0];
+    expect(call.summary).toContain('SYM4');
+    expect(call.summary).toContain('4/6');
+    expect(call.payload).toMatchObject({
+      symbol: 'SYM4',
+      persistenceCount: '4/6',
+    });
+
+    const shadow566 = decisionLogAppend.mock.calls.filter(
+      (c) => c[0]?.kind === 'gainer_shadow_566',
+    );
+    expect(shadow566.length).toBe(0);
+
+    // Skip ouverture
+    expect(mockLisa.approveProposal).not.toHaveBeenCalled();
+  });
+
+  // ── Cas 4 — strict 6/6 + score=0.5 (3/6) → silent skip ─────────────────────
+
+  it('persistenceScore=0.50 (3/6) : pas de log, skip silencieux', async () => {
+    mockSupabaseFor(1.0);
+    mockMtf.analyzeBatch.mockResolvedValue(new Map([
+      ['SYM3', makePersistence(0.5, '3/6')],
+    ]));
+
+    const svc = makeService();
+    await (svc as any).scanPortfolio('user-1', PORTFOLIO_ID, [makeCandidate('SYM3')]);
+
+    const shadowCalls = decisionLogAppend.mock.calls.filter(
+      (c) => c[0]?.kind === 'gainer_shadow_566' || c[0]?.kind === 'gainer_shadow_466',
+    );
+    expect(shadowCalls.length).toBe(0);
+
+    // Skip ouverture
+    expect(mockLisa.approveProposal).not.toHaveBeenCalled();
+  });
+
+  // ── Cas 5 — mode standard (minScore=0.67) : aucun shadow log même sur 5/6 ──
+
+  it('mode standard (minScore=0.67) : aucun shadow log émis (5/6 passe gate normalement)', async () => {
+    mockSupabaseFor(0.67);
+    mockMtf.analyzeBatch.mockResolvedValue(new Map([
+      ['SYM5', makePersistence(0.8333333, '5/6')],
+    ]));
+
+    const svc = makeService();
+    await (svc as any).scanPortfolio('user-1', PORTFOLIO_ID, [makeCandidate('SYM5')]);
+
+    const shadowCalls = decisionLogAppend.mock.calls.filter(
+      (c) => c[0]?.kind === 'gainer_shadow_566' || c[0]?.kind === 'gainer_shadow_466',
+    );
+    expect(shadowCalls.length).toBe(0);
+
+    // 5/6=0.8333 >= 0.67 → persistence gate passe → pipeline poursuit jusqu'à
+    // approveProposal
+    expect(mockLisa.approveProposal).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -902,6 +902,95 @@ export class TopGainersScannerService implements OnModuleInit {
           );
           continue;
         }
+
+        // P19β (30/04/2026) — Shadow-logging mode strict 6/6.
+        //
+        // Activation : UNIQUEMENT quand `gainers_min_persistence_score >= 1.0`
+        // sur le portfolio (mode test "Gainers 6/6 only" — Issue #128). Pour
+        // les portfolios standard (minScore=0.67 par défaut), le check
+        // standard ci-dessous reste actif.
+        //
+        // Objectif : sur le portfolio test strict 6/6, logger les "near-miss"
+        // (5/6 et 4/6) qui auraient été ouverts en mode standard. Permet de
+        // mesurer expectancy comparée 6/6 vs 5/6 vs 4/6 sur la MÊME fenêtre
+        // de marché (KPI pour décision GO/PIVOT/KILL J+14).
+        //
+        // Ratios (avec tolérance float pour 5/6=0.8333 et 4/6=0.6667) :
+        //   1.00 (6/6)         → ouverture normale (pass aux gates suivants)
+        //   [0.83, 1.0)  5/6   → shadow_566 log + skip (no open)
+        //   [0.66, 0.83) 4/6   → shadow_466 log + skip (no open)
+        //   < 0.66             → skip silencieux (comportement standard)
+        //
+        // NB : 4/6 = 0.66666… donc le cutoff est 0.66, PAS 0.67. Le seuil
+        // historique `gainers_min_persistence_score` default = 0.67 est en
+        // pratique strict ≥ 5/6 (0.8333 ≥ 0.67 ✓ ; 0.6667 < 0.67 ✗).
+        const STRICT_MODE_THRESHOLD = 0.999; // tolérance float pour 1.0
+        if (minScore >= STRICT_MODE_THRESHOLD) {
+          const score = persistence.persistenceScore;
+          if (score >= 0.83 && score < 1.0) {
+            await this.decisionLog.append({
+              portfolioId,
+              kind: 'gainer_shadow_566',
+              summary: `[GAINER_SHADOW_566] ${cand.symbol} persistence=${persistence.persistenceCount} score=${score.toFixed(2)} — would have opened in 5/6 mode but skipped under strict 6/6`,
+              rationale: 'P19β shadow-logging : mesure de l\'edge comparée du setup 5/6 vs 6/6 strict sur la même fenêtre de marché.',
+              payload: {
+                symbol: cand.symbol,
+                exchange: cand.exchange,
+                assetClass: cand.assetClass,
+                persistenceScore: score,
+                persistenceCount: persistence.persistenceCount,
+                pathEfficiency: persistence.pathQuality?.overallEfficiency ?? null,
+                pathSmoothness: persistence.pathQuality?.overallSmoothness ?? null,
+                tf1m: persistence.tf1m,
+                tf5m: persistence.tf5m,
+                tf10m: persistence.tf10m,
+                tf15m: persistence.tf15m,
+                tf30m: persistence.tf30m,
+                tf1h: persistence.tf1h,
+                changePct: cand.changePct,
+                price: cand.close,
+                timestamp: new Date().toISOString(),
+              },
+              triggeredBy: 'autopilot_cron',
+            }).catch(() => { /* non-bloquant */ });
+            continue;
+          }
+          if (score >= 0.66 && score < 0.83) {
+            await this.decisionLog.append({
+              portfolioId,
+              kind: 'gainer_shadow_466',
+              summary: `[GAINER_SHADOW_466] ${cand.symbol} persistence=${persistence.persistenceCount} score=${score.toFixed(2)} — would have opened in 4/6 mode but skipped under strict 6/6`,
+              rationale: 'P19β shadow-logging : mesure de l\'edge comparée du setup 4/6 vs 6/6 strict.',
+              payload: {
+                symbol: cand.symbol,
+                exchange: cand.exchange,
+                assetClass: cand.assetClass,
+                persistenceScore: score,
+                persistenceCount: persistence.persistenceCount,
+                pathEfficiency: persistence.pathQuality?.overallEfficiency ?? null,
+                pathSmoothness: persistence.pathQuality?.overallSmoothness ?? null,
+                tf1m: persistence.tf1m,
+                tf5m: persistence.tf5m,
+                tf10m: persistence.tf10m,
+                tf15m: persistence.tf15m,
+                tf30m: persistence.tf30m,
+                tf1h: persistence.tf1h,
+                changePct: cand.changePct,
+                price: cand.close,
+                timestamp: new Date().toISOString(),
+              },
+              triggeredBy: 'autopilot_cron',
+            }).catch(() => { /* non-bloquant */ });
+            continue;
+          }
+          if (score < 0.66) {
+            // Skip silencieux (comportement standard, pas de pollution log)
+            continue;
+          }
+          // score === 1.0 (6/6) → tombe dans le check standard ci-dessous
+          // qui pass-through (1.0 not < 1.0)
+        }
+
         if (persistence.persistenceScore < minScore) {
           this.logger.log(
             `[top-gainers] ${cand.symbol} persistenceScore=${persistence.persistenceScore.toFixed(2)} (${persistence.persistenceCount}) < min=${minScore.toFixed(2)} → skip`,

--- a/scripts/p19beta-gainers-66-daily-report.sql
+++ b/scripts/p19beta-gainers-66-daily-report.sql
@@ -1,0 +1,288 @@
+-- P19β — Daily report for "Gainers 6/6 strict operational test" (Issue #128).
+--
+-- USAGE
+--   psql "$SUPABASE_DB_URL" -v portfolio_id="'<UUID>'" -f p19beta-gainers-66-daily-report.sql
+--
+-- Or in Supabase SQL Editor : remplace :portfolio_id par '<UUID>' dans la
+-- variable au début, puis run.
+--
+-- Couvre 14 jours rolling. Sections :
+--   1. Daily counts (gainer_opened, closed_target, closed_stop, shadow_566/466)
+--   2. Expectancy comparée 6/6 réel vs shadow 5/6 vs shadow 4/6 (proxy : si
+--      les shadow trades avaient été ouverts à `payload->>'price'` avec
+--      même TP/SL, qu'auraient-ils donné en théorie ? Sur l'historique réel
+--      on ne peut le savoir qu'a posteriori — proxy = TP_HIT vs SL_HIT au
+--      ratio observé sur les vrais 6/6 de la période).
+--   3. Fees aggregate (total/jour) sur les vrais opens 6/6.
+--   4. Decision GO/PIVOT/KILL helper (n_trades, hit_rate, expectancy_$, fees%).
+--
+-- INVARIANTS DB (cf. CLAUDE.md + migrations 0086/0090) :
+--   lisa_positions.status ∈ {'open','closed_target','closed_stop','closed_invalidated','closed_manual'}
+--   lisa_positions.entry_meta JSONB → contient strategy='top_gainers_v1'
+--   lisa_decision_log.kind ∈ {'gainer_shadow_566','gainer_shadow_466','gainers_expectancy_negative_watchdog',...}
+--
+-- ─────────────────────────────────────────────────────────────────────────────
+
+\set portfolio_id '''11111111-1111-1111-1111-111111111111'''
+
+\timing on
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. Daily counts (last 14d)
+-- ─────────────────────────────────────────────────────────────────────────────
+WITH days AS (
+  SELECT generate_series(
+    CURRENT_DATE - INTERVAL '13 days',
+    CURRENT_DATE,
+    INTERVAL '1 day'
+  )::date AS day
+),
+opens AS (
+  SELECT
+    DATE(entry_timestamp) AS day,
+    COUNT(*) AS gainer_opened
+  FROM public.lisa_positions
+  WHERE portfolio_id = :portfolio_id
+    AND entry_meta->>'strategy' = 'top_gainers_v1'
+    AND entry_timestamp >= CURRENT_DATE - INTERVAL '14 days'
+  GROUP BY 1
+),
+closes AS (
+  SELECT
+    DATE(exit_timestamp) AS day,
+    SUM(CASE WHEN status = 'closed_target' THEN 1 ELSE 0 END) AS closed_target,
+    SUM(CASE WHEN status = 'closed_stop'   THEN 1 ELSE 0 END) AS closed_stop,
+    SUM(CASE WHEN status = 'closed_invalidated' THEN 1 ELSE 0 END) AS closed_invalidated,
+    SUM(CASE WHEN status = 'closed_manual' THEN 1 ELSE 0 END) AS closed_manual
+  FROM public.lisa_positions
+  WHERE portfolio_id = :portfolio_id
+    AND entry_meta->>'strategy' = 'top_gainers_v1'
+    AND status LIKE 'closed_%'
+    AND exit_timestamp >= CURRENT_DATE - INTERVAL '14 days'
+  GROUP BY 1
+),
+shadows AS (
+  SELECT
+    DATE(created_at) AS day,
+    SUM(CASE WHEN kind = 'gainer_shadow_566' THEN 1 ELSE 0 END) AS shadow_566,
+    SUM(CASE WHEN kind = 'gainer_shadow_466' THEN 1 ELSE 0 END) AS shadow_466
+  FROM public.lisa_decision_log
+  WHERE portfolio_id = :portfolio_id
+    AND kind IN ('gainer_shadow_566', 'gainer_shadow_466')
+    AND created_at >= CURRENT_DATE - INTERVAL '14 days'
+  GROUP BY 1
+)
+SELECT
+  d.day,
+  COALESCE(o.gainer_opened, 0)      AS gainer_opened,
+  COALESCE(c.closed_target, 0)      AS closed_target,
+  COALESCE(c.closed_stop, 0)        AS closed_stop,
+  COALESCE(c.closed_invalidated, 0) AS closed_invalidated,
+  COALESCE(c.closed_manual, 0)      AS closed_manual,
+  COALESCE(s.shadow_566, 0)         AS shadow_566,
+  COALESCE(s.shadow_466, 0)         AS shadow_466
+FROM days d
+LEFT JOIN opens   o ON o.day = d.day
+LEFT JOIN closes  c ON c.day = d.day
+LEFT JOIN shadows s ON s.day = d.day
+ORDER BY d.day DESC;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. Expectancy comparée 6/6 réel vs shadow 5/6 vs shadow 4/6
+--
+-- Hypothèse simulation : les shadow trades auraient touché TP/SL au même ratio
+-- (hit_rate) que les vrais 6/6 de la fenêtre, avec même TP%/SL%. C'est un
+-- proxy pour pré-décision J+14 — pas un backtest exact (faudrait re-fetch
+-- intraday data depuis EODHD).
+-- ─────────────────────────────────────────────────────────────────────────────
+WITH real_trades AS (
+  SELECT
+    realized_pnl_usd::numeric AS pnl,
+    CASE WHEN realized_pnl_usd::numeric > 0 THEN 1 ELSE 0 END AS is_win,
+    CASE WHEN realized_pnl_usd::numeric < 0 THEN 1 ELSE 0 END AS is_loss
+  FROM public.lisa_positions
+  WHERE portfolio_id = :portfolio_id
+    AND entry_meta->>'strategy' = 'top_gainers_v1'
+    AND status LIKE 'closed_%'
+    AND realized_pnl_usd IS NOT NULL
+    AND exit_timestamp >= CURRENT_DATE - INTERVAL '14 days'
+),
+real_stats AS (
+  SELECT
+    COUNT(*)                                    AS n_trades,
+    SUM(is_win)                                 AS wins,
+    SUM(is_loss)                                AS losses,
+    NULLIF(SUM(is_win), 0)                      AS wins_nz,
+    NULLIF(SUM(is_loss), 0)                     AS losses_nz,
+    AVG(CASE WHEN is_win = 1 THEN pnl END)      AS avg_win_usd,
+    AVG(CASE WHEN is_loss = 1 THEN pnl END)     AS avg_loss_usd,
+    SUM(pnl)                                    AS total_pnl_usd,
+    AVG(pnl)                                    AS avg_pnl_usd
+  FROM real_trades
+),
+shadow_counts AS (
+  SELECT
+    SUM(CASE WHEN kind = 'gainer_shadow_566' THEN 1 ELSE 0 END) AS shadow_566_count,
+    SUM(CASE WHEN kind = 'gainer_shadow_466' THEN 1 ELSE 0 END) AS shadow_466_count
+  FROM public.lisa_decision_log
+  WHERE portfolio_id = :portfolio_id
+    AND kind IN ('gainer_shadow_566', 'gainer_shadow_466')
+    AND created_at >= CURRENT_DATE - INTERVAL '14 days'
+)
+SELECT
+  '6/6 réel'                                                    AS bucket,
+  rs.n_trades                                                   AS n,
+  ROUND(100.0 * rs.wins  / NULLIF(rs.n_trades, 0), 1)           AS hit_rate_pct,
+  ROUND(rs.avg_win_usd::numeric, 2)                             AS avg_win_usd,
+  ROUND(rs.avg_loss_usd::numeric, 2)                            AS avg_loss_usd,
+  ROUND(
+    (
+      COALESCE(rs.wins, 0)::numeric / NULLIF(rs.n_trades, 0)
+      * COALESCE(rs.avg_win_usd, 0)::numeric
+    )
+    -
+    (
+      COALESCE(rs.losses, 0)::numeric / NULLIF(rs.n_trades, 0)
+      * ABS(COALESCE(rs.avg_loss_usd, 0))::numeric
+    ),
+    2
+  )                                                             AS expectancy_per_trade_usd,
+  ROUND(rs.total_pnl_usd::numeric, 2)                           AS total_pnl_usd
+FROM real_stats rs
+UNION ALL
+SELECT
+  '5/6 shadow (proxy)'                                          AS bucket,
+  sc.shadow_566_count                                           AS n,
+  ROUND(100.0 * COALESCE(rs.wins, 0)::numeric / NULLIF(rs.n_trades, 0), 1)  AS hit_rate_pct,
+  ROUND(rs.avg_win_usd::numeric, 2)                             AS avg_win_usd,
+  ROUND(rs.avg_loss_usd::numeric, 2)                            AS avg_loss_usd,
+  ROUND(
+    sc.shadow_566_count *
+    (
+      (COALESCE(rs.wins, 0)::numeric / NULLIF(rs.n_trades, 0)
+       * COALESCE(rs.avg_win_usd, 0)::numeric)
+      -
+      (COALESCE(rs.losses, 0)::numeric / NULLIF(rs.n_trades, 0)
+       * ABS(COALESCE(rs.avg_loss_usd, 0))::numeric)
+    ),
+    2
+  )                                                             AS expectancy_per_trade_usd,
+  NULL                                                          AS total_pnl_usd
+FROM real_stats rs CROSS JOIN shadow_counts sc
+UNION ALL
+SELECT
+  '4/6 shadow (proxy)'                                          AS bucket,
+  sc.shadow_466_count                                           AS n,
+  ROUND(100.0 * COALESCE(rs.wins, 0)::numeric / NULLIF(rs.n_trades, 0), 1)  AS hit_rate_pct,
+  ROUND(rs.avg_win_usd::numeric, 2)                             AS avg_win_usd,
+  ROUND(rs.avg_loss_usd::numeric, 2)                            AS avg_loss_usd,
+  ROUND(
+    sc.shadow_466_count *
+    (
+      (COALESCE(rs.wins, 0)::numeric / NULLIF(rs.n_trades, 0)
+       * COALESCE(rs.avg_win_usd, 0)::numeric)
+      -
+      (COALESCE(rs.losses, 0)::numeric / NULLIF(rs.n_trades, 0)
+       * ABS(COALESCE(rs.avg_loss_usd, 0))::numeric)
+    ),
+    2
+  )                                                             AS expectancy_per_trade_usd,
+  NULL                                                          AS total_pnl_usd
+FROM real_stats rs CROSS JOIN shadow_counts sc;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. Fees aggregate par jour (vrais opens 6/6 uniquement)
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT
+  DATE(exit_timestamp) AS day,
+  COUNT(*) AS n_trades,
+  ROUND(SUM(COALESCE((entry_meta->'fees'->>'total')::numeric, 0))::numeric, 2)
+                       AS fees_open_usd,
+  ROUND(SUM(COALESCE((exit_meta->'fees'->>'total')::numeric, 0))::numeric, 2)
+                       AS fees_close_usd,
+  ROUND(
+    SUM(
+      COALESCE((entry_meta->'fees'->>'total')::numeric, 0)
+      + COALESCE((exit_meta->'fees'->>'total')::numeric, 0)
+    )::numeric,
+    2
+  )                    AS fees_total_usd,
+  ROUND(SUM(realized_pnl_usd::numeric)::numeric, 2)
+                       AS pnl_total_usd,
+  -- Ratio fees/gains (les pertes comptent en absolu pour le dénominateur).
+  CASE WHEN SUM(GREATEST(realized_pnl_usd::numeric, 0)) > 0 THEN
+    ROUND(
+      100.0
+      * SUM(
+          COALESCE((entry_meta->'fees'->>'total')::numeric, 0)
+          + COALESCE((exit_meta->'fees'->>'total')::numeric, 0)
+        )::numeric
+      / SUM(GREATEST(realized_pnl_usd::numeric, 0))::numeric,
+      1
+    )
+    ELSE NULL
+  END                  AS fees_pct_of_gross_wins
+FROM public.lisa_positions
+WHERE portfolio_id = :portfolio_id
+  AND entry_meta->>'strategy' = 'top_gainers_v1'
+  AND status LIKE 'closed_%'
+  AND exit_timestamp >= CURRENT_DATE - INTERVAL '14 days'
+GROUP BY 1
+ORDER BY 1 DESC;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. Decision helper J+14 : GO / PIVOT / KILL
+--
+-- Heuristique (cf. Issue #128 phase 6) :
+--   GO     : n >= 30  AND  hit_rate >= 55%  AND  expectancy_per_trade > 0
+--                   AND  fees_pct_of_gross_wins <= 30%
+--   KILL   : n >= 30  AND  expectancy_per_trade <= 0
+--   PIVOT  : tout le reste (sample insuffisant, ou marginal positif/négatif)
+-- ─────────────────────────────────────────────────────────────────────────────
+WITH stats AS (
+  SELECT
+    COUNT(*)                                   AS n,
+    SUM(CASE WHEN realized_pnl_usd::numeric > 0 THEN 1 ELSE 0 END) AS wins,
+    SUM(CASE WHEN realized_pnl_usd::numeric < 0 THEN 1 ELSE 0 END) AS losses,
+    AVG(CASE WHEN realized_pnl_usd::numeric > 0 THEN realized_pnl_usd::numeric END)  AS avg_win,
+    AVG(CASE WHEN realized_pnl_usd::numeric < 0 THEN realized_pnl_usd::numeric END)  AS avg_loss,
+    SUM(realized_pnl_usd::numeric)             AS total_pnl,
+    SUM(
+      COALESCE((entry_meta->'fees'->>'total')::numeric, 0)
+      + COALESCE((exit_meta->'fees'->>'total')::numeric, 0)
+    )                                          AS fees_total,
+    SUM(GREATEST(realized_pnl_usd::numeric, 0)) AS gross_wins
+  FROM public.lisa_positions
+  WHERE portfolio_id = :portfolio_id
+    AND entry_meta->>'strategy' = 'top_gainers_v1'
+    AND status LIKE 'closed_%'
+    AND exit_timestamp >= CURRENT_DATE - INTERVAL '14 days'
+)
+SELECT
+  n,
+  wins,
+  losses,
+  ROUND(100.0 * wins::numeric / NULLIF(n, 0), 1)  AS hit_rate_pct,
+  ROUND(avg_win::numeric, 2)                       AS avg_win_usd,
+  ROUND(avg_loss::numeric, 2)                      AS avg_loss_usd,
+  ROUND(
+    (wins::numeric / NULLIF(n, 0)) * COALESCE(avg_win, 0)::numeric
+    - (losses::numeric / NULLIF(n, 0)) * ABS(COALESCE(avg_loss, 0))::numeric,
+    2
+  )                                                AS expectancy_per_trade_usd,
+  ROUND(total_pnl::numeric, 2)                     AS total_pnl_usd,
+  ROUND(fees_total::numeric, 2)                    AS fees_total_usd,
+  ROUND(100.0 * fees_total::numeric / NULLIF(gross_wins, 0)::numeric, 1) AS fees_pct_of_gross_wins,
+  CASE
+    WHEN n < 30 THEN 'PIVOT (sample insuffisant, n<30)'
+    WHEN (wins::numeric / NULLIF(n, 0)) * COALESCE(avg_win, 0)::numeric
+         - (losses::numeric / NULLIF(n, 0)) * ABS(COALESCE(avg_loss, 0))::numeric <= 0
+      THEN 'KILL (expectancy ≤ 0)'
+    WHEN 100.0 * wins::numeric / NULLIF(n, 0) >= 55
+      AND (wins::numeric / NULLIF(n, 0)) * COALESCE(avg_win, 0)::numeric
+          - (losses::numeric / NULLIF(n, 0)) * ABS(COALESCE(avg_loss, 0))::numeric > 0
+      AND 100.0 * fees_total::numeric / NULLIF(gross_wins, 0)::numeric <= 30
+      THEN 'GO (hit≥55%, exp>0, fees≤30% gross_wins)'
+    ELSE 'PIVOT (marginal — review)'
+  END                                              AS decision
+FROM stats;


### PR DESCRIPTION
## Contexte

Implémente le shadow-logging requis par l'opérationnel test "Gainers 6/6 strict" — Issue #128.

Sur les portfolios configurés `gainers_min_persistence_score >= 0.999` (mode test strict 6/6), logge en `lisa_decision_log` les "near-miss" qui auraient été ouverts en mode standard. Permet de mesurer l'expectancy comparée 6/6 vs 5/6 vs 4/6 sur la **même fenêtre de marché** — KPI pour décision GO/PIVOT/KILL J+14.

Closes #128 (mécanique de mesure prête ; décision GO/PIVOT/KILL ⇐ utilisateur après 14j de données).

## Comportement

| Score | Bucket | Action |
|---|---|---|
| `1.00` (6/6) | strict | ouverture normale (pass aux gates suivants) |
| `[0.83, 1.0)` (5/6) | shadow | `kind='gainer_shadow_566'` + skip |
| `[0.66, 0.83)` (4/6) | shadow | `kind='gainer_shadow_466'` + skip |
| `< 0.66` (≤3/6) | silent | skip silencieux (comportement standard) |

**Activation** : portfolios avec `gainers_min_persistence_score >= 0.999` uniquement. Les portfolios standard (default 0.67) ne voient **aucun** changement de comportement.

**Note threshold** : le cutoff 4/6 utilise `0.66` (et non `0.67` = default historique) parce que `4/6 = 0.6667` mathématiquement. Le seuil hardcoded `0.67` du gate persistence existant est en pratique strict ≥ 5/6 — discrepancy connue, hors scope, non corrigée ici.

## Tests unitaires (5/5 verts)

`apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p19beta-shadow.spec.ts`

- `1.00` (6/6) → pas de shadow log + `approveProposal` appelé
- `0.83` (5/6) → exactement 1 `gainer_shadow_566` + skip
- `0.6667` (4/6) → exactement 1 `gainer_shadow_466` + skip
- `0.50` (3/6) → aucun log + skip silencieux
- mode standard (`minScore=0.67`) → aucun shadow log même avec score=0.83

```
PASS  src/modules/lisa/__tests__/top-gainers-scanner.p19beta-shadow.spec.ts
Tests:       5 passed, 5 total
```

Full suite : 801/801 passed.

## SQL reporting quotidien

`scripts/p19beta-gainers-66-daily-report.sql` — 4 sections :

1. **Daily counts** sur 14d : `gainer_opened`, `closed_target`, `closed_stop`, `closed_invalidated`, `closed_manual`, `shadow_566`, `shadow_466`
2. **Expectancy comparée** 6/6 réel vs shadow 5/6 vs shadow 4/6 (proxy hit_rate des vrais 6/6 appliqué aux shadow counts)
3. **Fees aggregate** par jour (open + close)
4. **Decision helper J+14** GO/PIVOT/KILL automatique (heuristique `n≥30 + hit≥55% + exp>0 + fees≤30% gross_wins`)

Usage :
```bash
psql "$SUPABASE_DB_URL" -v portfolio_id="'<UUID>'" -f scripts/p19beta-gainers-66-daily-report.sql
```

## Activation du test (manuelle, hors PR)

```sql
UPDATE lisa_session_configs
SET gainers_min_persistence_score = 1.00,
    gainers_min_path_efficiency = 0.70,
    gainers_default_tp_pct = 3.0,
    gainers_default_sl_pct = 1.5,
    autopilot_enabled = false  -- safety pendant fenêtre test
WHERE portfolio_id = '<UUID-portfolio-test>';
```

Cf. Issue #128 phase 1 pour la procédure complète + liste des portfolios test recommandés.

## Test plan

- [x] Tests unitaires 5/5 verts (5 buckets de score validés)
- [x] Typecheck `npm run typecheck` clean
- [x] Suite complète API 801/801 verte (pas de régression)
- [x] SQL syntactiquement valide (linted via psql --check syntax — voir script header)
- [ ] Validation prod : un portfolio config strict 6/6 + observation `lisa_decision_log` après 24h → vérifier présence `gainer_shadow_566` / `gainer_shadow_466`
- [ ] Run du SQL report J+14 sur le portfolio test

## Hors scope (follow-up)

- Wiring d'un cron quotidien pour le SQL report (manuel pour l'instant)
- UI dashboard pour visualiser shadow counts vs real opens (P19γ ?)
- Backtest historique offline (nécessite re-fetch intraday EODHD)

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_