### PR TITLE
hotfix(scanner+quota): EODHD 422 non-US + quota counter desync false-positive

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
@@ -142,7 +142,12 @@ describe('fetchEodhdScreener — URL construction (P18c regression guard)', () =
     expect(decoded).not.toContain('limit=20');
   });
 
-  it('P19s+ — non-US exchanges (TSE, HK, KO, SS, SZ, …) build URL with UPPERCASE + change_p', async () => {
+  it('P19s++ HOTFIX — non-US exchanges build URL with UPPERCASE + NO 1d return filter', async () => {
+    // P19s++ (30/04/2026 08:10 UTC) — `change_p` n'est PAS un valid filter
+    // field per EODHD doc (c'est le nom dans la RÉPONSE seulement). Ça
+    // causait HTTP 422 sur LSE/MC/KO/HK :
+    //     {"errors":{"filters.1.field":["The selected filters.1.field is invalid."]}}
+    // Fix : DROP le filter 1d return pour non-US, post-filter client-side.
     const svc = makeService();
     const exchanges = ['TSE', 'HK', 'KO', 'SS', 'SZ', 'TO', 'AS', 'NSE', 'BSE', 'AU'];
     for (const ex of exchanges) {
@@ -150,10 +155,12 @@ describe('fetchEodhdScreener — URL construction (P18c regression guard)', () =
       await (svc as any).fetchEodhdScreener(ex, 'test-key');
       expect(capturedUrl).toBeDefined();
       const decoded = decodeURIComponent(capturedUrl!);
-      // P19s+ : exchange UPPERCASE, change_p (pas refund_1d_p) pour non-US
+      // Exchange UPPERCASE
       expect(decoded).toContain(`["exchange","=","${ex}"]`);
-      expect(decoded).toContain('["change_p",">",3]');
+      // P19s++ : pas de filter 1d return (ni change_p, ni refund_1d_p)
+      expect(decoded).not.toMatch(/\["change_p","[<>=]"/);
       expect(decoded).not.toMatch(/\["refund_1d_p","[<>=]"/);
+      // market_cap conservé (valid filter)
       expect(decoded).toContain('["market_capitalization",">",50000000]');
       expect(decoded).not.toMatch(/[?&]sort=/);
       expect(decoded).not.toContain('avgvol_50d');

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.multi-exchange.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.multi-exchange.spec.ts
@@ -75,9 +75,10 @@ describe('fetchEodhdScreener — multi-exchange UPPERCASE + changeField (P19s+ r
     // Exchange filter doit contenir "LSE" (UPPERCASE), pas "lse"
     expect(decoded).toContain('"LSE"');
     expect(decoded).not.toContain('"lse"');
-    // changeField doit être 'change_p' pour non-US
-    expect(decoded).toContain('change_p');
+    // P19s++ HOTFIX : pas de filter 1d return pour non-US (rejected as
+    // invalid filter field by EODHD validator). Post-filter client-side.
     expect(decoded).not.toContain('refund_1d_p');
+    expect(decoded).not.toContain('change_p');
   });
 
   it('passes UPPERCASE exchange + refund_1d_p for US to EODHD screener', async () => {
@@ -88,7 +89,7 @@ describe('fetchEodhdScreener — multi-exchange UPPERCASE + changeField (P19s+ r
     // Exchange filter doit contenir "US"
     expect(decoded).toContain('"US"');
     expect(decoded).not.toContain('"us"');
-    // changeField doit rester 'refund_1d_p' pour US (back-compat)
+    // refund_1d_p est un valid filter field UNIQUEMENT pour US (validé prod)
     expect(decoded).toContain('refund_1d_p');
     expect(decoded).not.toContain('change_p');
   });
@@ -98,7 +99,9 @@ describe('fetchEodhdScreener — multi-exchange UPPERCASE + changeField (P19s+ r
     await (svc as any).fetchEodhdScreener('XETRA', 'test_key');
     const decoded = decodeURIComponent(capturedUrl!);
     expect(decoded).toContain('"XETRA"');
-    expect(decoded).toContain('change_p');
+    // P19s++ : pas de filter 1d return pour non-US
+    expect(decoded).not.toContain('refund_1d_p');
+    expect(decoded).not.toContain('change_p');
   });
 
   it.each([
@@ -110,12 +113,15 @@ describe('fetchEodhdScreener — multi-exchange UPPERCASE + changeField (P19s+ r
     ['to', 'TO'],   // Toronto
     ['as', 'AS'],   // Amsterdam
     ['nse', 'NSE'], // India NSE
-  ])('non-US exchange "%s" sent as "%s" with change_p filter', async (input, expected) => {
+  ])('non-US exchange "%s" sent as "%s" without 1d return filter (post-filter client-side)', async (input, expected) => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener(input, 'test_key');
     const decoded = decodeURIComponent(capturedUrl!);
     expect(decoded).toContain(`"${expected}"`);
-    expect(decoded).toContain('change_p');
+    // P19s++ : pas de filter 1d return (rejected by EODHD validator pour non-US)
     expect(decoded).not.toContain('refund_1d_p');
+    expect(decoded).not.toContain('change_p');
+    // market_capitalization filter conservé
+    expect(decoded).toContain('market_capitalization');
   });
 });

--- a/apps/api/src/modules/lisa/services/realtime-price.service.ts
+++ b/apps/api/src/modules/lisa/services/realtime-price.service.ts
@@ -55,6 +55,18 @@ export class RealtimePriceService implements OnModuleDestroy {
   private eodhd24hCountAsOf = 0;
   private eodhdDailyLimit = EODHD_DAILY_FALLBACK_CAP;
   private eodhdExtraLimit = 0;
+  /**
+   * P19s++ HOTFIX (30/04/2026) — Track if the last refresh succeeded via
+   * EODHD /api/user (authoritative). When DB fallback is used, this is
+   * `false` and we treat the count as APPROXIMATIVE (may overcount due
+   * to retries/failures inflating eodhd_request_log).
+   *
+   * Bug observed prod 30/04 08:04 UTC : EODHD dashboard showed 13k actual
+   * usage but local DB counter said 100k → blocked all calls. Caused by
+   * eodhd_request_log inserting rows even on failed/retry calls, while
+   * EODHD only counts billable calls.
+   */
+  private eodhd24hCountAuthoritative = false;
 
   /** Sliding window des timestamps des appels EODHD sortants dans les
    *  dernières 60 s — pour bloquer avant de hit le rate limit 1000/min. */
@@ -268,10 +280,25 @@ export class RealtimePriceService implements OnModuleDestroy {
 
     // 2. Quota journalier — source prioritaire : /api/user (EODHD officiel)
     //    Fallback : count depuis eodhd_request_log si le call user échoue.
+    //
+    // P19s++ HOTFIX (30/04/2026 08:10 UTC) — DB fallback over-comptait
+    // (chaque retry/failure ajoute une row, mais EODHD ne compte que les
+    // billable calls). Résultat : compteur local 100k alors qu'EODHD voit
+    // 13k → blocage faux positif.
+    //
+    // Stratégie corrigée :
+    //   - Refresh API toutes les 60s (inchangé)
+    //   - Si API succeed → eodhd24hCountAuthoritative = true (truth source)
+    //   - Si API fail → KEEP LAST KNOWN GOOD VALUE (don't fall to DB count)
+    //   - DB count utilisé UNIQUEMENT au boot (premier call) si API down
+    //     → marqué non-authoritative et ne bloque jamais (garde-fou anti-faux-positif)
     if (now - this.eodhd24hCountAsOf > 60_000) {
       const refreshed = await this.refreshQuotaFromUserApi();
-      if (!refreshed) {
-        // Fallback DB count (calendaire 00:00 UTC)
+      if (refreshed) {
+        this.eodhd24hCountAuthoritative = true;
+      } else if (this.eodhd24hCountAsOf === 0) {
+        // Boot path : pas encore de valeur connue. DB count comme proxy
+        // initial (over-counting accepté ; sera corrigé au prochain refresh API).
         try {
           const nowDate = new Date(now);
           const startOfTodayUtc = new Date(Date.UTC(
@@ -285,10 +312,21 @@ export class RealtimePriceService implements OnModuleDestroy {
             .gte('timestamp', startOfTodayUtc);
           this.eodhd24hCount = count ?? 0;
           this.eodhd24hCountAsOf = now;
+          this.eodhd24hCountAuthoritative = false;
+          this.logger.warn(
+            `[quota] /api/user unreachable at boot, DB fallback count=${count ?? 0} `
+            + `(NON-AUTHORITATIVE, may overcount — won't block)`,
+          );
         } catch (e) {
           this.logger.warn(`Quota DB fallback failed: ${String(e).slice(0, 80)}`);
           return 'ok';
         }
+      } else {
+        // API failed but we have a previous value — keep it, log discrepancy.
+        // No update to eodhd24hCountAsOf so next call will retry the API.
+        this.logger.debug(
+          `[quota] /api/user refresh failed; keeping last known count=${this.eodhd24hCount}`,
+        );
       }
     }
 
@@ -296,11 +334,14 @@ export class RealtimePriceService implements OnModuleDestroy {
     const hardCapSafe = Math.floor(effectiveCap * 0.95); // 5% marge vs cap réel
     const warnThreshold = Math.floor(effectiveCap * 0.80);
 
-    if (this.eodhd24hCount >= hardCapSafe) {
+    // P19s++ HOTFIX — Bloque UNIQUEMENT si la valeur est authoritative
+    // (vient de /api/user EODHD officiel). Le DB count peut overcompter à
+    // cause des retries/failures, donc on ne bloque pas sur cette base.
+    if (this.eodhd24hCountAuthoritative && this.eodhd24hCount >= hardCapSafe) {
       this.logger.warn(`EODHD daily quota proche (${this.eodhd24hCount}/${effectiveCap}) — blocage`);
       return 'blocked';
     }
-    if (this.eodhd24hCount >= warnThreshold) return 'warn';
+    if (this.eodhd24hCountAuthoritative && this.eodhd24hCount >= warnThreshold) return 'warn';
     return 'ok';
   }
 

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -170,6 +170,16 @@ export class TopGainersScannerService implements OnModuleInit {
   /** P18e — Compteur cumulatif des candidats skip pour absence de persistence. */
   private skippedNoPersistenceCounter = 0;
 
+  /**
+   * P19s++ (30/04/2026 08:10 UTC HOTFIX) — Cache de fetchAllCandidates pour
+   * éviter le burn quota EODHD. Avant : UI poll /lisa/gainers-persistence-snapshot
+   * toutes les 60s × 11 exchanges = 660 calls/h juste pour 1 user. Avec
+   * cycle scanner 15min, le cache permet aux UI polls de partager la même
+   * fetch sans re-frapper EODHD.
+   */
+  private allCandidatesCache: { candidates: TopGainerCandidate[]; asOf: number } | null = null;
+  private readonly ALL_CANDIDATES_CACHE_TTL_MS = 15 * 60_000; // 15 min
+
   constructor(
     private readonly supabase: SupabaseService,
     private readonly lisa: LisaService,
@@ -510,6 +520,14 @@ export class TopGainersScannerService implements OnModuleInit {
    * Hors heures EU le scan est skip pour économiser EODHD et éviter les 422.
    */
   async fetchAllCandidates(now: Date = new Date()): Promise<TopGainerCandidate[]> {
+    // P19s++ — Cache hit (TTL 15min). Évite N×11 calls EODHD quand l'UI
+    // poll /lisa/gainers-persistence-snapshot toutes les 60s.
+    if (
+      this.allCandidatesCache
+      && now.getTime() - this.allCandidatesCache.asOf < this.ALL_CANDIDATES_CACHE_TTL_MS
+    ) {
+      return this.allCandidatesCache.candidates;
+    }
     const apiKey = this.config.get<string>('EODHD_API_KEY');
     const tasks: Promise<TopGainerCandidate[]>[] = [];
 
@@ -562,12 +580,17 @@ export class TopGainersScannerService implements OnModuleInit {
     // même ticker sur 2 codes d'exchange (AS/AMS, MC/BME) ou si plusieurs
     // sources retourneraient le même symbole.
     const seen = new Set<string>();
-    return merged.filter((c) => {
+    const deduped = merged.filter((c) => {
       const key = `${c.symbol}@${c.exchange ?? 'unknown'}`;
       if (seen.has(key)) return false;
       seen.add(key);
       return true;
     });
+
+    // P19s++ — Cache fill (TTL 15min). Permet aux UI polls et au cron scanner
+    // de partager la même fetch sans re-frapper EODHD.
+    this.allCandidatesCache = { candidates: deduped, asOf: now.getTime() };
+    return deduped;
   }
 
   /**
@@ -600,39 +623,33 @@ export class TopGainersScannerService implements OnModuleInit {
    */
   private async fetchEodhdScreener(exchange: string, apiKey: string): Promise<TopGainerCandidate[]> {
     const exUpper = exchange.toUpperCase();
-    // P19s+ — Le filter field "change %1d" diffère entre marchés :
-    //   - US      : refund_1d_p (sans alias)
-    //   - non-US  : change_p (le seul disponible côté EODHD screener EU/Asie)
     const isUs = exUpper === 'US';
-    const changeField = isUs ? 'refund_1d_p' : 'change_p';
-    // P19s (29/04/2026 18:53 UTC) — Fix 422 sur exchanges non-US.
+    // P19s++ (30/04/2026 08:10 UTC HOTFIX) — Revert `change_p` filter qui
+    // causait HTTP 422 sur LSE/MC/KO/HK :
+    //     {"errors":{"filters.1.field":["The selected filters.1.field is invalid."]}}
+    // EODHD doc officielle confirme : `change_p` n'est PAS un valid filter
+    // field — c'est le nom dans la RÉPONSE seulement. Les seuls valid filter
+    // fields pour 1d return sont `refund_1d_p`, `refund_5d_p`, `refund_ytd_p`.
+    // Mais `refund_1d_p` ne semble pas avoir de données pour la plupart des
+    // marchés non-US.
     //
-    // Diagnostic via curl LIVE contre demo + observation Fly logs prod :
-    //   1. `avgvol_50d` n'est PAS un valid filter field — la doc
-    //      `stock-screener-data.md:52` est out-of-date. EODHD répond :
-    //        {"errors":{"filters.X.field":["The selected ... is invalid."]}}
-    //      → DROP du filter (post-filter volume géré côté `mapEodhdRow`).
-    //
-    //   2. Le format `&sort=field&order=d` (doc + P19o.4) déclenche le
-    //      Laravel validator EODHD :
-    //        {"errors":{"sort.0.direction":["The sort.0.direction field is required."]}}
-    //      Sur US (en prod ALL-IN-ONE) ça passe parfois silencieusement, sur
-    //      tous les autres exchanges (TSE/HK/KO/SS/SZ/TO/AS/NSE/BSE/AU) c'est
-    //      rejeté avec 422 → 0 candidats Asie/EU non-EU/Toronto.
-    //      → DROP de `sort` + `order` ; on trie client-side dans le snapshot
-    //        endpoint par changePct desc anyway.
-    //
-    //   3. Pour compenser la perte du tri EODHD-side (au cas où l'ordre
-    //      naturel ne soit pas changePct desc), on bump limit 20 → 100 (max
-    //      autorisé par la doc) pour garantir qu'on attrape les vrais top
-    //      gainers même si EODHD retourne dans un ordre arbitraire.
-    const filters = encodeURIComponent(JSON.stringify([
+    // Stratégie multi-exchange :
+    //   - US      : keep `refund_1d_p > 3` filter (validé prod)
+    //   - non-US  : DROP le filter 1d return entirely. Filtre seulement par
+    //               exchange + market_capitalization. Post-filter changePct
+    //               appliqué client-side via mapEodhdRow + filter ci-dessous
+    //               (la valeur change_p existe dans la RÉPONSE, juste pas
+    //               comme filter input).
+    const filtersList: Array<[string, string, string | number]> = [
       ['exchange', '=', exUpper],
-      [changeField, '>', 3],
-      ['market_capitalization', '>', 50_000_000],
-    ]));
+    ];
+    if (isUs) {
+      filtersList.push(['refund_1d_p', '>', 3]);
+    }
+    filtersList.push(['market_capitalization', '>', 50_000_000]);
+    const filters = encodeURIComponent(JSON.stringify(filtersList));
     const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}&limit=100&offset=0&fmt=json`;
-    this.logger.debug(`[top-gainers] EODHD screener exchange=${exUpper} field=${changeField}`);
+    this.logger.debug(`[top-gainers] EODHD screener exchange=${exUpper} filters=${filtersList.length}`);
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
       if (!res.ok) {
@@ -646,9 +663,15 @@ export class TopGainersScannerService implements OnModuleInit {
       }
       const json = await res.json() as { data?: EodhdScreenerRow[] } | EodhdScreenerRow[];
       const rows: EodhdScreenerRow[] = Array.isArray(json) ? json : (json.data ?? []);
-      return rows
+      let mapped = rows
         .map((r) => this.mapEodhdRow(r, exUpper))
         .filter((c): c is TopGainerCandidate => c !== null);
+      // P19s++ — Post-filter client-side pour non-US (filter serveur dropped).
+      // Garde rows changePct > 3 cohérent avec filtre serveur côté US.
+      if (!isUs) {
+        mapped = mapped.filter((c) => (c.changePct ?? 0) > 3);
+      }
+      return mapped;
     } catch (e) {
       this.logger.debug(`[top-gainers] eodhd ${exUpper} fetch error: ${String(e).slice(0, 120)}`);
       return [];


### PR DESCRIPTION
## 🚨 Hotfix prod — 2 bugs critiques bloquant le scanner

### BUG #1 — EODHD HTTP 422 non-US (revert `change_p` filter)

PR #142 utilisait `change_p` comme filter field pour les exchanges non-US. Doc officielle EODHD confirme : **`change_p` n'EST PAS un valid filter field** — c'est le nom dans la RÉPONSE seulement.

**Logs prod 30/04 08:04 UTC** :
```
WARN [TopGainers] eodhd LSE HTTP 422 — body: {"errors":{"filters.1.field":
     ["The selected filters.1.field is invalid."]}}
WARN [TopGainers] eodhd MC HTTP 422 — idem
WARN [TopGainers] eodhd KO HTTP 422 — idem
WARN [TopGainers] eodhd HK HTTP 422 — idem
```

**Fix** :
- **US** : keep `refund_1d_p > 3` filter (validé prod, seul valid filter field 1d return documenté)
- **non-US** : DROP entirely le filter 1d return. Post-filter changePct côté client via `mapEodhdRow` qui lit `r.refund_1d_p ?? r.change_p` de la **réponse** EODHD.

### BUG #2 — Quota counter desync false-positive

User vérification EODHD dashboard officiel : **~13k consommés réels aujourd'hui**. Local SmartVest counter affichait `100k/100k → blocage`.

**Root cause** : `canCallEodhd()` fallback path quand `/api/user` API échoue → `count(*)` sur `eodhd_request_log` table. Mais cette table log **chaque** call (success + failures + retries), alors qu'EODHD ne compte que les billable calls.

Si `/api/user` timeout ou 5xx → fallback DB → over-count → blocage faux positif.

**Fix** :
- API succeed → `eodhd24hCountAuthoritative = true` (truth source)
- API fail mid-run → **KEEP LAST KNOWN GOOD VALUE** (ne fallback PAS to DB count)
- API fail au boot → DB count comme proxy initial **NON-AUTHORITATIVE**
- **Bloque UNIQUEMENT si valeur authoritative** (jamais sur DB count proxy)

⚠️ **Conservation du seuil 100k** (limite réelle du plan EODHD souscrit, sacré).

### BONUS — Cache `fetchAllCandidates` 15min

UI poll `/lisa/gainers-persistence-snapshot` toutes les 60s × 11 exchanges = **660 calls/h juste pour 1 user**.

```ts
this.allCandidatesCache = { candidates, asOf };
if (cached && now - asOf < 15min) return cached;
```

Permet aux UI polls + cron scanner (15min interval) de partager la même fetch. Réduction quota burn ~95% sur ce path.

## Tests (831/831 verts)

```
PASS  src/modules/lisa/__tests__/top-gainers-scanner.multi-exchange.spec.ts
PASS  src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
Test Suites: 73 passed, 73 total
Tests:       831 passed, 831 total
```

## Smoke test post-deploy

```bash
fly logs -a smartvest --since 5m | grep "eodhd LSE HTTP 422"
# → DOIT être vide (plus de 422 sur LSE/MC/KO/HK)

fly logs -a smartvest --since 5m | grep "EODHD daily quota proche"
# → DOIT être vide (counter authoritative reflète truth EODHD)
```

```sql
-- Après 1 cycle (~15 min) :
WITH tk AS (
  SELECT jsonb_array_elements(snapshot_json->'candidates') AS c
  FROM public.gainers_persistence_log
  WHERE captured_at >= NOW() - INTERVAL '15 minutes'
)
SELECT
  CASE WHEN (c->>'symbol') ~ '\.[A-Z]+$' THEN regexp_replace(c->>'symbol','^.*\.','')
       ELSE 'US' END AS ex,
  COUNT(*),
  COUNT(DISTINCT c->>'symbol')
FROM tk GROUP BY 1 ORDER BY 2 DESC;
-- Critère succès : ≥ 3 exchanges (US + au moins 2 non-US sans 422)
```

## Hors scope (follow-up P19t)

- Header `X-RateLimit-Remaining` reconciliation pour resync intra-minute
- Budget guard rate-limiter 150 req/min peak (lisser sur la journée 100k = 70/min avg)
- Audit refresh prix portfolio loop frequency (autre cause potentielle de burn)

## Activation

Per instruction user "Action-Réaction, je merge moi-même dès dry-run validé". Pas de review humaine requise.

⏸ **Awaiting user merge.**

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_