### PR TITLE
hotfix(rate-limit): per-minute throttle + 402 retry + concurrency cap + caches

### DIFF
--- a/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
+++ b/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
@@ -89,7 +89,13 @@ interface CacheEntry {
   asOf: number;
 }
 
-const CACHE_TTL_MS = 30_000;
+// P19u (30/04/2026 08:30 UTC HOTFIX RATE-LIMIT) — Bump cache TTL 30s → 5min.
+// L'intraday endpoint EODHD coûte 5 API calls per request. Avec UI poll
+// /lisa/gainers-persistence-snapshot toutes les 60s × 20 tickers × 5 calls
+// = 100 API calls / 60s = spike per-minute > 1000/min → HTTP 402.
+// Bump cache TTL 30s → 5min réduit le burn de 90 % (1 fetch toutes les 5 min
+// au lieu de toutes les 30 s). Les candles 5m intraday changent peu sur 5 min.
+const CACHE_TTL_MS = 5 * 60_000;
 const MAX_PARALLEL_PER_SOURCE = 5;
 
 @Injectable()

--- a/apps/api/src/modules/lisa/services/realtime-price.service.ts
+++ b/apps/api/src/modules/lisa/services/realtime-price.service.ts
@@ -278,27 +278,25 @@ export class RealtimePriceService implements OnModuleDestroy {
       return 'blocked';
     }
 
-    // 2. Quota journalier — source prioritaire : /api/user (EODHD officiel)
-    //    Fallback : count depuis eodhd_request_log si le call user échoue.
+    // 2. Quota journalier — REFRESH OBSERVABILITÉ UNIQUEMENT depuis /api/user
+    //    (pas un blocage hard). Permet au /quota-status endpoint de logger
+    //    l'usage main subscription avec exactitude.
     //
-    // P19s++ HOTFIX (30/04/2026 08:10 UTC) — DB fallback over-comptait
-    // (chaque retry/failure ajoute une row, mais EODHD ne compte que les
-    // billable calls). Résultat : compteur local 100k alors qu'EODHD voit
-    // 13k → blocage faux positif.
+    // P19u (30/04/2026 08:30 UTC HOTFIX RATE-LIMIT) — Removed daily 100k
+    // blocker entirely. User clarification : EODHD limite RÉELLEMENT au
+    // RATE per-minute (1000 req/min), pas au daily count. HTTP 402
+    // observé prod = burst > 1000 req/min, pas daily exhaustion.
     //
-    // Stratégie corrigée :
-    //   - Refresh API toutes les 60s (inchangé)
-    //   - Si API succeed → eodhd24hCountAuthoritative = true (truth source)
-    //   - Si API fail → KEEP LAST KNOWN GOOD VALUE (don't fall to DB count)
-    //   - DB count utilisé UNIQUEMENT au boot (premier call) si API down
-    //     → marqué non-authoritative et ne bloque jamais (garde-fou anti-faux-positif)
+    // Le compteur daily reste en place pour observabilité (/lisa/eodhd-stats)
+    // mais ne déclenche plus de blocage. Le rate-limiter sliding window
+    // ci-dessus (étape 1) est la VRAIE protection contre les 402.
     if (now - this.eodhd24hCountAsOf > 60_000) {
       const refreshed = await this.refreshQuotaFromUserApi();
       if (refreshed) {
         this.eodhd24hCountAuthoritative = true;
       } else if (this.eodhd24hCountAsOf === 0) {
         // Boot path : pas encore de valeur connue. DB count comme proxy
-        // initial (over-counting accepté ; sera corrigé au prochain refresh API).
+        // OBSERVABILITÉ (over-counting accepté, jamais bloque).
         try {
           const nowDate = new Date(now);
           const startOfTodayUtc = new Date(Date.UTC(
@@ -313,35 +311,14 @@ export class RealtimePriceService implements OnModuleDestroy {
           this.eodhd24hCount = count ?? 0;
           this.eodhd24hCountAsOf = now;
           this.eodhd24hCountAuthoritative = false;
-          this.logger.warn(
-            `[quota] /api/user unreachable at boot, DB fallback count=${count ?? 0} `
-            + `(NON-AUTHORITATIVE, may overcount — won't block)`,
-          );
         } catch (e) {
-          this.logger.warn(`Quota DB fallback failed: ${String(e).slice(0, 80)}`);
-          return 'ok';
+          this.logger.debug(`Quota DB fallback failed: ${String(e).slice(0, 80)}`);
         }
-      } else {
-        // API failed but we have a previous value — keep it, log discrepancy.
-        // No update to eodhd24hCountAsOf so next call will retry the API.
-        this.logger.debug(
-          `[quota] /api/user refresh failed; keeping last known count=${this.eodhd24hCount}`,
-        );
       }
     }
 
-    const effectiveCap = this.eodhdDailyLimit + this.eodhdExtraLimit;
-    const hardCapSafe = Math.floor(effectiveCap * 0.95); // 5% marge vs cap réel
-    const warnThreshold = Math.floor(effectiveCap * 0.80);
-
-    // P19s++ HOTFIX — Bloque UNIQUEMENT si la valeur est authoritative
-    // (vient de /api/user EODHD officiel). Le DB count peut overcompter à
-    // cause des retries/failures, donc on ne bloque pas sur cette base.
-    if (this.eodhd24hCountAuthoritative && this.eodhd24hCount >= hardCapSafe) {
-      this.logger.warn(`EODHD daily quota proche (${this.eodhd24hCount}/${effectiveCap}) — blocage`);
-      return 'blocked';
-    }
-    if (this.eodhd24hCountAuthoritative && this.eodhd24hCount >= warnThreshold) return 'warn';
+    // P19u — DAILY THRESHOLD REMOVED. Le rate-limiter per-minute (étape 1)
+    // est la seule barrière. Le compteur daily reste pour /quota-status.
     return 'ok';
   }
 

--- a/apps/api/src/modules/market-data/providers/eod/eod.provider.ts
+++ b/apps/api/src/modules/market-data/providers/eod/eod.provider.ts
@@ -8,10 +8,32 @@ import { normalizeEodRealtimeQuote, normalizeEodBar } from './eod-normalizer';
 
 const BASE_URL = 'https://eodhd.com/api';
 
+/**
+ * P19u (30/04/2026 08:30 UTC HOTFIX RATE-LIMIT) — Concurrency guard +
+ * retry on 402/429 + quote cache 60s.
+ *
+ * Bug observed prod : `fetchQuotes` parallelisé via Promise.allSettled sur
+ * 9 tickers + scanner top-gainers en parallèle = burst > 1000 req/min →
+ * EODHD répond HTTP 402 (rate limit per-minute exceeded).
+ *
+ * Fix :
+ *   - Concurrency cap : max 50 calls EODHD parallèles (sema simple).
+ *   - Retry on 402/429 : exponential backoff 1s/2s/4s, max 3 tries.
+ *     Lit Retry-After header si présent.
+ *   - Cache 60s sur quotes (ETF macro bougent peu sur 1 min).
+ *   - Dédup intra-batch : si 2 calls même ticker dans le batch → 1 seul.
+ */
+const QUOTE_CACHE_TTL_MS = 60_000;
+const RETRY_DELAYS_MS = [1_000, 2_000, 4_000]; // exponential backoff
+const MAX_PARALLEL_CALLS = 50;
+
 @Injectable()
 export class EodProvider implements MarketDataProvider {
   readonly name = 'eodhd';
   private readonly logger = new Logger(EodProvider.name);
+
+  /** P19u — Cache quotes par ticker. */
+  private quoteCache = new Map<string, { quote: InstrumentQuote; asOf: number }>();
 
   constructor(private readonly config: ConfigService) {}
 
@@ -19,26 +41,90 @@ export class EodProvider implements MarketDataProvider {
     return this.config.get<string>('EODHD_API_KEY') ?? 'demo';
   }
 
+  /**
+   * P19u — Throttled fetch avec retry on 402/429.
+   * Retourne null si exhausted (toutes retries échouées).
+   */
+  private async fetchWithRetry(url: string, label: string): Promise<Response | null> {
+    for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+      const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+      if (res.ok) return res;
+      // 402 = Payment Required (daily exhausted) ou rate per-minute
+      // 429 = Too Many Requests (rate per-minute)
+      if (res.status === 402 || res.status === 429) {
+        if (attempt >= RETRY_DELAYS_MS.length) {
+          this.logger.warn(
+            `[eod:retry] ${label} HTTP ${res.status} after ${RETRY_DELAYS_MS.length} retries — giving up`,
+          );
+          return res;
+        }
+        // Lire Retry-After header (en secondes ou date HTTP)
+        const retryAfter = res.headers.get('Retry-After');
+        let delayMs = RETRY_DELAYS_MS[attempt];
+        if (retryAfter) {
+          const parsed = parseInt(retryAfter, 10);
+          if (Number.isFinite(parsed) && parsed > 0) {
+            delayMs = Math.min(parsed * 1000, 30_000); // cap 30s pour éviter blocage cron
+          }
+        }
+        this.logger.debug(
+          `[eod:retry] ${label} HTTP ${res.status} attempt ${attempt + 1}/${RETRY_DELAYS_MS.length + 1}, sleep ${delayMs}ms`,
+        );
+        await new Promise((r) => setTimeout(r, delayMs));
+        continue;
+      }
+      // Other errors : no retry
+      return res;
+    }
+    return null;
+  }
+
   async fetchQuotes(assets: ProviderAsset[]): Promise<InstrumentQuote[]> {
     if (assets.length === 0) return [];
 
-    const results: InstrumentQuote[] = [];
-    const errors: string[] = [];
+    // P19u — Dédup intra-batch + cache hit pré-fetch
+    const now = Date.now();
+    const uniqueAssets = new Map<string, ProviderAsset>();
+    for (const a of assets) {
+      if (!uniqueAssets.has(a.providerTicker)) uniqueAssets.set(a.providerTicker, a);
+    }
 
-    // EOD real-time endpoint: one call per ticker
-    await Promise.allSettled(
-      assets.map(async (asset) => {
-        try {
-          const url = `${BASE_URL}/real-time/${encodeURIComponent(asset.providerTicker)}?api_token=${this.apiKey}&fmt=json`;
-          const res = await fetch(url);
-          if (!res.ok) throw new Error(`HTTP ${res.status}`);
-          const raw: EodRealtimeQuote = await res.json();
-          results.push(normalizeEodRealtimeQuote(raw, asset));
-        } catch (err) {
-          errors.push(`${asset.ticker}: ${(err as Error).message}`);
-        }
-      }),
-    );
+    const results: InstrumentQuote[] = [];
+    const toFetch: ProviderAsset[] = [];
+    for (const [_, asset] of uniqueAssets) {
+      const cached = this.quoteCache.get(asset.providerTicker);
+      if (cached && now - cached.asOf < QUOTE_CACHE_TTL_MS) {
+        results.push(cached.quote);
+      } else {
+        toFetch.push(asset);
+      }
+    }
+
+    if (toFetch.length === 0) return results;
+
+    // P19u — Concurrency guard : process by chunks de MAX_PARALLEL_CALLS
+    const errors: string[] = [];
+    for (let i = 0; i < toFetch.length; i += MAX_PARALLEL_CALLS) {
+      const chunk = toFetch.slice(i, i + MAX_PARALLEL_CALLS);
+      await Promise.allSettled(
+        chunk.map(async (asset) => {
+          try {
+            const url = `${BASE_URL}/real-time/${encodeURIComponent(asset.providerTicker)}?api_token=${this.apiKey}&fmt=json`;
+            const res = await this.fetchWithRetry(url, asset.ticker);
+            if (!res || !res.ok) {
+              throw new Error(`HTTP ${res?.status ?? 'no_response'}`);
+            }
+            const raw: EodRealtimeQuote = await res.json();
+            const normalized = normalizeEodRealtimeQuote(raw, asset);
+            results.push(normalized);
+            // P19u — Cache fill TTL 60s
+            this.quoteCache.set(asset.providerTicker, { quote: normalized, asOf: Date.now() });
+          } catch (err) {
+            errors.push(`${asset.ticker}: ${(err as Error).message}`);
+          }
+        }),
+      );
+    }
 
     if (errors.length > 0) {
       this.logger.warn(`fetchQuotes errors: ${errors.join(', ')}`);
@@ -56,23 +142,29 @@ export class EodProvider implements MarketDataProvider {
     const results: PriceBar[] = [];
     const errors: string[] = [];
 
-    await Promise.allSettled(
-      assets.map(async (asset) => {
-        try {
-          const url =
-            `${BASE_URL}/eod/${encodeURIComponent(asset.providerTicker)}` +
-            `?api_token=${this.apiKey}&fmt=json&from=${fromDate}&to=${toDate}&period=d`;
-          const res = await fetch(url);
-          if (!res.ok) throw new Error(`HTTP ${res.status}`);
-          const bars: EodEodBar[] = await res.json();
-          for (const bar of bars) {
-            results.push(normalizeEodBar(bar, asset));
+    // P19u — Concurrency cap aussi sur fetchDailyBars
+    for (let i = 0; i < assets.length; i += MAX_PARALLEL_CALLS) {
+      const chunk = assets.slice(i, i + MAX_PARALLEL_CALLS);
+      await Promise.allSettled(
+        chunk.map(async (asset) => {
+          try {
+            const url =
+              `${BASE_URL}/eod/${encodeURIComponent(asset.providerTicker)}` +
+              `?api_token=${this.apiKey}&fmt=json&from=${fromDate}&to=${toDate}&period=d`;
+            const res = await this.fetchWithRetry(url, asset.ticker);
+            if (!res || !res.ok) {
+              throw new Error(`HTTP ${res?.status ?? 'no_response'}`);
+            }
+            const bars: EodEodBar[] = await res.json();
+            for (const bar of bars) {
+              results.push(normalizeEodBar(bar, asset));
+            }
+          } catch (err) {
+            errors.push(`${asset.ticker}: ${(err as Error).message}`);
           }
-        } catch (err) {
-          errors.push(`${asset.ticker}: ${(err as Error).message}`);
-        }
-      }),
-    );
+        }),
+      );
+    }
 
     if (errors.length > 0) {
       this.logger.warn(`fetchDailyBars errors: ${errors.join(', ')}`);


### PR DESCRIPTION
## 🚨 Hotfix prod — HTTP 402 = burst > 1000 req/min

User clarification critique : EODHD limite RÉELLEMENT au **rate per-minute (1000 req/min)**, pas au daily 100k. HTTP 402 observé prod = burst > 1000/min, **self-DOS interne**.

## Root cause chiffrée

UI poll `/lisa/gainers-persistence-snapshot` toutes les 60s :
- × `analyzeBatch` top 20 tickers
- × intraday endpoint coûte **5 API calls** par request (per EODHD doc)
- = **100 calls / 60s** en spike — sur 11 exchanges scanner en parallèle, dépasse 1000/min

EODHD répond 402 → 9 tickers fail (XLE, TLT, PPLT, LMT, URA, SLV, IWM, GDX, CPER).

## Fix — 5 changements

### 1. `realtime-price.service.ts` — Remove daily 100k blocker

`canCallEodhd()` ne bloque plus sur le daily threshold. La **sliding window per-minute** (déjà en place à 900/min, 10% marge sous 1000) reste la SEULE barrière. Compteur daily conservé pour observability.

### 2. `eod.provider.ts` — Retry 402/429 + concurrency cap + cache 60s

- **`fetchWithRetry()`** : exponential backoff 1s/2s/4s sur 402/429, max 3 tries. Lit `Retry-After` header si présent (cap 30s).
- **`MAX_PARALLEL_CALLS = 50`** : process par chunks (avant : `Promise.allSettled` sur tout le batch sans cap, burst incontrôlé).
- **`quoteCache` TTL 60s** : ETF macro bougent peu sur 1 min.
- **Dédup intra-batch** : si même ticker demandé 2x → 1 seul appel.

### 3. `multi-tf-persistence.service.ts` — Cache TTL 30s → 5min

Intraday EODHD coûte 5x. Bump CACHE_TTL_MS 30s → 5min réduit burn **-90% sur ce path**. Candles 5m intraday changent peu sur 5 min (1 nouvelle candle max).

## Tests (831/831 verts)

```
Test Suites: 73 passed, 73 total
Tests:       831 passed, 831 total
```

Suite complète API : 0 régression.

## Smoke prod (post-deploy)

```bash
# Plus de 402 (retries auto + cache absorbe les bursts)
fly logs -a smartvest --since 5m | grep "HTTP 402"
# DOIT être vide

# Plus de blocage daily faux positif
fly logs -a smartvest --since 5m | grep "EODHD daily quota proche"
# DOIT être vide

# Rate-limit per-minute toujours actif (en cas de vrai burst > 900/min)
fly logs -a smartvest --since 5m | grep "EODHD rate limit proche"
# Présent UNIQUEMENT si vrai burst (auto-throttle)
```

## Hors scope (P19v follow-up)

- Centraliser rate limiter via shared semaphore cross-services
- Cost-aware tracking par endpoint (intraday=5, fundamentals=10 weights)
- Header `X-RateLimit-Remaining` EODHD reconciliation pour visibilité live

## Activation

User a dit "Action-Réaction, je merge dès CI vert". Pas de review humaine requise.

⏸ **Awaiting CI green + user merge.**

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_