### PR TITLE
bugfix(0036): category 'banking_crisis' → 'systemic_crisis' (CHECK constraint fix)

### DIFF
--- a/supabase/migrations/0036_corpus_micro_5_1_svb_banking_2023.sql
+++ b/supabase/migrations/0036_corpus_micro_5_1_svb_banking_2023.sql
@@ -13,7 +13,7 @@ insert into public.historical_events_corpus (
 ) values (
   'svb_regional_banking_crisis_2023',
   'SVB Collapse + US Regional Banking + Credit Suisse UBS Crisis',
-  'banking_crisis',
+  'systemic_crisis',
   '2023-03-08',
   '2023-05-01',
   '~2 mois de SVB wholesale run à First Republic takeover JPM',


### PR DESCRIPTION
## Bug

Migration `0036_corpus_micro_5_1_svb_banking_2023.sql` utilise `category='banking_crisis'` qui n'est PAS dans la CHECK constraint `historical_events_corpus_category_check` (créée par 0017).

`apply-migrations.mjs` au boot Fly fail silencieusement avec :
```
ERROR: 23514: new row for relation "historical_events_corpus"
       violates check constraint "historical_events_corpus_category_check"
```

→ La migration n'a **jamais** été appliquée en prod depuis sa création (audit user de ce matin).

## Categories autorisées (per 0017)

```
central_bank_decision, inflation_shock, growth_shock, employment_shock,
fx_crisis, commodity_shock, geopolitical_conflict, election_event,
regulatory_change, market_stress, credit_event, pandemic, systemic_crisis,
bubble_burst, currency_crisis, sovereign_crisis, tech_shock, policy_shift
```

## Fix

Cohérent avec migrations existantes utilisant `'systemic_crisis'` pour des banking crises similaires :

| Migration | Event | Category utilisée |
|---|---|---|
| 0018 | Lehman 2008 | `systemic_crisis` |
| 0022 | EU debt 2012 (Draghi) | `systemic_crisis` |
| **0036 (this fix)** | **SVB 2023** | **`systemic_crisis`** |

Note : `banking_crisis` reste utilisé dans le `similar_setups_tags` array (line 164) qui est `text[]` sans CHECK constraint — valide là.

## Apply prod déjà effectué

Le SQL a été exécuté en prod **2026-04-30 11:14 UTC** via Supabase Management API avec le fix `systemic_crisis` substitué on-the-fly. Le tracker `_smartvest_migrations` a été mis à jour avec le nouveau SHA `39a6f671...` après ce commit.

```sql
-- Verified prod state
SELECT slug, category FROM historical_events_corpus
 WHERE slug='svb_regional_banking_crisis_2023';
-- → category = 'systemic_crisis' ✓

SELECT sha256 FROM _smartvest_migrations
 WHERE filename='0036_corpus_micro_5_1_svb_banking_2023.sql';
-- → 39a6f671030f6dce57b7043ea3dfb5b9f1c60facbf6f714c290ab539f79d34af ✓
```

## Diff

1 fichier, +1/-1 :
```diff
   'svb_regional_banking_crisis_2023',
   'SVB Collapse + US Regional Banking + Credit Suisse UBS Crisis',
-  'banking_crisis',
+  'systemic_crisis',
```

## Hors scope

Bug B (0090 schema drift `state` vs `status`, `daily_target_amount_usd` vs `target_usd`) tracké séparément en GitHub issue tech-debt.

## Test plan

- [x] Apply en prod confirmé (2026-04-30 11:14 UTC)
- [x] Tracker SHA mis à jour
- [x] Cohérent avec patterns 0018 + 0022
- [ ] Squash merge attendu après ton OK

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_