### PR TITLE
feat(llm-arch): Phase 1 — Scanner chain simplifiée Gemini Flash Lite + Opus fallback (ADR-001)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/scanner-llm-router.adr001-phase1.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/scanner-llm-router.adr001-phase1.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * ADR-001 Phase 1 (30/04/2026) — Tests for scanner LLM router chain
+ * simplification.
+ *
+ * Per ADR-001 :
+ *   - Scanner uses Gemini 2.5 Flash Lite as PRIMARY
+ *   - Claude Opus 4.7 as FALLBACK ULTIME ONLY (no intermediate)
+ *   - OpenAI + Mistral REMOVED from chain (suppression scope simplification)
+ *
+ * Cf. docs/decision_records/ADR-001-llm-architecture.md
+ */
+
+import { Logger } from '@nestjs/common';
+import { ScannerLlmRouterService } from '../services/scanner-llm-router.service';
+
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+function makeConfig(overrides: Record<string, string | undefined>) {
+  return {
+    get: jest.fn((key: string) => overrides[key]),
+  } as any;
+}
+
+describe('ScannerLlmRouterService — ADR-001 Phase 1 chain simplification', () => {
+  it('router is INACTIVE when SCANNER_LLM_ROUTER_ENABLED=false (default)', () => {
+    const config = makeConfig({
+      SCANNER_LLM_ROUTER_ENABLED: 'false',
+      ANTHROPIC_API_KEY: 'sk-ant-test',
+      GEMINI_API_KEY: 'gemini-test-key',
+    });
+    const svc = new ScannerLlmRouterService(config);
+    expect(svc.isEnabled()).toBe(false);
+  });
+
+  it('router activates with Gemini + Claude when flag=true and both keys present', () => {
+    const config = makeConfig({
+      SCANNER_LLM_ROUTER_ENABLED: 'true',
+      ANTHROPIC_API_KEY: 'sk-ant-test',
+      GEMINI_API_KEY: 'gemini-test-key',
+    });
+    const svc = new ScannerLlmRouterService(config);
+    expect(svc.isEnabled()).toBe(true);
+  });
+
+  it('router activates with Gemini ONLY when ANTHROPIC_API_KEY missing', () => {
+    const config = makeConfig({
+      SCANNER_LLM_ROUTER_ENABLED: 'true',
+      GEMINI_API_KEY: 'gemini-test-key',
+    });
+    const svc = new ScannerLlmRouterService(config);
+    expect(svc.isEnabled()).toBe(true);
+  });
+
+  it('router DISABLES when flag=true but GEMINI_API_KEY missing AND ANTHROPIC_API_KEY missing', () => {
+    const config = makeConfig({
+      SCANNER_LLM_ROUTER_ENABLED: 'true',
+    });
+    const svc = new ScannerLlmRouterService(config);
+    expect(svc.isEnabled()).toBe(false);
+  });
+
+  it('call() throws when router disabled', async () => {
+    const config = makeConfig({ SCANNER_LLM_ROUTER_ENABLED: 'false' });
+    const svc = new ScannerLlmRouterService(config);
+    await expect(
+      svc.call({ system: 'sys', user: 'usr' } as any),
+    ).rejects.toThrow(/router disabled/);
+  });
+
+  it('ADR-001 invariant : OPENAI_API_KEY and MISTRAL_API_KEY are NOT consulted (chain simplifiée)', () => {
+    // Si openAI/mistral étaient encore dans la chain, le config.get serait
+    // appelé avec ces clés. Ce test vérifie qu'ils ne le sont pas.
+    const calls: string[] = [];
+    const config = {
+      get: jest.fn((key: string) => {
+        calls.push(key);
+        if (key === 'SCANNER_LLM_ROUTER_ENABLED') return 'true';
+        if (key === 'GEMINI_API_KEY') return 'gemini-test-key';
+        if (key === 'ANTHROPIC_API_KEY') return 'sk-ant-test';
+        return undefined;
+      }),
+    } as any;
+    new ScannerLlmRouterService(config);
+    expect(calls).toContain('GEMINI_API_KEY');
+    expect(calls).toContain('ANTHROPIC_API_KEY');
+    expect(calls).not.toContain('OPENAI_API_KEY');
+    expect(calls).not.toContain('MISTRAL_API_KEY');
+  });
+});

--- a/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
+++ b/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
@@ -1,15 +1,19 @@
 /**
- * P17 — ScannerLlmRouterService — wrapping NestJS du MultiVendorLlmRouter.
+ * P17 + ADR-001 (30/04/2026) — ScannerLlmRouterService.
  *
  * Service injectable qui :
  *   - Lit les API keys depuis ConfigService (.env)
- *   - Construit la chaîne fallback : Gemini Flash-Lite → GPT-4.1-nano → Codestral → Claude
+ *   - Construit la chain SIMPLIFIÉE per ADR-001 :
+ *       Gemini 2.5 Flash Lite (primary) → Claude Opus 4.7 (fallback ultime)
+ *   - Suppression OpenAI + Mistral (réduction surface providers)
  *   - Gate le routing derrière le feature flag SCANNER_LLM_ROUTER_ENABLED
  *   - Loggue chaque appel (provider, model, latencyMs, costUsd, fallbackUsed)
  *   - Auto-désactive si le flag est off OU si aucun provider n'est configuré
  *
  * Cf. bench P16 — Gemini Flash-Lite gagne avec composite 0.66, $0.00011/prompt
  * (-99.3% vs Claude Sonnet 4.5 sur la tâche de sélection scanner).
+ *
+ * Cf. docs/decision_records/ADR-001-llm-architecture.md
  */
 
 import { Injectable, Logger } from '@nestjs/common';
@@ -18,8 +22,6 @@ import Anthropic from '@anthropic-ai/sdk';
 import {
   MultiVendorLlmRouter,
   GeminiProvider,
-  OpenAiProvider,
-  MistralProvider,
   ClaudeProvider,
   type LlmCallParams,
   type MultiVendorCallMetrics,
@@ -40,16 +42,17 @@ export class ScannerLlmRouterService {
       return;
     }
 
+    // ADR-001 — Chain simplifiée : Gemini primary + Claude Opus fallback ultime.
+    // Suppression OpenAI + Mistral (était P17 fallback chain) : ne sont plus
+    // dans le contrat d'archi LLM. Réduit la surface providers à 2 (Google + Anthropic).
     const anthropicKey = this.config.get<string>('ANTHROPIC_API_KEY');
-    const claudeChain = anthropicKey
+    const claudeFallback = anthropicKey
       ? [new ClaudeProvider({ anthropic: new Anthropic({ apiKey: anthropicKey }) })]
       : [];
 
     const chain = [
       new GeminiProvider({ apiKey: this.config.get<string>('GEMINI_API_KEY') }),
-      new OpenAiProvider({ apiKey: this.config.get<string>('OPENAI_API_KEY') }),
-      new MistralProvider({ apiKey: this.config.get<string>('MISTRAL_API_KEY') }),
-      ...claudeChain,
+      ...claudeFallback,
     ];
 
     try {
@@ -79,7 +82,7 @@ export class ScannerLlmRouterService {
    */
   async call(params: LlmCallParams): Promise<{ content: string; providerId: string; costUsd: number; latencyMs: number; fallbackUsed: boolean }> {
     if (!this.router) {
-      throw new Error('ScannerLlmRouterService.call() — router disabled (check SCANNER_LLM_ROUTER_ENABLED + API keys)');
+      throw new Error('ScannerLlmRouterService.call() — router disabled (check SCANNER_LLM_ROUTER_ENABLED + GEMINI_API_KEY)');
     }
     const res = await this.router.call(params);
     return {


### PR DESCRIPTION
## Contexte — ADR-001 Phase 1

Per **ADR-001** (commited direct main `a55de24` ce matin) :
- **Opus 4.7** = UNIQUEMENT décision finale (`thesis_generation`)
- **Gemini 2.5 Flash Lite** = TOUT LE RESTE (scanner, news, regime, binary, audit, summary…)
- **Plus aucun call** Sonnet, Haiku, OpenAI, Mistral

Cette PR est **Phase 1** : simplification chain scanner gainers.

## Diff

### `apps/api/src/modules/lisa/services/scanner-llm-router.service.ts`

```diff
-import {
-  MultiVendorLlmRouter,
-  GeminiProvider,
-  OpenAiProvider,    // ❌ retiré chain
-  MistralProvider,   // ❌ retiré chain
-  ClaudeProvider,
-  ...
-} from '@smartvest/ai-analyst';

+import {
+  MultiVendorLlmRouter,
+  GeminiProvider,
+  ClaudeProvider,
+  ...
+} from '@smartvest/ai-analyst';

-    const chain = [
-      new GeminiProvider({ apiKey: ... }),
-      new OpenAiProvider({ apiKey: ... }),    // ❌
-      new MistralProvider({ apiKey: ... }),   // ❌
-      ...claudeChain,
-    ];

+    const chain = [
+      new GeminiProvider({ apiKey: ... }),
+      ...claudeFallback,
+    ];
```

→ **Chain simplifiée à 2 providers** : Google Gemini (primary) → Anthropic Claude (fallback ultime).

Provider classes `OpenAiProvider` + `MistralProvider` restent dans `@smartvest/ai-analyst/src/llm/providers/` pour cette PR (suppression complète en **Phase 4 cleanup** — minimise diff Phase 1).

### Nouveau test `scanner-llm-router.adr001-phase1.spec.ts`

6 cas testés :
- Router inactive flag=false (default)
- Router active avec Gemini + Claude
- Router active avec Gemini ONLY (no Anthropic)
- Router disabled si aucune key
- `call()` throw si disabled
- **ADR-001 invariant** : `OPENAI_API_KEY` + `MISTRAL_API_KEY` jamais consultés

## Tests

```
PASS  src/modules/lisa/__tests__/scanner-llm-router.adr001-phase1.spec.ts (6/6)
Test Suites: 74 passed, 74 total
Tests:       837 passed, 837 total
```

Suite complète **+6 tests, 0 régression**.

## Activation post-merge — actions Fly secrets (côté user)

```bash
# 1. Activate scanner LLM router
flyctl secrets set SCANNER_LLM_ROUTER_ENABLED=true -a smartvest

# 2. Cleanup secrets obsolètes (chain simplifiée)
flyctl secrets unset OPENAI_API_KEY MISTRAL_API_KEY \
                     CLAUDE_MODEL_SONNET CLAUDE_MODEL_HAIKU -a smartvest

# 3. Verify (GEMINI_API_KEY + ANTHROPIC_API_KEY déjà set per user check)
flyctl secrets list -a smartvest | grep -E "GEMINI|ANTHROPIC|SCANNER_LLM"
```

## Smoke test post-deploy

```bash
fly logs -a smartvest --since 5m | grep "scanner-llm.*provider="
# Attendu: "provider=gemini-2.5-flash-lite" sur analyzeSignal / rankCandidates / generateThesis
```

```bash
# Vérifier qu'aucun call OpenAI/Mistral ne se déclenche
fly logs -a smartvest --since 30m | grep -E "openai|mistral|gpt-|codestral"
# Attendu: vide
```

## Rollback rapide

```bash
flyctl secrets unset SCANNER_LLM_ROUTER_ENABLED -a smartvest
# → Retour legacy Claude-only path scanner
```

## Phases suivantes (PRs séparées, après ce merge)

- **Phase 2** : `NewsClassification` + `Summary` tasks → Gemini direct, fallback Opus
- **Phase 3** : `regime_classification` + `binary_decision` + `audit_explanation` → Gemini, suppression `claude-sonnet-4-6` + `claude-haiku-4-5*` du `MODEL_BY_TASK`
- **Phase 4** : Cleanup `OpenAiProvider` + `MistralProvider` classes (code mort), update ADR-001 final state

## Caveat sandbox agent

Je ne peux **pas** exécuter `flyctl secrets set` depuis le sandbox (auth Fly absente, mêmes limites toute la session). Les commandes ci-dessus sont à exécuter par toi post-merge. CI verte + merge → toi tu fais le set/unset secrets → smoke test → confirmation.

## Liens

- **ADR-001** : `docs/decision_records/ADR-001-llm-architecture.md` (commit `a55de24` main)
- Bench source : workflow `bench-scanner-eu` (commits `b9fe782`, `f0e33c0`)
- P17 origin : commit `e2f2594`

⏸ **DRAFT — ne pas merger avant ton GO + Fly secrets prêts.**

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_