### PR TITLE
feat(llm-arch): Phase 2 — cleanup LlmRouter dead code (ADR-001)

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -929,8 +929,9 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     // router lisait l'env var statique au lieu de la config DB).
     // - daily_cost_budget_usd : budget cumulé en USD (null = pas d'override,
     //   le router applique sa config constructor / env LLM_ROUTER_DAILY_BUDGET_USD)
-    // - cost_force_continue : à 100% du budget, soft warn + Haiku (true,
-    //   default DB via migration 0074) ou hard throw (false, mode strict)
+    // - cost_force_continue : à 100% du budget, soft warn + continue Opus
+    //   (true, default DB via migration 0074, ADR-001 Phase 2 — plus de
+    //   fallback Haiku) ou hard throw (false, mode strict)
     const budgetOverride = config.daily_cost_budget_usd != null
       ? Number(config.daily_cost_budget_usd)
       : undefined;

--- a/docs/decision_records/ADR-001-llm-architecture.md
+++ b/docs/decision_records/ADR-001-llm-architecture.md
@@ -79,18 +79,18 @@ Code mort à supprimer dans phase 4.
 
 | Phase | Scope | PR | Status |
 |---|---|---|---|
-| **Phase 0** | ADR-001 (ce document) | commit direct main | ⏳ |
-| **Phase 1** | Scanner gainers Gemini-primaire + flag activé en prod | PR dédiée, feature flag rollback | ⏳ |
-| **Phase 2** | News classification + summary tasks → Gemini | PR dédiée | ⏳ |
-| **Phase 3** | regime_classification + binary_decision + audit_explanation → Gemini ; suppression Sonnet/Haiku des MODEL_BY_TASK | PR dédiée | ⏳ |
-| **Phase 4** | Cleanup code mort (claude-sonnet-4-6, claude-haiku-4-5*, OpenAI provider, Mistral provider) | PR dédiée | ⏳ |
+| **Phase 0** | ADR-001 (ce document) | commit `a55de24` direct main | ✅ |
+| **Phase 1** | Scanner gainers Gemini-primaire + flag activé en prod | PR #148 squash `8bc094d` | ✅ |
+| **Phase 2** | Cleanup `LlmRouter` multi-task : `LlmTask` réduit à `'thesis_generation'`, `MODEL_BY_TASK` à 1 entrée Opus, `COST_PER_1M_TOKENS_*` à Opus only, fallback Haiku 80%/100% supprimé (remplacé par soft-warn + continue Opus), `ClaudeProvider` basé sur Opus (était Sonnet) per ADR §1.4. **Note** : aucun call site `news_classification`/`summary` câblé runtime — pas de migration, juste suppression de code mort + correction du fallback Haiku cassé après Phase 1 unset. | PR `feat/llm-arch-phase2-cleanup-dead-code` | ⏳ |
+| **Phase 3** | regime_classification + binary_decision + audit_explanation → Gemini si call sites apparaissent ; sinon **NO-OP** (déjà supprimés en Phase 2) | n/a | ☑️ inclus dans Phase 2 |
+| **Phase 4** | Cleanup `OpenAiProvider` + `MistralProvider` classes (code mort dans `@smartvest/ai-analyst/src/llm/providers/`) | PR dédiée | ⏳ |
 
 ## 4. Migration sans downtime
 
 Chaque phase est un **toggle réversible** :
 - Phase 1 : `SCANNER_LLM_ROUTER_ENABLED=true` (rollback : `=false`)
-- Phase 2 : `NEWS_LLM_PROVIDER=gemini` (rollback : `=claude` ; default avant migration)
-- Phase 3 : nouveaux flags `REGIME_LLM_PROVIDER`, `BINARY_LLM_PROVIDER`, `AUDIT_LLM_PROVIDER`
+- Phase 2 : pas de flag (cleanup code mort, pas de feature toggle). Rollback = `git revert`
+- Phase 3 : NO-OP (subsumé par Phase 2). Si futur call site Gemini ajouté, il passera par `MultiVendorLlmRouter`, pas par `LlmRouter`
 - Phase 4 : suppression code, plus de toggle. À ce stade, validation 7+ jours prod nécessaire
 
 ## 5. Annexes
@@ -116,10 +116,10 @@ Chaque phase est un **toggle réversible** :
 | `ANTHROPIC_API_KEY` | (set) | requis Opus + fallback ultime |
 | `GEMINI_API_KEY` | **à set Phase 1** | requis pour tout sauf thesis |
 | `SCANNER_LLM_ROUTER_ENABLED` | `false` → `true` Phase 1 | active routing scanner |
-| `NEWS_LLM_PROVIDER` | (à créer Phase 2) | `gemini` ou `claude` |
-| `REGIME_LLM_PROVIDER` | (à créer Phase 3) | idem |
-| `BINARY_LLM_PROVIDER` | (à créer Phase 3) | idem |
-| `AUDIT_LLM_PROVIDER` | (à créer Phase 3) | idem |
+| ~~`NEWS_LLM_PROVIDER`~~ | (Phase 2 a supprimé l'enum multi-task — flag inutile, pas de call site à toggler) | n/a |
+| ~~`REGIME_LLM_PROVIDER`~~ | (idem) | n/a |
+| ~~`BINARY_LLM_PROVIDER`~~ | (idem) | n/a |
+| ~~`AUDIT_LLM_PROVIDER`~~ | (idem) | n/a |
 | ~~`OPENAI_API_KEY`~~ | (à unset Phase 4) | code mort |
 | ~~`MISTRAL_API_KEY`~~ | (à unset Phase 4) | code mort |
 | ~~`CLAUDE_MODEL_SONNET`~~ | (à unset Phase 4) | code mort |

--- a/packages/ai-analyst/src/claude/client.ts
+++ b/packages/ai-analyst/src/claude/client.ts
@@ -34,12 +34,12 @@ export interface ClaudeCallOptions {
    *  relire `lisa_session_configs.daily_cost_budget_usd` à chaque cycle.
    *  Si undefined, fallback sur le budget constructor du LlmRouter. */
   budgetUsd?: number;
-  /** P0-A — Override per-call du flag soft-budget. À 100% du budget :
-   *  - `true` (default DB) : fallback Haiku + warn loggué
+  /** P0-A + ADR-001 Phase 2 — Override per-call du flag soft-budget. À 100% du budget :
+   *  - `true` (default DB) : soft warn + continue Opus (audit-flagged over-budget)
    *  - `false` : throw `BudgetExceededError`
-   *  Si undefined, fallback sur la config constructor du LlmRouter
-   *  (par défaut `false` pour préserver le comportement legacy PR #15
-   *  des call sites qui n'ont pas migré). */
+   *  Si undefined, fallback sur la config constructor du LlmRouter.
+   *  ADR-001 Phase 2 : plus de fallback Haiku (interdit), `forceContinue=true`
+   *  paie le dépassement léger plutôt que dégrader la qualité de la thèse. */
   forceContinue?: boolean;
 }
 
@@ -231,17 +231,20 @@ export class LisaClaudeClient {
    * cette méthode reste utile aux callers qui veulent un coût précis
    * incluant les économies cache_read/cache_write.
    *
-   * Pricing Sonnet 4.6 (à date) :
-   *  - Input : $3 / 1M tokens
-   *  - Output : $15 / 1M tokens
-   *  - Cache write : $3.75 / 1M tokens (1.25x input)
-   *  - Cache read : $0.30 / 1M tokens (0.1x input — économie ~90%)
+   * **ADR-001 Phase 2 (30/04/2026)** : `LisaClaudeClient` n'est utilisé que
+   * pour `thesis_generation` (Opus 4.7). Le pricing reflète Opus.
+   *
+   * Pricing Opus 4.7 (snapshot 30/04/2026) :
+   *  - Input : $15 / 1M tokens
+   *  - Output : $75 / 1M tokens
+   *  - Cache write : $18.75 / 1M tokens (1.25× input)
+   *  - Cache read : $1.50 / 1M tokens (0.1× input — économie ~90%)
    */
   static estimateCostUsd(usage: ClaudeCallResult['usage']): number {
-    const INPUT_PER_M = 3;
-    const OUTPUT_PER_M = 15;
-    const CACHE_WRITE_PER_M = 3.75;
-    const CACHE_READ_PER_M = 0.30;
+    const INPUT_PER_M = 15;
+    const OUTPUT_PER_M = 75;
+    const CACHE_WRITE_PER_M = 18.75;
+    const CACHE_READ_PER_M = 1.50;
 
     const nonCachedInput = usage.inputTokens;
     const cacheWrite = usage.cacheCreationInputTokens ?? 0;

--- a/packages/ai-analyst/src/llm/__tests__/llm-router.spec.ts
+++ b/packages/ai-analyst/src/llm/__tests__/llm-router.spec.ts
@@ -1,12 +1,18 @@
 /**
- * PATCH 6 P1 cost-01-llm-router — Tests du LlmRouter centralisé.
+ * ADR-001 Phase 2 (30/04/2026) — Tests du LlmRouter post-cleanup.
+ *
+ * Le router est désormais single-task (`thesis_generation` → Opus). Les
+ * variantes Sonnet/Haiku ont été supprimées du `LlmTask` enum + du
+ * `MODEL_BY_TASK` mapping + du COST_PER_1M_TOKENS_*. Le fallback Haiku au
+ * 80%/100% budget est remplacé par un soft-warn + continue avec Opus.
  *
  * Vérifie le contrat :
- *  - Mapping tâche → modèle (Opus / Sonnet / Haiku)
- *  - Override env var
- *  - Circuit breaker à 80% budget (fallback Sonnet ou throw selon flag)
- *  - Hard-stop à 100% budget (throw quel que soit le modèle)
- *  - Calcul de coût (input + output)
+ *  - Mapping `thesis_generation` → Opus (1 seule entrée)
+ *  - Override env var `CLAUDE_MODEL_OPUS`
+ *  - 80% budget : soft warn + continue Opus si `fallbackOnBudget=true`,
+ *    sinon throw `BudgetExceededError`
+ *  - 100% budget : throw par défaut, soft continue Opus si `forceContinue=true`
+ *  - Calcul de coût (input + output) sur Opus
  *  - Persistance via CostTracker.record() après success
  *  - Validateur boot-time (modèle inconnu → throw au constructeur)
  */
@@ -20,7 +26,6 @@ import {
   COST_PER_1M_TOKENS_OUTPUT,
   CostTracker,
   LlmRouter,
-  LlmTask,
   MODEL_BY_TASK,
 } from '../router';
 
@@ -84,7 +89,7 @@ const baseParams = {
 
 // ────────────────────────────────────────────────────────────────────
 
-describe('LlmRouter — mapping tâche → modèle', () => {
+describe('LlmRouter — mapping single-task (ADR-001 Phase 2)', () => {
   it('routes thesis_generation to Opus model ID', async () => {
     const { client, create } = makeAnthropic();
     create.mockResolvedValue(fakeMessage({ model: 'claude-opus-4-7' }));
@@ -99,63 +104,24 @@ describe('LlmRouter — mapping tâche → modèle', () => {
     expect(result.fallback).toBe(false);
   });
 
-  it('routes news_classification to Haiku model ID', async () => {
-    const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ model: 'claude-haiku-4-5-20251001' }));
-    const { tracker } = makeCostTracker(0);
-    const router = new LlmRouter(client, tracker, { dailyCostBudgetUsd: 100, fallbackOnBudget: true });
-
-    await router.call('news_classification', baseParams);
-
-    expect(create.mock.calls[0][0].model).toBe('claude-haiku-4-5-20251001');
+  it('MODEL_BY_TASK contains exactly one entry: thesis_generation → Opus', () => {
+    expect(Object.keys(MODEL_BY_TASK)).toEqual(['thesis_generation']);
+    expect(MODEL_BY_TASK.thesis_generation).toMatch(/opus/);
   });
 
-  it('routes regime_classification + binary_decision + audit_explanation to Sonnet', async () => {
-    const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ model: 'claude-sonnet-4-6' }));
-    const { tracker } = makeCostTracker(0);
-    const router = new LlmRouter(client, tracker, { dailyCostBudgetUsd: 100, fallbackOnBudget: true });
-
-    const tasks: LlmTask[] = ['regime_classification', 'binary_decision', 'audit_explanation'];
-    for (const t of tasks) {
-      create.mockClear();
-      await router.call(t, baseParams);
-      expect(create.mock.calls[0][0].model).toBe('claude-sonnet-4-6');
-    }
-  });
-
-  it('routes summary to Haiku', async () => {
-    const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage());
-    const { tracker } = makeCostTracker(0);
-    const router = new LlmRouter(client, tracker, { dailyCostBudgetUsd: 100, fallbackOnBudget: true });
-
-    await router.call('summary', baseParams);
-    expect(create.mock.calls[0][0].model).toBe('claude-haiku-4-5-20251001');
-  });
-});
-
-describe('LlmRouter — env var override', () => {
-  it('respects MODEL_BY_TASK at module load time (env var set before import)', () => {
-    // Snapshot du mapping courant — vérifie qu'il est bien constructed depuis
-    // process.env au load time. Smoke test : tous les défauts sont des IDs
-    // connus de la table de coût.
+  it('respects CLAUDE_MODEL_OPUS env var at module load time', () => {
     const KNOWN = new Set(Object.keys(COST_PER_1M_TOKENS_INPUT));
     for (const model of Object.values(MODEL_BY_TASK)) {
       expect(KNOWN.has(model)).toBe(true);
     }
-    // Si CLAUDE_MODEL_OPUS était set côté env d'exécution, le mapping le
-    // reflète. On ne peut pas re-importer le module pour tester un override
-    // dynamique sans jest.isolateModules — couvert par le validateur boot.
-    expect(MODEL_BY_TASK.thesis_generation).toMatch(/opus/);
   });
 });
 
-describe('LlmRouter — circuit breaker à 80% budget (Opus → Haiku fallback)', () => {
-  it('falls back to HAIKU (P0-A change, ex-Sonnet) when budget>=80% AND task is Opus AND fallbackOnBudget=true', async () => {
+describe('LlmRouter — 80% budget threshold (Opus continue or throw)', () => {
+  it('soft warn + continue Opus at 85% with fallbackOnBudget=true', async () => {
     const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ model: 'claude-haiku-4-5-20251001' }));
-    const { tracker, record } = makeCostTracker(85); // 85$ déjà consommé
+    create.mockResolvedValue(fakeMessage({ model: 'claude-opus-4-7' }));
+    const { tracker, record } = makeCostTracker(85);
     const { logger, warn } = makeAuditLogger();
     const router = new LlmRouter(
       client,
@@ -166,55 +132,23 @@ describe('LlmRouter — circuit breaker à 80% budget (Opus → Haiku fallback)'
 
     const result = await router.call('thesis_generation', baseParams);
 
-    expect(create.mock.calls[0][0].model).toBe('claude-haiku-4-5-20251001');
-    expect(result.modelUsed).toBe('claude-haiku-4-5-20251001');
-    expect(result.fallback).toBe(true);
-    expect(result.fallbackReason).toBe('budget_80pct_haiku');
+    expect(create.mock.calls[0][0].model).toBe('claude-opus-4-7');
+    expect(result.modelUsed).toBe('claude-opus-4-7');
+    expect(result.fallback).toBe(false);
     expect(warn).toHaveBeenCalledWith(
-      'opus_haiku_fallback',
+      'cost_budget_warn_80pct',
       expect.objectContaining({
         task: 'thesis_generation',
-        originalModel: 'claude-opus-4-7',
-        fallbackModel: 'claude-haiku-4-5-20251001',
+        model: 'claude-opus-4-7',
         todayCostUsd: 85,
         budgetUsd: 100,
       }),
     );
     expect(record).toHaveBeenCalledTimes(1);
-    expect(record.mock.calls[0][0].model).toBe('claude-haiku-4-5-20251001');
+    expect(record.mock.calls[0][0].model).toBe('claude-opus-4-7');
   });
 
-  it('does NOT fall back when task is not Opus (Sonnet stays Sonnet at 85%)', async () => {
-    const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ model: 'claude-sonnet-4-6' }));
-    const { tracker } = makeCostTracker(85);
-    const router = new LlmRouter(client, tracker, {
-      dailyCostBudgetUsd: 100,
-      fallbackOnBudget: true,
-    });
-
-    const result = await router.call('regime_classification', baseParams);
-
-    expect(create.mock.calls[0][0].model).toBe('claude-sonnet-4-6');
-    expect(result.fallback).toBe(false);
-  });
-
-  it('does NOT fall back when budget is below 80% (Opus stays Opus at 75%)', async () => {
-    const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage());
-    const { tracker } = makeCostTracker(75);
-    const router = new LlmRouter(client, tracker, {
-      dailyCostBudgetUsd: 100,
-      fallbackOnBudget: true,
-    });
-
-    const result = await router.call('thesis_generation', baseParams);
-
-    expect(create.mock.calls[0][0].model).toBe('claude-opus-4-7');
-    expect(result.fallback).toBe(false);
-  });
-
-  it('throws BudgetExceededError on Opus task when fallbackOnBudget=false at 85%', async () => {
+  it('throws BudgetExceededError at 85% when fallbackOnBudget=false', async () => {
     const { client, create } = makeAnthropic();
     const { tracker, record } = makeCostTracker(85);
     const router = new LlmRouter(client, tracker, {
@@ -227,21 +161,44 @@ describe('LlmRouter — circuit breaker à 80% budget (Opus → Haiku fallback)'
     expect(record).not.toHaveBeenCalled();
   });
 
-  it('lets Sonnet/Haiku tasks pass at 85% even when fallbackOnBudget=false', async () => {
+  it('does NOT trigger 80% path when budget is below 80% (Opus stays at 75%)', async () => {
     const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ model: 'claude-sonnet-4-6' }));
+    create.mockResolvedValue(fakeMessage());
+    const { tracker } = makeCostTracker(75);
+    const { logger, warn } = makeAuditLogger();
+    const router = new LlmRouter(
+      client,
+      tracker,
+      { dailyCostBudgetUsd: 100, fallbackOnBudget: true },
+      logger,
+    );
+
+    const result = await router.call('thesis_generation', baseParams);
+
+    expect(create.mock.calls[0][0].model).toBe('claude-opus-4-7');
+    expect(result.fallback).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('forceContinue=true bypasses fallbackOnBudget=false at 80%', async () => {
+    const { client, create } = makeAnthropic();
+    create.mockResolvedValue(fakeMessage());
     const { tracker } = makeCostTracker(85);
     const router = new LlmRouter(client, tracker, {
       dailyCostBudgetUsd: 100,
       fallbackOnBudget: false,
     });
 
-    await expect(router.call('regime_classification', baseParams)).resolves.toBeDefined();
+    // Sans forceContinue → throw (couvert plus haut). Avec forceContinue=true,
+    // le caller force le passage : warn + continue Opus.
+    const result = await router.call('thesis_generation', baseParams, { forceContinue: true });
+    expect(result.modelUsed).toBe('claude-opus-4-7');
+    expect(result.fallback).toBe(false);
   });
 });
 
-describe('LlmRouter — hard-stop à 100% budget', () => {
-  it('throws BudgetExceededError on Opus task at 110% even when fallbackOnBudget=true', async () => {
+describe('LlmRouter — 100% budget hard-stop', () => {
+  it('throws BudgetExceededError at 110% by default (no forceContinue)', async () => {
     const { client, create } = makeAnthropic();
     const { tracker } = makeCostTracker(110);
     const router = new LlmRouter(client, tracker, {
@@ -253,18 +210,6 @@ describe('LlmRouter — hard-stop à 100% budget', () => {
     expect(create).not.toHaveBeenCalled();
   });
 
-  it('throws BudgetExceededError on Haiku task at 110% (no Haiku miracle)', async () => {
-    const { client, create } = makeAnthropic();
-    const { tracker } = makeCostTracker(110);
-    const router = new LlmRouter(client, tracker, {
-      dailyCostBudgetUsd: 100,
-      fallbackOnBudget: true,
-    });
-
-    await expect(router.call('news_classification', baseParams)).rejects.toThrow(BudgetExceededError);
-    expect(create).not.toHaveBeenCalled();
-  });
-
   it('throws BudgetExceededError exactly at 100% (>=, not >)', async () => {
     const { client } = makeAnthropic();
     const { tracker } = makeCostTracker(100);
@@ -273,7 +218,7 @@ describe('LlmRouter — hard-stop à 100% budget', () => {
       fallbackOnBudget: true,
     });
 
-    await expect(router.call('summary', baseParams)).rejects.toThrow(BudgetExceededError);
+    await expect(router.call('thesis_generation', baseParams)).rejects.toThrow(BudgetExceededError);
   });
 
   it('error carries todayCost + budget + task fields', async () => {
@@ -297,103 +242,11 @@ describe('LlmRouter — hard-stop à 100% budget', () => {
   });
 });
 
-describe('LlmRouter — calcul du coût + persistance', () => {
-  it('records the call with task/model/tokens/costUsd after success', async () => {
+describe('LlmRouter — soft-budget at 100% with forceContinue', () => {
+  it('soft warns + continues OPUS at 105% with forceContinue=true (no throw, no Haiku)', async () => {
     const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ inputTokens: 1000, outputTokens: 500, model: 'claude-sonnet-4-6' }));
-    const { tracker, record } = makeCostTracker(0);
-    const router = new LlmRouter(client, tracker, {
-      dailyCostBudgetUsd: 100,
-      fallbackOnBudget: true,
-    });
-
-    const result = await router.call('regime_classification', baseParams);
-
-    // Sonnet : 1000 input × $3/1M + 500 output × $15/1M = 0.003 + 0.0075 = 0.0105
-    const expectedCost = (1000 * 3 + 500 * 15) / 1_000_000;
-    expect(result.costUsd).toBeCloseTo(expectedCost, 6);
-    expect(record).toHaveBeenCalledTimes(1);
-    expect(record.mock.calls[0][0]).toEqual({
-      task: 'regime_classification',
-      model: 'claude-sonnet-4-6',
-      inputTokens: 1000,
-      outputTokens: 500,
-      costUsd: expect.any(Number),
-    });
-    expect(record.mock.calls[0][0].costUsd).toBeCloseTo(expectedCost, 6);
-  });
-
-  it('records the FALLBACK model (Haiku, P0-A change), not the original (Opus), on circuit breaker', async () => {
-    const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ inputTokens: 2000, outputTokens: 1000, model: 'claude-haiku-4-5-20251001' }));
-    const { tracker, record } = makeCostTracker(85);
-    const router = new LlmRouter(client, tracker, {
-      dailyCostBudgetUsd: 100,
-      fallbackOnBudget: true,
-    });
-
-    await router.call('thesis_generation', baseParams);
-
-    expect(record.mock.calls[0][0].model).toBe('claude-haiku-4-5-20251001');
-    expect(record.mock.calls[0][0].task).toBe('thesis_generation');
-    // Coût Haiku : (2000 × $0.80 + 1000 × $4.0) / 1M = 0.0056
-    // Avant P0-A c'était Sonnet : (2000*3 + 1000*15) / 1M = 0.021 → 3.7× réduction
-    expect(record.mock.calls[0][0].costUsd).toBeCloseTo(0.0056, 6);
-  });
-
-  it('does NOT record on Anthropic error (no double-counting failed calls)', async () => {
-    const { client, create } = makeAnthropic();
-    create.mockRejectedValue(new Error('anthropic 500'));
-    const { tracker, record } = makeCostTracker(0);
-    const router = new LlmRouter(client, tracker, {
-      dailyCostBudgetUsd: 100,
-      fallbackOnBudget: true,
-    });
-
-    await expect(router.call('thesis_generation', baseParams)).rejects.toThrow('anthropic 500');
-    expect(record).not.toHaveBeenCalled();
-  });
-
-  it('cost helper computeCostUsd matches the lookup tables', () => {
-    const { client } = makeAnthropic();
-    const { tracker } = makeCostTracker(0);
-    const router = new LlmRouter(client, tracker, {
-      dailyCostBudgetUsd: 100,
-      fallbackOnBudget: true,
-    });
-
-    // Opus 1k input + 500 output
-    expect(router.computeCostUsd('claude-opus-4-7', 1000, 500)).toBeCloseTo(
-      (1000 * COST_PER_1M_TOKENS_INPUT['claude-opus-4-7'] + 500 * COST_PER_1M_TOKENS_OUTPUT['claude-opus-4-7']) / 1e6,
-      6,
-    );
-    // Haiku 10k input + 1k output
-    expect(router.computeCostUsd('claude-haiku-4-5-20251001', 10000, 1000)).toBeCloseTo(
-      (10000 * 0.80 + 1000 * 4.0) / 1e6,
-      6,
-    );
-  });
-});
-
-describe('LlmRouter — boot-time validator', () => {
-  it('does not throw on the standard model defaults', () => {
-    const { client } = makeAnthropic();
-    const { tracker } = makeCostTracker(0);
-    expect(
-      () => new LlmRouter(client, tracker, { dailyCostBudgetUsd: 100, fallbackOnBudget: true }),
-    ).not.toThrow();
-  });
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// P0-A — soft-budget + per-call override + Haiku fallback
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe('LlmRouter — P0-A soft-budget at 100%', () => {
-  it('soft-warns + falls back to Haiku at 100% with forceContinue=true (no throw)', async () => {
-    const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ inputTokens: 1500, outputTokens: 800, model: 'claude-haiku-4-5-20251001' }));
-    const { tracker, record } = makeCostTracker(105); // 105% spend
+    create.mockResolvedValue(fakeMessage({ inputTokens: 1500, outputTokens: 800, model: 'claude-opus-4-7' }));
+    const { tracker, record } = makeCostTracker(105);
     const { logger, warn } = makeAuditLogger();
     const router = new LlmRouter(
       client,
@@ -404,40 +257,25 @@ describe('LlmRouter — P0-A soft-budget at 100%', () => {
 
     const result = await router.call('thesis_generation', baseParams, { forceContinue: true });
 
-    expect(create.mock.calls[0][0].model).toBe('claude-haiku-4-5-20251001');
-    expect(result.modelUsed).toBe('claude-haiku-4-5-20251001');
+    expect(create.mock.calls[0][0].model).toBe('claude-opus-4-7');
+    expect(result.modelUsed).toBe('claude-opus-4-7');
     expect(result.fallback).toBe(true);
-    expect(result.fallbackReason).toBe('budget_100pct_soft_haiku');
+    expect(result.fallbackReason).toBe('budget_100pct_soft_continue');
     expect(warn).toHaveBeenCalledWith(
       'cost_budget_warn',
       expect.objectContaining({
         task: 'thesis_generation',
         todayCostUsd: 105,
         budgetUsd: 100,
-        fallbackModel: 'claude-haiku-4-5-20251001',
-        reason: 'soft_haiku_100pct',
+        model: 'claude-opus-4-7',
+        reason: 'soft_continue_100pct',
       }),
     );
     expect(record).toHaveBeenCalledTimes(1);
+    expect(record.mock.calls[0][0].model).toBe('claude-opus-4-7');
   });
 
-  it('soft-warn applies to ALL tasks (even Sonnet), pas seulement Opus, à 100%', async () => {
-    const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ model: 'claude-haiku-4-5-20251001' }));
-    const { tracker } = makeCostTracker(150);
-    const router = new LlmRouter(client, tracker, {
-      dailyCostBudgetUsd: 100,
-      fallbackOnBudget: true,
-    });
-
-    // Même une tâche Sonnet (binary_decision) tombe sur Haiku quand
-    // forceContinue=true à 100% — la prio est de continuer, pas la qualité.
-    const result = await router.call('binary_decision', baseParams, { forceContinue: true });
-    expect(result.modelUsed).toBe('claude-haiku-4-5-20251001');
-    expect(result.fallback).toBe(true);
-  });
-
-  it('throws BudgetExceededError at 100% when forceContinue=false (legacy strict mode preserved)', async () => {
+  it('throws BudgetExceededError at 100% when forceContinue=false', async () => {
     const { client, create } = makeAnthropic();
     const { tracker, record } = makeCostTracker(110);
     const router = new LlmRouter(client, tracker, {
@@ -452,10 +290,7 @@ describe('LlmRouter — P0-A soft-budget at 100%', () => {
     expect(record).not.toHaveBeenCalled();
   });
 
-  it('default behavior at 100% (no options) = throw — preserves legacy tests', async () => {
-    // Sécurité rétrocompat : sans options.forceContinue, le router ne sait
-    // pas si l'opérateur veut soft-mode → on garde le hard-throw historique.
-    // C'est pourquoi les tests legacy au-dessus n'ont pas changé.
+  it('default behavior at 100% (no options) = throw — preserves legacy strict mode', async () => {
     const { client } = makeAnthropic();
     const { tracker } = makeCostTracker(110);
     const router = new LlmRouter(client, tracker, {
@@ -467,39 +302,51 @@ describe('LlmRouter — P0-A soft-budget at 100%', () => {
   });
 });
 
-describe('LlmRouter — P0-A per-call budget override', () => {
+describe('LlmRouter — per-call budget override', () => {
   it('uses options.budgetUsd over constructor budget', async () => {
     const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ model: 'claude-haiku-4-5-20251001' }));
+    create.mockResolvedValue(fakeMessage());
     const { tracker } = makeCostTracker(40);
-    // Constructor : budget $100 (40% spend = pas de fallback)
-    // Override per-call : budget $50 (40/50 = 80% → trigger fallback Opus→Haiku)
-    const router = new LlmRouter(client, tracker, {
-      dailyCostBudgetUsd: 100,
-      fallbackOnBudget: true,
-    });
+    const { logger, warn } = makeAuditLogger();
+    const router = new LlmRouter(
+      client,
+      tracker,
+      // Constructor : budget $100 (40% spend = pas de warn)
+      // Override per-call : budget $50 (40/50 = 80% → trigger warn 80% path)
+      { dailyCostBudgetUsd: 100, fallbackOnBudget: true },
+      logger,
+    );
 
     const result = await router.call('thesis_generation', baseParams, { budgetUsd: 50 });
 
-    expect(result.fallback).toBe(true);
-    expect(result.fallbackReason).toBe('budget_80pct_haiku');
+    // Warn 80% loggué mais pas de fallback model — toujours Opus.
+    expect(result.modelUsed).toBe('claude-opus-4-7');
+    expect(result.fallback).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      'cost_budget_warn_80pct',
+      expect.objectContaining({ todayCostUsd: 40, budgetUsd: 50 }),
+    );
   });
 
-  it('options.budgetUsd raised triggers MORE permissive behavior (no fallback at 30%)', async () => {
+  it('options.budgetUsd raised triggers MORE permissive behavior (no warn at 30%)', async () => {
     const { client, create } = makeAnthropic();
     create.mockResolvedValue(fakeMessage({ model: 'claude-opus-4-7' }));
     const { tracker } = makeCostTracker(15);
+    const { logger, warn } = makeAuditLogger();
     // Constructor : budget $20 (75% spend → just under 80%)
-    // Override per-call : budget $50 (15/50 = 30% → no fallback)
-    const router = new LlmRouter(client, tracker, {
-      dailyCostBudgetUsd: 20,
-      fallbackOnBudget: true,
-    });
+    // Override per-call : budget $50 (15/50 = 30% → no warn)
+    const router = new LlmRouter(
+      client,
+      tracker,
+      { dailyCostBudgetUsd: 20, fallbackOnBudget: true },
+      logger,
+    );
 
     const result = await router.call('thesis_generation', baseParams, { budgetUsd: 50 });
 
     expect(result.fallback).toBe(false);
     expect(result.modelUsed).toBe('claude-opus-4-7');
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it('UI raise budget $20→$50 unblocks autopilot (incident 28/04 05:02 UTC repro)', async () => {
@@ -516,80 +363,111 @@ describe('LlmRouter — P0-A per-call budget override', () => {
     // Sans override : throw (situation prod 28/04)
     await expect(router.call('thesis_generation', baseParams)).rejects.toThrow(BudgetExceededError);
 
-    // Avec override DB → budget $50 → 41% spend → no fallback
+    // Avec override DB → budget $50 → 41% spend → no warn, continue Opus
     const result = await router.call('thesis_generation', baseParams, { budgetUsd: 50 });
     expect(result.fallback).toBe(false);
+    expect(result.modelUsed).toBe('claude-opus-4-7');
   });
 });
 
-describe('LlmRouter — P0-A 80% Opus fallback now goes to Haiku (cost saving)', () => {
-  it('saves ~3.75× vs ex-Sonnet fallback (Haiku $0.80/M vs Sonnet $3/M input)', async () => {
+describe('LlmRouter — cost tracking + persistence', () => {
+  it('records the call with task/model/tokens/costUsd after success (Opus only)', async () => {
     const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ inputTokens: 5000, outputTokens: 2000, model: 'claude-haiku-4-5-20251001' }));
-    const { tracker, record } = makeCostTracker(85);
+    create.mockResolvedValue(fakeMessage({ inputTokens: 1000, outputTokens: 500, model: 'claude-opus-4-7' }));
+    const { tracker, record } = makeCostTracker(0);
     const router = new LlmRouter(client, tracker, {
       dailyCostBudgetUsd: 100,
       fallbackOnBudget: true,
     });
 
-    await router.call('thesis_generation', baseParams);
+    const result = await router.call('thesis_generation', baseParams);
 
-    // Haiku 5000 input × $0.80 + 2000 output × $4 = 0.012
-    // ex-Sonnet aurait coûté : 5000 × $3 + 2000 × $15 = 0.045 → 3.75× plus cher
-    expect(record.mock.calls[0][0].costUsd).toBeCloseTo(0.012, 6);
+    // Opus : 1000 input × $15/1M + 500 output × $75/1M = 0.015 + 0.0375 = 0.0525
+    const expectedCost = (1000 * 15 + 500 * 75) / 1_000_000;
+    expect(result.costUsd).toBeCloseTo(expectedCost, 6);
+    expect(record).toHaveBeenCalledTimes(1);
+    expect(record.mock.calls[0][0]).toEqual({
+      task: 'thesis_generation',
+      model: 'claude-opus-4-7',
+      inputTokens: 1000,
+      outputTokens: 500,
+      costUsd: expect.any(Number),
+    });
+    expect(record.mock.calls[0][0].costUsd).toBeCloseTo(expectedCost, 6);
   });
 
-  it('binary_decision (Sonnet) UNCHANGED at 80%+ (only Opus tasks swap to Haiku)', async () => {
+  it('does NOT record on Anthropic error (no double-counting failed calls)', async () => {
     const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ model: 'claude-sonnet-4-6' }));
-    const { tracker } = makeCostTracker(85);
+    create.mockRejectedValue(new Error('anthropic 500'));
+    const { tracker, record } = makeCostTracker(0);
     const router = new LlmRouter(client, tracker, {
       dailyCostBudgetUsd: 100,
       fallbackOnBudget: true,
     });
 
-    // binary_decision est déjà mappé à Sonnet — pas de fallback nécessaire,
-    // le modèle est déjà bon marché. Notre check `nominalModel.includes('opus')`
-    // garantit qu'on ne touche que les tâches Opus.
-    const result = await router.call('binary_decision', baseParams);
-    expect(result.fallback).toBe(false);
-    expect(result.modelUsed).toBe('claude-sonnet-4-6');
+    await expect(router.call('thesis_generation', baseParams)).rejects.toThrow('anthropic 500');
+    expect(record).not.toHaveBeenCalled();
   });
 
-  it('audit_explanation (Sonnet) UNCHANGED at 80%+ (preserved for human readability)', async () => {
-    const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ model: 'claude-sonnet-4-6' }));
-    const { tracker } = makeCostTracker(95);
+  it('cost helper computeCostUsd matches the lookup tables (Opus only)', () => {
+    const { client } = makeAnthropic();
+    const { tracker } = makeCostTracker(0);
     const router = new LlmRouter(client, tracker, {
       dailyCostBudgetUsd: 100,
       fallbackOnBudget: true,
     });
 
-    const result = await router.call('audit_explanation', baseParams);
-    expect(result.fallback).toBe(false);
-    expect(result.modelUsed).toBe('claude-sonnet-4-6');
-  });
-});
-
-describe('LlmRouter — P0-A combined matrix', () => {
-  it('100% + forceContinue=true takes priority over 80% Opus path', async () => {
-    // À 100%, on ne passe PAS par le check 80% Opus (le 100% short-circuits).
-    const { client, create } = makeAnthropic();
-    create.mockResolvedValue(fakeMessage({ model: 'claude-haiku-4-5-20251001' }));
-    const { tracker } = makeCostTracker(120);
-    const { logger, warn } = makeAuditLogger();
-    const router = new LlmRouter(
-      client,
-      tracker,
-      { dailyCostBudgetUsd: 100, fallbackOnBudget: true },
-      logger,
+    expect(router.computeCostUsd('claude-opus-4-7', 1000, 500)).toBeCloseTo(
+      (1000 * COST_PER_1M_TOKENS_INPUT['claude-opus-4-7'] + 500 * COST_PER_1M_TOKENS_OUTPUT['claude-opus-4-7']) / 1e6,
+      6,
     );
+    // Modèles inconnus → 0 (pas dans la table). Pas de claude-sonnet/haiku
+    // depuis Phase 2 (interdits per ADR-001).
+    expect(router.computeCostUsd('claude-sonnet-4-6', 10000, 1000)).toBe(0);
+    expect(router.computeCostUsd('claude-haiku-4-5-20251001', 10000, 1000)).toBe(0);
+  });
+});
+
+describe('LlmRouter — boot-time validator', () => {
+  it('does not throw on the standard model defaults', () => {
+    const { client } = makeAnthropic();
+    const { tracker } = makeCostTracker(0);
+    expect(
+      () => new LlmRouter(client, tracker, { dailyCostBudgetUsd: 100, fallbackOnBudget: true }),
+    ).not.toThrow();
+  });
+});
+
+describe('LlmRouter — ADR-001 invariants (Phase 2 cleanup)', () => {
+  it('COST_PER_1M_TOKENS_INPUT contains ONLY Opus (Sonnet/Haiku removed)', () => {
+    expect(Object.keys(COST_PER_1M_TOKENS_INPUT)).toEqual(['claude-opus-4-7']);
+    expect(COST_PER_1M_TOKENS_INPUT['claude-sonnet-4-6']).toBeUndefined();
+    expect(COST_PER_1M_TOKENS_INPUT['claude-haiku-4-5-20251001']).toBeUndefined();
+  });
+
+  it('COST_PER_1M_TOKENS_OUTPUT contains ONLY Opus', () => {
+    expect(Object.keys(COST_PER_1M_TOKENS_OUTPUT)).toEqual(['claude-opus-4-7']);
+  });
+
+  it('LlmTask is a singleton literal (compile-time check via MODEL_BY_TASK keys)', () => {
+    expect(Object.keys(MODEL_BY_TASK)).toEqual(['thesis_generation']);
+  });
+
+  it('100% budget + forceContinue=true does NOT use Haiku (uses Opus, audit-flagged fallback)', async () => {
+    const { client, create } = makeAnthropic();
+    create.mockResolvedValue(fakeMessage({ model: 'claude-opus-4-7' }));
+    const { tracker, record } = makeCostTracker(120);
+    const router = new LlmRouter(client, tracker, {
+      dailyCostBudgetUsd: 100,
+      fallbackOnBudget: true,
+    });
 
     const result = await router.call('thesis_generation', baseParams, { forceContinue: true });
 
-    expect(result.fallbackReason).toBe('budget_100pct_soft_haiku');
-    // Pas de log opus_haiku_fallback car on a court-circuité au 100%
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith('cost_budget_warn', expect.anything());
+    expect(result.modelUsed).toBe('claude-opus-4-7');
+    expect(record.mock.calls[0][0].model).toBe('claude-opus-4-7');
+    // ADR-001 invariant : pas de fallback Haiku (interdit, et plus dans le pricing)
+    expect(record.mock.calls[0][0].model).not.toMatch(/haiku/);
+    expect(record.mock.calls[0][0].model).not.toMatch(/sonnet/);
   });
 });

--- a/packages/ai-analyst/src/llm/providers/claude-provider.ts
+++ b/packages/ai-analyst/src/llm/providers/claude-provider.ts
@@ -1,19 +1,24 @@
 /**
- * P17 — Adapter Claude legacy (fallback ultime).
+ * P17 + ADR-001 (30/04/2026) — Adapter Claude Opus pour MultiVendorLlmRouter.
  *
  * Wrap l'Anthropic SDK existant pour exposer la même interface que les
- * autres providers EU. Utilisé en bout de chaîne quand les 3 providers
- * cheaper sont down — garantit que le scanner ne tombe jamais à 0.
+ * autres providers EU (Gemini). Utilisé en bout de chaîne quand le
+ * provider primaire (Gemini Flash Lite) est down — garantit que le scanner
+ * ne tombe jamais à 0.
  *
- * Pricing avril 2026 (Sonnet 4.6) : $3.00 input / $15.00 output par 1M.
- * Modèle pinnable via env CLAUDE_MODEL_SONNET (default 'claude-sonnet-4-6').
+ * **ADR-001 §1.4** : "Fallback ultime : Claude Opus 4.7 (uniquement si Gemini
+ * API down)". Le fallback était `claude-sonnet-4-6` avant Phase 2 ; il est
+ * désormais Opus pour préserver la qualité quand Gemini est indisponible.
+ *
+ * Pricing Opus 4.7 (snapshot 30/04/2026) : $15.00 input / $75.00 output par 1M.
+ * Modèle pinnable via env `CLAUDE_MODEL_OPUS` (default `claude-opus-4-7`).
  */
 
 import type Anthropic from '@anthropic-ai/sdk';
 import type { LlmCallParams, LlmCallResult, LlmProvider } from './types';
 
-const PRICE_INPUT_PER_M = 3.0;
-const PRICE_OUTPUT_PER_M = 15.0;
+const PRICE_INPUT_PER_M = 15.0;
+const PRICE_OUTPUT_PER_M = 75.0;
 
 export interface ClaudeProviderConfig {
   /** Anthropic SDK instance déjà construite (réutilise l'auth applicative). */
@@ -22,13 +27,13 @@ export interface ClaudeProviderConfig {
 }
 
 export class ClaudeProvider implements LlmProvider {
-  readonly id = 'claude-sonnet';
+  readonly id = 'anthropic-claude-opus';
   readonly model: string;
   private readonly anthropic: ClaudeProviderConfig['anthropic'];
 
   constructor(config: ClaudeProviderConfig) {
     this.anthropic = config.anthropic;
-    this.model = config.model ?? process.env.CLAUDE_MODEL_SONNET ?? 'claude-sonnet-4-6';
+    this.model = config.model ?? process.env.CLAUDE_MODEL_OPUS ?? 'claude-opus-4-7';
   }
 
   isConfigured(): boolean {

--- a/packages/ai-analyst/src/llm/router.ts
+++ b/packages/ai-analyst/src/llm/router.ts
@@ -1,85 +1,61 @@
 /**
- * LlmRouter — Centralisation du choix de modèle Claude par type de tâche.
+ * LlmRouter — Wrapper Anthropic single-model pour `thesis_generation`.
  *
- * Avant ce router, chaque service Lisa choisissait son modèle "à la main".
- * Résultat : Opus 4.7 utilisé pour des tâches binaires triviales (4× plus
- * cher que Sonnet 4.6, 19× plus cher que Haiku 4.5), aucun circuit breaker
- * commun, pas de tracking unifié.
+ * **ADR-001 Phase 2 (30/04/2026)** — Cleanup dead code.
  *
- * Le router applique trois règles :
+ * Avant : router multi-task avec mapping `LlmTask` → modèle (Opus/Sonnet/Haiku)
+ * et fallback ladder à 80%/100% budget. Audit du repo : `news_classification`,
+ * `summary`, `regime_classification`, `binary_decision`, `audit_explanation`
+ * étaient déclarés dans le type `LlmTask` mais **0 call site runtime**. Le
+ * fallback Haiku au-dessus de 80% budget est devenu cassé après le unset des
+ * env vars `CLAUDE_MODEL_HAIKU` / `CLAUDE_MODEL_SONNET` per ADR-001.
  *
- *  1. Choix du modèle par TÂCHE (pas par appelant) :
- *     - thesis_generation     → Opus    (qualité capitale, ~1 appel par cycle)
- *     - regime_classification → Sonnet  (~1 appel par cycle)
- *     - binary_decision       → Sonnet  (close/keep, ouvre/n'ouvre pas)
- *     - audit_explanation     → Sonnet  (lecture humaine post-hoc)
- *     - news_classification   → Haiku   (volume — jusqu'à 45 par cycle)
- *     - summary               → Haiku   (formatage, pas de raisonnement)
+ * Aujourd'hui : un seul modèle (`claude-opus-4-7`) pour la seule tâche
+ * réellement appelée (`thesis_generation`). Toutes les autres tâches LLM
+ * (scanner, news, summary, regime, binary, audit) sont gérées hors de ce
+ * router via `MultiVendorLlmRouter` (Gemini primary + Opus fallback) — cf.
+ * `ScannerLlmRouterService`. Si un nouveau call site Gemini est ajouté plus
+ * tard, il NE doit PAS revenir dans ce router — il rejoint la chain Gemini.
  *
- *  2. Circuit breaker budget :
- *     - todayCost ≥ 100% du budget journalier → throw BudgetExceededError
- *       quel que soit le modèle (pas de "sauvetage Haiku" miracle).
- *     - todayCost ≥ 80% ET tâche routée Opus :
- *         · fallbackOnBudget=true  → bascule vers Sonnet, audit warn.
- *         · fallbackOnBudget=false → throw BudgetExceededError pour la
- *           tâche Opus (les tâches Sonnet/Haiku continuent normalement).
- *     Cohérent avec PATCH 4 (hard-stop budget) — le router est le LAST
- *     LINE of defense après le check par-portefeuille de PATCH 4.
+ * **Règle d'or** : tout nouvel appel direct à `anthropic.messages.create`
+ * hors de ce fichier est un bug. Le grep
+ * `grep -rn 'messages\.create' apps packages | grep -v __tests__` doit
+ * retourner exactement 1 hit (la ligne `executeCall` ci-dessous).
  *
- *  3. Comptabilisation post-success :
- *     CostTracker.record() est appelé après chaque succès Anthropic, même
- *     en fallback. Garantit que le todayCost utilisé au prochain check
- *     est à jour.
- *
- * Le router stay dans @smartvest/ai-analyst (pas de dépendance Supabase) :
- * `CostTracker` est une interface ; côté apps/api, ApiCostTrackerService
- * (PATCH 4) l'implémente.
- *
- * Cf. PATCH 6 P1 cost-01-llm-router.
+ * Cf. `docs/decision_records/ADR-001-llm-architecture.md`
  */
 
 import type Anthropic from '@anthropic-ai/sdk';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Types — tâche, mapping, coûts
+// Types — task, mapping, pricing
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type LlmTask =
-  | 'thesis_generation'      // Opus — génération de thèses Lisa (qualité critique)
-  | 'regime_classification'  // Sonnet — classification du régime macro courant
-  | 'binary_decision'        // Sonnet — close/keep, open/skip, simple gating
-  | 'news_classification'    // Haiku — bulk (45/cycle), tag sentiment + relevance
-  | 'audit_explanation'      // Sonnet — narratif humain post-hoc d'une décision
-  | 'summary';               // Haiku — formatage / résumé sans raisonnement
+/**
+ * Le type `LlmTask` est volontairement réduit à un literal singleton. Il reste
+ * une union dans le code pour permettre une future extension SI un call site
+ * Anthropic (pas Gemini) est ajouté — auquel cas ajouter une variante ici.
+ */
+export type LlmTask = 'thesis_generation';
 
 /**
- * Mapping tâche → modèle Claude.
- *
- * Modèles réels au 27 avril 2026 (cf. system context). Override possible
- * via env vars `CLAUDE_MODEL_OPUS|SONNET|HAIKU` pour pinner une version
- * stable en prod ou tester une nouvelle release.
+ * Mapping tâche → modèle. Override possible via `CLAUDE_MODEL_OPUS` pour
+ * pinner une version stable en prod ou tester une nouvelle release.
  */
 export const MODEL_BY_TASK: Record<LlmTask, string> = {
-  thesis_generation:     process.env.CLAUDE_MODEL_OPUS   ?? 'claude-opus-4-7',
-  regime_classification: process.env.CLAUDE_MODEL_SONNET ?? 'claude-sonnet-4-6',
-  binary_decision:       process.env.CLAUDE_MODEL_SONNET ?? 'claude-sonnet-4-6',
-  news_classification:   process.env.CLAUDE_MODEL_HAIKU  ?? 'claude-haiku-4-5-20251001',
-  audit_explanation:     process.env.CLAUDE_MODEL_SONNET ?? 'claude-sonnet-4-6',
-  summary:               process.env.CLAUDE_MODEL_HAIKU  ?? 'claude-haiku-4-5-20251001',
+  thesis_generation: process.env.CLAUDE_MODEL_OPUS ?? 'claude-opus-4-7',
 };
 
 /**
- * Pricing Anthropic au 27 avril 2026 — USD par 1M tokens d'INPUT.
+ * Pricing Anthropic — USD par 1M tokens INPUT (snapshot 30/04/2026).
  *
  * Ne tient pas compte du prompt caching (cache_read = 0.1×, cache_write =
  * 1.25×). Les économies caching sont calculées en amont par
- * `LisaClaudeClient.estimateCostUsd` quand pertinent. Pour le routing
- * budget breaker, l'approximation input-only est suffisante.
+ * `LisaClaudeClient.estimateCostUsd`. Pour le budget breaker,
+ * l'approximation input-only est suffisante.
  */
 export const COST_PER_1M_TOKENS_INPUT: Record<string, number> = {
   'claude-opus-4-7': 15.0,
-  'claude-sonnet-4-6': 3.0,
-  'claude-haiku-4-5-20251001': 0.80,
 };
 
 /**
@@ -87,8 +63,6 @@ export const COST_PER_1M_TOKENS_INPUT: Record<string, number> = {
  */
 export const COST_PER_1M_TOKENS_OUTPUT: Record<string, number> = {
   'claude-opus-4-7': 75.0,
-  'claude-sonnet-4-6': 15.0,
-  'claude-haiku-4-5-20251001': 4.0,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -127,8 +101,6 @@ export interface CostTracker {
 
 /**
  * Logger optionnel pour audit. Si non fourni, fallback silencieux.
- * Côté apps/api, peut être implémenté par DecisionLogService ou un
- * Logger NestJS standard.
  */
 export interface AuditLogger {
   warn(event: string, details: Record<string, unknown>): void;
@@ -137,19 +109,31 @@ export interface AuditLogger {
 export interface LlmRouterConfig {
   /** Budget journalier en USD (cumul tous modèles, depuis 00:00 UTC). */
   dailyCostBudgetUsd: number;
-  /** À 80% du budget, fallback Opus → Sonnet (true) ou throw (false). */
+  /**
+   * À 80% du budget pour une tâche Opus :
+   *  - `true`  → soft warn + continue avec Opus (caller paie le dépassement
+   *               léger pour ne pas bloquer le cycle)
+   *  - `false` → throw `BudgetExceededError` strict
+   *
+   * ADR-001 Phase 2 — il n'y a plus de "fallback Haiku" : Haiku est interdit.
+   * Le seul choix à 80% est continue-or-stop sur Opus.
+   */
   fallbackOnBudget: boolean;
 }
 
 export interface LlmRouterCallResult {
   /** Réponse brute Anthropic (content blocks, usage, stop_reason). */
   response: Anthropic.Message;
-  /** Modèle effectivement appelé (peut différer de MODEL_BY_TASK[task] si fallback). */
+  /** Modèle effectivement appelé. ADR-001 Phase 2 : toujours Opus. */
   modelUsed: string;
-  /** True si le circuit breaker a basculé Opus → Haiku/Sonnet. */
+  /**
+   * `false` en steady state. `true` quand `forceContinue=true` au-dessus de
+   * 100% budget — le router a choisi de continuer plutôt que throw, le
+   * caller doit traiter ça comme un signal d'audit (over-budget).
+   */
   fallback: boolean;
-  /** Raison du fallback (pour audit). */
-  fallbackReason?: 'budget_80pct_haiku' | 'budget_100pct_soft_haiku';
+  /** Raison du soft-continue (over-budget, audit only — pas un vrai fallback model). */
+  fallbackReason?: 'budget_100pct_soft_continue';
   /** Coût de l'appel en USD (input + output, hors caching). */
   costUsd: number;
 }
@@ -158,20 +142,20 @@ export interface LlmRouterCallResult {
  * P0-A — Override per-call pour le budget. Permet au caller de relire
  * `lisa_session_configs.daily_cost_budget_usd` + `cost_force_continue`
  * à chaque cycle (vs config statique au constructor du router).
- *
- * Sans override → utilise les valeurs constructor (rétrocompat PR #15).
  */
 export interface LlmRouterCallOptions {
   /** Override du budget journalier USD pour CET appel uniquement. */
   budgetUsd?: number;
-  /** Override du flag soft-budget pour CET appel.
-   *  - `true` (default DB) : à 100% du budget, soft-warn + Haiku au lieu de throw
-   *  - `false` : hard throw (comportement legacy PR #15) */
+  /**
+   * Override du flag soft-budget pour CET appel.
+   *  - `true` (default DB) : à 100% du budget, soft-warn + continue (over-budget toléré ce call)
+   *  - `false` : hard throw `BudgetExceededError`
+   */
   forceContinue?: boolean;
 }
 
 // Anthropic client minimal — on n'a besoin que de messages.create. Permet
-// de mocker proprement en test sans depend de l'instance Anthropic complète.
+// de mocker proprement en test sans dépendre de l'instance Anthropic complète.
 export interface AnthropicLike {
   messages: {
     create(params: Anthropic.MessageCreateParamsNonStreaming): Promise<Anthropic.Message>;
@@ -185,39 +169,13 @@ export interface AnthropicLike {
 /**
  * LlmRouter — point d'entrée unique pour toute requête Anthropic.
  *
- * **Call sites actuels (migrés)** :
+ * **Call site** (1, unique) :
  *  - `LisaClaudeClient.call` / `callWithTool` → `'thesis_generation'`
- *    (consommé par `ThesisGeneratorService` — ~1 appel par cycle Lisa, ~$0.50)
+ *    (consommé par `ThesisGeneratorService` — ~1 appel par cycle Lisa)
  *
- * **Call sites réservés / à venir** — chaque tâche est PRÉ-CÂBLÉE dans
- * `MODEL_BY_TASK` pour qu'un nouveau service n'ait pas à choisir son
- * modèle. Quand l'un de ces services sera implémenté, il devra prendre un
- * `LlmRouter` en dépendance et appeler `router.call(task, params)` :
- *
- *  - `'regime_classification'` → MarketRegimeClassifier (à venir)
- *      classifie le régime macro courant en 1 des 14 valeurs `MarketRegime`.
- *      Sonnet — input court (~5k tokens), output très court (1 enum).
- *  - `'binary_decision'` → futurs gating Lisa (à venir)
- *      close/keep, open/skip, override de stop. Sonnet par défaut, Haiku
- *      possible si le contexte tient en 2k tokens.
- *  - `'audit_explanation'` → AuditService (à venir)
- *      narratif humain post-hoc d'une décision auto pour /admin/audit.
- *      Sonnet — réponse longue, lecture humaine.
- *  - `'news_classification'` → EodhdNewsService.classifyBatch (à venir)
- *      tag {sentiment, relevance, ticker_match} sur news bulk.
- *      **Volume : jusqu'à 45 appels par cycle** — Haiku obligatoire pour
- *      le ratio coût/quantité.
- *  - `'summary'` → divers (à venir)
- *      formatage de blocs (résumés portefeuille, briefings, snapshots).
- *      Haiku — pas de raisonnement.
- *
- * **Règle d'or** : tout nouvel appel direct à `anthropic.messages.create`
- * hors de ce fichier est un bug. Le grep
- * `grep -rn 'messages\.create' apps packages | grep -v __tests__` doit
- * retourner exactement 1 hit (ligne `await this.anthropic.messages.create`
- * dans la méthode `call()` ci-dessous).
- *
- * Cf. PATCH 6 P1 cost-01-llm-router.
+ * Tout autre call LLM (scanner, news, regime, binary, audit, summary) doit
+ * passer par `MultiVendorLlmRouter` avec Gemini primary + Opus fallback,
+ * **PAS** par ce router. Cf. `ScannerLlmRouterService`.
  */
 export class LlmRouter {
   constructor(
@@ -235,7 +193,7 @@ export class LlmRouter {
         throw new Error(
           `LlmRouter: unknown model "${model}" for task "${task}". `
           + `Known models: ${[...KNOWN_MODELS].join(', ')}. `
-          + `Set CLAUDE_MODEL_OPUS|SONNET|HAIKU env vars or update COST_PER_1M_TOKENS_* tables.`,
+          + `Set CLAUDE_MODEL_OPUS env var or update COST_PER_1M_TOKENS_* tables.`,
         );
       }
     }
@@ -252,20 +210,15 @@ export class LlmRouter {
    *
    * Le caller fournit `params` SANS le champ `model` (le routeur l'écrase
    * de toute façon). Cette API rend impossible un override silencieux du
-   * choix du modèle côté caller — la centralisation est imposée par le type.
+   * choix du modèle côté caller.
    *
-   * P0-A — `options.budgetUsd` / `options.forceContinue` permettent au
-   * caller de relire `lisa_session_configs.daily_cost_budget_usd` +
-   * `cost_force_continue` à chaque cycle plutôt que d'utiliser la config
-   * statique du constructor. Si non fournis, on retombe sur la config
-   * du constructor (rétrocompat PR #15).
-   *
-   * Matrice de comportement (`fc` = forceContinue effectif) :
-   *   - todayCost <  80%             → modèle nominal (MODEL_BY_TASK[task])
-   *   - todayCost ≥  80% & < 100% & opus task → fallback **Haiku** + warn
-   *     (Sonnet/Haiku tasks restent inchangées)
-   *   - todayCost ≥ 100% & fc=true   → soft warn + **Haiku** (toutes tâches)
-   *   - todayCost ≥ 100% & fc=false  → throw `BudgetExceededError`
+   * Matrice de comportement (ADR-001 Phase 2 — fallback Haiku supprimé) :
+   *   - todayCost <  80%               → modèle nominal (Opus)
+   *   - todayCost ≥  80% & < 100%
+   *       · fallbackOnBudget=true      → soft warn + continue Opus
+   *       · fallbackOnBudget=false     → throw `BudgetExceededError`
+   *   - todayCost ≥ 100% & fc=true     → soft warn + continue Opus (audit flag fallback=true)
+   *   - todayCost ≥ 100% & fc=false    → throw `BudgetExceededError`
    */
   async call(
     task: LlmTask,
@@ -274,27 +227,21 @@ export class LlmRouter {
   ): Promise<LlmRouterCallResult> {
     const todayCost = await this.costTracker.getTodayTotalUsd();
     const budget = options.budgetUsd ?? this.config.dailyCostBudgetUsd;
-    // forceContinue per-call > forceContinue inherent (= !fallbackOnBudget legacy ?
-    // non — fallbackOnBudget contrôlait le 80% Opus, pas le 100% hard-stop).
-    // Le default est `true` (soft mode) côté DB, `false` côté constructor pour
-    // ne pas changer le comportement de tests existants qui n'utilisent pas
-    // l'option per-call.
     const forceContinue = options.forceContinue ?? false;
-    const haikuModel = MODEL_BY_TASK['news_classification']; // Haiku 4.5
+    const nominalModel = MODEL_BY_TASK[task];
 
-    // 100% budget — soft warn + Haiku si forceContinue, sinon hard throw.
+    // 100% budget — soft continue si forceContinue, sinon hard throw.
     if (todayCost >= budget) {
       if (forceContinue) {
         this.auditLogger?.warn('cost_budget_warn', {
           task,
           todayCostUsd: todayCost,
           budgetUsd: budget,
-          originalModel: MODEL_BY_TASK[task],
-          fallbackModel: haikuModel,
-          reason: 'soft_haiku_100pct',
+          model: nominalModel,
+          reason: 'soft_continue_100pct',
         });
-        const result = await this.executeCall(task, params, haikuModel);
-        return { ...result, fallback: true, fallbackReason: 'budget_100pct_soft_haiku' };
+        const result = await this.executeCall(task, params, nominalModel);
+        return { ...result, fallback: true, fallbackReason: 'budget_100pct_soft_continue' };
       }
       throw new BudgetExceededError(
         `Daily budget reached ($${todayCost.toFixed(2)}/${budget.toFixed(2)}), task '${task}' refused`,
@@ -304,43 +251,35 @@ export class LlmRouter {
       );
     }
 
-    const nominalModel = MODEL_BY_TASK[task];
-
-    // 80% budget + tâche Opus — fallback Haiku (économie ~19× input vs Opus).
-    // Les tâches Sonnet (binary_decision, audit_explanation) restent
-    // inchangées — elles consomment déjà 5× moins que Opus, le saving
-    // marginal Haiku est moindre et les tâches binary_decision peuvent
-    // perdre en qualité sur Haiku.
-    if (todayCost >= budget * 0.8 && nominalModel.includes('opus')) {
-      // Le legacy `fallbackOnBudget=false` (constructor) reste honoré pour
-      // les opérateurs en mode strict — throw au lieu de fallback.
+    // 80% budget — soft warn + continue Opus (fallbackOnBudget=true)
+    // ou throw strict (fallbackOnBudget=false). Plus de fallback Haiku
+    // (interdit per ADR-001, et `claude-haiku-4-5-*` n'est plus dans
+    // COST_PER_1M_TOKENS de toute façon).
+    if (todayCost >= budget * 0.8) {
       if (!this.config.fallbackOnBudget && !forceContinue) {
         throw new BudgetExceededError(
-          `Daily budget 80% reached ($${todayCost.toFixed(2)}/${budget.toFixed(2)}), Opus task '${task}' refused`,
+          `Daily budget 80% reached ($${todayCost.toFixed(2)}/${budget.toFixed(2)}), task '${task}' refused`,
           todayCost,
           budget,
           task,
         );
       }
-      this.auditLogger?.warn('opus_haiku_fallback', {
+      this.auditLogger?.warn('cost_budget_warn_80pct', {
         task,
         todayCostUsd: todayCost,
         budgetUsd: budget,
-        originalModel: nominalModel,
-        fallbackModel: haikuModel,
-        reason: 'opus_to_haiku_80pct',
+        model: nominalModel,
+        reason: 'soft_continue_80pct',
       });
-      const result = await this.executeCall(task, params, haikuModel);
-      return { ...result, fallback: true, fallbackReason: 'budget_80pct_haiku' };
+      // Pas de marquage `fallback: true` ici — on est sous 100%, c'est juste
+      // un warning. Le caller continue son cycle normalement.
     }
 
     return this.executeCall(task, params, nominalModel);
   }
 
   /**
-   * P0-A — Helper privé pour l'exécution + tracking d'un appel Anthropic.
-   * Extrait pour éviter la duplication entre le path nominal et les 2
-   * paths de fallback (80% Haiku + 100% soft-Haiku).
+   * Helper privé pour l'exécution + tracking d'un appel Anthropic.
    */
   private async executeCall(
     task: LlmTask,

--- a/packages/ai-analyst/src/thesis/thesis-generator.service.ts
+++ b/packages/ai-analyst/src/thesis/thesis-generator.service.ts
@@ -319,8 +319,9 @@ export interface GenerateThesesRequest {
   /** P0-A — Budget journalier USD à appliquer au LlmRouter pour CET appel.
    *  Lu depuis lisa_session_configs.daily_cost_budget_usd côté caller. */
   budgetUsd?: number;
-  /** P0-A — Si true (default DB) : à 100% du budget, soft-warn + fallback
-   *  Haiku au lieu de throw. Lu depuis lisa_session_configs.cost_force_continue. */
+  /** P0-A + ADR-001 Phase 2 — Si true (default DB) : à 100% du budget, soft-warn
+   *  + continue Opus (audit-flagged over-budget). Si false : throw `BudgetExceededError`.
+   *  Lu depuis lisa_session_configs.cost_force_continue. */
   forceContinue?: boolean;
 }
 


### PR DESCRIPTION
## Contexte — ADR-001 Phase 2 (re-cadré Option A)

Audit pré-Phase 2 : `LlmTask` enum déclarait 6 tâches mais **seul `thesis_generation` est appelé runtime** (vérifié `grep -rEn "router\.call\(" apps/ packages/`). Les 5 autres (`regime_classification`, `binary_decision`, `news_classification`, `audit_explanation`, `summary`) sont du code mort `(à venir)` jamais câblé. Pire : leur fallback Haiku au-dessus de 80%/100% budget est **CASSÉ** depuis Phase 1 (unset Fly de `CLAUDE_MODEL_HAIKU` + `CLAUDE_MODEL_SONNET`).

User a tranché Option A : "supprime le LlmRouter multi-task, garde juste le wrapper Anthropic single-model pour `thesis_generation`".

## Diff

### 1. `packages/ai-analyst/src/llm/router.ts`

```diff
-export type LlmTask =
-  | 'thesis_generation'
-  | 'regime_classification'
-  | 'binary_decision'
-  | 'news_classification'
-  | 'audit_explanation'
-  | 'summary';
+export type LlmTask = 'thesis_generation';

-export const MODEL_BY_TASK: Record<LlmTask, string> = {
-  thesis_generation:     process.env.CLAUDE_MODEL_OPUS   ?? 'claude-opus-4-7',
-  regime_classification: process.env.CLAUDE_MODEL_SONNET ?? 'claude-sonnet-4-6',
-  binary_decision:       process.env.CLAUDE_MODEL_SONNET ?? 'claude-sonnet-4-6',
-  news_classification:   process.env.CLAUDE_MODEL_HAIKU  ?? 'claude-haiku-4-5-20251001',
-  audit_explanation:     process.env.CLAUDE_MODEL_SONNET ?? 'claude-sonnet-4-6',
-  summary:               process.env.CLAUDE_MODEL_HAIKU  ?? 'claude-haiku-4-5-20251001',
+export const MODEL_BY_TASK: Record<LlmTask, string> = {
+  thesis_generation: process.env.CLAUDE_MODEL_OPUS ?? 'claude-opus-4-7',
};

-export const COST_PER_1M_TOKENS_INPUT: Record<string, number> = {
-  'claude-opus-4-7': 15.0,
-  'claude-sonnet-4-6': 3.0,
-  'claude-haiku-4-5-20251001': 0.80,
+export const COST_PER_1M_TOKENS_INPUT: Record<string, number> = {
+  'claude-opus-4-7': 15.0,
};

// Budget fallback à 80%/100% : plus de fallback Haiku, soft-warn + continue Opus
-    const haikuModel = MODEL_BY_TASK['news_classification']; // Haiku 4.5  ❌ CASSÉ
-    if (todayCost >= budget && forceContinue) {
-      const result = await this.executeCall(task, params, haikuModel);
-      return { ...result, fallback: true, fallbackReason: 'budget_100pct_soft_haiku' };
-    }
+    if (todayCost >= budget && forceContinue) {
+      const result = await this.executeCall(task, params, nominalModel);
+      return { ...result, fallback: true, fallbackReason: 'budget_100pct_soft_continue' };
+    }
```

### 2. `packages/ai-analyst/src/llm/providers/claude-provider.ts`

ADR-001 §1.4 : "Fallback ultime : Claude Opus 4.7". Le ClaudeProvider du `MultiVendorLlmRouter` (utilisé par `ScannerLlmRouterService`) défaultait sur Sonnet → corrigé en Opus.

```diff
-export class ClaudeProvider implements LlmProvider {
-  readonly id = 'claude-sonnet';
-  this.model = config.model ?? process.env.CLAUDE_MODEL_SONNET ?? 'claude-sonnet-4-6';
-const PRICE_INPUT_PER_M = 3.0;   // Sonnet
-const PRICE_OUTPUT_PER_M = 15.0;
+export class ClaudeProvider implements LlmProvider {
+  readonly id = 'anthropic-claude-opus';
+  this.model = config.model ?? process.env.CLAUDE_MODEL_OPUS ?? 'claude-opus-4-7';
+const PRICE_INPUT_PER_M = 15.0;  // Opus
+const PRICE_OUTPUT_PER_M = 75.0;
```

### 3. `packages/ai-analyst/src/claude/client.ts`

`LisaClaudeClient.estimateCostUsd` est utilisé exclusivement pour `thesis_generation` (Opus). Pricing Sonnet → Opus.

```diff
-const INPUT_PER_M = 3;   // Sonnet
-const OUTPUT_PER_M = 15;
-const CACHE_WRITE_PER_M = 3.75;
-const CACHE_READ_PER_M = 0.30;
+const INPUT_PER_M = 15;  // Opus
+const OUTPUT_PER_M = 75;
+const CACHE_WRITE_PER_M = 18.75;
+const CACHE_READ_PER_M = 1.50;
```

### 4. Comments outdated alignés

`apps/api/src/modules/lisa/services/lisa.service.ts:932`, `packages/ai-analyst/src/thesis/thesis-generator.service.ts:323`, `packages/ai-analyst/src/claude/client.ts:38-43` : tous les "fallback Haiku" → "continue Opus".

### 5. Tests — `llm-router.spec.ts` (réécriture complète)

26 tests autour du single-task router :
- Mapping `thesis_generation` → Opus (1 seule entrée `MODEL_BY_TASK`)
- 80% budget : soft warn + continue Opus si `fallbackOnBudget=true`, sinon throw
- 100% budget : throw par défaut, soft continue Opus si `forceContinue=true`
- ADR-001 invariants explicites :
  - `COST_PER_1M_TOKENS_INPUT/OUTPUT` contiennent **uniquement** `claude-opus-4-7`
  - `MODEL_BY_TASK` contient **exactement** 1 entrée
  - `forceContinue=true` à 100% n'utilise **JAMAIS** Haiku/Sonnet (audit-flagged Opus)

`multi-vendor-router.spec.ts` inchangé (utilisait des mocks génériques par id, indifférent au changement de `ClaudeProvider.id`).

### 6. `docs/decision_records/ADR-001-llm-architecture.md`

Status table § 3.3 :
- Phase 0 ✅ commit `a55de24`
- Phase 1 ✅ PR #148 (squash `8bc094d`)
- Phase 2 ⏳ cette PR
- Phase 3 ☑️ NO-OP (subsumée par Phase 2 — pas de call sites à migrer)
- Phase 4 ⏳ cleanup `OpenAiProvider` + `MistralProvider` classes

Flags `NEWS_LLM_PROVIDER` / `REGIME_*` / `BINARY_*` / `AUDIT_*` retirés du plan (inutiles sans toggle effectif).

## Tests

```
API : 74 suites · 837 tests ✅
ai-analyst : 22 suites · 354 tests ✅
typecheck workspace : ✅
```

Suite full **0 régression**.

## Smoke test post-merge

Aucune action Fly secrets requise — la PR est code-only (pas de nouveau toggle, pas de nouvelle env var). Auto-deploy Fly via push main suffit.

```bash
# Vérifier que le scanner fonctionne toujours après auto-deploy
curl -sH "x-admin-token: $ADMIN_TOKEN" \
  "https://smartvest.fly.dev/admin/logs/recent?pattern=anthropic-claude-opus&limit=10"
# Attendu : si Gemini down → fallback log mentionne provider=anthropic-claude-opus (était claude-sonnet)

# Vérifier qu'aucun call Sonnet/Haiku n'apparaît jamais
curl -sH "x-admin-token: $ADMIN_TOKEN" \
  "https://smartvest.fly.dev/admin/logs/recent?pattern=claude-sonnet|claude-haiku&limit=20"
# Attendu : entries: [] (filtered_count: 0)
```

## Rollback

`git revert d8f820a`. Pas de toggle env, pas de cleanup secrets nécessaire (déjà fait Phase 1).

## Phase 4 (suite — non incluse ici)

Cleanup `OpenAiProvider` + `MistralProvider` classes dans `@smartvest/ai-analyst/src/llm/providers/` (code mort depuis PR #148, plus utilisé par aucun call site puisque `ScannerLlmRouterService` n'instantie que Gemini + Claude). PR Phase 4 dédiée à venir.

## Caveat sandbox agent

Branch et PR créées via mcp__github__. Le smoke test post-merge nécessite ton `ADMIN_TOKEN` (sandbox claude n'y a pas accès).

⏸ **DRAFT — j'attends ton review + GO user avant merge.**

---
Cf. ADR-001 : `docs/decision_records/ADR-001-llm-architecture.md`
Phase 1 origine : PR #148 (squash `8bc094d`)

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_