### PR TITLE
chore(deps): sync lockfile with Phase 4 dep removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1682,17 +1682,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.15.1.tgz",
-      "integrity": "sha512-fb995eiz3r0KsBGtRjFV+/iLbX+UpfalxpF+YitT3R6ukrPD4PN+FGwwmYcRFhNAzVzDUtTVxQYnjQWEnwV5nw==",
-      "dev": true,
-      "dependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.24.1"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -11254,54 +11243,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -15007,16 +14948,6 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
     "node_modules/zustand": {
       "version": "4.5.7",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
@@ -15069,27 +15000,17 @@
       },
       "devDependencies": {
         "@google/genai": "^0.7.0",
-        "@mistralai/mistralai": "^1.3.0",
         "@types/jest": "^29.5.13",
         "@types/node": "^20.14.15",
         "jest": "^29.7.0",
-        "openai": "^4.65.0",
         "ts-jest": "^29.2.5",
         "typescript": "^5.5.4"
       },
       "peerDependencies": {
-        "@google/genai": "*",
-        "@mistralai/mistralai": "*",
-        "openai": "*"
+        "@google/genai": "*"
       },
       "peerDependenciesMeta": {
         "@google/genai": {
-          "optional": true
-        },
-        "@mistralai/mistralai": {
-          "optional": true
-        },
-        "openai": {
           "optional": true
         }
       }


### PR DESCRIPTION
## Contexte

Suite mécanique de PR #150 (Phase 4 ADR-001) qui a retiré `openai` + `@mistralai/mistralai` de `packages/ai-analyst/package.json`. Le `package-lock.json` n'avait pas été régénéré dans cette PR, ce qui laissait des entries orphelines référençant les SDKs supprimés.

`npm install` propre depuis main nettoie le lockfile :

```
D node_modules/openai/...
D node_modules/openai/node_modules/@types/node
D node_modules/openai/node_modules/undici-types
D node_modules/@mistralai/mistralai
```

## Diff

`package-lock.json` : **1 insertion / 80 deletions**. Aucun changement runtime, juste alignement lockfile ↔ package.json.

## Tests

Mécanique. Le typecheck workspace + suite Jest API (837) + ai-analyst (354) sont restés verts en local après ce sync.

## Pourquoi maintenant

CI a accepté PR #150 sans cette sync (probablement `npm install` tolérant > `npm ci` strict), mais les `npm install` futurs sur fresh clone auraient régénéré le lockfile à chaque fois → diff parasite. Mieux vaut nettoyer une bonne fois.

---
Cf. ADR-001 §1.3 : "Plus aucun appel vers gpt-4.1-nano / OpenAI ; codestral-latest / Mistral. Code mort à supprimer dans phase 4."

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_