### PR TITLE
feat(ux-gp): Sprint 1 — vocabulaire grand public + RBAC monitoring (ADR-002)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,36 @@ Guide de travail pour Claude Code sur ce repo.
 
 ---
 
+## ADR-002 — Nomenclature UI grand public (Sprint 1, 30/04/2026)
+
+Toute mention texte côté front (sidebar, h1, breadcrumb, document.title) doit
+utiliser le vocabulaire grand public. Routes inchangées (deeplinks préservés).
+
+| Route | Label sidebar / h1 |
+|---|---|
+| `/` | Mon tableau de bord |
+| `/portfolio` | Mon portefeuille |
+| `/performance` | Mes résultats |
+| `/lisa` | Mon assistant Lisa |
+| `/backtest` | Tester sur le passé |
+| `/monte-carlo` | Projections futures |
+| `/optimizer` | Améliorer mon portefeuille |
+| `/bot-lab` | Mes stratégies auto (mode démo) |
+| `/alerts` | Mes notifications |
+| `/history` | Mes opérations |
+| `/settings` | Mon compte |
+| `/help` | Aide |
+| `/admin/monitoring` | Monitoring (masqué non-admin via `useIsAdmin()` hook) |
+
+Nouveaux libellés interdits dans le code/UI :
+- "Backtest harness", "Monte Carlo Simulation", "Strategy Optimizer",
+  "Bot Profitability Lab", "AI Analyst", "Aide & Documentation"
+- Tout anglicisme non glosé (cf. CLAUDE.md §1 wording)
+
+Cf. `docs/adr/ADR-002-grand-public-ready.md` pour le plan 8 sprints complet.
+
+---
+
 ## EODHD API Reference (OFFICIAL SKILL — vendor/eodhd-claude-skills)
 
 P19k.2 — Le skill officiel EODHD `eodhd-claude-skills` est vendoré dans

--- a/apps/web/src/app/alerts/page.tsx
+++ b/apps/web/src/app/alerts/page.tsx
@@ -12,7 +12,7 @@ export default function AlertsPage() {
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-6">
       <div>
-        <h1 className="text-xl font-semibold">Alertes</h1>
+        <h1 className="text-xl font-semibold">Mes notifications</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Alertes et règles de surveillance par portefeuille.
         </p>

--- a/apps/web/src/app/backtest/page.tsx
+++ b/apps/web/src/app/backtest/page.tsx
@@ -115,7 +115,7 @@ export default function BacktestPage() {
   return (
     <div className="container mx-auto py-6 space-y-6 max-w-6xl">
       <div>
-        <h1 className="text-2xl font-semibold">Backtest harness</h1>
+        <h1 className="text-2xl font-semibold">Tester sur le passé</h1>
         <p className="text-sm text-muted-foreground">
           Rejoue la stratégie sur des données EODHD historiques pour estimer Sharpe, drawdown, win rate.
           Mock Lisa déterministe (rule-based) — teste le framework, pas l'intuition Claude.

--- a/apps/web/src/app/bot-lab/page.tsx
+++ b/apps/web/src/app/bot-lab/page.tsx
@@ -41,12 +41,12 @@ export default function BotLabPage() {
           </Link>
           <h1 className="text-2xl font-bold flex items-center gap-2">
             <FlaskConical className="h-6 w-6 text-blue-600" />
-            Bot Profitability Lab
+            Mes stratégies auto <span className="text-sm font-normal text-muted-foreground">(mode démo)</span>
           </h1>
           <p className="text-sm text-muted-foreground mt-1 max-w-2xl">
-            Importe des bots externes (CSV ou stratégies), mesure leurs perfs avec
-            métriques standardisées (Sharpe, Sortino, MaxDD, Profit Factor) et
-            extrais les patterns robustes pour les transférer à Lisa.
+            Importe des bots externes (CSV ou stratégies), mesure leurs performances avec
+            des indicateurs standardisés (Sharpe, Sortino, drawdown maximum, profit factor)
+            et identifie les patterns robustes à transférer à Lisa. 100 % simulation, aucun argent réel engagé.
           </p>
         </div>
         <Link

--- a/apps/web/src/app/help/page.tsx
+++ b/apps/web/src/app/help/page.tsx
@@ -25,7 +25,7 @@ export default function HelpIndexPage() {
       <BackButton />
 
       <div>
-        <h1 className="text-xl font-semibold">Aide & Documentation</h1>
+        <h1 className="text-xl font-semibold">Aide</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Guides utilisateur, concepts produit, audits internes. Tous les documents
           sont versionnés dans le repo Git et synchronisés ici à chaque déploiement.

--- a/apps/web/src/app/history/page.tsx
+++ b/apps/web/src/app/history/page.tsx
@@ -22,7 +22,7 @@ export default function HistoryPage() {
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-6">
       <div>
-        <h1 className="text-xl font-semibold">Historique</h1>
+        <h1 className="text-xl font-semibold">Mes opérations</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Consultez l'historique de vos mouvements et opérations.
         </p>

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -457,10 +457,10 @@ export default function LisaPage() {
           <div>
             <h1 className="flex items-center gap-2 text-xl font-semibold">
               <Sparkles className="h-5 w-5 text-primary" />
-              Lisa — AI Analyst
+              Mon assistant Lisa
             </h1>
             <p className="text-sm text-muted-foreground">
-              Multi-asset agnostic, anti-consensus, simulation-only
+              Multi-actifs · approche anti-consensus · 100 % simulation
             </p>
           </div>
         </div>
@@ -492,10 +492,10 @@ export default function LisaPage() {
           <div>
             <h1 className="flex items-center gap-2 text-xl font-semibold">
               <Sparkles className="h-5 w-5 text-primary" />
-              Lisa — AI Analyst Multi-Asset
+              Mon assistant Lisa
             </h1>
             <p className="text-sm text-muted-foreground">
-              Agnostique aux classes d'actifs · Anti-consensus · Corpus 25+ événements ·
+              Multi-actifs · approche anti-consensus · corpus de 25+ événements historiques ·
               100 % simulation
             </p>
           </div>

--- a/apps/web/src/app/monte-carlo/page.tsx
+++ b/apps/web/src/app/monte-carlo/page.tsx
@@ -84,7 +84,7 @@ export default function MonteCarloPage() {
   return (
     <div className="container mx-auto py-6 space-y-6 max-w-6xl">
       <div>
-        <h1 className="text-2xl font-semibold">Monte Carlo Simulation</h1>
+        <h1 className="text-2xl font-semibold">Projections futures</h1>
         <p className="text-sm text-muted-foreground">
           Projette N trajectoires possibles à partir des rendements historiques bootstrappés.
           Estime la distribution des résultats, la VaR, et la probabilité d'atteindre une cible.

--- a/apps/web/src/app/optimizer/page.tsx
+++ b/apps/web/src/app/optimizer/page.tsx
@@ -171,7 +171,7 @@ export default function OptimizerPage() {
   return (
     <div className="container mx-auto py-6 space-y-6 max-w-6xl">
       <div>
-        <h1 className="text-2xl font-semibold">Strategy Optimizer</h1>
+        <h1 className="text-2xl font-semibold">Améliorer mon portefeuille</h1>
         <p className="text-sm text-muted-foreground">
           Test de configurations multiples sur données historiques. 3 modes sélectionnables.
         </p>

--- a/apps/web/src/app/performance/page.tsx
+++ b/apps/web/src/app/performance/page.tsx
@@ -12,7 +12,7 @@ export default function PerformancePage() {
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-6">
       <div>
-        <h1 className="text-xl font-semibold">Performance</h1>
+        <h1 className="text-xl font-semibold">Mes résultats</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Analyse de la performance de vos portefeuilles. Les performances passées ne préjugent pas des performances futures.
         </p>

--- a/apps/web/src/app/portfolio/page.tsx
+++ b/apps/web/src/app/portfolio/page.tsx
@@ -34,7 +34,7 @@ export default function PortfolioPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Portefeuilles</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">Mon portefeuille</h1>
           <p className="mt-1 text-sm text-muted-foreground">
             Gérez vos portefeuilles et les comptes associés.
           </p>

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -47,7 +47,7 @@ export default function SettingsPage() {
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-6">
       <div>
-        <h1 className="text-xl font-semibold">Paramètres</h1>
+        <h1 className="text-xl font-semibold">Mon compte</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Configurez votre espace SmartVest.
         </p>

--- a/apps/web/src/components/dashboard-placeholder.tsx
+++ b/apps/web/src/components/dashboard-placeholder.tsx
@@ -9,7 +9,7 @@ export function DashboardPlaceholder() {
       <DisclaimerBanner />
 
       <div>
-        <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Tableau de bord</h1>
+        <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Mon tableau de bord</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Vue d&apos;ensemble du portefeuille. Les chiffres ci-dessous sont des placeholders
           tant que la connexion aux comptes n&apos;est pas configurée.

--- a/apps/web/src/components/dashboard/connected-dashboard.tsx
+++ b/apps/web/src/components/dashboard/connected-dashboard.tsx
@@ -148,7 +148,7 @@ export function ConnectedDashboard() {
         <div>
           <div className="flex flex-wrap items-center gap-2">
             <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
-              {activePortfolio?.name ?? 'Tableau de bord'}
+              {activePortfolio?.name ?? 'Mon tableau de bord'}
             </h1>
             {(activePortfolio as { is_simulation?: boolean } | null)?.is_simulation && (
               <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -19,28 +19,36 @@ import {
   BookOpen,
 } from 'lucide-react';
 import { useUIStore } from '@/stores/ui';
+import { useIsAdmin } from '@/hooks/use-is-admin';
 import { cn } from '@/lib/utils';
 
+// ADR-002 Sprint 1 — Vocabulaire grand public.
+// Routes inchangées (préserve deeplinks/bookmarks). Seuls les `label` changent.
+// `adminOnly` masque l'item pour les non-admins (RBAC côté UI ; gating réel
+// côté backend via `x-admin-token`).
 const items = [
-  { href: '/', label: 'Tableau de bord', icon: LayoutDashboard },
-  { href: '/portfolio', label: 'Portefeuille', icon: Wallet },
-  { href: '/performance', label: 'Performance', icon: BarChart3 },
-  { href: '/lisa', label: 'Lisa', icon: Brain },
-  { href: '/backtest', label: 'Backtest', icon: FlaskConical },
-  { href: '/monte-carlo', label: 'Monte Carlo', icon: Dices },
-  { href: '/optimizer', label: 'Optimizer', icon: Sliders },
-  { href: '/bot-lab', label: 'Bot Lab', icon: Bot },
-  { href: '/alerts', label: 'Alertes', icon: Bell },
-  { href: '/history', label: 'Historique', icon: History },
-  { href: '/settings', label: 'Paramètres', icon: Settings },
-  { href: '/help', label: 'Aide & Docs', icon: BookOpen },
-  { href: '/admin/monitoring', label: 'Monitoring', icon: Activity },
+  { href: '/', label: 'Mon tableau de bord', icon: LayoutDashboard },
+  { href: '/portfolio', label: 'Mon portefeuille', icon: Wallet },
+  { href: '/performance', label: 'Mes résultats', icon: BarChart3 },
+  { href: '/lisa', label: 'Mon assistant Lisa', icon: Brain },
+  { href: '/backtest', label: 'Tester sur le passé', icon: FlaskConical },
+  { href: '/monte-carlo', label: 'Projections futures', icon: Dices },
+  { href: '/optimizer', label: 'Améliorer mon portefeuille', icon: Sliders },
+  { href: '/bot-lab', label: 'Mes stratégies auto (mode démo)', icon: Bot },
+  { href: '/alerts', label: 'Mes notifications', icon: Bell },
+  { href: '/history', label: 'Mes opérations', icon: History },
+  { href: '/settings', label: 'Mon compte', icon: Settings },
+  { href: '/help', label: 'Aide', icon: BookOpen },
+  { href: '/admin/monitoring', label: 'Monitoring', icon: Activity, adminOnly: true },
 ] as const;
 
 export function Sidebar() {
   const pathname = usePathname();
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const setSidebar = useUIStore((s) => s.setSidebar);
+  const isAdmin = useIsAdmin();
+
+  const visibleItems = items.filter((item) => !('adminOnly' in item && item.adminOnly) || isAdmin);
 
   return (
     <aside
@@ -52,7 +60,7 @@ export function Sidebar() {
       aria-label="Navigation principale"
     >
       <nav className="flex flex-col gap-1 p-3">
-        {items.map((item) => {
+        {visibleItems.map((item) => {
           const Icon = item.icon;
           const active = pathname === item.href;
           return (

--- a/apps/web/src/hooks/use-is-admin.ts
+++ b/apps/web/src/hooks/use-is-admin.ts
@@ -1,0 +1,51 @@
+'use client';
+
+/**
+ * ADR-002 Sprint 1 — Hook minimaliste pour gating sidebar `/admin/*`.
+ *
+ * MVP : un user est "admin" si son `user_metadata.role === 'admin'` OU si son
+ * email matche `NEXT_PUBLIC_ADMIN_EMAILS` (CSV configuré côté Vercel).
+ *
+ * Page-level gating (vrai contrôle d'accès) reste assuré côté backend dans
+ * les endpoints `/admin/*` via `x-admin-token`. Ce hook ne sert QUE à cacher
+ * le lien dans la sidebar pour les non-admins (réduction du bruit UX).
+ */
+
+import { useEffect, useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+
+export function useIsAdmin(): boolean {
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const supabase = createSupabaseBrowserClient();
+      const { data } = await supabase.auth.getUser();
+      const user = data.user;
+      if (cancelled || !user) return;
+
+      const role = (user.app_metadata?.role ?? user.user_metadata?.role) as
+        | string
+        | undefined;
+      if (role === 'admin') {
+        setIsAdmin(true);
+        return;
+      }
+
+      const allowedCsv = process.env.NEXT_PUBLIC_ADMIN_EMAILS ?? '';
+      const allowed = allowedCsv
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean);
+      if (user.email && allowed.includes(user.email.toLowerCase())) {
+        setIsAdmin(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return isAdmin;
+}

--- a/docs/adr/ADR-002-grand-public-ready.md
+++ b/docs/adr/ADR-002-grand-public-ready.md
@@ -1,0 +1,108 @@
+# ADR-002 — SmartVest "Grand Public Ready"
+
+- **Date** : 2026-04-30
+- **Owner** : Yannick (yannicke819-max)
+- **Status** : ACCEPTED
+- **Source** : `docs/audit-2026-04.md` (1117 lignes, 5 phases, 47 routes, 13 sidebar — réel ~25-30% MVP public)
+
+## 1. Décision
+
+SmartVest passe d'app technique devs/traders à site opérationnel grand public.
+Vocabulaire humain partout, guide utilisateur intégré expliquant chaque champ
+technique et les risques encourus selon les choix. **Toutes pages opérationnelles**
+de l'onboarding au "Mon compte".
+
+## 2. Plan 8 sprints
+
+Ordre exécution (S5 remonté car bloquant parcours utilisateur, S8 ajouté pour
+légal MVP) :
+
+| # | Sprint | Durée | Scope résumé |
+|---|---|---|---|
+| **S1** | Renommage humain | 3j | Sidebar + titles + breadcrumbs : Tableau de bord→Mon tableau de bord, Lisa→Mon assistant Lisa, Backtest→Tester sur le passé, etc. RBAC `/admin/monitoring` masqué non-admin. |
+| **S2** | `<HelpTip>` + Glossaire | 5j | Composant popover (terme→déf simple/avancée+risque+exemple). Table `glossary_terms` seed 80 entrées. Page `/aide/glossaire` recherche fuzzy + filtre niveau. |
+| **S3** | `<RiskBadge>` + phrase humaine | 2j | 🟢 faible / 🟡 modéré / 🟠 élevé / 🔴 extrême. Mapping auto vol annualisée → niveau. Plug Bot Lab / Optimizer / Monte Carlo / ordres simulés. |
+| **S5** | Refonte onboarding **complète** | 7j | Landing publique → sign-up email/OAuth → wizard 6 étapes (prénom, niveau, objectif, horizon, réaction risque, récap profil) → portfolio initial proposé selon profil → 1er usage guidé (tour 5-7 spots shepherd.js). Persistance mid-flow. Templates email Resend (welcome, J+1, J+7, J+30). |
+| **S4** | Guide `/aide` complet | 10j | `/aide` hub + recherche, `/aide/premiers-pas` (5min), `/aide/comprendre` (12 articles), `/aide/utiliser` (13 articles 1/page sidebar), `/aide/glossaire`, `/aide/faq` (30 Q), `/aide/risques`, `/aide/contact`. |
+| **S6** | Pages vides/squelettes | 5j | `/performance`, `/alerts`, `/history`, `/help`, `/settings` (profil/sécurité/notifs/abonnement/données). |
+| **S7** | Empty states + first-run tour | 2j | CTA explicite + lien aide sur chaque page vide. Tour produit shepherd.js post-onboarding. |
+| **S8** | Légal MVP (bloquant Go-Live) | 3j | `/legal/cgu`, `/legal/confidentialite`, `/legal/cookies` + bandeau, `/legal/mentions`. Endpoints `GET /me/export` (RGPD) et `DELETE /me` (soft-delete + double conf). |
+
+## 3. Règles non-négociables (cf. CLAUDE.md §1 produit + §6 mandats)
+
+1. **Français courant**, zéro anglicisme non glosé
+2. Chaque champ formulaire = label clair + `<HelpTip>` + placeholder + risk hint si applicable
+3. `SAFE_PUBLIC_MODE=true` : badges "🎮 Mode simulation" sur Bot Lab / Backtest / Optimizer / ordres
+4. Compliance wording feature-flagged
+5. Aucune action irréversible sans confirmation + résumé de l'impact
+6. Mobile-first <375px sur **toutes** les pages
+7. A11y WCAG AA min (focus visible, contrastes, aria-label)
+8. Tests E2E Playwright 3 parcours : débutant / initié / expert
+
+## 4. Persona-based UI (S5 + composant `useExperienceLevel`)
+
+Source de vérité : `user_profile.experience_level ∈ { 'debutant', 'initie', 'expert' }`.
+
+| Niveau | Sidebar visible |
+|---|---|
+| Débutant | Mon tableau de bord, Mon portefeuille, Mes résultats, Mon assistant Lisa, Mes notifications, Mes opérations, Mon compte, Aide |
+| Initié | + Tester sur le passé, Projections futures |
+| Expert | + Améliorer mon portefeuille, Mes stratégies auto |
+
+Toggle "Afficher les fonctions avancées" dans Mon compte permet à un Débutant
+de débloquer manuellement.
+
+## 5. Mapping renommage Sprint 1
+
+| Avant | Après | Route |
+|---|---|---|
+| Tableau de bord | Mon tableau de bord | `/` |
+| Portefeuille | Mon portefeuille | `/portfolio` |
+| Performance | Mes résultats | `/performance` |
+| Lisa | Mon assistant Lisa | `/lisa` |
+| Backtest | Tester sur le passé | `/backtest` |
+| Monte Carlo | Projections futures | `/monte-carlo` |
+| Optimizer | Améliorer mon portefeuille | `/optimizer` |
+| Bot Lab | Mes stratégies auto (mode démo) | `/bot-lab` |
+| Alertes | Mes notifications | `/alerts` |
+| Historique | Mes opérations | `/history` |
+| Paramètres | Mon compte | `/settings` |
+| Aide & Docs | Aide | `/help` |
+| Monitoring | (masqué non-admin via RBAC) | `/admin/monitoring` |
+
+Routes inchangées (préservation deeplinks externes / bookmarks).
+
+## 6. Livrables
+
+- ADR-002 (ce document)
+- 1 PR par sprint, branche `feat/ux-gp-sprint-N-<topic>`, auto-merge si CI verte
+- Mise à jour `CLAUDE.md` section pages avec nouvelle nomenclature (S1)
+- Tests E2E Playwright avant clôture S7
+- Pages légales `/legal/*` avant Go-Live (S8)
+
+## 7. Choix techniques
+
+| Sujet | Choix | Justification |
+|---|---|---|
+| Tour produit | **shepherd.js** | Plus léger qu'`intro.js`, mieux maintenu, support React FN sans wrapper |
+| Email | **Resend** | Déjà mentionné dans le brief, API REST simple, free tier 100/jour |
+| Glossaire stockage | **Supabase table `glossary_terms`** | Seed via migration, indexable RLS-friendly, fuzzy via Postgres `pg_trgm` |
+| Risk levels | **4 niveaux** (vert/jaune/orange/rouge) | Mapping vol annualisée déterministe (cf. S3) |
+
+## 8. Hors scope (pour mémoire — explicitement EXCLU de cette ADR)
+
+- Vrai déploiement live de KYC/AML (compliance produit régulé) — `REGULATED_MODE` reste `false`
+- Multi-utilisateur / collaboration / partage portefeuille
+- Mobile natif (responsive web suffit)
+- App marketplace publique (App Store / Play Store)
+- Internationalisation (FR uniquement v1)
+
+## 9. Méta — réversibilité par sprint
+
+Chaque sprint est **mergeable indépendamment**. Rollback = `git revert` du squash
+de la PR. Aucune migration DB destructive — seules additions (nouvelles tables,
+nouvelles colonnes nullable). Schemas Supabase versionnés sous `supabase/migrations/`.
+
+---
+
+**Validation** : Yannick (yannicke819-max) — 30/04/2026


### PR DESCRIPTION
## Contexte — ADR-002 Sprint 1

ADR-002 "Grand Public Ready" lance la transformation SmartVest d'app technique devs/traders → site opérationnel grand public. Sprint 1 = renommage humain partout (sidebar + h1 + dashboard fallback) avec RBAC `useIsAdmin()` pour masquer `/admin/monitoring` aux non-admins.

**Routes inchangées** (préservation deeplinks/bookmarks). Seuls les libellés affichés changent.

## Mapping appliqué

| Avant | Après |
|---|---|
| Tableau de bord | **Mon tableau de bord** |
| Portefeuilles | **Mon portefeuille** |
| Performance | **Mes résultats** |
| Lisa — AI Analyst | **Mon assistant Lisa** |
| Backtest harness | **Tester sur le passé** |
| Monte Carlo Simulation | **Projections futures** |
| Strategy Optimizer | **Améliorer mon portefeuille** |
| Bot Profitability Lab | **Mes stratégies auto (mode démo)** |
| Alertes | **Mes notifications** |
| Historique | **Mes opérations** |
| Paramètres | **Mon compte** |
| Aide & Documentation | **Aide** |
| Monitoring | (masqué non-admin) |

## Diff

### Nouveaux fichiers
- `docs/adr/ADR-002-grand-public-ready.md` (plan 8 sprints complet : S1 renommage / S2 HelpTip+Glossaire / S3 RiskBadge / S5 refonte onboarding / S4 guide aide / S6 pages squelettes / S7 first-run tour / S8 légal MVP)
- `apps/web/src/hooks/use-is-admin.ts` (hook RBAC sidebar)

### Modifiés
- `apps/web/src/components/layout/sidebar.tsx` : 13 labels + filtrage adminOnly via `useIsAdmin()`
- 11 pages `app/**/page.tsx` : h1 mis à jour
- `apps/web/src/components/dashboard-placeholder.tsx` + `connected-dashboard.tsx` : h1 fallback dashboard
- `CLAUDE.md` : section "ADR-002 — Nomenclature UI grand public" en tête (table de mapping + libellés interdits)

## Tests

- Workspace typecheck ✅
- Aucun test ne matche les anciens libellés (vérifié via grep) — suite Jest 837+354 inchangée

## Sprints suivants (cf. ADR-002 §2)

S2 HelpTip+Glossaire (5j) → S3 RiskBadge (2j) → **S5 refonte onboarding complète** (7j, remonté car bloquant parcours) → S4 guide aide (10j) → S6 pages squelettes (5j) → S7 first-run tour (2j) → S8 légal MVP (3j).

## Rollback

`git revert <squash>`. Aucun changement de route, aucune migration DB. Hook `useIsAdmin` peut être stub-é à `() => true` pour rétablir affichage Monitoring si besoin.

⏸ DRAFT — auto-merge dès CI verte (règle CLAUDE.md).

---
Cf. `docs/adr/ADR-002-grand-public-ready.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_