### PR TITLE
feat(ux-gp): Sprints 6+9 — Mon compte sub-pages + WCAG AA audit (ADR-002)

### DIFF
--- a/apps/web/src/app/alerts/page.tsx
+++ b/apps/web/src/app/alerts/page.tsx
@@ -5,16 +5,26 @@ import { Bell } from 'lucide-react';
 import { usePortfolios } from '@/hooks/use-portfolio';
 import { SkeletonCard } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/states/empty-state';
+import { BackButton } from '@/components/ui/back-button';
+import { HelpTip } from '@/components/ui/help-tip';
 
 export default function AlertsPage() {
   const { data: portfolios, isLoading } = usePortfolios();
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <BackButton />
       <div>
-        <h1 className="text-xl font-semibold">Mes notifications</h1>
+        <h1 className="flex items-center gap-2 text-xl font-semibold">
+          Mes notifications
+          <HelpTip
+            text="Alertes déclenchées automatiquement sur vos positions (seuil de perte, objectif atteint, anomalie). Vous choisissez les règles."
+            glossarySlug="alerte"
+            side="right"
+          />
+        </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Alertes et règles de surveillance par portefeuille.
+          Règles de surveillance par portefeuille.
         </p>
       </div>
 

--- a/apps/web/src/app/history/page.tsx
+++ b/apps/web/src/app/history/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { ArrowLeftRight, BookOpen, History } from 'lucide-react';
+import { BackButton } from '@/components/ui/back-button';
 
 const SECTIONS = [
   {
@@ -21,10 +22,11 @@ const SECTIONS = [
 export default function HistoryPage() {
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <BackButton />
       <div>
         <h1 className="text-xl font-semibold">Mes opérations</h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Consultez l'historique de vos mouvements et opérations.
+          Historique de vos mouvements de trésorerie et transferts.
         </p>
       </div>
 

--- a/apps/web/src/app/performance/page.tsx
+++ b/apps/web/src/app/performance/page.tsx
@@ -5,16 +5,26 @@ import { BarChart3 } from 'lucide-react';
 import { usePortfolios } from '@/hooks/use-portfolio';
 import { SkeletonCard } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/states/empty-state';
+import { BackButton } from '@/components/ui/back-button';
+import { HelpTip } from '@/components/ui/help-tip';
 
 export default function PerformancePage() {
   const { data: portfolios, isLoading } = usePortfolios();
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <BackButton />
       <div>
-        <h1 className="text-xl font-semibold">Mes résultats</h1>
+        <h1 className="flex items-center gap-2 text-xl font-semibold">
+          Mes résultats
+          <HelpTip
+            text="Évolution de la valeur de vos portefeuilles dans le temps. Les performances passées ne préjugent pas des performances futures."
+            glossarySlug="performance"
+            side="right"
+          />
+        </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Analyse de la performance de vos portefeuilles. Les performances passées ne préjugent pas des performances futures.
+          Analyse de la performance de vos portefeuilles.
         </p>
       </div>
 

--- a/apps/web/src/app/settings/abonnement/page.tsx
+++ b/apps/web/src/app/settings/abonnement/page.tsx
@@ -1,0 +1,89 @@
+import type { Route } from 'next';
+import Link from 'next/link';
+import { BackButton } from '@/components/ui/back-button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { FlaskConical, Sparkles } from 'lucide-react';
+
+export default function AbonnementPage() {
+  return (
+    <div className="mx-auto max-w-xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Abonnement</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Votre plan actuel et ses fonctionnalités.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <FlaskConical className="h-4 w-4 text-amber-500" />
+            Plan actuel — Simulation personnelle
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-900/20">
+            <p className="text-xs text-amber-800 dark:text-amber-300">
+              SmartVest est actuellement en accès personnel gratuit.
+              Toutes les fonctionnalités de simulation sont disponibles sans limite.
+            </p>
+          </div>
+
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            {[
+              'Portefeuilles de simulation illimités',
+              "Analyse IA via Lisa (sous quota d'API)",
+              'Données de marché en différé (15 min)',
+              'Guides utilisateur et glossaire',
+              'Export des données (RGPD)',
+            ].map((feature) => (
+              <li key={feature} className="flex items-start gap-2">
+                <span className="mt-0.5 text-emerald-500">✓</span>
+                {feature}
+              </li>
+            ))}
+          </ul>
+
+          <div className="border-t pt-4">
+            <p className="text-xs text-muted-foreground">
+              Les données de marché sont fournies par EODHD et Binance.
+              Certaines données peuvent être en différé de 15 minutes.{' '}
+              <Link
+                href={'/legal/cgu' as Route}
+                className="text-primary underline underline-offset-4"
+              >
+                Voir les CGU
+              </Link>
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <Sparkles className="h-4 w-4 text-primary" />
+            Fonctionnalités à venir
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            {[
+              'Connexion broker en lecture (Interactive Brokers, Saxo, Trading 212)',
+              'Données temps réel',
+              'Alertes SMS',
+              'Rapports PDF personnalisés',
+            ].map((feature) => (
+              <li key={feature} className="flex items-start gap-2">
+                <span className="mt-0.5 text-muted-foreground/40">○</span>
+                {feature}
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/donnees/page.tsx
+++ b/apps/web/src/app/settings/donnees/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState } from 'react';
+import type { Route } from 'next';
+import Link from 'next/link';
+import { BackButton } from '@/components/ui/back-button';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { useRouter } from 'next/navigation';
+import { Download, Trash2 } from 'lucide-react';
+
+export default function DonneesPage() {
+  const [exporting, setExporting] = useState(false);
+  const [deleteStep, setDeleteStep] = useState<'idle' | 'confirm' | 'deleting'>('idle');
+  const [confirmText, setConfirmText] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function handleExport() {
+    setExporting(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) throw new Error('Non connecté');
+      const res = await fetch('/api/me/export', {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) throw new Error(`Erreur ${res.status}`);
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `smartvest-export-${new Date().toISOString().slice(0, 10)}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  async function handleDeleteAccount() {
+    setDeleteStep('deleting');
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) throw new Error('Non connecté');
+      const res = await fetch('/api/me', {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) throw new Error(`Erreur ${res.status}`);
+      await supabase.auth.signOut();
+      router.push('/');
+    } catch (e) {
+      setError((e as Error).message);
+      setDeleteStep('confirm');
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Mes données</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Exportez ou supprimez vos données personnelles (RGPD).
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <Download className="h-4 w-4" />
+            Exporter mes données
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Téléchargez une copie de toutes vos données : profil, portefeuilles,
+            positions, transactions et paramètres. Format JSON.
+          </p>
+          <Button variant="outline" onClick={handleExport} disabled={exporting}>
+            {exporting ? 'Export en cours…' : 'Télécharger mes données'}
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            Conformément au{' '}
+            <Link href={'/legal/confidentialite' as Route} className="text-primary underline underline-offset-4">
+              droit à la portabilité (RGPD)
+            </Link>
+            .
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card className="border-destructive/30">
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium text-destructive">
+            <Trash2 className="h-4 w-4" />
+            Supprimer mon compte
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Supprime définitivement votre compte et toutes vos données sous 30 jours.
+            Cette action est irréversible.
+          </p>
+
+          {deleteStep === 'idle' && (
+            <Button
+              variant="outline"
+              className="border-destructive/50 text-destructive hover:bg-destructive/10"
+              onClick={() => setDeleteStep('confirm')}
+            >
+              Supprimer mon compte
+            </Button>
+          )}
+
+          {deleteStep === 'confirm' && (
+            <div className="space-y-3 rounded-lg border border-destructive/30 p-4">
+              <p className="text-sm font-medium text-destructive">
+                Confirmation requise
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Tapez <strong>SUPPRIMER</strong> pour confirmer la suppression
+                définitive de votre compte et de toutes vos données.
+              </p>
+              <input
+                type="text"
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder="SUPPRIMER"
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-destructive"
+                aria-label="Tapez SUPPRIMER pour confirmer"
+              />
+              <div className="flex gap-2">
+                <Button
+                  variant="destructive"
+                  onClick={handleDeleteAccount}
+                  disabled={confirmText !== 'SUPPRIMER'}
+                >
+                  Confirmer la suppression
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => { setDeleteStep('idle'); setConfirmText(''); }}
+                >
+                  Annuler
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {deleteStep === 'deleting' && (
+            <p className="text-sm text-muted-foreground">Suppression en cours…</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/notifications/page.tsx
+++ b/apps/web/src/app/settings/notifications/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState } from 'react';
+import { BackButton } from '@/components/ui/back-button';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useUserProfile } from '@/hooks/use-portfolio';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { useQueryClient } from '@tanstack/react-query';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const NOTIFICATION_OPTIONS = [
+  {
+    key: 'email_alerts',
+    label: 'Alertes de portefeuille',
+    description: 'Recevez un email quand une alerte se déclenche (seuil de perte, objectif atteint).',
+  },
+  {
+    key: 'email_weekly_summary',
+    label: 'Résumé hebdomadaire',
+    description: 'Un récapitulatif de vos performances chaque lundi matin.',
+  },
+  {
+    key: 'email_suggestions',
+    label: 'Nouvelles suggestions Lisa',
+    description: "Notification quand Lisa propose un scénario ou une analyse à valider.",
+  },
+] as const;
+
+type NotifKey = (typeof NOTIFICATION_OPTIONS)[number]['key'];
+
+export default function NotificationsPage() {
+  const { data: profile, isLoading } = useUserProfile();
+  const [prefs, setPrefs] = useState<Partial<Record<NotifKey, boolean>>>({});
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const qc = useQueryClient();
+
+  function getChecked(key: NotifKey): boolean {
+    if (key in prefs) return !!prefs[key];
+    const p = profile as Record<string, unknown> | null;
+    if (p && key in p) return !!p[key];
+    return true;
+  }
+
+  function toggle(key: NotifKey) {
+    setPrefs((prev) => ({ ...prev, [key]: !getChecked(key) }));
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Non connecté');
+      const update: Record<string, boolean> = {};
+      for (const { key } of NOTIFICATION_OPTIONS) {
+        update[key] = getChecked(key);
+      }
+      const { error: err } = await supabase
+        .from('user_profiles')
+        .update(update)
+        .eq('id', user.id);
+      if (err) throw new Error(err.message);
+      await qc.invalidateQueries({ queryKey: ['user_profile'] });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Notifications</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Choisissez quels emails vous souhaitez recevoir de SmartVest.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => <Skeleton key={i} className="h-16 w-full" />)}
+        </div>
+      ) : (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium">Préférences email</CardTitle>
+          </CardHeader>
+          <CardContent className="divide-y">
+            {NOTIFICATION_OPTIONS.map(({ key, label, description }) => (
+              <div key={key} className="flex items-start justify-between gap-4 py-3 first:pt-0 last:pb-0">
+                <div>
+                  <p className="text-sm font-medium">{label}</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={getChecked(key)}
+                  onClick={() => toggle(key)}
+                  className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ${
+                    getChecked(key) ? 'bg-primary' : 'bg-input'
+                  }`}
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-background shadow-lg transition-transform ${
+                      getChecked(key) ? 'translate-x-4' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      {saved && <p className="text-sm text-emerald-600">Préférences enregistrées.</p>}
+
+      <Button onClick={handleSave} disabled={saving || isLoading}>
+        {saving ? 'Enregistrement…' : 'Enregistrer'}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,27 +1,66 @@
 'use client';
 
+import type { Route } from 'next';
 import Link from 'next/link';
 import {
+  Bell,
   Bot,
   Cable,
   ChevronRight,
+  CreditCard,
+  Database,
+  Lock,
   Shield,
   Sliders,
+  User,
   Zap,
 } from 'lucide-react';
 
-const SECTIONS = [
+const PROFILE_SECTIONS = [
+  {
+    href: '/settings/profil',
+    icon: User,
+    label: 'Mon profil',
+    description: 'Prénom, niveau d\'expérience, langue.',
+  },
+  {
+    href: '/settings/securite',
+    icon: Lock,
+    label: 'Sécurité',
+    description: 'Mot de passe, sessions actives.',
+  },
+  {
+    href: '/settings/notifications',
+    icon: Bell,
+    label: 'Notifications',
+    description: 'Alertes email, résumés hebdomadaires.',
+  },
+  {
+    href: '/settings/abonnement',
+    icon: CreditCard,
+    label: 'Abonnement',
+    description: 'Plan actuel, limites et informations de facturation.',
+  },
+  {
+    href: '/settings/donnees',
+    icon: Database,
+    label: 'Mes données',
+    description: 'Exporter ou supprimer votre compte (RGPD).',
+  },
+] as const;
+
+const ADVANCED_SECTIONS = [
   {
     href: '/settings/delegation',
     icon: Shield,
     label: 'Délégation & Mandats',
-    description: "Configurez les garde-fous et mandats d'autonomie.",
+    description: "Garde-fous et mandats d'autonomie pour Lisa.",
   },
   {
     href: '/settings/strategy-mode',
     icon: Sliders,
     label: 'Mode stratégique',
-    description: "Choisissez le mode d'analyse et de cadence.",
+    description: "Mode d'analyse : investissement, harvest ou gainers.",
   },
   {
     href: '/settings/hyper-trading',
@@ -43,6 +82,29 @@ const SECTIONS = [
   },
 ] as const;
 
+function SectionList({ sections }: { sections: readonly { href: string; icon: React.ElementType; label: string; description: string }[] }) {
+  return (
+    <div className="rounded-lg border divide-y">
+      {sections.map(({ href, icon: Icon, label, description }) => (
+        <Link
+          key={href}
+          href={href as Route}
+          className="flex items-center gap-4 px-4 py-4 transition-colors hover:bg-muted/30"
+        >
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-muted/40">
+            <Icon className="h-4 w-4 text-muted-foreground" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium">{label}</p>
+            <p className="text-xs text-muted-foreground">{description}</p>
+          </div>
+          <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+        </Link>
+      ))}
+    </div>
+  );
+}
+
 export default function SettingsPage() {
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-6">
@@ -53,24 +115,15 @@ export default function SettingsPage() {
         </p>
       </div>
 
-      <div className="rounded-lg border divide-y">
-        {SECTIONS.map(({ href, icon: Icon, label, description }) => (
-          <Link
-            key={href}
-            href={href}
-            className="flex items-center gap-4 px-4 py-4 transition-colors hover:bg-muted/30"
-          >
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-muted/40">
-              <Icon className="h-4 w-4 text-muted-foreground" />
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium">{label}</p>
-              <p className="text-xs text-muted-foreground">{description}</p>
-            </div>
-            <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
-          </Link>
-        ))}
-      </div>
+      <section className="space-y-2">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground px-1">Profil & préférences</p>
+        <SectionList sections={PROFILE_SECTIONS} />
+      </section>
+
+      <section className="space-y-2">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground px-1">Simulation & automatisation</p>
+        <SectionList sections={ADVANCED_SECTIONS} />
+      </section>
     </div>
   );
 }

--- a/apps/web/src/app/settings/profil/page.tsx
+++ b/apps/web/src/app/settings/profil/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { BackButton } from '@/components/ui/back-button';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useUserProfile } from '@/hooks/use-portfolio';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { useQueryClient } from '@tanstack/react-query';
+import { RiskBadge } from '@/components/ui/risk-badge';
+import type { RiskProfile } from '@/components/ui/risk-badge';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const EXPERIENCE_OPTIONS = [
+  { value: 'debutant', label: '🌱 Je débute', description: 'Nouveaux concepts à chaque étape.' },
+  { value: 'basic', label: '💼 Familier', description: "Je connais actions, obligations, ETF." },
+  { value: 'moderate', label: '📊 Occasionnel', description: 'J\'investis de temps en temps.' },
+  { value: 'advanced', label: '⚙️ Expérimenté', description: 'Je lis bilans et analyses.' },
+  { value: 'expert', label: '🎯 Expert', description: 'Dérivés, arbitrage, gestion active.' },
+] as const;
+
+export default function ProfilPage() {
+  const { data: profile, isLoading } = useUserProfile();
+  const [firstName, setFirstName] = useState('');
+  const [experience, setExperience] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const qc = useQueryClient();
+  const router = useRouter();
+
+  const currentFirstName = firstName || (profile?.first_name ?? '');
+  const currentExperience = experience || (profile?.experience_level ?? '');
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Non connecté');
+      const { error: err } = await supabase
+        .from('user_profiles')
+        .update({ first_name: currentFirstName, experience_level: currentExperience })
+        .eq('id', user.id);
+      if (err) throw new Error(err.message);
+      await qc.invalidateQueries({ queryKey: ['user_profile'] });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Mon profil</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Informations personnelles et niveau d'expérience.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm font-medium">Prénom</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <input
+                type="text"
+                value={currentFirstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                placeholder="Votre prénom"
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm font-medium">Adresse e-mail</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">{profile?.email ?? '—'}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                L'adresse e-mail ne peut pas être modifiée ici. Contactez le support.
+              </p>
+            </CardContent>
+          </Card>
+
+          {profile?.risk_profile && (
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-sm font-medium">Profil de risque</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <RiskBadge
+                  profile={profile.risk_profile as RiskProfile}
+                  size="md"
+                  showPhrase
+                  showTip={false}
+                />
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Défini lors de l'onboarding.{' '}
+                  <a href="/onboarding" className="text-primary underline underline-offset-4">Refaire le questionnaire</a>
+                </p>
+              </CardContent>
+            </Card>
+          )}
+
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm font-medium">Niveau d'expérience</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {EXPERIENCE_OPTIONS.map(({ value, label, description }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setExperience(value)}
+                  className={`w-full flex items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors hover:bg-muted/30 ${
+                    currentExperience === value ? 'border-primary bg-primary/5' : ''
+                  }`}
+                >
+                  <div className={`h-3 w-3 shrink-0 rounded-full border-2 ${currentExperience === value ? 'border-primary bg-primary' : 'border-muted-foreground'}`} />
+                  <div>
+                    <p className="text-sm font-medium">{label}</p>
+                    <p className="text-xs text-muted-foreground">{description}</p>
+                  </div>
+                </button>
+              ))}
+            </CardContent>
+          </Card>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {saved && <p className="text-sm text-emerald-600">Profil mis à jour.</p>}
+
+          <div className="flex gap-3">
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? 'Enregistrement…' : 'Enregistrer'}
+            </Button>
+            <Button variant="outline" onClick={() => router.back()}>
+              Annuler
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/securite/page.tsx
+++ b/apps/web/src/app/settings/securite/page.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import { BackButton } from '@/components/ui/back-button';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { ShieldCheck } from 'lucide-react';
+
+export default function SecuritePage() {
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleChangePassword() {
+    if (newPassword !== confirmPassword) {
+      setError('Les mots de passe ne correspondent pas.');
+      return;
+    }
+    if (newPassword.length < 8) {
+      setError('Le nouveau mot de passe doit contenir au moins 8 caractères.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { error: err } = await supabase.auth.updateUser({ password: newPassword });
+      if (err) throw new Error(err.message);
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      setSaved(true);
+      setTimeout(() => setSaved(false), 4000);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSignOutAll() {
+    const supabase = createSupabaseBrowserClient();
+    await supabase.auth.signOut({ scope: 'global' });
+    window.location.href = '/';
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Sécurité</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Mot de passe et gestion des sessions.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <ShieldCheck className="h-4 w-4" />
+            Changer de mot de passe
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">Mot de passe actuel</label>
+            <input
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              placeholder="••••••••"
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">Nouveau mot de passe</label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              placeholder="8 caractères minimum"
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">Confirmer le nouveau mot de passe</label>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="Répétez le mot de passe"
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {saved && <p className="text-sm text-emerald-600">Mot de passe mis à jour.</p>}
+
+          <Button onClick={handleChangePassword} disabled={saving || !newPassword}>
+            {saving ? 'Mise à jour…' : 'Mettre à jour'}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm font-medium">Sessions</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Déconnectez-vous de toutes les sessions actives sur tous les appareils.
+          </p>
+          <Button variant="outline" onClick={handleSignOutAll}>
+            Se déconnecter partout
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/welcome-banner.tsx
+++ b/apps/web/src/components/dashboard/welcome-banner.tsx
@@ -4,7 +4,6 @@ import type { Route } from 'next';
 import Link from 'next/link';
 import { useState, useEffect } from 'react';
 import { X, BookOpen, FlaskConical, Sparkles, ChevronRight } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 
 const STORAGE_KEY = 'smartvest_welcome_dismissed_v1';
 
@@ -59,15 +58,15 @@ export function WelcomeBanner() {
             Voici 3 étapes pour bien démarrer.
           </p>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
+        {/* min 32×32 touch target (WCAG 2.5.8) */}
+        <button
+          type="button"
           onClick={dismiss}
-          className="h-6 w-6 shrink-0 p-0 text-muted-foreground hover:text-foreground"
+          className="shrink-0 rounded-md p-2 text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           aria-label="Fermer ce message de bienvenue"
         >
-          <X className="h-3.5 w-3.5" />
-        </Button>
+          <X className="h-4 w-4" />
+        </button>
       </div>
 
       <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
@@ -99,7 +98,7 @@ export function WelcomeBanner() {
         <button
           type="button"
           onClick={dismiss}
-          className="text-[11px] text-muted-foreground hover:text-foreground"
+          className="rounded py-1.5 px-2 text-[11px] text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           Ne plus afficher
         </button>

--- a/apps/web/src/components/kpi-card.tsx
+++ b/apps/web/src/components/kpi-card.tsx
@@ -28,7 +28,7 @@ export function KpiCard({ label, value, hint, helpTip, helpGlossarySlug, delta, 
         {icon ? <span className="text-muted-foreground">{icon}</span> : null}
       </CardHeader>
       <CardContent>
-        <div className="text-2xl font-semibold tracking-tight">{value}</div>
+        <div className="text-xl font-semibold tracking-tight sm:text-2xl break-words">{value}</div>
         {delta ? (
           <p
             className={cn(

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -6,7 +6,7 @@ import { useUIStore } from '@/stores/ui';
 import { KillSwitchBanner } from '@/components/kill-switch-banner';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { User as SupabaseUser } from '@supabase/supabase-js';
 
 export function Header() {
@@ -27,6 +27,21 @@ export function Header() {
   }
 
   const initials = user?.email?.slice(0, 2).toUpperCase() ?? '?';
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click/touch
+  useEffect(() => {
+    if (!menuOpen) return;
+    function close(e: MouseEvent | TouchEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
+    }
+    document.addEventListener('mousedown', close);
+    document.addEventListener('touchstart', close);
+    return () => {
+      document.removeEventListener('mousedown', close);
+      document.removeEventListener('touchstart', close);
+    };
+  }, [menuOpen]);
 
   return (
     <header className="sticky top-0 z-30 border-b bg-background/80 backdrop-blur">
@@ -52,27 +67,34 @@ export function Header() {
             Phase 5 · Délégation
           </span>
           {user && (
-            <div className="relative">
+            <div className="relative" ref={menuRef}>
+              {/* min 36×36 touch target */}
               <button
                 onClick={() => setMenuOpen((o) => !o)}
-                className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary hover:bg-primary/20 transition-colors"
+                aria-expanded={menuOpen}
+                aria-haspopup="menu"
                 aria-label="Mon compte"
+                className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary hover:bg-primary/20 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 {initials}
               </button>
               {menuOpen && (
-                <div className="absolute right-0 top-10 z-50 w-48 rounded-md border bg-background shadow-lg">
+                <div
+                  role="menu"
+                  className="absolute right-0 top-10 z-50 w-48 rounded-md border bg-background shadow-lg"
+                >
                   <div className="border-b px-3 py-2">
                     <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                      <User className="h-3 w-3" />
+                      <User className="h-3 w-3" aria-hidden />
                       {user.email}
                     </p>
                   </div>
                   <button
+                    role="menuitem"
                     onClick={() => void handleSignOut()}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-muted transition-colors"
+                    className="flex w-full items-center gap-2 px-3 py-2.5 text-sm text-destructive hover:bg-muted transition-colors focus:outline-none focus-visible:bg-muted"
                   >
-                    <LogOut className="h-3.5 w-3.5" />
+                    <LogOut className="h-3.5 w-3.5" aria-hidden />
                     Se déconnecter
                   </button>
                 </div>

--- a/apps/web/src/components/ui/help-tip.tsx
+++ b/apps/web/src/components/ui/help-tip.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useRef, useEffect } from 'react';
 import type { Route } from 'next';
 import Link from 'next/link';
 import { Info } from 'lucide-react';
@@ -12,15 +13,27 @@ interface HelpTipProps {
   side?: 'top' | 'bottom' | 'left' | 'right';
 }
 
-/**
- * Tooltip contextuel léger — complément à <Help id="..."/> (qui nécessite un article complet).
- * Utiliser HelpTip pour une explication courte inline (label + hint).
- *
- * Usage :
- *   <HelpTip text="Le P&L latent est le gain/perte non encore réalisé." />
- *   <HelpTip text="..." glossarySlug="drawdown" />
- */
 export function HelpTip({ text, glossarySlug, className, side = 'top' }: HelpTipProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  // Close on outside pointer event or Escape — covers both mouse and touch.
+  useEffect(() => {
+    if (!open) return;
+    function close(e: Event) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('pointerdown', close);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('pointerdown', close);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
   const positionClasses: Record<typeof side, string> = {
     top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
     bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
@@ -29,35 +42,48 @@ export function HelpTip({ text, glossarySlug, className, side = 'top' }: HelpTip
   };
 
   return (
-    <span className={cn('relative inline-flex items-center group', className)}>
+    <span ref={ref} className={cn('relative inline-flex items-center', className)}>
+      {/* Touch-safe trigger: click toggles, keyboard accessible */}
       <span
         role="button"
         tabIndex={0}
         aria-label={`Aide : ${text.slice(0, 60)}`}
-        className="inline-flex cursor-help text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded"
+        aria-expanded={open}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setOpen((v) => !v);
+          }
+        }}
+        className="inline-flex cursor-pointer text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
       >
         <Info className="h-3.5 w-3.5" />
       </span>
 
-      <span
-        role="tooltip"
-        className={cn(
-          'pointer-events-none absolute z-50 w-64 rounded-lg border bg-background px-3 py-2 shadow-md text-xs text-foreground',
-          'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-150',
-          positionClasses[side],
-        )}
-      >
-        <span className="block leading-relaxed">{text}</span>
-        {glossarySlug && (
-          <Link
-            href={`/help/glossaire#${glossarySlug}` as Route}
-            className="pointer-events-auto mt-1.5 block text-[11px] text-primary underline underline-offset-2"
-            tabIndex={0}
-          >
-            Voir le glossaire →
-          </Link>
-        )}
-      </span>
+      {open && (
+        <span
+          role="tooltip"
+          className={cn(
+            'absolute z-50 w-56 max-w-[calc(100vw-2rem)] rounded-lg border bg-background px-3 py-2 shadow-md text-xs text-foreground',
+            positionClasses[side],
+          )}
+        >
+          <span className="block leading-relaxed">{text}</span>
+          {glossarySlug && (
+            <Link
+              href={`/help/glossaire#${glossarySlug}` as Route}
+              onClick={() => setOpen(false)}
+              className="mt-1.5 block text-[11px] text-primary underline underline-offset-2"
+            >
+              Voir le glossaire →
+            </Link>
+          )}
+        </span>
+      )}
     </span>
   );
 }


### PR DESCRIPTION
## Sprint 9 — Audit mobile-first + WCAG AA

### `HelpTip` — tooltip hover-only → click/tap universel
- Toggle `open` géré en React state (click/tap sur l'icône Info)
- Fermeture via `Escape` ou `pointerdown` en dehors (couvre mouse + touch)
- `w-56 max-w-[calc(100vw-2rem)]` : évite le débordement sur 375px
- `pointer-events` géré en JS — le lien glossaire est maintenant cliquable
- `focus-visible:ring-2` (était `ring-1`)

### `WelcomeBanner` — touch targets WCAG 2.5.8
- Bouton × → `p-2` autour de l'icône 16px = 32×32px zone tactile (était 24px)
- "Ne plus afficher" → `py-1.5 px-2` + `focus-visible:ring-2`

### `KpiCard` — valeur responsive
- `text-xl sm:text-2xl break-words` (était `text-2xl` fixe)

### `Header` — avatar dropdown accessibility
- Avatar → `h-9 w-9` + `focus-visible:ring-2`
- `aria-expanded` + `aria-haspopup="menu"` sur le bouton
- `role="menu"` / `role="menuitem"` sur le dropdown
- Fermeture au clic extérieur via `mousedown` + `touchstart`

---

## Sprint 6 — Pages squelettes Mon compte

### `/settings` restructuré
- 2 groupes : "Profil & préférences" + "Simulation & automatisation"

### Nouvelles sous-pages
| Route | Contenu |
|---|---|
| `/settings/profil` | Édition prénom, niveau expérience, RiskBadge en lecture, lien questionnaire |
| `/settings/securite` | Changement mot de passe (supabase.auth.updateUser) + déconnexion globale |
| `/settings/notifications` | Toggles email : alertes, résumé hebdo, suggestions Lisa |
| `/settings/abonnement` | Plan actuel (simulation personnelle gratuite) + features à venir |
| `/settings/donnees` | Export RGPD (GET /api/me/export) + suppression compte avec double confirmation |

### Pages existantes enrichies
- `/performance`, `/alerts`, `/history` : ajout `<BackButton />`
- `/performance`, `/alerts` : ajout `<HelpTip />` sur le titre

## TypeScript

```
tsc -b → ✅ 0 erreur
```

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_