### PR TITLE
feat(me): RGPD export + account deletion (GET /me/export, DELETE /me)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -29,6 +29,7 @@ import { BacktestModule } from './modules/backtest/backtest.module';
 import { StrategyOptimizerModule } from './modules/strategy-optimizer/optimizer.module';
 import { MonteCarloModule } from './modules/monte-carlo/monte-carlo.module';
 import { AdminModule } from './modules/admin/admin.module';
+import { MeModule } from './modules/me/me.module';
 
 @Module({
   imports: [
@@ -68,6 +69,7 @@ import { AdminModule } from './modules/admin/admin.module';
     StrategyOptimizerModule,
     MonteCarloModule,
     AdminModule,
+    MeModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/modules/me/__tests__/me.controller.spec.ts
+++ b/apps/api/src/modules/me/__tests__/me.controller.spec.ts
@@ -1,0 +1,102 @@
+import { MeController } from '../me.controller';
+import { MeService } from '../me.service';
+
+function makeMeService(overrides?: Partial<MeService>): MeService {
+  return {
+    validateToken: jest.fn().mockResolvedValue({ userId: 'user-123', email: 'test@example.com' }),
+    checkDeleteRateLimit: jest.fn(),
+    exportUserData: jest.fn().mockResolvedValue({ schemaVersion: '1', userId: 'user-123' }),
+    deleteAccount: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as MeService;
+}
+
+function makeResponse() {
+  const res = {
+    setHeader: jest.fn(),
+    send: jest.fn(),
+  };
+  return res;
+}
+
+// ─── GET /me/export ───────────────────────────────────────────────────────────
+
+describe('MeController.export', () => {
+  it('calls validateToken with Authorization header', async () => {
+    const svc = makeMeService();
+    const ctrl = new MeController(svc);
+    const res = makeResponse();
+    await ctrl.export({ authorization: 'Bearer tok' }, res as never);
+    expect(svc.validateToken).toHaveBeenCalledWith('Bearer tok');
+  });
+
+  it('sets Content-Disposition to attachment', async () => {
+    const svc = makeMeService();
+    const ctrl = new MeController(svc);
+    const res = makeResponse();
+    await ctrl.export({ authorization: 'Bearer tok' }, res as never);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="smartvest-export.json"',
+    );
+  });
+
+  it('sends JSON payload', async () => {
+    const svc = makeMeService();
+    const ctrl = new MeController(svc);
+    const res = makeResponse();
+    await ctrl.export({ authorization: 'Bearer tok' }, res as never);
+    expect(res.send).toHaveBeenCalledWith(
+      expect.stringContaining('"schemaVersion"'),
+    );
+  });
+
+  it('propagates UnauthorizedException from validateToken', async () => {
+    const { UnauthorizedException } = await import('@nestjs/common');
+    const svc = makeMeService({
+      validateToken: jest.fn().mockRejectedValue(new UnauthorizedException('Token invalide')),
+    });
+    const ctrl = new MeController(svc);
+    await expect(ctrl.export({ authorization: 'Bearer bad' }, makeResponse() as never))
+      .rejects.toThrow(UnauthorizedException);
+  });
+});
+
+// ─── DELETE /me ───────────────────────────────────────────────────────────────
+
+describe('MeController.deleteAccount', () => {
+  it('calls validateToken then checkDeleteRateLimit then deleteAccount', async () => {
+    const svc = makeMeService();
+    const ctrl = new MeController(svc);
+    await ctrl.deleteAccount({ authorization: 'Bearer tok', 'x-forwarded-for': '1.2.3.4' });
+    expect(svc.validateToken).toHaveBeenCalledWith('Bearer tok');
+    expect(svc.checkDeleteRateLimit).toHaveBeenCalledWith('user-123');
+    expect(svc.deleteAccount).toHaveBeenCalledWith('user-123', 'test@example.com', '1.2.3.4');
+  });
+
+  it('extracts first IP from x-forwarded-for chain', async () => {
+    const svc = makeMeService();
+    const ctrl = new MeController(svc);
+    await ctrl.deleteAccount({ authorization: 'Bearer tok', 'x-forwarded-for': '10.0.0.1, 1.2.3.4' });
+    expect(svc.deleteAccount).toHaveBeenCalledWith('user-123', 'test@example.com', '10.0.0.1');
+  });
+
+  it('falls back to x-real-ip when x-forwarded-for is absent', async () => {
+    const svc = makeMeService();
+    const ctrl = new MeController(svc);
+    await ctrl.deleteAccount({ authorization: 'Bearer tok', 'x-real-ip': '5.6.7.8' });
+    expect(svc.deleteAccount).toHaveBeenCalledWith('user-123', 'test@example.com', '5.6.7.8');
+  });
+
+  it('propagates 429 from checkDeleteRateLimit', async () => {
+    const { HttpException } = await import('@nestjs/common');
+    const svc = makeMeService({
+      checkDeleteRateLimit: jest.fn().mockImplementation(() => {
+        throw new HttpException({ message: 'rate limit' }, 429);
+      }),
+    });
+    const ctrl = new MeController(svc);
+    await expect(ctrl.deleteAccount({ authorization: 'Bearer tok' })).rejects.toThrow(HttpException);
+    expect(svc.deleteAccount).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/me/__tests__/me.service.spec.ts
+++ b/apps/api/src/modules/me/__tests__/me.service.spec.ts
@@ -1,0 +1,225 @@
+import { HttpException } from '@nestjs/common';
+import { MeService } from '../me.service';
+
+// ─── Minimal mock builder ─────────────────────────────────────────────────────
+
+function makeChain(result: unknown = []) {
+  const chain: Record<string, jest.Mock> = {};
+  const methods = ['select', 'eq', 'limit', 'order', 'insert', 'update', 'maybeSingle', 'single', 'filter'];
+  for (const m of methods) {
+    chain[m] = jest.fn(() => chain);
+  }
+  // Make the chain awaitable — resolves to { data: result, error: null }
+  const resolved = Promise.resolve({ data: result, error: null });
+  (chain as unknown as { then: unknown }).then = resolved.then.bind(resolved);
+  return chain;
+}
+
+function makeSupabase(overrides?: {
+  getUser?: unknown;
+  insertResult?: unknown;
+  connectionsResult?: unknown;
+  deleteUserResult?: unknown;
+  updateResult?: unknown;
+}) {
+  const insertChain = makeChain(overrides?.insertResult ?? [{ id: 'audit-1' }]);
+  const connectionsChain = makeChain(overrides?.connectionsResult ?? []);
+  const updateChain = makeChain(null);
+
+  // single() on insertChain
+  insertChain.single = jest.fn().mockResolvedValue({
+    data: overrides?.insertResult ?? { id: 'audit-1' },
+    error: null,
+  });
+
+  const fromFn = jest.fn((table: string) => {
+    if (table === 'account_deletion_audit') return insertChain;
+    if (table === 'broker_connections') return connectionsChain;
+    return updateChain;
+  });
+
+  return {
+    getClient: () => ({
+      from: fromFn,
+      auth: {
+        getUser: jest.fn().mockResolvedValue(overrides?.getUser ?? {
+          data: { user: { id: 'user-123', email: 'test@example.com' } },
+          error: null,
+        }),
+        admin: {
+          deleteUser: jest.fn().mockResolvedValue(
+            overrides?.deleteUserResult ?? { error: null },
+          ),
+        },
+      },
+    }),
+  };
+}
+
+function makeVault() {
+  return { clear: jest.fn().mockResolvedValue(undefined) };
+}
+
+// ─── validateToken ────────────────────────────────────────────────────────────
+
+describe('MeService.validateToken', () => {
+  it('returns userId + email on valid Bearer token', async () => {
+    const svc = new MeService(makeSupabase() as never, makeVault() as never);
+    const result = await svc.validateToken('Bearer valid-token');
+    expect(result).toEqual({ userId: 'user-123', email: 'test@example.com' });
+  });
+
+  it('throws UnauthorizedException when no Bearer prefix', async () => {
+    const svc = new MeService(makeSupabase() as never, makeVault() as never);
+    await expect(svc.validateToken('token-only')).rejects.toThrow('Token Bearer manquant');
+  });
+
+  it('throws UnauthorizedException when getUser returns error', async () => {
+    const sb = makeSupabase({ getUser: { data: { user: null }, error: { message: 'invalid' } } });
+    const svc = new MeService(sb as never, makeVault() as never);
+    await expect(svc.validateToken('Bearer bad')).rejects.toThrow('Token invalide ou expiré');
+  });
+});
+
+// ─── checkDeleteRateLimit ─────────────────────────────────────────────────────
+
+describe('MeService.checkDeleteRateLimit', () => {
+  it('allows up to 3 attempts within the window', () => {
+    const svc = new MeService(makeSupabase() as never, makeVault() as never);
+    expect(() => svc.checkDeleteRateLimit('u1')).not.toThrow();
+    expect(() => svc.checkDeleteRateLimit('u1')).not.toThrow();
+    expect(() => svc.checkDeleteRateLimit('u1')).not.toThrow();
+  });
+
+  it('throws 429 on the 4th attempt within the window', () => {
+    const svc = new MeService(makeSupabase() as never, makeVault() as never);
+    svc.checkDeleteRateLimit('u2');
+    svc.checkDeleteRateLimit('u2');
+    svc.checkDeleteRateLimit('u2');
+    expect(() => svc.checkDeleteRateLimit('u2')).toThrow(HttpException);
+  });
+
+  it('resets the window after the 60s window expires', () => {
+    jest.useFakeTimers();
+    const svc = new MeService(makeSupabase() as never, makeVault() as never);
+    svc.checkDeleteRateLimit('u3');
+    svc.checkDeleteRateLimit('u3');
+    svc.checkDeleteRateLimit('u3');
+    // Advance past the 60s window
+    jest.advanceTimersByTime(61_000);
+    expect(() => svc.checkDeleteRateLimit('u3')).not.toThrow();
+    jest.useRealTimers();
+  });
+
+  it('tracks rate limits per user independently', () => {
+    const svc = new MeService(makeSupabase() as never, makeVault() as never);
+    svc.checkDeleteRateLimit('ua');
+    svc.checkDeleteRateLimit('ua');
+    svc.checkDeleteRateLimit('ua');
+    // ua is at limit, but ub is fresh
+    expect(() => svc.checkDeleteRateLimit('ub')).not.toThrow();
+  });
+});
+
+// ─── hashIp ───────────────────────────────────────────────────────────────────
+
+describe('MeService.hashIp', () => {
+  it('returns sha256 hex for a known IP', () => {
+    const hash = MeService.hashIp('127.0.0.1');
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(MeService.hashIp(undefined)).toBeUndefined();
+  });
+
+  it('is deterministic', () => {
+    expect(MeService.hashIp('1.2.3.4')).toBe(MeService.hashIp('1.2.3.4'));
+  });
+});
+
+// ─── deleteAccount ────────────────────────────────────────────────────────────
+
+describe('MeService.deleteAccount', () => {
+  it('purges vault refs and calls auth.admin.deleteUser', async () => {
+    const deleteUserMock = jest.fn().mockResolvedValue({ error: null });
+    const vaultClearMock = jest.fn().mockResolvedValue(undefined);
+
+    const connectionChain = makeChain([{ credentials_vault_ref: 'vault-ref-1' }]);
+    const auditChain = makeChain({ id: 'audit-1' });
+    auditChain.single = jest.fn().mockResolvedValue({ data: { id: 'audit-1' }, error: null });
+
+    const sb = {
+      getClient: () => ({
+        from: jest.fn((table: string) => {
+          if (table === 'broker_connections') return connectionChain;
+          return auditChain;
+        }),
+        auth: { admin: { deleteUser: deleteUserMock } },
+      }),
+    };
+    const vault = { clear: vaultClearMock };
+    const svc = new MeService(sb as never, vault as never);
+
+    await svc.deleteAccount('user-123', 'test@example.com', '127.0.0.1');
+
+    expect(vaultClearMock).toHaveBeenCalledWith('vault-ref-1');
+    expect(deleteUserMock).toHaveBeenCalledWith('user-123');
+  });
+
+  it('marks audit as failed and re-throws when deleteUser fails', async () => {
+    const deleteUserMock = jest.fn().mockResolvedValue({ error: { message: 'db error' } });
+    const auditChain = makeChain({ id: 'audit-1' });
+    auditChain.single = jest.fn().mockResolvedValue({ data: { id: 'audit-1' }, error: null });
+    const connectionChain = makeChain([]);
+
+    const updateMock = jest.fn(() => ({ eq: jest.fn().mockResolvedValue({ error: null }) }));
+    const fromFn = jest.fn((table: string) => {
+      if (table === 'broker_connections') return connectionChain;
+      const chain = makeChain({ id: 'audit-1' });
+      chain.single = jest.fn().mockResolvedValue({ data: { id: 'audit-1' }, error: null });
+      chain.update = updateMock;
+      return chain;
+    });
+
+    const sb = {
+      getClient: () => ({
+        from: fromFn,
+        auth: { admin: { deleteUser: deleteUserMock } },
+      }),
+    };
+    const svc = new MeService(sb as never, makeVault() as never);
+
+    await expect(svc.deleteAccount('user-fail', undefined, undefined)).rejects.toThrow('auth.admin.deleteUser failed');
+    expect(updateMock).toHaveBeenCalled();
+  });
+
+  it('does NOT expose credentials_vault_ref in broker_connections export', async () => {
+    // Track which column string is passed to select() for broker_connections.
+    let brokerSelectCols: string | undefined;
+    const brokerChain = makeChain([]);
+    const origSelect = brokerChain.select as jest.Mock;
+    brokerChain.select = jest.fn((cols?: string) => {
+      brokerSelectCols = cols;
+      return origSelect.call(brokerChain, cols);
+    });
+
+    const defaultChain = makeChain(null);
+    defaultChain.maybeSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+
+    const sb = {
+      getClient: () => ({
+        from: jest.fn((table: string) => table === 'broker_connections' ? brokerChain : defaultChain),
+        auth: { getUser: jest.fn() },
+      }),
+    };
+    const svc = new MeService(sb as never, makeVault() as never);
+    await svc.exportUserData('user-xyz');
+
+    expect(brokerSelectCols).toBeDefined();
+    expect(brokerSelectCols).not.toContain('credentials_vault_ref');
+    expect(brokerSelectCols).not.toContain('*');
+    expect(brokerSelectCols).toContain('provider');
+  });
+});

--- a/apps/api/src/modules/me/me.controller.ts
+++ b/apps/api/src/modules/me/me.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Delete, Get, Headers, HttpCode, HttpStatus, Res } from '@nestjs/common';
+import type { Response } from 'express';
+import { MeService } from './me.service';
+
+@Controller('me')
+export class MeController {
+  constructor(private readonly me: MeService) {}
+
+  /**
+   * GET /me/export
+   * RGPD — exports all user data as a downloadable JSON file.
+   * Auth: live JWT validation (Bearer token, server-side verification).
+   */
+  @Get('export')
+  async export(
+    @Headers() headers: Record<string, string>,
+    @Res() res: Response,
+  ): Promise<void> {
+    const { userId } = await this.me.validateToken(headers['authorization']);
+    const data = await this.me.exportUserData(userId);
+    const json = JSON.stringify(data, null, 2);
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Disposition', 'attachment; filename="smartvest-export.json"');
+    res.setHeader('Content-Length', Buffer.byteLength(json, 'utf8'));
+    res.send(json);
+  }
+
+  /**
+   * DELETE /me
+   * RGPD — permanently deletes the authenticated user account and all data.
+   * Rate-limited: 3 attempts per 60 seconds per user.
+   * Auth: live JWT validation (Bearer token, server-side verification).
+   */
+  @Delete()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteAccount(
+    @Headers() headers: Record<string, string>,
+  ): Promise<void> {
+    const { userId, email } = await this.me.validateToken(headers['authorization']);
+    this.me.checkDeleteRateLimit(userId);
+
+    const rawIp = headers['x-forwarded-for']?.split(',')[0]?.trim()
+      ?? headers['x-real-ip'];
+
+    await this.me.deleteAccount(userId, email, rawIp);
+  }
+}

--- a/apps/api/src/modules/me/me.module.ts
+++ b/apps/api/src/modules/me/me.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { BrokersModule } from '../brokers/brokers.module';
+import { MeController } from './me.controller';
+import { MeService } from './me.service';
+
+@Module({
+  imports: [SupabaseModule, BrokersModule],
+  controllers: [MeController],
+  providers: [MeService],
+})
+export class MeModule {}

--- a/apps/api/src/modules/me/me.service.ts
+++ b/apps/api/src/modules/me/me.service.ts
@@ -1,0 +1,185 @@
+import { HttpException, HttpStatus, Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import { SupabaseService } from '../supabase/supabase.service';
+import { CredentialsVaultService } from '../brokers/services/credentials-vault.service';
+
+// Rate limit: 3 DELETE attempts per 60-second window per user.
+const DELETE_MAX = 3;
+const DELETE_WINDOW_MS = 60_000;
+
+interface RateLimitEntry {
+  attempts: number;
+  windowStart: number;
+}
+
+@Injectable()
+export class MeService {
+  private readonly logger = new Logger(MeService.name);
+  private readonly deleteRateMap = new Map<string, RateLimitEntry>();
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly vault: CredentialsVaultService,
+  ) {}
+
+  // ─── Live JWT validation ───────────────────────────────────────────
+
+  async validateToken(authorization: string | undefined): Promise<{ userId: string; email: string | undefined }> {
+    if (!authorization?.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Token Bearer manquant');
+    }
+    const token = authorization.slice(7);
+    const { data, error } = await this.supabase.getClient().auth.getUser(token);
+    if (error || !data.user?.id) {
+      throw new UnauthorizedException('Token invalide ou expiré');
+    }
+    return { userId: data.user.id, email: data.user.email };
+  }
+
+  // ─── Rate limiter (DELETE only) ────────────────────────────────────
+
+  checkDeleteRateLimit(userId: string): void {
+    const now = Date.now();
+    const entry = this.deleteRateMap.get(userId);
+    if (!entry || now - entry.windowStart > DELETE_WINDOW_MS) {
+      this.deleteRateMap.set(userId, { attempts: 1, windowStart: now });
+      return;
+    }
+    if (entry.attempts >= DELETE_MAX) {
+      throw new HttpException(
+        { message: 'Trop de tentatives. Réessayez dans 60 secondes.', statusCode: 429 },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+    entry.attempts += 1;
+  }
+
+  // ─── RGPD Export ──────────────────────────────────────────────────
+
+  async exportUserData(userId: string): Promise<Record<string, unknown>> {
+    const db = this.supabase.getClient();
+
+    const [
+      profile,
+      portfolios,
+      positions,
+      goals,
+      alerts,
+      funding,
+      lisaDecisions,
+      paperTrades,
+      brokerConnections,
+      sniperSessions,
+    ] = await Promise.all([
+      db.from('user_profiles').select('*').eq('user_id', userId).maybeSingle(),
+      db.from('portfolios').select('*').eq('user_id', userId),
+      db.from('positions').select('*').eq('user_id', userId),
+      db.from('goals').select('*').eq('user_id', userId),
+      db.from('alerts').select('*').eq('user_id', userId),
+      db.from('funding_transfers').select('*').eq('user_id', userId),
+      db.from('lisa_decision_log').select('*').eq('user_id', userId).limit(1000).order('created_at', { ascending: false }),
+      db.from('paper_trades').select('*').eq('user_id', userId).limit(500).order('created_at', { ascending: false }),
+      // Explicit column list — NEVER expose credentials_vault_ref
+      db.from('broker_connections').select(
+        'id, user_id, provider, label, status, supports_read, supports_execution, supports_streaming, supports_options, supports_crypto, supports_csv_import, connected_at, last_sync_at, meta, created_at, updated_at',
+      ).eq('user_id', userId),
+      db.from('sniper_sessions').select(
+        'id, user_id, status, started_at, expires_at, ended_at, revoke_reason, ttl_minutes',
+      ).eq('user_id', userId),
+    ]);
+
+    return {
+      schemaVersion: '1',
+      exportedAt: new Date().toISOString(),
+      userId,
+      profile: profile.data ?? null,
+      portfolios: portfolios.data ?? [],
+      positions: positions.data ?? [],
+      goals: goals.data ?? [],
+      alerts: alerts.data ?? [],
+      fundingTransfers: funding.data ?? [],
+      lisaDecisionLog: lisaDecisions.data ?? [],
+      paperTrades: paperTrades.data ?? [],
+      brokerConnections: brokerConnections.data ?? [],
+      sniperSessions: sniperSessions.data ?? [],
+    };
+  }
+
+  // ─── RGPD Account Deletion ────────────────────────────────────────
+
+  async deleteAccount(
+    userId: string,
+    userEmail: string | undefined,
+    rawIp: string | undefined,
+  ): Promise<void> {
+    const db = this.supabase.getClient();
+    const ipHash = MeService.hashIp(rawIp);
+
+    // 1. Insert audit row (initiated)
+    const { data: auditRow, error: auditInsertError } = await db
+      .from('account_deletion_audit')
+      .insert({
+        user_id: userId,
+        user_email: userEmail ?? null,
+        ip_hash: ipHash ?? null,
+        status: 'initiated',
+      })
+      .select('id')
+      .single();
+
+    if (auditInsertError) {
+      this.logger.error(`audit insert failed user=${userId.slice(0, 8)}: ${auditInsertError.message}`);
+    }
+    const auditId = auditRow?.id as string | undefined;
+
+    try {
+      // 2. Purge Vault secrets for broker_connections
+      const { data: connections } = await db
+        .from('broker_connections')
+        .select('credentials_vault_ref')
+        .eq('user_id', userId);
+
+      if (connections?.length) {
+        await Promise.allSettled(
+          (connections as Array<{ credentials_vault_ref: string | null }>)
+            .filter((c) => c.credentials_vault_ref)
+            .map((c) => this.vault.clear(c.credentials_vault_ref as string)),
+        );
+        this.logger.log(`Vault purged ${connections.length} secret(s) for user=${userId.slice(0, 8)}`);
+      }
+
+      // 3. Delete the Supabase Auth user → cascades all rows via ON DELETE CASCADE
+      const { error: deleteError } = await db.auth.admin.deleteUser(userId);
+      if (deleteError) {
+        throw new Error(`auth.admin.deleteUser failed: ${deleteError.message}`);
+      }
+
+      // 4. Mark audit row completed
+      if (auditId) {
+        await db
+          .from('account_deletion_audit')
+          .update({ status: 'completed', completed_at: new Date().toISOString() })
+          .eq('id', auditId);
+      }
+
+      this.logger.log(`Account deleted: user=${userId.slice(0, 8)}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`deleteAccount failed user=${userId.slice(0, 8)}: ${msg}`);
+      if (auditId) {
+        await db
+          .from('account_deletion_audit')
+          .update({ status: 'failed', completed_at: new Date().toISOString(), error_message: msg })
+          .eq('id', auditId);
+      }
+      throw err;
+    }
+  }
+
+  // ─── Utility ──────────────────────────────────────────────────────
+
+  static hashIp(ip: string | undefined): string | undefined {
+    if (!ip) return undefined;
+    return createHash('sha256').update(ip).digest('hex');
+  }
+}

--- a/apps/web/src/app/alerts/page.tsx
+++ b/apps/web/src/app/alerts/page.tsx
@@ -5,16 +5,26 @@ import { Bell } from 'lucide-react';
 import { usePortfolios } from '@/hooks/use-portfolio';
 import { SkeletonCard } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/states/empty-state';
+import { BackButton } from '@/components/ui/back-button';
+import { HelpTip } from '@/components/ui/help-tip';
 
 export default function AlertsPage() {
   const { data: portfolios, isLoading } = usePortfolios();
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <BackButton />
       <div>
-        <h1 className="text-xl font-semibold">Mes notifications</h1>
+        <h1 className="flex items-center gap-2 text-xl font-semibold">
+          Mes notifications
+          <HelpTip
+            text="Alertes déclenchées automatiquement sur vos positions (seuil de perte, objectif atteint, anomalie). Vous choisissez les règles."
+            glossarySlug="alerte"
+            side="right"
+          />
+        </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Alertes et règles de surveillance par portefeuille.
+          Règles de surveillance par portefeuille.
         </p>
       </div>
 

--- a/apps/web/src/app/api/me/export/route.ts
+++ b/apps/web/src/app/api/me/export/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const authorization = req.headers.get('authorization');
+  if (!authorization) {
+    return NextResponse.json({ message: 'Authentification requise' }, { status: 401 });
+  }
+
+  const upstream = await fetch(`${API_URL}/me/export`, {
+    headers: { authorization },
+  });
+
+  if (!upstream.ok) {
+    const body = await upstream.text().catch(() => 'Erreur serveur');
+    return NextResponse.json({ message: body }, { status: upstream.status });
+  }
+
+  const blob = await upstream.blob();
+  return new NextResponse(blob, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Disposition': 'attachment; filename="smartvest-export.json"',
+    },
+  });
+}

--- a/apps/web/src/app/api/me/route.ts
+++ b/apps/web/src/app/api/me/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  const authorization = req.headers.get('authorization');
+  if (!authorization) {
+    return NextResponse.json({ message: 'Authentification requise' }, { status: 401 });
+  }
+
+  const forwardedFor = req.headers.get('x-forwarded-for')
+    ?? req.headers.get('x-real-ip')
+    ?? undefined;
+
+  const headers: Record<string, string> = { authorization };
+  if (forwardedFor) headers['x-forwarded-for'] = forwardedFor;
+
+  const upstream = await fetch(`${API_URL}/me`, {
+    method: 'DELETE',
+    headers,
+  });
+
+  if (upstream.status === 204) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const body = await upstream.text().catch(() => 'Erreur serveur');
+  return NextResponse.json({ message: body }, { status: upstream.status });
+}

--- a/apps/web/src/app/history/page.tsx
+++ b/apps/web/src/app/history/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { ArrowLeftRight, BookOpen, History } from 'lucide-react';
+import { BackButton } from '@/components/ui/back-button';
 
 const SECTIONS = [
   {
@@ -21,10 +22,11 @@ const SECTIONS = [
 export default function HistoryPage() {
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <BackButton />
       <div>
         <h1 className="text-xl font-semibold">Mes opérations</h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Consultez l'historique de vos mouvements et opérations.
+          Historique de vos mouvements de trésorerie et transferts.
         </p>
       </div>
 

--- a/apps/web/src/app/performance/page.tsx
+++ b/apps/web/src/app/performance/page.tsx
@@ -5,16 +5,26 @@ import { BarChart3 } from 'lucide-react';
 import { usePortfolios } from '@/hooks/use-portfolio';
 import { SkeletonCard } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/states/empty-state';
+import { BackButton } from '@/components/ui/back-button';
+import { HelpTip } from '@/components/ui/help-tip';
 
 export default function PerformancePage() {
   const { data: portfolios, isLoading } = usePortfolios();
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <BackButton />
       <div>
-        <h1 className="text-xl font-semibold">Mes résultats</h1>
+        <h1 className="flex items-center gap-2 text-xl font-semibold">
+          Mes résultats
+          <HelpTip
+            text="Évolution de la valeur de vos portefeuilles dans le temps. Les performances passées ne préjugent pas des performances futures."
+            glossarySlug="performance"
+            side="right"
+          />
+        </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Analyse de la performance de vos portefeuilles. Les performances passées ne préjugent pas des performances futures.
+          Analyse de la performance de vos portefeuilles.
         </p>
       </div>
 

--- a/apps/web/src/app/settings/abonnement/page.tsx
+++ b/apps/web/src/app/settings/abonnement/page.tsx
@@ -1,0 +1,89 @@
+import type { Route } from 'next';
+import Link from 'next/link';
+import { BackButton } from '@/components/ui/back-button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { FlaskConical, Sparkles } from 'lucide-react';
+
+export default function AbonnementPage() {
+  return (
+    <div className="mx-auto max-w-xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Abonnement</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Votre plan actuel et ses fonctionnalités.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <FlaskConical className="h-4 w-4 text-amber-500" />
+            Plan actuel — Simulation personnelle
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-900/20">
+            <p className="text-xs text-amber-800 dark:text-amber-300">
+              SmartVest est actuellement en accès personnel gratuit.
+              Toutes les fonctionnalités de simulation sont disponibles sans limite.
+            </p>
+          </div>
+
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            {[
+              'Portefeuilles de simulation illimités',
+              "Analyse IA via Lisa (sous quota d'API)",
+              'Données de marché en différé (15 min)',
+              'Guides utilisateur et glossaire',
+              'Export des données (RGPD)',
+            ].map((feature) => (
+              <li key={feature} className="flex items-start gap-2">
+                <span className="mt-0.5 text-emerald-500">✓</span>
+                {feature}
+              </li>
+            ))}
+          </ul>
+
+          <div className="border-t pt-4">
+            <p className="text-xs text-muted-foreground">
+              Les données de marché sont fournies par EODHD et Binance.
+              Certaines données peuvent être en différé de 15 minutes.{' '}
+              <Link
+                href={'/legal/cgu' as Route}
+                className="text-primary underline underline-offset-4"
+              >
+                Voir les CGU
+              </Link>
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <Sparkles className="h-4 w-4 text-primary" />
+            Fonctionnalités à venir
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            {[
+              'Connexion broker en lecture (Interactive Brokers, Saxo, Trading 212)',
+              'Données temps réel',
+              'Alertes SMS',
+              'Rapports PDF personnalisés',
+            ].map((feature) => (
+              <li key={feature} className="flex items-start gap-2">
+                <span className="mt-0.5 text-muted-foreground/40">○</span>
+                {feature}
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/donnees/page.tsx
+++ b/apps/web/src/app/settings/donnees/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState } from 'react';
+import type { Route } from 'next';
+import Link from 'next/link';
+import { BackButton } from '@/components/ui/back-button';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { useRouter } from 'next/navigation';
+import { Download, Trash2 } from 'lucide-react';
+
+export default function DonneesPage() {
+  const [exporting, setExporting] = useState(false);
+  const [deleteStep, setDeleteStep] = useState<'idle' | 'confirm' | 'deleting'>('idle');
+  const [confirmText, setConfirmText] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function handleExport() {
+    setExporting(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) throw new Error('Non connecté');
+      const res = await fetch('/api/me/export', {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) throw new Error(`Erreur ${res.status}`);
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `smartvest-export-${new Date().toISOString().slice(0, 10)}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  async function handleDeleteAccount() {
+    setDeleteStep('deleting');
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) throw new Error('Non connecté');
+      const res = await fetch('/api/me', {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) throw new Error(`Erreur ${res.status}`);
+      await supabase.auth.signOut();
+      router.push('/');
+    } catch (e) {
+      setError((e as Error).message);
+      setDeleteStep('confirm');
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Mes données</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Exportez ou supprimez vos données personnelles (RGPD).
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <Download className="h-4 w-4" />
+            Exporter mes données
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Téléchargez une copie de toutes vos données : profil, portefeuilles,
+            positions, transactions et paramètres. Format JSON.
+          </p>
+          <Button variant="outline" onClick={handleExport} disabled={exporting}>
+            {exporting ? 'Export en cours…' : 'Télécharger mes données'}
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            Conformément au{' '}
+            <Link href={'/legal/confidentialite' as Route} className="text-primary underline underline-offset-4">
+              droit à la portabilité (RGPD)
+            </Link>
+            .
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card className="border-destructive/30">
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium text-destructive">
+            <Trash2 className="h-4 w-4" />
+            Supprimer mon compte
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Supprime définitivement votre compte et toutes vos données sous 30 jours.
+            Cette action est irréversible.
+          </p>
+
+          {deleteStep === 'idle' && (
+            <Button
+              variant="outline"
+              className="border-destructive/50 text-destructive hover:bg-destructive/10"
+              onClick={() => setDeleteStep('confirm')}
+            >
+              Supprimer mon compte
+            </Button>
+          )}
+
+          {deleteStep === 'confirm' && (
+            <div className="space-y-3 rounded-lg border border-destructive/30 p-4">
+              <p className="text-sm font-medium text-destructive">
+                Confirmation requise
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Tapez <strong>SUPPRIMER</strong> pour confirmer la suppression
+                définitive de votre compte et de toutes vos données.
+              </p>
+              <input
+                type="text"
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder="SUPPRIMER"
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-destructive"
+                aria-label="Tapez SUPPRIMER pour confirmer"
+              />
+              <div className="flex gap-2">
+                <Button
+                  variant="destructive"
+                  onClick={handleDeleteAccount}
+                  disabled={confirmText !== 'SUPPRIMER'}
+                >
+                  Confirmer la suppression
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => { setDeleteStep('idle'); setConfirmText(''); }}
+                >
+                  Annuler
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {deleteStep === 'deleting' && (
+            <p className="text-sm text-muted-foreground">Suppression en cours…</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/notifications/page.tsx
+++ b/apps/web/src/app/settings/notifications/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState } from 'react';
+import { BackButton } from '@/components/ui/back-button';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useUserProfile } from '@/hooks/use-portfolio';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { useQueryClient } from '@tanstack/react-query';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const NOTIFICATION_OPTIONS = [
+  {
+    key: 'email_alerts',
+    label: 'Alertes de portefeuille',
+    description: 'Recevez un email quand une alerte se déclenche (seuil de perte, objectif atteint).',
+  },
+  {
+    key: 'email_weekly_summary',
+    label: 'Résumé hebdomadaire',
+    description: 'Un récapitulatif de vos performances chaque lundi matin.',
+  },
+  {
+    key: 'email_suggestions',
+    label: 'Nouvelles suggestions Lisa',
+    description: "Notification quand Lisa propose un scénario ou une analyse à valider.",
+  },
+] as const;
+
+type NotifKey = (typeof NOTIFICATION_OPTIONS)[number]['key'];
+
+export default function NotificationsPage() {
+  const { data: profile, isLoading } = useUserProfile();
+  const [prefs, setPrefs] = useState<Partial<Record<NotifKey, boolean>>>({});
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const qc = useQueryClient();
+
+  function getChecked(key: NotifKey): boolean {
+    if (key in prefs) return !!prefs[key];
+    const p = profile as Record<string, unknown> | null;
+    if (p && key in p) return !!p[key];
+    return true;
+  }
+
+  function toggle(key: NotifKey) {
+    setPrefs((prev) => ({ ...prev, [key]: !getChecked(key) }));
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Non connecté');
+      const update: Record<string, boolean> = {};
+      for (const { key } of NOTIFICATION_OPTIONS) {
+        update[key] = getChecked(key);
+      }
+      const { error: err } = await supabase
+        .from('user_profiles')
+        .update(update)
+        .eq('id', user.id);
+      if (err) throw new Error(err.message);
+      await qc.invalidateQueries({ queryKey: ['user_profile'] });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Notifications</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Choisissez quels emails vous souhaitez recevoir de SmartVest.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => <Skeleton key={i} className="h-16 w-full" />)}
+        </div>
+      ) : (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium">Préférences email</CardTitle>
+          </CardHeader>
+          <CardContent className="divide-y">
+            {NOTIFICATION_OPTIONS.map(({ key, label, description }) => (
+              <div key={key} className="flex items-start justify-between gap-4 py-3 first:pt-0 last:pb-0">
+                <div>
+                  <p className="text-sm font-medium">{label}</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={getChecked(key)}
+                  onClick={() => toggle(key)}
+                  className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ${
+                    getChecked(key) ? 'bg-primary' : 'bg-input'
+                  }`}
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-background shadow-lg transition-transform ${
+                      getChecked(key) ? 'translate-x-4' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      {saved && <p className="text-sm text-emerald-600">Préférences enregistrées.</p>}
+
+      <Button onClick={handleSave} disabled={saving || isLoading}>
+        {saving ? 'Enregistrement…' : 'Enregistrer'}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,27 +1,66 @@
 'use client';
 
+import type { Route } from 'next';
 import Link from 'next/link';
 import {
+  Bell,
   Bot,
   Cable,
   ChevronRight,
+  CreditCard,
+  Database,
+  Lock,
   Shield,
   Sliders,
+  User,
   Zap,
 } from 'lucide-react';
 
-const SECTIONS = [
+const PROFILE_SECTIONS = [
+  {
+    href: '/settings/profil',
+    icon: User,
+    label: 'Mon profil',
+    description: 'Prénom, niveau d\'expérience, langue.',
+  },
+  {
+    href: '/settings/securite',
+    icon: Lock,
+    label: 'Sécurité',
+    description: 'Mot de passe, sessions actives.',
+  },
+  {
+    href: '/settings/notifications',
+    icon: Bell,
+    label: 'Notifications',
+    description: 'Alertes email, résumés hebdomadaires.',
+  },
+  {
+    href: '/settings/abonnement',
+    icon: CreditCard,
+    label: 'Abonnement',
+    description: 'Plan actuel, limites et informations de facturation.',
+  },
+  {
+    href: '/settings/donnees',
+    icon: Database,
+    label: 'Mes données',
+    description: 'Exporter ou supprimer votre compte (RGPD).',
+  },
+] as const;
+
+const ADVANCED_SECTIONS = [
   {
     href: '/settings/delegation',
     icon: Shield,
     label: 'Délégation & Mandats',
-    description: "Configurez les garde-fous et mandats d'autonomie.",
+    description: "Garde-fous et mandats d'autonomie pour Lisa.",
   },
   {
     href: '/settings/strategy-mode',
     icon: Sliders,
     label: 'Mode stratégique',
-    description: "Choisissez le mode d'analyse et de cadence.",
+    description: "Mode d'analyse : investissement, harvest ou gainers.",
   },
   {
     href: '/settings/hyper-trading',
@@ -43,6 +82,29 @@ const SECTIONS = [
   },
 ] as const;
 
+function SectionList({ sections }: { sections: readonly { href: string; icon: React.ElementType; label: string; description: string }[] }) {
+  return (
+    <div className="rounded-lg border divide-y">
+      {sections.map(({ href, icon: Icon, label, description }) => (
+        <Link
+          key={href}
+          href={href as Route}
+          className="flex items-center gap-4 px-4 py-4 transition-colors hover:bg-muted/30"
+        >
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-muted/40">
+            <Icon className="h-4 w-4 text-muted-foreground" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium">{label}</p>
+            <p className="text-xs text-muted-foreground">{description}</p>
+          </div>
+          <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+        </Link>
+      ))}
+    </div>
+  );
+}
+
 export default function SettingsPage() {
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-6">
@@ -53,24 +115,15 @@ export default function SettingsPage() {
         </p>
       </div>
 
-      <div className="rounded-lg border divide-y">
-        {SECTIONS.map(({ href, icon: Icon, label, description }) => (
-          <Link
-            key={href}
-            href={href}
-            className="flex items-center gap-4 px-4 py-4 transition-colors hover:bg-muted/30"
-          >
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-muted/40">
-              <Icon className="h-4 w-4 text-muted-foreground" />
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium">{label}</p>
-              <p className="text-xs text-muted-foreground">{description}</p>
-            </div>
-            <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
-          </Link>
-        ))}
-      </div>
+      <section className="space-y-2">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground px-1">Profil & préférences</p>
+        <SectionList sections={PROFILE_SECTIONS} />
+      </section>
+
+      <section className="space-y-2">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground px-1">Simulation & automatisation</p>
+        <SectionList sections={ADVANCED_SECTIONS} />
+      </section>
     </div>
   );
 }

--- a/apps/web/src/app/settings/profil/page.tsx
+++ b/apps/web/src/app/settings/profil/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { BackButton } from '@/components/ui/back-button';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useUserProfile } from '@/hooks/use-portfolio';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { useQueryClient } from '@tanstack/react-query';
+import { RiskBadge } from '@/components/ui/risk-badge';
+import type { RiskProfile } from '@/components/ui/risk-badge';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const EXPERIENCE_OPTIONS = [
+  { value: 'debutant', label: '🌱 Je débute', description: 'Nouveaux concepts à chaque étape.' },
+  { value: 'basic', label: '💼 Familier', description: "Je connais actions, obligations, ETF." },
+  { value: 'moderate', label: '📊 Occasionnel', description: 'J\'investis de temps en temps.' },
+  { value: 'advanced', label: '⚙️ Expérimenté', description: 'Je lis bilans et analyses.' },
+  { value: 'expert', label: '🎯 Expert', description: 'Dérivés, arbitrage, gestion active.' },
+] as const;
+
+export default function ProfilPage() {
+  const { data: profile, isLoading } = useUserProfile();
+  const [firstName, setFirstName] = useState('');
+  const [experience, setExperience] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const qc = useQueryClient();
+  const router = useRouter();
+
+  const currentFirstName = firstName || (profile?.first_name ?? '');
+  const currentExperience = experience || (profile?.experience_level ?? '');
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Non connecté');
+      const { error: err } = await supabase
+        .from('user_profiles')
+        .update({ first_name: currentFirstName, experience_level: currentExperience })
+        .eq('id', user.id);
+      if (err) throw new Error(err.message);
+      await qc.invalidateQueries({ queryKey: ['user_profile'] });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Mon profil</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Informations personnelles et niveau d'expérience.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm font-medium">Prénom</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <input
+                type="text"
+                value={currentFirstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                placeholder="Votre prénom"
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm font-medium">Adresse e-mail</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">{profile?.email ?? '—'}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                L'adresse e-mail ne peut pas être modifiée ici. Contactez le support.
+              </p>
+            </CardContent>
+          </Card>
+
+          {profile?.risk_profile && (
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-sm font-medium">Profil de risque</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <RiskBadge
+                  profile={profile.risk_profile as RiskProfile}
+                  size="md"
+                  showPhrase
+                  showTip={false}
+                />
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Défini lors de l'onboarding.{' '}
+                  <a href="/onboarding" className="text-primary underline underline-offset-4">Refaire le questionnaire</a>
+                </p>
+              </CardContent>
+            </Card>
+          )}
+
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm font-medium">Niveau d'expérience</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {EXPERIENCE_OPTIONS.map(({ value, label, description }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setExperience(value)}
+                  className={`w-full flex items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors hover:bg-muted/30 ${
+                    currentExperience === value ? 'border-primary bg-primary/5' : ''
+                  }`}
+                >
+                  <div className={`h-3 w-3 shrink-0 rounded-full border-2 ${currentExperience === value ? 'border-primary bg-primary' : 'border-muted-foreground'}`} />
+                  <div>
+                    <p className="text-sm font-medium">{label}</p>
+                    <p className="text-xs text-muted-foreground">{description}</p>
+                  </div>
+                </button>
+              ))}
+            </CardContent>
+          </Card>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {saved && <p className="text-sm text-emerald-600">Profil mis à jour.</p>}
+
+          <div className="flex gap-3">
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? 'Enregistrement…' : 'Enregistrer'}
+            </Button>
+            <Button variant="outline" onClick={() => router.back()}>
+              Annuler
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/securite/page.tsx
+++ b/apps/web/src/app/settings/securite/page.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import { BackButton } from '@/components/ui/back-button';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { ShieldCheck } from 'lucide-react';
+
+export default function SecuritePage() {
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleChangePassword() {
+    if (newPassword !== confirmPassword) {
+      setError('Les mots de passe ne correspondent pas.');
+      return;
+    }
+    if (newPassword.length < 8) {
+      setError('Le nouveau mot de passe doit contenir au moins 8 caractères.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { error: err } = await supabase.auth.updateUser({ password: newPassword });
+      if (err) throw new Error(err.message);
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      setSaved(true);
+      setTimeout(() => setSaved(false), 4000);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSignOutAll() {
+    const supabase = createSupabaseBrowserClient();
+    await supabase.auth.signOut({ scope: 'global' });
+    window.location.href = '/';
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Sécurité</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Mot de passe et gestion des sessions.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <ShieldCheck className="h-4 w-4" />
+            Changer de mot de passe
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">Mot de passe actuel</label>
+            <input
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              placeholder="••••••••"
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">Nouveau mot de passe</label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              placeholder="8 caractères minimum"
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">Confirmer le nouveau mot de passe</label>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="Répétez le mot de passe"
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {saved && <p className="text-sm text-emerald-600">Mot de passe mis à jour.</p>}
+
+          <Button onClick={handleChangePassword} disabled={saving || !newPassword}>
+            {saving ? 'Mise à jour…' : 'Mettre à jour'}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm font-medium">Sessions</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Déconnectez-vous de toutes les sessions actives sur tous les appareils.
+          </p>
+          <Button variant="outline" onClick={handleSignOutAll}>
+            Se déconnecter partout
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/welcome-banner.tsx
+++ b/apps/web/src/components/dashboard/welcome-banner.tsx
@@ -4,7 +4,6 @@ import type { Route } from 'next';
 import Link from 'next/link';
 import { useState, useEffect } from 'react';
 import { X, BookOpen, FlaskConical, Sparkles, ChevronRight } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 
 const STORAGE_KEY = 'smartvest_welcome_dismissed_v1';
 
@@ -59,15 +58,15 @@ export function WelcomeBanner() {
             Voici 3 étapes pour bien démarrer.
           </p>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
+        {/* min 32×32 touch target (WCAG 2.5.8) */}
+        <button
+          type="button"
           onClick={dismiss}
-          className="h-6 w-6 shrink-0 p-0 text-muted-foreground hover:text-foreground"
+          className="shrink-0 rounded-md p-2 text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           aria-label="Fermer ce message de bienvenue"
         >
-          <X className="h-3.5 w-3.5" />
-        </Button>
+          <X className="h-4 w-4" />
+        </button>
       </div>
 
       <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
@@ -99,7 +98,7 @@ export function WelcomeBanner() {
         <button
           type="button"
           onClick={dismiss}
-          className="text-[11px] text-muted-foreground hover:text-foreground"
+          className="rounded py-1.5 px-2 text-[11px] text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           Ne plus afficher
         </button>

--- a/apps/web/src/components/kpi-card.tsx
+++ b/apps/web/src/components/kpi-card.tsx
@@ -28,7 +28,7 @@ export function KpiCard({ label, value, hint, helpTip, helpGlossarySlug, delta, 
         {icon ? <span className="text-muted-foreground">{icon}</span> : null}
       </CardHeader>
       <CardContent>
-        <div className="text-2xl font-semibold tracking-tight">{value}</div>
+        <div className="text-xl font-semibold tracking-tight sm:text-2xl break-words">{value}</div>
         {delta ? (
           <p
             className={cn(

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -6,7 +6,7 @@ import { useUIStore } from '@/stores/ui';
 import { KillSwitchBanner } from '@/components/kill-switch-banner';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { User as SupabaseUser } from '@supabase/supabase-js';
 
 export function Header() {
@@ -27,6 +27,21 @@ export function Header() {
   }
 
   const initials = user?.email?.slice(0, 2).toUpperCase() ?? '?';
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click/touch
+  useEffect(() => {
+    if (!menuOpen) return;
+    function close(e: MouseEvent | TouchEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
+    }
+    document.addEventListener('mousedown', close);
+    document.addEventListener('touchstart', close);
+    return () => {
+      document.removeEventListener('mousedown', close);
+      document.removeEventListener('touchstart', close);
+    };
+  }, [menuOpen]);
 
   return (
     <header className="sticky top-0 z-30 border-b bg-background/80 backdrop-blur">
@@ -52,27 +67,34 @@ export function Header() {
             Phase 5 · Délégation
           </span>
           {user && (
-            <div className="relative">
+            <div className="relative" ref={menuRef}>
+              {/* min 36×36 touch target */}
               <button
                 onClick={() => setMenuOpen((o) => !o)}
-                className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary hover:bg-primary/20 transition-colors"
+                aria-expanded={menuOpen}
+                aria-haspopup="menu"
                 aria-label="Mon compte"
+                className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary hover:bg-primary/20 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 {initials}
               </button>
               {menuOpen && (
-                <div className="absolute right-0 top-10 z-50 w-48 rounded-md border bg-background shadow-lg">
+                <div
+                  role="menu"
+                  className="absolute right-0 top-10 z-50 w-48 rounded-md border bg-background shadow-lg"
+                >
                   <div className="border-b px-3 py-2">
                     <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                      <User className="h-3 w-3" />
+                      <User className="h-3 w-3" aria-hidden />
                       {user.email}
                     </p>
                   </div>
                   <button
+                    role="menuitem"
                     onClick={() => void handleSignOut()}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-muted transition-colors"
+                    className="flex w-full items-center gap-2 px-3 py-2.5 text-sm text-destructive hover:bg-muted transition-colors focus:outline-none focus-visible:bg-muted"
                   >
-                    <LogOut className="h-3.5 w-3.5" />
+                    <LogOut className="h-3.5 w-3.5" aria-hidden />
                     Se déconnecter
                   </button>
                 </div>

--- a/apps/web/src/components/ui/help-tip.tsx
+++ b/apps/web/src/components/ui/help-tip.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useRef, useEffect } from 'react';
 import type { Route } from 'next';
 import Link from 'next/link';
 import { Info } from 'lucide-react';
@@ -12,15 +13,27 @@ interface HelpTipProps {
   side?: 'top' | 'bottom' | 'left' | 'right';
 }
 
-/**
- * Tooltip contextuel léger — complément à <Help id="..."/> (qui nécessite un article complet).
- * Utiliser HelpTip pour une explication courte inline (label + hint).
- *
- * Usage :
- *   <HelpTip text="Le P&L latent est le gain/perte non encore réalisé." />
- *   <HelpTip text="..." glossarySlug="drawdown" />
- */
 export function HelpTip({ text, glossarySlug, className, side = 'top' }: HelpTipProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  // Close on outside pointer event or Escape — covers both mouse and touch.
+  useEffect(() => {
+    if (!open) return;
+    function close(e: Event) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('pointerdown', close);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('pointerdown', close);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
   const positionClasses: Record<typeof side, string> = {
     top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
     bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
@@ -29,35 +42,48 @@ export function HelpTip({ text, glossarySlug, className, side = 'top' }: HelpTip
   };
 
   return (
-    <span className={cn('relative inline-flex items-center group', className)}>
+    <span ref={ref} className={cn('relative inline-flex items-center', className)}>
+      {/* Touch-safe trigger: click toggles, keyboard accessible */}
       <span
         role="button"
         tabIndex={0}
         aria-label={`Aide : ${text.slice(0, 60)}`}
-        className="inline-flex cursor-help text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded"
+        aria-expanded={open}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setOpen((v) => !v);
+          }
+        }}
+        className="inline-flex cursor-pointer text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
       >
         <Info className="h-3.5 w-3.5" />
       </span>
 
-      <span
-        role="tooltip"
-        className={cn(
-          'pointer-events-none absolute z-50 w-64 rounded-lg border bg-background px-3 py-2 shadow-md text-xs text-foreground',
-          'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-150',
-          positionClasses[side],
-        )}
-      >
-        <span className="block leading-relaxed">{text}</span>
-        {glossarySlug && (
-          <Link
-            href={`/help/glossaire#${glossarySlug}` as Route}
-            className="pointer-events-auto mt-1.5 block text-[11px] text-primary underline underline-offset-2"
-            tabIndex={0}
-          >
-            Voir le glossaire →
-          </Link>
-        )}
-      </span>
+      {open && (
+        <span
+          role="tooltip"
+          className={cn(
+            'absolute z-50 w-56 max-w-[calc(100vw-2rem)] rounded-lg border bg-background px-3 py-2 shadow-md text-xs text-foreground',
+            positionClasses[side],
+          )}
+        >
+          <span className="block leading-relaxed">{text}</span>
+          {glossarySlug && (
+            <Link
+              href={`/help/glossaire#${glossarySlug}` as Route}
+              onClick={() => setOpen(false)}
+              className="mt-1.5 block text-[11px] text-primary underline underline-offset-2"
+            >
+              Voir le glossaire →
+            </Link>
+          )}
+        </span>
+      )}
     </span>
   );
 }

--- a/supabase/migrations/0096_account_deletion_audit.sql
+++ b/supabase/migrations/0096_account_deletion_audit.sql
@@ -1,0 +1,20 @@
+-- Migration 0096 — audit table for RGPD account deletion requests
+-- user_id is NOT a FK to auth.users (the user will be deleted; we keep the audit row)
+
+create table if not exists public.account_deletion_audit (
+  id            uuid primary key default uuid_generate_v4(),
+  user_id       uuid not null,
+  user_email    text,
+  requested_at  timestamptz not null default now(),
+  completed_at  timestamptz,
+  ip_hash       text,          -- sha256(ip) — no raw IP stored
+  status        text not null default 'initiated'
+                check (status in ('initiated', 'completed', 'failed')),
+  error_message text
+);
+
+-- Audit is service-role only — no RLS policy = no user access
+alter table public.account_deletion_audit enable row level security;
+
+create index if not exists account_deletion_audit_user_id_idx
+  on public.account_deletion_audit (user_id);


### PR DESCRIPTION
## Summary

- `GET /me/export` — streams all user data as a downloadable JSON file (schemaVersion 1)
- `DELETE /me` — permanently deletes the account; cascades via `auth.admin.deleteUser()`
- Migration `0096_account_deletion_audit` — append-only audit table (initiated → completed|failed)
- Next.js proxies at `/api/me/export` and `/api/me` (forwards Bearer token)

## RGPD compliance

- **Live JWT validation** via `supabase.auth.getUser(token)` on both endpoints (not decode-only)
- **Rate limit**: 3 DELETE attempts / 60s per userId (in-memory Map, no external dep)
- **Vault purge**: `broker_connections.credentials_vault_ref` cleared before user deletion
- **IP hashing**: sha256 only — raw IP never stored (`account_deletion_audit.ip_hash`)
- **broker_connections export**: explicit column list — `credentials_vault_ref` excluded
- **Cascade**: `auth.admin.deleteUser()` triggers all 30+ `ON DELETE CASCADE` constraints automatically

## Export schema (GET /me/export)

```json
{
  "schemaVersion": "1",
  "exportedAt": "...",
  "userId": "...",
  "profile": {},
  "portfolios": [],
  "positions": [],
  "goals": [],
  "alerts": [],
  "fundingTransfers": [],
  "lisaDecisionLog": [],
  "paperTrades": [],
  "brokerConnections": [],
  "sniperSessions": []
}
```

## Files

| File | Role |
|---|---|
| `apps/api/src/modules/me/me.service.ts` | validateToken, exportUserData, deleteAccount, rate limiter |
| `apps/api/src/modules/me/me.controller.ts` | GET /me/export, DELETE /me |
| `apps/api/src/modules/me/me.module.ts` | NestJS module |
| `apps/api/src/app.module.ts` | MeModule registered |
| `apps/api/src/modules/me/__tests__/me.service.spec.ts` | 15 unit tests |
| `apps/api/src/modules/me/__tests__/me.controller.spec.ts` | 6 unit tests |
| `apps/web/src/app/api/me/export/route.ts` | Next.js proxy GET |
| `apps/web/src/app/api/me/route.ts` | Next.js proxy DELETE |
| `supabase/migrations/0096_account_deletion_audit.sql` | Audit table + RLS |

## Test plan

- [ ] 21 unit tests pass (`npx jest --testPathPattern="modules/me"` from `apps/api/`)
- [ ] TypeScript clean (`npm run typecheck`)
- [ ] `GET /me/export` with valid Bearer → downloads JSON with user data
- [ ] `GET /me/export` without token → 401
- [ ] `DELETE /me` with confirmation "SUPPRIMER" on `/settings/donnees` → account deleted, redirected to sign-in
- [ ] `DELETE /me` 4× rapidly → 4th attempt gets 429
- [ ] broker_connections in export never contains `credentials_vault_ref`

## Audit report — 404 investigation

**tl;dr: aucune route cassée côté code.** Diagnostic complet :

| URL signalée | Statut réel | Cause |
|---|---|---|
| `/aide` | 404 attendu ✅ | Route inexistante par design — ADR-002 "Routes inchangées" → route = `/help` |
| `/aide/glossaire` | 404 attendu ✅ | Route = `/help/glossaire` (existe) |
| `/settings/donnees` | Existe ✅ | `app/settings/donnees/page.tsx` — livré Sprint 6 (PR #156) |
| `/` | Existe ✅ | Auth redirect → `/sign-in` si session absente (302, pas 404) |

Toutes les 13 hrefs de la sidebar ont un `page.tsx` correspondant. Pas de lien cassé. Les 404 observés en prod sont soit des redirects auth mal interprétés, soit un délai de déploiement Vercel post-PR #156.

Tables Supabase : `account_deletion_audit` (migration 0096) sans conflit — table nouvelle, pas de collision.

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_