### PR TITLE
fix(settings): admin gating + "Réglages avancés" (Bloquant #2)

### DIFF
--- a/apps/web/src/app/settings/brokers/layout.tsx
+++ b/apps/web/src/app/settings/brokers/layout.tsx
@@ -1,0 +1,5 @@
+import { AdminGuard } from '@/components/auth/admin-guard';
+
+export default function BrokersLayout({ children }: { children: React.ReactNode }) {
+  return <AdminGuard>{children}</AdminGuard>;
+}

--- a/apps/web/src/app/settings/delegation/layout.tsx
+++ b/apps/web/src/app/settings/delegation/layout.tsx
@@ -1,0 +1,5 @@
+import { AdminGuard } from '@/components/auth/admin-guard';
+
+export default function DelegationLayout({ children }: { children: React.ReactNode }) {
+  return <AdminGuard>{children}</AdminGuard>;
+}

--- a/apps/web/src/app/settings/hyper-trading/layout.tsx
+++ b/apps/web/src/app/settings/hyper-trading/layout.tsx
@@ -1,0 +1,5 @@
+import { AdminGuard } from '@/components/auth/admin-guard';
+
+export default function HyperTradingLayout({ children }: { children: React.ReactNode }) {
+  return <AdminGuard>{children}</AdminGuard>;
+}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -15,6 +15,7 @@ import {
   User,
   Zap,
 } from 'lucide-react';
+import { useIsAdmin } from '@/hooks/use-is-admin';
 
 const PROFILE_SECTIONS = [
   {
@@ -106,6 +107,8 @@ function SectionList({ sections }: { sections: readonly { href: string; icon: Re
 }
 
 export default function SettingsPage() {
+  const isAdmin = useIsAdmin();
+
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-6">
       <div>
@@ -120,10 +123,12 @@ export default function SettingsPage() {
         <SectionList sections={PROFILE_SECTIONS} />
       </section>
 
-      <section className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground px-1">Simulation & automatisation</p>
-        <SectionList sections={ADVANCED_SECTIONS} />
-      </section>
+      {isAdmin && (
+        <section className="space-y-2">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground px-1">Réglages avancés</p>
+          <SectionList sections={ADVANCED_SECTIONS} />
+        </section>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/settings/sniper/layout.tsx
+++ b/apps/web/src/app/settings/sniper/layout.tsx
@@ -1,0 +1,5 @@
+import { AdminGuard } from '@/components/auth/admin-guard';
+
+export default function SniperLayout({ children }: { children: React.ReactNode }) {
+  return <AdminGuard>{children}</AdminGuard>;
+}

--- a/apps/web/src/app/settings/strategy-mode/layout.tsx
+++ b/apps/web/src/app/settings/strategy-mode/layout.tsx
@@ -1,0 +1,5 @@
+import { AdminGuard } from '@/components/auth/admin-guard';
+
+export default function StrategyModeLayout({ children }: { children: React.ReactNode }) {
+  return <AdminGuard>{children}</AdminGuard>;
+}

--- a/apps/web/src/components/auth/admin-guard.tsx
+++ b/apps/web/src/components/auth/admin-guard.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAdminStatus } from '@/hooks/use-is-admin';
+
+/**
+ * Guards an admin-only settings page. Redirects non-admins to /settings.
+ *
+ * Note: this is a UX-only guard (hides admin pages from non-admin users).
+ * Real access control lives in the backend `/admin/*` endpoints which
+ * enforce `x-admin-token` + role checks. Front-end gating prevents non-admin
+ * users from seeing an empty/error UI when API calls would fail.
+ */
+export function AdminGuard({ children }: { children: React.ReactNode }) {
+  const { isAdmin, isLoaded } = useAdminStatus();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isLoaded && !isAdmin) {
+      router.replace('/settings');
+    }
+  }, [isLoaded, isAdmin, router]);
+
+  if (!isLoaded) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-4 p-6">
+        <div className="h-6 w-40 animate-pulse rounded bg-muted" />
+        <div className="h-32 animate-pulse rounded-lg bg-muted/40" />
+      </div>
+    );
+  }
+
+  if (!isAdmin) return null;
+
+  return <>{children}</>;
+}

--- a/apps/web/src/hooks/use-is-admin.ts
+++ b/apps/web/src/hooks/use-is-admin.ts
@@ -14,8 +14,18 @@
 import { useEffect, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
-export function useIsAdmin(): boolean {
-  const [isAdmin, setIsAdmin] = useState(false);
+export interface AdminStatus {
+  isAdmin: boolean;
+  isLoaded: boolean;
+}
+
+/**
+ * Returns admin status with explicit loading state. Use this when you need to
+ * differentiate "still checking" from "confirmed not admin" (e.g. before
+ * redirecting non-admins from a guarded page).
+ */
+export function useAdminStatus(): AdminStatus {
+  const [state, setState] = useState<AdminStatus>({ isAdmin: false, isLoaded: false });
 
   useEffect(() => {
     let cancelled = false;
@@ -23,13 +33,17 @@ export function useIsAdmin(): boolean {
       const supabase = createSupabaseBrowserClient();
       const { data } = await supabase.auth.getUser();
       const user = data.user;
-      if (cancelled || !user) return;
+      if (cancelled) return;
+      if (!user) {
+        setState({ isAdmin: false, isLoaded: true });
+        return;
+      }
 
       const role = (user.app_metadata?.role ?? user.user_metadata?.role) as
         | string
         | undefined;
       if (role === 'admin') {
-        setIsAdmin(true);
+        setState({ isAdmin: true, isLoaded: true });
         return;
       }
 
@@ -38,14 +52,21 @@ export function useIsAdmin(): boolean {
         .split(',')
         .map((s) => s.trim().toLowerCase())
         .filter(Boolean);
-      if (user.email && allowed.includes(user.email.toLowerCase())) {
-        setIsAdmin(true);
-      }
+      const isAdmin = !!user.email && allowed.includes(user.email.toLowerCase());
+      setState({ isAdmin, isLoaded: true });
     })();
     return () => {
       cancelled = true;
     };
   }, []);
 
-  return isAdmin;
+  return state;
+}
+
+/**
+ * Backwards-compat boolean variant. Returns `false` during initial load — do
+ * not use for redirect guards (race condition on first paint).
+ */
+export function useIsAdmin(): boolean {
+  return useAdminStatus().isAdmin;
 }


### PR DESCRIPTION
## Summary

Bloquant #2 du rapport Phase 1 — admin gating absent sur 5 routes `/settings/*` + wording "Simulation & automatisation".

- **Wording** : « Simulation & automatisation » → « Réglages avancés » (1 string)
- **Section gating** : `/settings` masque la section "Réglages avancés" aux non-admins
- **Page guards** : 5 layouts `<AdminGuard>` sur `/settings/{delegation,strategy-mode,hyper-trading,sniper,brokers}` (couvre les routes nested `/brokers/new`, `/brokers/[id]`)
- **Hook upgrade** : nouveau `useAdminStatus()` avec `{ isAdmin, isLoaded }` pour éviter race condition au premier render

## Architecture

| Fichier | Rôle |
|---|---|
| `hooks/use-is-admin.ts` | Ajoute `useAdminStatus()` (loading state explicite) ; `useIsAdmin()` inchangé (back-compat) |
| `components/auth/admin-guard.tsx` | Affiche skeleton pendant `!isLoaded`, redirect `/settings` si `isLoaded && !isAdmin` |
| `app/settings/page.tsx` | Section ADVANCED_SECTIONS conditionnelle sur `isAdmin` |
| `app/settings/{delegation,strategy-mode,hyper-trading,sniper,brokers}/layout.tsx` | `<AdminGuard>` wrapper |

## Sécurité

⚠️ **C'est un gate UX uniquement** — le contrôle d'accès réel reste côté backend dans les endpoints `/admin/*` (header `x-admin-token`). Ce gate empêche juste les non-admins de voir une UI vide quand les API calls retourneraient 403.

## Test plan

- [ ] User non-admin : `/settings` n'affiche que "Profil & préférences", pas "Réglages avancés"
- [ ] User non-admin : `/settings/delegation` redirect vers `/settings` (idem hyper-trading, sniper, brokers, strategy-mode)
- [ ] User admin : voit les 2 sections + accède aux 5 routes normalement
- [ ] Premier render : skeleton visible (pas de flash "Forbidden" puis redirect)
- [ ] TypeScript clean ✅

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_