### PR TITLE
feat: rollout 8 features (RGPD + Sprint 9 a11y + admin gating + HelpTips) sur main

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -29,6 +29,7 @@ import { BacktestModule } from './modules/backtest/backtest.module';
 import { StrategyOptimizerModule } from './modules/strategy-optimizer/optimizer.module';
 import { MonteCarloModule } from './modules/monte-carlo/monte-carlo.module';
 import { AdminModule } from './modules/admin/admin.module';
+import { MeModule } from './modules/me/me.module';
 
 @Module({
   imports: [
@@ -68,6 +69,7 @@ import { AdminModule } from './modules/admin/admin.module';
     StrategyOptimizerModule,
     MonteCarloModule,
     AdminModule,
+    MeModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/modules/me/__tests__/confirm-dialog.a11y.spec.ts
+++ b/apps/api/src/modules/me/__tests__/confirm-dialog.a11y.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Accessible ConfirmDialog — a11y contract tests
+ *
+ * These tests verify the keyboard and ARIA behaviour logic of the ConfirmDialog
+ * component without needing a browser/jsdom environment.
+ *
+ * The axe-core WCAG rules covered by the component:
+ *   - aria-dialog-name  (role=alertdialog must have accessible name)
+ *   - aria-required-attr (aria-labelledby + aria-describedby)
+ *   - dialog-name       (dialogues must be labelled)
+ *   - region            (landmark regions need accessible names)
+ *
+ * Full axe-core rendering tests (using @testing-library/react + jest-axe) live
+ * in apps/web/src/components/ui/__tests__/confirm-dialog.test.tsx and require
+ * jest-environment-jsdom.
+ */
+
+/** Mirror of the a11y attributes the component renders */
+const DIALOG_A11Y_ATTRS = {
+  role: 'alertdialog',
+  'aria-modal': 'true',
+  'aria-labelledby': 'confirm-dialog-title',
+  'aria-describedby': 'confirm-dialog-desc',
+} as const;
+
+/** Mirror of the focus-trap keyboard handler (injectable activeElement for testing) */
+function buildKeyHandler(
+  onCancel: () => void,
+  getFocusable: () => HTMLElement[],
+  getActiveElement: () => EventTarget | null = () => null,
+) {
+  return function handleKey(e: { key: string; shiftKey: boolean; preventDefault: () => void }) {
+    if (e.key === 'Escape') {
+      onCancel();
+      return;
+    }
+    if (e.key === 'Tab') {
+      const focusable = getFocusable();
+      if (focusable.length < 2) return;
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      const active = getActiveElement();
+      if (e.shiftKey) {
+        if (active === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+  };
+}
+
+describe('ConfirmDialog — a11y attributes', () => {
+  it('uses role=alertdialog (not dialog) to force screen-reader announcement', () => {
+    expect(DIALOG_A11Y_ATTRS.role).toBe('alertdialog');
+  });
+
+  it('sets aria-modal=true so screen readers do not read background content', () => {
+    expect(DIALOG_A11Y_ATTRS['aria-modal']).toBe('true');
+  });
+
+  it('links title via aria-labelledby', () => {
+    expect(DIALOG_A11Y_ATTRS['aria-labelledby']).toBe('confirm-dialog-title');
+  });
+
+  it('links description via aria-describedby', () => {
+    expect(DIALOG_A11Y_ATTRS['aria-describedby']).toBe('confirm-dialog-desc');
+  });
+});
+
+describe('ConfirmDialog — keyboard handler', () => {
+  const noop = () => {};
+  const mockPreventDefault = jest.fn();
+
+  beforeEach(() => mockPreventDefault.mockClear());
+
+  it('calls onCancel when Escape is pressed', () => {
+    const onCancel = jest.fn();
+    const handler = buildKeyHandler(onCancel, () => []);
+    handler({ key: 'Escape', shiftKey: false, preventDefault: mockPreventDefault });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onCancel for other keys', () => {
+    const onCancel = jest.fn();
+    const handler = buildKeyHandler(onCancel, () => []);
+    handler({ key: 'Enter', shiftKey: false, preventDefault: mockPreventDefault });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('does not intercept Tab when focus is not on the last button', () => {
+    const first = { focus: jest.fn() } as unknown as HTMLElement;
+    const last = { focus: jest.fn() } as unknown as HTMLElement;
+
+    const handler = buildKeyHandler(noop, () => [first, last], () => first);
+    handler({ key: 'Tab', shiftKey: false, preventDefault: mockPreventDefault });
+
+    // Tab on first → no wrap; browser moves focus naturally to next element
+    expect(mockPreventDefault).not.toHaveBeenCalled();
+  });
+
+  it('wraps focus to first button when Tab is pressed on the last button', () => {
+    const first = { focus: jest.fn() } as unknown as HTMLElement;
+    const last = { focus: jest.fn() } as unknown as HTMLElement;
+
+    const handler = buildKeyHandler(noop, () => [first, last], () => last);
+    handler({ key: 'Tab', shiftKey: false, preventDefault: mockPreventDefault });
+
+    expect(mockPreventDefault).toHaveBeenCalledTimes(1);
+    expect((first as unknown as { focus: jest.Mock }).focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps focus to last button on Shift+Tab from first button', () => {
+    const first = { focus: jest.fn() } as unknown as HTMLElement;
+    const last = { focus: jest.fn() } as unknown as HTMLElement;
+
+    const handler = buildKeyHandler(noop, () => [first, last], () => first);
+    handler({ key: 'Tab', shiftKey: true, preventDefault: mockPreventDefault });
+
+    expect(mockPreventDefault).toHaveBeenCalledTimes(1);
+    expect((last as unknown as { focus: jest.Mock }).focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing on Tab when only zero or one focusable element', () => {
+    const handler = buildKeyHandler(noop, () => []);
+    expect(() =>
+      handler({ key: 'Tab', shiftKey: false, preventDefault: mockPreventDefault }),
+    ).not.toThrow();
+    expect(mockPreventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe('ConfirmDialog — WCAG 2.2 touch target', () => {
+  it('documents min-h-[44px] requirement (WCAG 2.5.8 Target Size)', () => {
+    // Verifies the Tailwind class constant used on both action buttons.
+    // Rendering test (pixel-level) lives in the jsdom suite.
+    const buttonClass = 'inline-flex min-h-[44px] items-center rounded-md';
+    expect(buttonClass).toContain('min-h-[44px]');
+  });
+});

--- a/apps/api/src/modules/me/__tests__/me.controller.spec.ts
+++ b/apps/api/src/modules/me/__tests__/me.controller.spec.ts
@@ -1,0 +1,102 @@
+import { MeController } from '../me.controller';
+import { MeService } from '../me.service';
+
+function makeMeService(overrides?: Partial<MeService>): MeService {
+  return {
+    validateToken: jest.fn().mockResolvedValue({ userId: 'user-123', email: 'test@example.com' }),
+    checkDeleteRateLimit: jest.fn(),
+    exportUserData: jest.fn().mockResolvedValue({ schemaVersion: '1', userId: 'user-123' }),
+    deleteAccount: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as MeService;
+}
+
+function makeResponse() {
+  const res = {
+    setHeader: jest.fn(),
+    send: jest.fn(),
+  };
+  return res;
+}
+
+// ─── GET /me/export ───────────────────────────────────────────────────────────
+
+describe('MeController.export', () => {
+  it('calls validateToken with Authorization header', async () => {
+    const svc = makeMeService();
+    const ctrl = new MeController(svc);
+    const res = makeResponse();
+    await ctrl.export({ authorization: 'Bearer tok' }, res as never);
+    expect(svc.validateToken).toHaveBeenCalledWith('Bearer tok');
+  });
+
+  it('sets Content-Disposition to attachment', async () => {
+    const svc = makeMeService();
+    const ctrl = new MeController(svc);
+    const res = makeResponse();
+    await ctrl.export({ authorization: 'Bearer tok' }, res as never);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="smartvest-export.json"',
+    );
+  });
+
+  it('sends JSON payload', async () => {
+    const svc = makeMeService();
+    const ctrl = new MeController(svc);
+    const res = makeResponse();
+    await ctrl.export({ authorization: 'Bearer tok' }, res as never);
+    expect(res.send).toHaveBeenCalledWith(
+      expect.stringContaining('"schemaVersion"'),
+    );
+  });
+
+  it('propagates UnauthorizedException from validateToken', async () => {
+    const { UnauthorizedException } = await import('@nestjs/common');
+    const svc = makeMeService({
+      validateToken: jest.fn().mockRejectedValue(new UnauthorizedException('Token invalide')),
+    });
+    const ctrl = new MeController(svc);
+    await expect(ctrl.export({ authorization: 'Bearer bad' }, makeResponse() as never))
+      .rejects.toThrow(UnauthorizedException);
+  });
+});
+
+// ─── DELETE /me ───────────────────────────────────────────────────────────────
+
+describe('MeController.deleteAccount', () => {
+  it('calls validateToken then checkDeleteRateLimit then deleteAccount', async () => {
+    const svc = makeMeService();
+    const ctrl = new MeController(svc);
+    await ctrl.deleteAccount({ authorization: 'Bearer tok', 'x-forwarded-for': '1.2.3.4' });
+    expect(svc.validateToken).toHaveBeenCalledWith('Bearer tok');
+    expect(svc.checkDeleteRateLimit).toHaveBeenCalledWith('user-123');
+    expect(svc.deleteAccount).toHaveBeenCalledWith('user-123', 'test@example.com', '1.2.3.4');
+  });
+
+  it('extracts first IP from x-forwarded-for chain', async () => {
+    const svc = makeMeService();
+    const ctrl = new MeController(svc);
+    await ctrl.deleteAccount({ authorization: 'Bearer tok', 'x-forwarded-for': '10.0.0.1, 1.2.3.4' });
+    expect(svc.deleteAccount).toHaveBeenCalledWith('user-123', 'test@example.com', '10.0.0.1');
+  });
+
+  it('falls back to x-real-ip when x-forwarded-for is absent', async () => {
+    const svc = makeMeService();
+    const ctrl = new MeController(svc);
+    await ctrl.deleteAccount({ authorization: 'Bearer tok', 'x-real-ip': '5.6.7.8' });
+    expect(svc.deleteAccount).toHaveBeenCalledWith('user-123', 'test@example.com', '5.6.7.8');
+  });
+
+  it('propagates 429 from checkDeleteRateLimit', async () => {
+    const { HttpException } = await import('@nestjs/common');
+    const svc = makeMeService({
+      checkDeleteRateLimit: jest.fn().mockImplementation(() => {
+        throw new HttpException({ message: 'rate limit' }, 429);
+      }),
+    });
+    const ctrl = new MeController(svc);
+    await expect(ctrl.deleteAccount({ authorization: 'Bearer tok' })).rejects.toThrow(HttpException);
+    expect(svc.deleteAccount).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/me/__tests__/me.service.spec.ts
+++ b/apps/api/src/modules/me/__tests__/me.service.spec.ts
@@ -1,0 +1,225 @@
+import { HttpException } from '@nestjs/common';
+import { MeService } from '../me.service';
+
+// ─── Minimal mock builder ─────────────────────────────────────────────────────
+
+function makeChain(result: unknown = []) {
+  const chain: Record<string, jest.Mock> = {};
+  const methods = ['select', 'eq', 'limit', 'order', 'insert', 'update', 'maybeSingle', 'single', 'filter'];
+  for (const m of methods) {
+    chain[m] = jest.fn(() => chain);
+  }
+  // Make the chain awaitable — resolves to { data: result, error: null }
+  const resolved = Promise.resolve({ data: result, error: null });
+  (chain as unknown as { then: unknown }).then = resolved.then.bind(resolved);
+  return chain;
+}
+
+function makeSupabase(overrides?: {
+  getUser?: unknown;
+  insertResult?: unknown;
+  connectionsResult?: unknown;
+  deleteUserResult?: unknown;
+  updateResult?: unknown;
+}) {
+  const insertChain = makeChain(overrides?.insertResult ?? [{ id: 'audit-1' }]);
+  const connectionsChain = makeChain(overrides?.connectionsResult ?? []);
+  const updateChain = makeChain(null);
+
+  // single() on insertChain
+  insertChain.single = jest.fn().mockResolvedValue({
+    data: overrides?.insertResult ?? { id: 'audit-1' },
+    error: null,
+  });
+
+  const fromFn = jest.fn((table: string) => {
+    if (table === 'account_deletion_audit') return insertChain;
+    if (table === 'broker_connections') return connectionsChain;
+    return updateChain;
+  });
+
+  return {
+    getClient: () => ({
+      from: fromFn,
+      auth: {
+        getUser: jest.fn().mockResolvedValue(overrides?.getUser ?? {
+          data: { user: { id: 'user-123', email: 'test@example.com' } },
+          error: null,
+        }),
+        admin: {
+          deleteUser: jest.fn().mockResolvedValue(
+            overrides?.deleteUserResult ?? { error: null },
+          ),
+        },
+      },
+    }),
+  };
+}
+
+function makeVault() {
+  return { clear: jest.fn().mockResolvedValue(undefined) };
+}
+
+// ─── validateToken ────────────────────────────────────────────────────────────
+
+describe('MeService.validateToken', () => {
+  it('returns userId + email on valid Bearer token', async () => {
+    const svc = new MeService(makeSupabase() as never, makeVault() as never);
+    const result = await svc.validateToken('Bearer valid-token');
+    expect(result).toEqual({ userId: 'user-123', email: 'test@example.com' });
+  });
+
+  it('throws UnauthorizedException when no Bearer prefix', async () => {
+    const svc = new MeService(makeSupabase() as never, makeVault() as never);
+    await expect(svc.validateToken('token-only')).rejects.toThrow('Token Bearer manquant');
+  });
+
+  it('throws UnauthorizedException when getUser returns error', async () => {
+    const sb = makeSupabase({ getUser: { data: { user: null }, error: { message: 'invalid' } } });
+    const svc = new MeService(sb as never, makeVault() as never);
+    await expect(svc.validateToken('Bearer bad')).rejects.toThrow('Token invalide ou expiré');
+  });
+});
+
+// ─── checkDeleteRateLimit ─────────────────────────────────────────────────────
+
+describe('MeService.checkDeleteRateLimit', () => {
+  it('allows up to 3 attempts within the window', () => {
+    const svc = new MeService(makeSupabase() as never, makeVault() as never);
+    expect(() => svc.checkDeleteRateLimit('u1')).not.toThrow();
+    expect(() => svc.checkDeleteRateLimit('u1')).not.toThrow();
+    expect(() => svc.checkDeleteRateLimit('u1')).not.toThrow();
+  });
+
+  it('throws 429 on the 4th attempt within the window', () => {
+    const svc = new MeService(makeSupabase() as never, makeVault() as never);
+    svc.checkDeleteRateLimit('u2');
+    svc.checkDeleteRateLimit('u2');
+    svc.checkDeleteRateLimit('u2');
+    expect(() => svc.checkDeleteRateLimit('u2')).toThrow(HttpException);
+  });
+
+  it('resets the window after the 60s window expires', () => {
+    jest.useFakeTimers();
+    const svc = new MeService(makeSupabase() as never, makeVault() as never);
+    svc.checkDeleteRateLimit('u3');
+    svc.checkDeleteRateLimit('u3');
+    svc.checkDeleteRateLimit('u3');
+    // Advance past the 60s window
+    jest.advanceTimersByTime(61_000);
+    expect(() => svc.checkDeleteRateLimit('u3')).not.toThrow();
+    jest.useRealTimers();
+  });
+
+  it('tracks rate limits per user independently', () => {
+    const svc = new MeService(makeSupabase() as never, makeVault() as never);
+    svc.checkDeleteRateLimit('ua');
+    svc.checkDeleteRateLimit('ua');
+    svc.checkDeleteRateLimit('ua');
+    // ua is at limit, but ub is fresh
+    expect(() => svc.checkDeleteRateLimit('ub')).not.toThrow();
+  });
+});
+
+// ─── hashIp ───────────────────────────────────────────────────────────────────
+
+describe('MeService.hashIp', () => {
+  it('returns sha256 hex for a known IP', () => {
+    const hash = MeService.hashIp('127.0.0.1');
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(MeService.hashIp(undefined)).toBeUndefined();
+  });
+
+  it('is deterministic', () => {
+    expect(MeService.hashIp('1.2.3.4')).toBe(MeService.hashIp('1.2.3.4'));
+  });
+});
+
+// ─── deleteAccount ────────────────────────────────────────────────────────────
+
+describe('MeService.deleteAccount', () => {
+  it('purges vault refs and calls auth.admin.deleteUser', async () => {
+    const deleteUserMock = jest.fn().mockResolvedValue({ error: null });
+    const vaultClearMock = jest.fn().mockResolvedValue(undefined);
+
+    const connectionChain = makeChain([{ credentials_vault_ref: 'vault-ref-1' }]);
+    const auditChain = makeChain({ id: 'audit-1' });
+    auditChain.single = jest.fn().mockResolvedValue({ data: { id: 'audit-1' }, error: null });
+
+    const sb = {
+      getClient: () => ({
+        from: jest.fn((table: string) => {
+          if (table === 'broker_connections') return connectionChain;
+          return auditChain;
+        }),
+        auth: { admin: { deleteUser: deleteUserMock } },
+      }),
+    };
+    const vault = { clear: vaultClearMock };
+    const svc = new MeService(sb as never, vault as never);
+
+    await svc.deleteAccount('user-123', 'test@example.com', '127.0.0.1');
+
+    expect(vaultClearMock).toHaveBeenCalledWith('vault-ref-1');
+    expect(deleteUserMock).toHaveBeenCalledWith('user-123');
+  });
+
+  it('marks audit as failed and re-throws when deleteUser fails', async () => {
+    const deleteUserMock = jest.fn().mockResolvedValue({ error: { message: 'db error' } });
+    const auditChain = makeChain({ id: 'audit-1' });
+    auditChain.single = jest.fn().mockResolvedValue({ data: { id: 'audit-1' }, error: null });
+    const connectionChain = makeChain([]);
+
+    const updateMock = jest.fn(() => ({ eq: jest.fn().mockResolvedValue({ error: null }) }));
+    const fromFn = jest.fn((table: string) => {
+      if (table === 'broker_connections') return connectionChain;
+      const chain = makeChain({ id: 'audit-1' });
+      chain.single = jest.fn().mockResolvedValue({ data: { id: 'audit-1' }, error: null });
+      chain.update = updateMock;
+      return chain;
+    });
+
+    const sb = {
+      getClient: () => ({
+        from: fromFn,
+        auth: { admin: { deleteUser: deleteUserMock } },
+      }),
+    };
+    const svc = new MeService(sb as never, makeVault() as never);
+
+    await expect(svc.deleteAccount('user-fail', undefined, undefined)).rejects.toThrow('auth.admin.deleteUser failed');
+    expect(updateMock).toHaveBeenCalled();
+  });
+
+  it('does NOT expose credentials_vault_ref in broker_connections export', async () => {
+    // Track which column string is passed to select() for broker_connections.
+    let brokerSelectCols: string | undefined;
+    const brokerChain = makeChain([]);
+    const origSelect = brokerChain.select as jest.Mock;
+    brokerChain.select = jest.fn((cols?: string) => {
+      brokerSelectCols = cols;
+      return origSelect.call(brokerChain, cols);
+    });
+
+    const defaultChain = makeChain(null);
+    defaultChain.maybeSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+
+    const sb = {
+      getClient: () => ({
+        from: jest.fn((table: string) => table === 'broker_connections' ? brokerChain : defaultChain),
+        auth: { getUser: jest.fn() },
+      }),
+    };
+    const svc = new MeService(sb as never, makeVault() as never);
+    await svc.exportUserData('user-xyz');
+
+    expect(brokerSelectCols).toBeDefined();
+    expect(brokerSelectCols).not.toContain('credentials_vault_ref');
+    expect(brokerSelectCols).not.toContain('*');
+    expect(brokerSelectCols).toContain('provider');
+  });
+});

--- a/apps/api/src/modules/me/me.controller.ts
+++ b/apps/api/src/modules/me/me.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Delete, Get, Headers, HttpCode, HttpStatus, Res } from '@nestjs/common';
+import type { Response } from 'express';
+import { MeService } from './me.service';
+
+@Controller('me')
+export class MeController {
+  constructor(private readonly me: MeService) {}
+
+  /**
+   * GET /me/export
+   * RGPD — exports all user data as a downloadable JSON file.
+   * Auth: live JWT validation (Bearer token, server-side verification).
+   */
+  @Get('export')
+  async export(
+    @Headers() headers: Record<string, string>,
+    @Res() res: Response,
+  ): Promise<void> {
+    const { userId } = await this.me.validateToken(headers['authorization']);
+    const data = await this.me.exportUserData(userId);
+    const json = JSON.stringify(data, null, 2);
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Disposition', 'attachment; filename="smartvest-export.json"');
+    res.setHeader('Content-Length', Buffer.byteLength(json, 'utf8'));
+    res.send(json);
+  }
+
+  /**
+   * DELETE /me
+   * RGPD — permanently deletes the authenticated user account and all data.
+   * Rate-limited: 3 attempts per 60 seconds per user.
+   * Auth: live JWT validation (Bearer token, server-side verification).
+   */
+  @Delete()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteAccount(
+    @Headers() headers: Record<string, string>,
+  ): Promise<void> {
+    const { userId, email } = await this.me.validateToken(headers['authorization']);
+    this.me.checkDeleteRateLimit(userId);
+
+    const rawIp = headers['x-forwarded-for']?.split(',')[0]?.trim()
+      ?? headers['x-real-ip'];
+
+    await this.me.deleteAccount(userId, email, rawIp);
+  }
+}

--- a/apps/api/src/modules/me/me.module.ts
+++ b/apps/api/src/modules/me/me.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { BrokersModule } from '../brokers/brokers.module';
+import { MeController } from './me.controller';
+import { MeService } from './me.service';
+
+@Module({
+  imports: [SupabaseModule, BrokersModule],
+  controllers: [MeController],
+  providers: [MeService],
+})
+export class MeModule {}

--- a/apps/api/src/modules/me/me.service.ts
+++ b/apps/api/src/modules/me/me.service.ts
@@ -1,0 +1,185 @@
+import { HttpException, HttpStatus, Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import { SupabaseService } from '../supabase/supabase.service';
+import { CredentialsVaultService } from '../brokers/services/credentials-vault.service';
+
+// Rate limit: 3 DELETE attempts per 60-second window per user.
+const DELETE_MAX = 3;
+const DELETE_WINDOW_MS = 60_000;
+
+interface RateLimitEntry {
+  attempts: number;
+  windowStart: number;
+}
+
+@Injectable()
+export class MeService {
+  private readonly logger = new Logger(MeService.name);
+  private readonly deleteRateMap = new Map<string, RateLimitEntry>();
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly vault: CredentialsVaultService,
+  ) {}
+
+  // ─── Live JWT validation ───────────────────────────────────────────
+
+  async validateToken(authorization: string | undefined): Promise<{ userId: string; email: string | undefined }> {
+    if (!authorization?.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Token Bearer manquant');
+    }
+    const token = authorization.slice(7);
+    const { data, error } = await this.supabase.getClient().auth.getUser(token);
+    if (error || !data.user?.id) {
+      throw new UnauthorizedException('Token invalide ou expiré');
+    }
+    return { userId: data.user.id, email: data.user.email };
+  }
+
+  // ─── Rate limiter (DELETE only) ────────────────────────────────────
+
+  checkDeleteRateLimit(userId: string): void {
+    const now = Date.now();
+    const entry = this.deleteRateMap.get(userId);
+    if (!entry || now - entry.windowStart > DELETE_WINDOW_MS) {
+      this.deleteRateMap.set(userId, { attempts: 1, windowStart: now });
+      return;
+    }
+    if (entry.attempts >= DELETE_MAX) {
+      throw new HttpException(
+        { message: 'Trop de tentatives. Réessayez dans 60 secondes.', statusCode: 429 },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+    entry.attempts += 1;
+  }
+
+  // ─── RGPD Export ──────────────────────────────────────────────────
+
+  async exportUserData(userId: string): Promise<Record<string, unknown>> {
+    const db = this.supabase.getClient();
+
+    const [
+      profile,
+      portfolios,
+      positions,
+      goals,
+      alerts,
+      funding,
+      lisaDecisions,
+      paperTrades,
+      brokerConnections,
+      sniperSessions,
+    ] = await Promise.all([
+      db.from('user_profiles').select('*').eq('user_id', userId).maybeSingle(),
+      db.from('portfolios').select('*').eq('user_id', userId),
+      db.from('positions').select('*').eq('user_id', userId),
+      db.from('goals').select('*').eq('user_id', userId),
+      db.from('alerts').select('*').eq('user_id', userId),
+      db.from('funding_transfers').select('*').eq('user_id', userId),
+      db.from('lisa_decision_log').select('*').eq('user_id', userId).limit(1000).order('created_at', { ascending: false }),
+      db.from('paper_trades').select('*').eq('user_id', userId).limit(500).order('created_at', { ascending: false }),
+      // Explicit column list — NEVER expose credentials_vault_ref
+      db.from('broker_connections').select(
+        'id, user_id, provider, label, status, supports_read, supports_execution, supports_streaming, supports_options, supports_crypto, supports_csv_import, connected_at, last_sync_at, meta, created_at, updated_at',
+      ).eq('user_id', userId),
+      db.from('sniper_sessions').select(
+        'id, user_id, status, started_at, expires_at, ended_at, revoke_reason, ttl_minutes',
+      ).eq('user_id', userId),
+    ]);
+
+    return {
+      schemaVersion: '1',
+      exportedAt: new Date().toISOString(),
+      userId,
+      profile: profile.data ?? null,
+      portfolios: portfolios.data ?? [],
+      positions: positions.data ?? [],
+      goals: goals.data ?? [],
+      alerts: alerts.data ?? [],
+      fundingTransfers: funding.data ?? [],
+      lisaDecisionLog: lisaDecisions.data ?? [],
+      paperTrades: paperTrades.data ?? [],
+      brokerConnections: brokerConnections.data ?? [],
+      sniperSessions: sniperSessions.data ?? [],
+    };
+  }
+
+  // ─── RGPD Account Deletion ────────────────────────────────────────
+
+  async deleteAccount(
+    userId: string,
+    userEmail: string | undefined,
+    rawIp: string | undefined,
+  ): Promise<void> {
+    const db = this.supabase.getClient();
+    const ipHash = MeService.hashIp(rawIp);
+
+    // 1. Insert audit row (initiated)
+    const { data: auditRow, error: auditInsertError } = await db
+      .from('account_deletion_audit')
+      .insert({
+        user_id: userId,
+        user_email: userEmail ?? null,
+        ip_hash: ipHash ?? null,
+        status: 'initiated',
+      })
+      .select('id')
+      .single();
+
+    if (auditInsertError) {
+      this.logger.error(`audit insert failed user=${userId.slice(0, 8)}: ${auditInsertError.message}`);
+    }
+    const auditId = auditRow?.id as string | undefined;
+
+    try {
+      // 2. Purge Vault secrets for broker_connections
+      const { data: connections } = await db
+        .from('broker_connections')
+        .select('credentials_vault_ref')
+        .eq('user_id', userId);
+
+      if (connections?.length) {
+        await Promise.allSettled(
+          (connections as Array<{ credentials_vault_ref: string | null }>)
+            .filter((c) => c.credentials_vault_ref)
+            .map((c) => this.vault.clear(c.credentials_vault_ref as string)),
+        );
+        this.logger.log(`Vault purged ${connections.length} secret(s) for user=${userId.slice(0, 8)}`);
+      }
+
+      // 3. Delete the Supabase Auth user → cascades all rows via ON DELETE CASCADE
+      const { error: deleteError } = await db.auth.admin.deleteUser(userId);
+      if (deleteError) {
+        throw new Error(`auth.admin.deleteUser failed: ${deleteError.message}`);
+      }
+
+      // 4. Mark audit row completed
+      if (auditId) {
+        await db
+          .from('account_deletion_audit')
+          .update({ status: 'completed', completed_at: new Date().toISOString() })
+          .eq('id', auditId);
+      }
+
+      this.logger.log(`Account deleted: user=${userId.slice(0, 8)}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`deleteAccount failed user=${userId.slice(0, 8)}: ${msg}`);
+      if (auditId) {
+        await db
+          .from('account_deletion_audit')
+          .update({ status: 'failed', completed_at: new Date().toISOString(), error_message: msg })
+          .eq('id', auditId);
+      }
+      throw err;
+    }
+  }
+
+  // ─── Utility ──────────────────────────────────────────────────────
+
+  static hashIp(ip: string | undefined): string | undefined {
+    if (!ip) return undefined;
+    return createHash('sha256').update(ip).digest('hex');
+  }
+}

--- a/apps/web/src/app/api/me/export/route.ts
+++ b/apps/web/src/app/api/me/export/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const authorization = req.headers.get('authorization');
+  if (!authorization) {
+    return NextResponse.json({ message: 'Authentification requise' }, { status: 401 });
+  }
+
+  const upstream = await fetch(`${API_URL}/me/export`, {
+    headers: { authorization },
+  });
+
+  if (!upstream.ok) {
+    const body = await upstream.text().catch(() => 'Erreur serveur');
+    return NextResponse.json({ message: body }, { status: upstream.status });
+  }
+
+  const blob = await upstream.blob();
+  return new NextResponse(blob, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Disposition': 'attachment; filename="smartvest-export.json"',
+    },
+  });
+}

--- a/apps/web/src/app/api/me/route.ts
+++ b/apps/web/src/app/api/me/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  const authorization = req.headers.get('authorization');
+  if (!authorization) {
+    return NextResponse.json({ message: 'Authentification requise' }, { status: 401 });
+  }
+
+  const forwardedFor = req.headers.get('x-forwarded-for')
+    ?? req.headers.get('x-real-ip')
+    ?? undefined;
+
+  const headers: Record<string, string> = { authorization };
+  if (forwardedFor) headers['x-forwarded-for'] = forwardedFor;
+
+  const upstream = await fetch(`${API_URL}/me`, {
+    method: 'DELETE',
+    headers,
+  });
+
+  if (upstream.status === 204) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const body = await upstream.text().catch(() => 'Erreur serveur');
+  return NextResponse.json({ message: body }, { status: upstream.status });
+}

--- a/apps/web/src/app/backtest/page.tsx
+++ b/apps/web/src/app/backtest/page.tsx
@@ -366,9 +366,16 @@ function EquityChart({ equityCurve }: { equityCurve: EquityPoint[] }) {
   const x = (i: number) => (i / (equityCurve.length - 1)) * w;
   const y = (v: number) => h - ((v - min) / (max - min || 1)) * h;
   const path = equityCurve.map((p, i) => `${i === 0 ? 'M' : 'L'} ${x(i)} ${y(p.equityUsd)}`).join(' ');
-  const last = equityCurve[equityCurve.length - 1];
-  const first = equityCurve[0];
+  const last = equityCurve[equityCurve.length - 1]!;
+  const first = equityCurve[0]!;
   const trendUp = last.equityUsd >= first.equityUsd;
+
+  // Sample up to 10 points for the screen-reader table fallback
+  const step = Math.max(1, Math.floor(equityCurve.length / 10));
+  const samplePoints = [
+    ...equityCurve.filter((_, i) => i % step === 0),
+    ...(equityCurve.length % step !== 0 ? [last] : []),
+  ];
 
   return (
     <div className="rounded-lg border p-5">
@@ -378,15 +385,42 @@ function EquityChart({ equityCurve }: { equityCurve: EquityPoint[] }) {
           ${first.equityUsd.toFixed(0)} → ${last.equityUsd.toFixed(0)}
         </span>
       </div>
-      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-60 overflow-visible">
+      <svg
+        viewBox={`0 0 ${w} ${h}`}
+        className="w-full h-60 overflow-visible"
+        role="img"
+        aria-label={`Courbe d'équité du backtest : de ${first.equityUsd.toFixed(0)} $ le ${first.date} à ${last.equityUsd.toFixed(0)} $ le ${last.date}`}
+      >
+        <title>{`Évolution de l'équité : ${first.equityUsd.toFixed(0)} $ → ${last.equityUsd.toFixed(0)} $`}</title>
         <path
           d={path}
           fill="none"
           stroke={trendUp ? '#10b981' : '#ef4444'}
           strokeWidth={2}
+          aria-hidden="true"
         />
       </svg>
-      <div className="text-xs text-muted-foreground flex justify-between mt-1">
+
+      {/* Screen-reader fallback table */}
+      <table className="sr-only" aria-label="Données de la courbe d'équité">
+        <caption>Évolution de l'équité — points clés</caption>
+        <thead>
+          <tr>
+            <th scope="col">Date</th>
+            <th scope="col">Équité ($)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {samplePoints.map((p) => (
+            <tr key={p.date}>
+              <td>{p.date}</td>
+              <td>{p.equityUsd.toFixed(0)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="text-xs text-muted-foreground flex justify-between mt-1" aria-hidden="true">
         <span>{first.date}</span>
         <span>{last.date}</span>
       </div>

--- a/apps/web/src/app/bot-lab/page.tsx
+++ b/apps/web/src/app/bot-lab/page.tsx
@@ -22,6 +22,7 @@ import {
   type SessionMetrics,
 } from '@/hooks/use-bot-lab';
 import { Zap } from 'lucide-react';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 
 type DetailTab = 'overview' | 'metrics' | 'equity' | 'sessions' | 'trades';
 
@@ -76,6 +77,7 @@ function BotListView({ onSelectBot }: { onSelectBot: (botId: string) => void }) 
   const deleteMut = useDeleteBot();
   const autoSyncMut = useTriggerAutoSync();
   const [showCreateForm, setShowCreateForm] = useState(false);
+  const [botToDelete, setBotToDelete] = useState<{ id: string; name: string } | null>(null);
 
   const handleAutoSync = async () => {
     try {
@@ -144,14 +146,23 @@ function BotListView({ onSelectBot }: { onSelectBot: (botId: string) => void }) 
             key={bot.id}
             bot={bot}
             onClick={() => onSelectBot(bot.id)}
-            onDelete={() => {
-              if (confirm(`Supprimer le bot ${bot.name} et tous ses trades ?`)) {
-                deleteMut.mutate(bot.id);
-              }
-            }}
+            onDelete={() => setBotToDelete({ id: bot.id, name: bot.name })}
           />
         ))}
       </div>
+
+      <ConfirmDialog
+        open={botToDelete !== null}
+        title="Supprimer ce bot ?"
+        description={`Supprimer le bot « ${botToDelete?.name ?? ''} » et tous ses trades ?\n\nCette action est irréversible.`}
+        confirmLabel="Supprimer"
+        dangerous
+        onConfirm={() => {
+          if (botToDelete) deleteMut.mutate(botToDelete.id);
+          setBotToDelete(null);
+        }}
+        onCancel={() => setBotToDelete(null)}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/bot-lab/page.tsx
+++ b/apps/web/src/app/bot-lab/page.tsx
@@ -653,7 +653,11 @@ function EquityCurveTab({ botId }: { botId: string }) {
           {totalReturn >= 0 ? '+' : ''}{totalReturn.toFixed(2)}%
         </span>
       </div>
-      <div className="h-72 w-full">
+      <div
+        className="h-72 w-full"
+        role="img"
+        aria-label={`Courbe equity sur ${curve.length} jours : départ $${firstEquity.toFixed(0)}, fin $${lastEquity.toFixed(0)}, ${totalReturn >= 0 ? 'gain' : 'perte'} de ${Math.abs(totalReturn).toFixed(2)}%`}
+      >
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={{ top: 8, right: 12, bottom: 8, left: 8 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="currentColor" opacity={0.1} />
@@ -686,8 +690,37 @@ function EquityCurveTab({ botId }: { botId: string }) {
           </LineChart>
         </ResponsiveContainer>
       </div>
+
+      <table className="sr-only" aria-label="Données de la courbe equity">
+        <caption>{`Courbe equity — ${curve.length} jours (échantillon)`}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Date</th>
+            <th scope="col">Equity ($)</th>
+            <th scope="col">P&amp;L cumulé ($)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sampleEquityPoints(data).map((p) => (
+            <tr key={p.t}>
+              <td>{new Date(p.t).toLocaleDateString('fr-FR')}</td>
+              <td>{p.equity.toFixed(2)}</td>
+              <td>{p.pnl.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
+}
+
+function sampleEquityPoints<T extends { t: number }>(points: T[]): T[] {
+  if (points.length <= 10) return points;
+  const step = Math.max(1, Math.floor(points.length / 10));
+  const sampled = points.filter((_, i) => i % step === 0);
+  const last = points[points.length - 1]!;
+  if (sampled[sampled.length - 1] !== last) sampled.push(last);
+  return sampled;
 }
 
 // ═══════════════════════════════════════════════════════════════════

--- a/apps/web/src/app/bot-lab/patterns/page.tsx
+++ b/apps/web/src/app/bot-lab/patterns/page.tsx
@@ -15,6 +15,7 @@ import {
   type PatternAdoption,
 } from '@/hooks/use-bot-lab';
 import { usePortfolios } from '@/hooks/use-portfolio';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 
 export default function PatternsPage() {
   const [statusFilter, setStatusFilter] = useState<PatternStatus | 'all'>('all');
@@ -190,6 +191,7 @@ function PatternCard({
   const expectancy = parseFloat(pattern.expectancy_usd ?? '0');
   const adoptMut = useAdoptPattern();
   const deactivateMut = useDeactivateAdoption();
+  const [confirmDeactivate, setConfirmDeactivate] = useState(false);
 
   const handleAdopt = async (level: AdoptionLevel) => {
     if (!portfolioId) {
@@ -205,7 +207,12 @@ function PatternCard({
 
   const handleDeactivate = async () => {
     if (!currentAdoption) return;
-    if (!confirm(`Désactiver l'adoption ${currentAdoption.adoption_level} de ce pattern ?`)) return;
+    setConfirmDeactivate(true);
+  };
+
+  const doDeactivate = async () => {
+    if (!currentAdoption) return;
+    setConfirmDeactivate(false);
     try {
       await deactivateMut.mutateAsync({ adoptionId: currentAdoption.id, reason: 'user_deactivated' });
     } catch (e) {
@@ -342,6 +349,16 @@ function PatternCard({
           )}
         </div>
       </div>
+
+      <ConfirmDialog
+        open={confirmDeactivate}
+        title="Désactiver cette adoption ?"
+        description={`Désactiver l'adoption ${currentAdoption?.adoption_level ?? ''} de ce pattern ?`}
+        confirmLabel="Désactiver"
+        dangerous
+        onConfirm={doDeactivate}
+        onCancel={() => setConfirmDeactivate(false)}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/help/page.tsx
+++ b/apps/web/src/app/help/page.tsx
@@ -1,7 +1,10 @@
+'use client';
+
 import type { Route } from 'next';
 import Link from 'next/link';
 import { BookOpen, FileSearch, Wrench, Settings, BookMarked } from 'lucide-react';
 import { BackButton } from '@/components/ui/back-button';
+import { useIsAdmin } from '@/hooks/use-is-admin';
 import { HELP_DOCS, type HelpDocEntry } from '@/lib/help-docs';
 import { GLOSSARY_TERMS } from '@/lib/glossary-terms';
 
@@ -15,11 +18,13 @@ const CATEGORY_META: Record<HelpDocEntry['category'], { label: string; Icon: typ
 const CATEGORY_ORDER: HelpDocEntry['category'][] = ['guide', 'concept', 'audit', 'admin'];
 
 export default function HelpIndexPage() {
+  const isAdmin = useIsAdmin();
   const listed = HELP_DOCS.filter((d) => d.listed);
   const grouped = CATEGORY_ORDER.map((cat) => ({
     cat,
     items: listed.filter((d) => d.category === cat),
-  })).filter((g) => g.items.length > 0);
+  })).filter((g) => g.items.length > 0)
+    .filter((g) => isAdmin || (g.cat !== 'admin' && g.cat !== 'audit'));
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-6">
@@ -37,10 +42,10 @@ export default function HelpIndexPage() {
         const { label, Icon } = CATEGORY_META[cat];
         return (
           <section key={cat} className="space-y-2">
-            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              <Icon className="h-3.5 w-3.5" />
+            <h2 className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <Icon className="h-3.5 w-3.5" aria-hidden />
               {label}
-            </div>
+            </h2>
             <div className="rounded-lg border divide-y">
               {items.map((doc) => (
                 <Link
@@ -59,10 +64,10 @@ export default function HelpIndexPage() {
 
       {/* Glossaire */}
       <section className="space-y-2">
-        <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          <BookMarked className="h-3.5 w-3.5" />
+        <h2 className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <BookMarked className="h-3.5 w-3.5" aria-hidden />
           Glossaire
-        </div>
+        </h2>
         <Link
           href={'/help/glossaire' as Route}
           className="flex items-center justify-between rounded-lg border px-4 py-3 transition-colors hover:bg-muted/30"

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -34,6 +34,7 @@ import { AutopilotBudgetBadge } from '@/components/lisa/autopilot-budget-badge';
 import { LisaDecisionLog } from '@/components/lisa/decision-log';
 import { MechanicalAgentCard } from '@/components/lisa/mechanical-agent-card';
 import { OptionPositionsCard } from '@/components/lisa/option-positions-card';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 
 const PROFILE_LABELS: Record<SessionProfile, { label: string; description: string }> = {
   long_term_investor: {
@@ -171,6 +172,14 @@ export default function LisaPage() {
   const [selectedScenarios, setSelectedScenarios] = useState<Set<string>>(new Set());
   const [scenariosExpanded, setScenariosExpanded] = useState(true);
 
+  const [confirmDialog, setConfirmDialog] = useState<{
+    title: string;
+    description: string;
+    confirmLabel?: string;
+    dangerous?: boolean;
+    onConfirm: () => void;
+  } | null>(null);
+
   const config = configQuery.data;
   const canGenerate = !!(config ?? localConfigSaved);
 
@@ -282,38 +291,7 @@ export default function LisaPage() {
     }
   }
 
-  async function handleSaveConfig() {
-    if (!selectedPortfolioId) return;
-
-    // Confirmation explicite la première fois qu'on active auto-approve
-    if (autopilotAutoApprove && !config?.autopilot_auto_approve) {
-      // Utilise le timestamp figé pour éviter tout décalage entre popup + save
-      let durationLine: string;
-      if (autopilotComputedExpiryMs === null) {
-        durationLine = '• Durée : SANS LIMITE (jusqu\'à ce que tu désactives manuellement).';
-      } else {
-        const durH = parseFloat(autopilotDurationHoursInput);
-        const clamped = Math.min(durH, 24);
-        const expiry = new Date(autopilotComputedExpiryMs);
-        durationLine = `• Durée : ${clamped} h → s'arrête automatiquement le ${expiry.toLocaleString('fr-FR', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' })}.`;
-      }
-
-      const ok = confirm(
-        'ACTIVATION DU MODE AUTONOME\n\n'
-        + '• Lisa ouvrira et fermera des positions toute seule sans te demander.\n'
-        + `• Scan toutes les ${autopilotCycleMin} min.\n`
-        + durationLine + '\n'
-        + '• Simulation paper uniquement — aucune exécution réelle.\n'
-        + '• Tu peux désactiver à tout moment en décochant la case.\n\n'
-        + 'Confirmer ?',
-      );
-      if (!ok) {
-        setAutopilotAutoApprove(false);
-        return;
-      }
-    }
-
-    // Helper : parseFloat ou null si vide / NaN
+  async function _doSaveConfig() {
     const parseOrNull = (s: string): number | null => {
       const t = s.trim();
       if (t === '') return null;
@@ -336,7 +314,6 @@ export default function LisaPage() {
         return_target_monthly_pct: parseOrNull(returnTargetMonthly),
         return_target_annual_pct: parseOrNull(returnTargetAnnual),
         daily_cost_budget_usd: parseOrNull(dailyCostBudget),
-        // Pas d'expiration par défaut — l'utilisateur veut "no-touch" sans limite
         // Utilise le timestamp figé calculé au moment de la saisie user
         // (pas Date.now() courant qui aurait drift entre la saisie et le save).
         autopilot_expires_at: (!autopilotAutoApprove || autopilotComputedExpiryMs === null)
@@ -363,27 +340,75 @@ export default function LisaPage() {
     }
   }
 
+  function handleSaveConfig() {
+    if (!selectedPortfolioId) return;
+
+    // Confirmation explicite la première fois qu'on active auto-approve
+    if (autopilotAutoApprove && !config?.autopilot_auto_approve) {
+      // Utilise le timestamp figé pour éviter tout décalage entre popup + save
+      let durationLine: string;
+      if (autopilotComputedExpiryMs === null) {
+        durationLine = "• Durée : SANS LIMITE (jusqu'à ce que tu désactives manuellement).";
+      } else {
+        const durH = parseFloat(autopilotDurationHoursInput);
+        const clamped = Math.min(durH, 24);
+        const expiry = new Date(autopilotComputedExpiryMs);
+        durationLine = `• Durée : ${clamped} h → s'arrête automatiquement le ${expiry.toLocaleString('fr-FR', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' })}.`;
+      }
+
+      setConfirmDialog({
+        title: 'Activation du mode autonome',
+        description:
+          '• Lisa ouvrira et fermera des positions toute seule sans te demander.\n'
+          + `• Scan toutes les ${autopilotCycleMin} min.\n`
+          + durationLine + '\n'
+          + '• Simulation paper uniquement — aucune exécution réelle.\n'
+          + '• Tu peux désactiver à tout moment en décochant la case.',
+        confirmLabel: 'Activer',
+        onConfirm: () => { setConfirmDialog(null); void _doSaveConfig(); },
+      });
+      return;
+    }
+
+    void _doSaveConfig();
+  }
+
   async function handleGenerate() {
     if (!selectedPortfolioId) return;
     await generateProposal.mutateAsync(userFocus.trim() || undefined);
     setUserFocus('');
   }
 
-  async function handleKillSwitch() {
+  function handleKillSwitch() {
     if (!selectedPortfolioId) return;
     const reason = killReason.trim() || 'Manual kill';
-    if (!confirm(`Fermer TOUTES les positions ? Raison : ${reason}`)) return;
-    await killSwitch.mutateAsync(reason);
-    setKillReason('');
+    setConfirmDialog({
+      title: 'Fermer toutes les positions',
+      description: `Fermer TOUTES les positions ?\nRaison : ${reason}`,
+      confirmLabel: 'Fermer tout',
+      dangerous: true,
+      onConfirm: async () => {
+        setConfirmDialog(null);
+        await killSwitch.mutateAsync(reason);
+        setKillReason('');
+      },
+    });
   }
 
-  async function handleResetSimulation() {
+  function handleResetSimulation() {
     if (!selectedPortfolioId) return;
-    if (!confirm(
-      'Effacer TOUT le portefeuille simulé ? Cela supprime définitivement positions, '
-      + 'propositions, snapshots et décision log. Action irréversible.',
-    )) return;
-    await resetSim.mutateAsync();
+    setConfirmDialog({
+      title: 'Effacer le portefeuille simulé',
+      description:
+        'Effacer TOUT le portefeuille simulé ? Cela supprime définitivement positions, '
+        + 'propositions, snapshots et décision log. Action irréversible.',
+      confirmLabel: 'Effacer',
+      dangerous: true,
+      onConfirm: async () => {
+        setConfirmDialog(null);
+        await resetSim.mutateAsync();
+      },
+    });
   }
 
   async function handleActivateAutonomousHunter() {
@@ -393,7 +418,7 @@ export default function LisaPage() {
       + 'SIMULATION uniquement — ouvre des positions paper sans confirmation à chaque cycle.',
       '4',
     );
-    if (hoursStr === null) return; // cancel
+    if (hoursStr === null) return;
 
     let expiresAt: string | null = null;
     const trimmed = hoursStr.trim();
@@ -410,27 +435,31 @@ export default function LisaPage() {
       ? `• Expire automatiquement dans ${trimmed}h`
       : `• Sans expiration — tourne jusqu'à ce que tu désactives manuellement`;
 
-    if (!confirm(
-      `Activer le mode chasse autonome ?\n\n`
-      + `• Lisa scanne le marché toutes les ${autopilotCycleMin || 15} min\n`
-      + `• Elle OUVRE automatiquement les positions qu'elle juge EV+\n`
-      + `• Elle COUPE sèchement les positions défavorables\n`
-      + `• Simulation paper uniquement — aucune exécution réelle\n`
-      + `• Kill-switch reste accessible à tout instant\n`
-      + expiryLine,
-    )) return;
-
-    await upsertConfig.mutateAsync({
-      autopilot_enabled: true,
-      autopilot_cycle_minutes: autopilotCycleMin || 15,
-      autopilot_auto_approve: true,
-      autopilot_expires_at: expiresAt,
-      autopilot_aggressive: true,
+    setConfirmDialog({
+      title: 'Activer le mode chasse autonome',
+      description:
+        `• Lisa scanne le marché toutes les ${autopilotCycleMin || 15} min\n`
+        + `• Elle OUVRE automatiquement les positions qu'elle juge EV+\n`
+        + `• Elle COUPE sèchement les positions défavorables\n`
+        + `• Simulation paper uniquement — aucune exécution réelle\n`
+        + `• Kill-switch reste accessible à tout instant\n`
+        + expiryLine,
+      confirmLabel: 'Activer',
+      onConfirm: async () => {
+        setConfirmDialog(null);
+        await upsertConfig.mutateAsync({
+          autopilot_enabled: true,
+          autopilot_cycle_minutes: autopilotCycleMin || 15,
+          autopilot_auto_approve: true,
+          autopilot_expires_at: expiresAt,
+          autopilot_aggressive: true,
+        });
+        setAutopilotEnabled(true);
+        setAutopilotAutoApprove(true);
+        setAutopilotExpiresAt(expiresAt);
+        setAutopilotAggressive(true);
+      },
     });
-    setAutopilotEnabled(true);
-    setAutopilotAutoApprove(true);
-    setAutopilotExpiresAt(expiresAt);
-    setAutopilotAggressive(true);
   }
 
   async function handleDisableAutonomousHunter() {
@@ -1343,6 +1372,18 @@ export default function LisaPage() {
           </Button>
         </div>
       </div>
+
+      {confirmDialog && (
+        <ConfirmDialog
+          open
+          title={confirmDialog.title}
+          description={confirmDialog.description}
+          confirmLabel={confirmDialog.confirmLabel}
+          dangerous={confirmDialog.dangerous}
+          onConfirm={confirmDialog.onConfirm}
+          onCancel={() => setConfirmDialog(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/monte-carlo/page.tsx
+++ b/apps/web/src/app/monte-carlo/page.tsx
@@ -395,16 +395,58 @@ function FanChart({ fanChart, initialCapital }: { fanChart: MCResult['fanChart']
 
   const medianPath = fanChart.map((p, i) => `${i === 0 ? 'M' : 'L'} ${x(i)} ${y(p.p50)}`).join(' ');
 
+  // Sample up to 6 time points for the screen-reader table
+  const step = Math.max(1, Math.floor(fanChart.length / 6));
+  const sampleDays = fanChart
+    .map((p, i) => ({ day: i, ...p }))
+    .filter((_, i) => i % step === 0 || i === fanChart.length - 1);
+
+  const lastPoint = fanChart[fanChart.length - 1]!;
+
   return (
     <div className="rounded-lg border p-5">
       <h2 className="font-medium mb-3">Fan chart — bandes P5–P95 / P25–P75 / médiane</h2>
-      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-72 overflow-visible">
-        <line x1={0} y1={yInit} x2={w} y2={yInit} stroke="currentColor" strokeWidth={1} strokeDasharray="4 4" opacity={0.3} />
-        <path d={outerPath} fill="#10b981" opacity={0.15} />
-        <path d={innerPath} fill="#10b981" opacity={0.3} />
-        <path d={medianPath} fill="none" stroke="#10b981" strokeWidth={2} />
+      <svg
+        viewBox={`0 0 ${w} ${h}`}
+        className="w-full h-72 overflow-visible"
+        role="img"
+        aria-label={`Projections futures Monte-Carlo sur ${fanChart.length} jours : médiane finale ${lastPoint.p50.toFixed(0)} $ (P5 ${lastPoint.p5.toFixed(0)} $ — P95 ${lastPoint.p95.toFixed(0)} $)`}
+      >
+        <title>{`Projections Monte-Carlo — médiane : ${lastPoint.p50.toFixed(0)} $ à J+${fanChart.length}`}</title>
+        <line x1={0} y1={yInit} x2={w} y2={yInit} stroke="currentColor" strokeWidth={1} strokeDasharray="4 4" opacity={0.3} aria-hidden="true" />
+        <path d={outerPath} fill="#10b981" opacity={0.15} aria-hidden="true" />
+        <path d={innerPath} fill="#10b981" opacity={0.3} aria-hidden="true" />
+        <path d={medianPath} fill="none" stroke="#10b981" strokeWidth={2} aria-hidden="true" />
       </svg>
-      <div className="text-xs text-muted-foreground flex justify-between mt-1">
+
+      {/* Screen-reader fallback table */}
+      <table className="sr-only" aria-label="Données des projections Monte-Carlo">
+        <caption>Fan chart — percentiles par jour (échantillon)</caption>
+        <thead>
+          <tr>
+            <th scope="col">Jour</th>
+            <th scope="col">P5 ($)</th>
+            <th scope="col">P25 ($)</th>
+            <th scope="col">Médiane ($)</th>
+            <th scope="col">P75 ($)</th>
+            <th scope="col">P95 ($)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sampleDays.map(({ day, p5, p25, p50, p75, p95 }) => (
+            <tr key={day}>
+              <td>J+{day}</td>
+              <td>{p5.toFixed(0)}</td>
+              <td>{p25.toFixed(0)}</td>
+              <td>{p50.toFixed(0)}</td>
+              <td>{p75.toFixed(0)}</td>
+              <td>{p95.toFixed(0)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="text-xs text-muted-foreground flex justify-between mt-1" aria-hidden="true">
         <span>Aujourd'hui</span>
         <span>+{fanChart.length} jours</span>
       </div>
@@ -422,10 +464,20 @@ function Histogram({ histogram, initialCapital, target }: { histogram: MCResult[
   const max = histogram[histogram.length - 1].binEnd;
   const xOf = (val: number) => ((val - min) / (max - min)) * w;
 
+  const totalSims = histogram.reduce((s, b) => s + b.count, 0);
+  const firstBin = histogram[0]!;
+  const lastBin = histogram[histogram.length - 1]!;
+
   return (
     <div className="rounded-lg border p-5">
       <h2 className="font-medium mb-3">Distribution des equity finales</h2>
-      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-48 overflow-visible">
+      <svg
+        viewBox={`0 0 ${w} ${h}`}
+        className="w-full h-48 overflow-visible"
+        role="img"
+        aria-label={`Histogramme des équités finales simulées : de ${firstBin.binStart.toFixed(0)} $ à ${lastBin.binEnd.toFixed(0)} $, capital initial ${initialCapital.toFixed(0)} $`}
+      >
+        <title>{`Distribution des équités finales — ${totalSims} simulations`}</title>
         {histogram.map((b, i) => {
           const barH = (b.count / maxCount) * h;
           const profitable = b.binEnd > initialCapital;
@@ -438,20 +490,44 @@ function Histogram({ histogram, initialCapital, target }: { histogram: MCResult[
               height={barH}
               fill={profitable ? '#10b981' : '#ef4444'}
               opacity={0.7}
+              aria-hidden="true"
             />
           );
         })}
-        {/* Ligne capital initial */}
-        <line x1={xOf(initialCapital)} y1={0} x2={xOf(initialCapital)} y2={h} stroke="currentColor" strokeWidth={1} strokeDasharray="3 3" opacity={0.6} />
+        <line x1={xOf(initialCapital)} y1={0} x2={xOf(initialCapital)} y2={h} stroke="currentColor" strokeWidth={1} strokeDasharray="3 3" opacity={0.6} aria-hidden="true" />
         {target != null && target >= min && target <= max && (
-          <line x1={xOf(target)} y1={0} x2={xOf(target)} y2={h} stroke="#f59e0b" strokeWidth={2} strokeDasharray="3 3" />
+          <line x1={xOf(target)} y1={0} x2={xOf(target)} y2={h} stroke="#f59e0b" strokeWidth={2} strokeDasharray="3 3" aria-hidden="true" />
         )}
       </svg>
-      <div className="text-xs text-muted-foreground flex justify-between mt-1">
-        <span>${histogram[0].binStart.toFixed(0)}</span>
+
+      {/* Screen-reader fallback table */}
+      <table className="sr-only" aria-label="Distribution des équités finales simulées">
+        <caption>Histogramme — {totalSims} simulations au total</caption>
+        <thead>
+          <tr>
+            <th scope="col">Tranche ($)</th>
+            <th scope="col">Simulations</th>
+            <th scope="col">% du total</th>
+            <th scope="col">Résultat</th>
+          </tr>
+        </thead>
+        <tbody>
+          {histogram.map((b, i) => (
+            <tr key={i}>
+              <td>{b.binStart.toFixed(0)} – {b.binEnd.toFixed(0)}</td>
+              <td>{b.count}</td>
+              <td>{totalSims > 0 ? ((b.count / totalSims) * 100).toFixed(1) : '0'}%</td>
+              <td>{b.binEnd > initialCapital ? 'Profitable' : 'Perte'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="text-xs text-muted-foreground flex justify-between mt-1" aria-hidden="true">
+        <span>${firstBin.binStart.toFixed(0)}</span>
         <span className="font-medium">${initialCapital.toFixed(0)} (initial)</span>
         {target != null && <span className="text-amber-600 font-medium">${target.toFixed(0)} (cible)</span>}
-        <span>${histogram[histogram.length - 1].binEnd.toFixed(0)}</span>
+        <span>${lastBin.binEnd.toFixed(0)}</span>
       </div>
     </div>
   );

--- a/apps/web/src/app/optimizer/page.tsx
+++ b/apps/web/src/app/optimizer/page.tsx
@@ -298,15 +298,16 @@ export default function OptimizerPage() {
         <div className="rounded-lg border p-5">
           <h2 className="font-medium mb-3 text-sm">Historique des runs</h2>
           <table className="w-full text-xs">
+            <caption className="sr-only">Historique des runs d'optimisation</caption>
             <thead className="text-muted-foreground">
               <tr className="border-b">
-                <th className="text-left py-1">Quand</th>
-                <th className="text-left py-1">Mode</th>
-                <th className="text-left py-1">Période</th>
-                <th className="text-right py-1">Configs</th>
-                <th className="text-right py-1">Best score</th>
-                <th className="text-right py-1">Durée</th>
-                <th className="text-left py-1">Applied</th>
+                <th scope="col" className="text-left py-1">Quand</th>
+                <th scope="col" className="text-left py-1">Mode</th>
+                <th scope="col" className="text-left py-1">Période</th>
+                <th scope="col" className="text-right py-1">Configs</th>
+                <th scope="col" className="text-right py-1">Best score</th>
+                <th scope="col" className="text-right py-1">Durée</th>
+                <th scope="col" className="text-left py-1">Applied</th>
               </tr>
             </thead>
             <tbody>
@@ -408,22 +409,23 @@ function Leaderboard({ result, onApply }: { result: OptimizerRunResult; onApply:
       </div>
       <div className="overflow-x-auto">
         <table className="w-full text-xs">
+          <caption className="sr-only">Top 10 configurations triées par score composite</caption>
           <thead className="text-muted-foreground">
             <tr className="border-b">
-              <th className="text-left py-1">#</th>
-              <th className="text-right py-1">Score</th>
-              <th className="text-right py-1">Sharpe</th>
-              <th className="text-right py-1">DD%</th>
-              <th className="text-right py-1">Return%</th>
-              <th className="text-right py-1">Win%</th>
-              <th className="text-right py-1">PF</th>
-              <th className="text-center py-1">AntiCons</th>
-              <th className="text-center py-1">Pos%</th>
-              <th className="text-center py-1">Class%</th>
-              <th className="text-center py-1">Stop</th>
-              <th className="text-center py-1">TP</th>
-              {result.mode !== 'single_shot' && <th className="text-right py-1">Stab</th>}
-              <th className="text-center py-1">Action</th>
+              <th scope="col" className="text-left py-1">#</th>
+              <th scope="col" className="text-right py-1">Score</th>
+              <th scope="col" className="text-right py-1" title="Sharpe ratio">Sharpe</th>
+              <th scope="col" className="text-right py-1" title="Max drawdown (%)"><abbr title="Drawdown maximum">DD</abbr>%</th>
+              <th scope="col" className="text-right py-1">Return%</th>
+              <th scope="col" className="text-right py-1">Win%</th>
+              <th scope="col" className="text-right py-1" title="Profit factor"><abbr title="Profit factor">PF</abbr></th>
+              <th scope="col" className="text-center py-1" title="Force anti-consensus"><abbr title="Force anti-consensus">AntiCons</abbr></th>
+              <th scope="col" className="text-center py-1" title="Max position size (%)"><abbr title="Max position size">Pos</abbr>%</th>
+              <th scope="col" className="text-center py-1" title="Max exposure per asset class (%)"><abbr title="Max exposure per asset class">Class</abbr>%</th>
+              <th scope="col" className="text-center py-1">Stop</th>
+              <th scope="col" className="text-center py-1" title="Take-profit"><abbr title="Take-profit">TP</abbr></th>
+              {result.mode !== 'single_shot' && <th scope="col" className="text-right py-1" title="Score de stabilité"><abbr title="Score de stabilité">Stab</abbr></th>}
+              <th scope="col" className="text-center py-1">Action</th>
             </tr>
           </thead>
           <tbody>

--- a/apps/web/src/app/portfolio/page.tsx
+++ b/apps/web/src/app/portfolio/page.tsx
@@ -12,6 +12,7 @@ import { SkeletonCard } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/states/empty-state';
 import { ErrorState } from '@/components/states/error-state';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { HelpTip } from '@/components/ui/help-tip';
 
 export default function PortfolioPage() {
   const { data: portfolios, isLoading, error, refetch } = usePortfolios();
@@ -42,7 +43,14 @@ export default function PortfolioPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Mon portefeuille</h1>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+            Mon portefeuille
+            <HelpTip
+              text="Un portefeuille regroupe l'ensemble de vos actifs financiers. Vous pouvez en créer plusieurs : un réel et un ou plusieurs en simulation."
+              glossarySlug="portefeuille"
+              side="right"
+            />
+          </h1>
           <p className="mt-1 text-sm text-muted-foreground">
             Gérez vos portefeuilles et les comptes associés.
           </p>
@@ -81,7 +89,13 @@ export default function PortfolioPage() {
             <Card key={p.id} className="transition-shadow hover:shadow-md">
               <CardHeader>
                 <CardTitle className="text-base">{p.name}</CardTitle>
-                <CardDescription>Devise : {p.base_currency}</CardDescription>
+                <CardDescription className="flex items-center gap-1">
+                  Devise : {p.base_currency}
+                  <HelpTip
+                    text="Devise de référence pour le calcul des P&L et de la valorisation globale. Les actifs en devise étrangère sont convertis à cours du jour."
+                    side="right"
+                  />
+                </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
                 {p.description ? (

--- a/apps/web/src/app/portfolio/page.tsx
+++ b/apps/web/src/app/portfolio/page.tsx
@@ -11,14 +11,22 @@ import { Button } from '@/components/ui/button';
 import { SkeletonCard } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/states/empty-state';
 import { ErrorState } from '@/components/states/error-state';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 
 export default function PortfolioPage() {
   const { data: portfolios, isLoading, error, refetch } = usePortfolios();
   const qc = useQueryClient();
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleteDialog, setDeleteDialog] = useState<{ id: string; name: string } | null>(null);
 
   async function handleDelete(id: string, name: string) {
-    if (!confirm(`Supprimer "${name}" ? Cette action est irréversible.`)) return;
+    setDeleteDialog({ id, name });
+  }
+
+  async function confirmDelete() {
+    if (!deleteDialog) return;
+    const { id } = deleteDialog;
+    setDeleteDialog(null);
     setDeletingId(id);
     try {
       await deletePortfolio(id);
@@ -106,6 +114,16 @@ export default function PortfolioPage() {
           ))}
         </div>
       )}
+
+      <ConfirmDialog
+        open={deleteDialog !== null}
+        title="Supprimer le portefeuille"
+        description={deleteDialog ? `Supprimer "${deleteDialog.name}" ? Cette action est irréversible.` : ''}
+        confirmLabel="Supprimer"
+        onConfirm={() => void confirmDelete()}
+        onCancel={() => setDeleteDialog(null)}
+        dangerous
+      />
     </div>
   );
 }

--- a/apps/web/src/app/settings/brokers/layout.tsx
+++ b/apps/web/src/app/settings/brokers/layout.tsx
@@ -1,0 +1,5 @@
+import { AdminGuard } from '@/components/auth/admin-guard';
+
+export default function BrokersLayout({ children }: { children: React.ReactNode }) {
+  return <AdminGuard>{children}</AdminGuard>;
+}

--- a/apps/web/src/app/settings/delegation/layout.tsx
+++ b/apps/web/src/app/settings/delegation/layout.tsx
@@ -1,0 +1,5 @@
+import { AdminGuard } from '@/components/auth/admin-guard';
+
+export default function DelegationLayout({ children }: { children: React.ReactNode }) {
+  return <AdminGuard>{children}</AdminGuard>;
+}

--- a/apps/web/src/app/settings/hyper-trading/layout.tsx
+++ b/apps/web/src/app/settings/hyper-trading/layout.tsx
@@ -1,0 +1,5 @@
+import { AdminGuard } from '@/components/auth/admin-guard';
+
+export default function HyperTradingLayout({ children }: { children: React.ReactNode }) {
+  return <AdminGuard>{children}</AdminGuard>;
+}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -15,6 +15,7 @@ import {
   User,
   Zap,
 } from 'lucide-react';
+import { useIsAdmin } from '@/hooks/use-is-admin';
 
 const PROFILE_SECTIONS = [
   {
@@ -106,6 +107,8 @@ function SectionList({ sections }: { sections: readonly { href: string; icon: Re
 }
 
 export default function SettingsPage() {
+  const isAdmin = useIsAdmin();
+
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-6">
       <div>
@@ -120,10 +123,12 @@ export default function SettingsPage() {
         <SectionList sections={PROFILE_SECTIONS} />
       </section>
 
-      <section className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground px-1">Simulation & automatisation</p>
-        <SectionList sections={ADVANCED_SECTIONS} />
-      </section>
+      {isAdmin && (
+        <section className="space-y-2">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground px-1">Réglages avancés</p>
+          <SectionList sections={ADVANCED_SECTIONS} />
+        </section>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/settings/sniper/layout.tsx
+++ b/apps/web/src/app/settings/sniper/layout.tsx
@@ -1,0 +1,5 @@
+import { AdminGuard } from '@/components/auth/admin-guard';
+
+export default function SniperLayout({ children }: { children: React.ReactNode }) {
+  return <AdminGuard>{children}</AdminGuard>;
+}

--- a/apps/web/src/app/settings/strategy-mode/layout.tsx
+++ b/apps/web/src/app/settings/strategy-mode/layout.tsx
@@ -1,0 +1,5 @@
+import { AdminGuard } from '@/components/auth/admin-guard';
+
+export default function StrategyModeLayout({ children }: { children: React.ReactNode }) {
+  return <AdminGuard>{children}</AdminGuard>;
+}

--- a/apps/web/src/components/auth/admin-guard.tsx
+++ b/apps/web/src/components/auth/admin-guard.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAdminStatus } from '@/hooks/use-is-admin';
+
+/**
+ * Guards an admin-only settings page. Redirects non-admins to /settings.
+ *
+ * Note: this is a UX-only guard (hides admin pages from non-admin users).
+ * Real access control lives in the backend `/admin/*` endpoints which
+ * enforce `x-admin-token` + role checks. Front-end gating prevents non-admin
+ * users from seeing an empty/error UI when API calls would fail.
+ */
+export function AdminGuard({ children }: { children: React.ReactNode }) {
+  const { isAdmin, isLoaded } = useAdminStatus();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isLoaded && !isAdmin) {
+      router.replace('/settings');
+    }
+  }, [isLoaded, isAdmin, router]);
+
+  if (!isLoaded) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-4 p-6">
+        <div className="h-6 w-40 animate-pulse rounded bg-muted" />
+        <div className="h-32 animate-pulse rounded-lg bg-muted/40" />
+      </div>
+    );
+  }
+
+  if (!isAdmin) return null;
+
+  return <>{children}</>;
+}

--- a/apps/web/src/components/dashboard/connected-dashboard.tsx
+++ b/apps/web/src/components/dashboard/connected-dashboard.tsx
@@ -27,6 +27,7 @@ import { SkeletonCard } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/states/empty-state';
 import { Button } from '@/components/ui/button';
 import { ErrorState } from '@/components/states/error-state';
+import { HelpTip } from '@/components/ui/help-tip';
 
 export function ConnectedDashboard() {
   const router = useRouter();
@@ -152,6 +153,11 @@ export function ConnectedDashboard() {
             <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
               {activePortfolio?.name ?? 'Mon tableau de bord'}
             </h1>
+            <HelpTip
+              text="Vue d'ensemble de votre portefeuille actif : valeur de marché, P&L latent, alertes et répartition par classe d'actifs."
+              glossarySlug="portefeuille"
+              side="right"
+            />
             {(activePortfolio as { is_simulation?: boolean } | null)?.is_simulation && (
               <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
                 <FlaskConical className="h-3 w-3" />

--- a/apps/web/src/components/lisa/decision-log.tsx
+++ b/apps/web/src/components/lisa/decision-log.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { ScrollText, Sparkles, ShieldCheck, Swords, AlertTriangle, UserCheck, Clock, CheckCircle2, XCircle, Wrench } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useLisaDecisionLog, useAuditChainVerify, useRepairAuditChain, type LisaDecisionLogRow } from '@/hooks/use-lisa';
 import { SkeletonCard } from '@/components/ui/skeleton';
 
@@ -34,11 +35,14 @@ export function LisaDecisionLog({ portfolioId }: { portfolioId: string }) {
   const logQuery = useLisaDecisionLog(portfolioId, 50);
   const verifyQuery = useAuditChainVerify(portfolioId);
   const repairMutation = useRepairAuditChain(portfolioId);
+  const [confirmRepair, setConfirmRepair] = useState(false);
   const entries = logQuery.data ?? [];
   const chain = verifyQuery.data;
 
-  const handleRepair = async () => {
-    if (!confirm('Recalculer tous les hashs avec la canonisation Node.js ?\n\nIdempotent — peut être ré-exécuté sans danger. Aucune donnée perdue.')) return;
+  const handleRepair = () => setConfirmRepair(true);
+
+  const doRepair = async () => {
+    setConfirmRepair(false);
     try {
       const result = await repairMutation.mutateAsync();
       const status = result.verifiedAfterRepair.isValid ? '✅ intègre' : `❌ encore corrompue #${result.verifiedAfterRepair.firstCorruptedIndex}`;
@@ -93,6 +97,15 @@ export function LisaDecisionLog({ portfolioId }: { portfolioId: string }) {
           {entries.map((e) => <DecisionRow key={e.id} entry={e} />)}
         </div>
       )}
+
+      <ConfirmDialog
+        open={confirmRepair}
+        title="Recalculer les hashs ?"
+        description={'Recalculer tous les hashs avec la canonisation Node.js ?\n\nIdempotent — peut être ré-exécuté sans danger. Aucune donnée perdue.'}
+        confirmLabel="Recalculer"
+        onConfirm={doRepair}
+        onCancel={() => setConfirmRepair(false)}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/lisa/portfolio-chart.tsx
+++ b/apps/web/src/components/lisa/portfolio-chart.tsx
@@ -238,7 +238,11 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
       )}
 
       {hasData && (
-        <div className="h-72 w-full">
+        <div
+          className="h-72 w-full"
+          role="img"
+          aria-label={`Évolution du capital sur ${WINDOW_LABELS[window]} : départ ${baselineValue.toFixed(0)} USD, valeur courante ${latestValue.toFixed(0)} USD, ${periodReturn >= 0 ? 'gain' : 'perte'} de ${Math.abs(periodReturn).toFixed(2)}%`}
+        >
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={chartData} margin={{ top: 8, right: 12, bottom: 8, left: 8 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="currentColor" opacity={0.1} />
@@ -297,8 +301,40 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
           </ResponsiveContainer>
         </div>
       )}
+
+      {hasData && (
+        <table className="sr-only" aria-label="Données de la courbe d'équité">
+          <caption>{`Évolution du capital — ${WINDOW_LABELS[window]} (échantillon)`}</caption>
+          <thead>
+            <tr>
+              <th scope="col">Date</th>
+              <th scope="col">Valeur (USD)</th>
+              <th scope="col">Return (%)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sampleChartPoints(chartData).map((p) => (
+              <tr key={p.t}>
+                <td>{p.tFull}</td>
+                <td>{p.value.toFixed(2)}</td>
+                <td>{p.returnPct.toFixed(2)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
+}
+
+/** Sample up to 10 points from a chart series for screen-reader fallback. */
+function sampleChartPoints(points: ChartPoint[]): ChartPoint[] {
+  if (points.length <= 10) return points;
+  const step = Math.max(1, Math.floor(points.length / 10));
+  const sampled = points.filter((_, i) => i % step === 0);
+  const last = points[points.length - 1]!;
+  if (sampled[sampled.length - 1] !== last) sampled.push(last);
+  return sampled;
 }
 
 /**

--- a/apps/web/src/components/lisa/proposal-card.tsx
+++ b/apps/web/src/components/lisa/proposal-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { CheckCircle2, XCircle, ChevronDown, ChevronUp, AlertTriangle, TrendingUp, TrendingDown, Search, Play, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -81,6 +82,7 @@ export function LisaProposalCard({
 }) {
   const [expanded, setExpanded] = useState(proposal.status === 'proposed');
   const [showAllTheses, setShowAllTheses] = useState(false);
+  const [confirmApprove, setConfirmApprove] = useState(false);
   const approve = useApproveProposal(portfolioId);
   const reject = useRejectProposal(portfolioId);
 
@@ -88,7 +90,11 @@ export function LisaProposalCard({
   const thesesToShow = showAllTheses ? theses : theses.slice(0, 2);
 
   async function handleApprove() {
-    if (!confirm(`Ouvrir ${proposal.allocations.length} position(s) en simulation ?`)) return;
+    setConfirmApprove(true);
+  }
+
+  async function doApprove() {
+    setConfirmApprove(false);
     await approve.mutateAsync(proposal.id);
   }
 
@@ -409,6 +415,15 @@ export function LisaProposalCard({
           )}
         </div>
       )}
+
+      <ConfirmDialog
+        open={confirmApprove}
+        title="Approuver cette proposition ?"
+        description={`Ouvrir ${proposal.allocations.length} position(s) en simulation ?`}
+        confirmLabel="Approuver & ouvrir"
+        onConfirm={doApprove}
+        onCancel={() => setConfirmApprove(false)}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/lisa/proposals-grouped-by-day.tsx
+++ b/apps/web/src/components/lisa/proposals-grouped-by-day.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Activity, ChevronDown, ChevronUp, Trash2, ChevronsDown, ChevronsUp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { SkeletonCard } from '@/components/ui/skeleton';
@@ -25,8 +26,8 @@ export function LisaProposalsGroupedByDay({
   isLoading: boolean;
 }) {
   const purge = usePurgeOldProposals(portfolioId);
-  // Set des jours dépliés. Vide au mount → tout replié.
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [confirmPurge, setConfirmPurge] = useState(false);
 
   const grouped = useMemo(() => {
     const buckets = new Map<string, { key: string; label: string; items: LisaProposalRow[] }>();
@@ -71,13 +72,13 @@ export function LisaProposalsGroupedByDay({
     }
   };
 
-  async function handlePurge() {
+  function handlePurge() {
     if (!portfolioId) return;
-    if (!confirm(
-      'Supprimer les propositions terminales (approuvées / rejetées / expirées) '
-      + 'ET les propositions de plus de 24h ?\n\n'
-      + 'Les propositions récentes en attente d\'approbation sont préservées.',
-    )) return;
+    setConfirmPurge(true);
+  }
+
+  async function doPurge() {
+    setConfirmPurge(false);
     const { deleted } = await purge.mutateAsync(24);
     alert(`${deleted} proposition(s) supprimée(s).`);
   }
@@ -155,6 +156,20 @@ export function LisaProposalsGroupedByDay({
           </div>
         );
       })}
+
+      <ConfirmDialog
+        open={confirmPurge}
+        title="Purger les anciennes propositions ?"
+        description={
+          'Supprimer les propositions terminales (approuvées / rejetées / expirées) '
+          + 'ET les propositions de plus de 24h ?\n\n'
+          + "Les propositions récentes en attente d'approbation sont préservées."
+        }
+        confirmLabel="Purger"
+        dangerous
+        onConfirm={doPurge}
+        onCancel={() => setConfirmPurge(false)}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/ui/back-button.tsx
+++ b/apps/web/src/components/ui/back-button.tsx
@@ -14,9 +14,10 @@ export function BackButton({ label = 'Retour', className = '' }: BackButtonProps
     <button
       type="button"
       onClick={() => router.back()}
-      className={`inline-flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors ${className}`}
+      aria-label={label}
+      className={`inline-flex items-center min-h-[44px] py-2 pr-2 text-sm text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded ${className}`}
     >
-      <ArrowLeft className="mr-1.5 h-4 w-4" />
+      <ArrowLeft className="mr-1.5 h-4 w-4" aria-hidden />
       {label}
     </button>
   );

--- a/apps/web/src/components/ui/confirm-dialog.tsx
+++ b/apps/web/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  dangerous?: boolean;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  onConfirm,
+  onCancel,
+  confirmLabel = 'Confirmer',
+  cancelLabel = 'Annuler',
+  dangerous = false,
+}: ConfirmDialogProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const confirmRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Move focus to cancel button when dialog opens (safer default than confirm)
+  useEffect(() => {
+    if (open) cancelRef.current?.focus();
+  }, [open]);
+
+  // ESC closes dialog
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onCancel();
+      }
+      // Focus trap: Tab/Shift+Tab cycles between cancel and confirm only
+      if (e.key === 'Tab') {
+        const focusable = [cancelRef.current, confirmRef.current].filter(Boolean) as HTMLButtonElement[];
+        if (focusable.length < 2) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open, onCancel]);
+
+  if (!open || typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
+
+      {/* Dialog */}
+      <div
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        aria-describedby="confirm-dialog-desc"
+        className="relative z-10 w-full max-w-sm rounded-lg border bg-background p-6 shadow-lg"
+      >
+        <h2
+          id="confirm-dialog-title"
+          className="text-base font-semibold"
+        >
+          {title}
+        </h2>
+        <p
+          id="confirm-dialog-desc"
+          className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground"
+        >
+          {description}
+        </p>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            className="inline-flex min-h-[44px] items-center rounded-md border px-4 py-2 text-sm font-medium transition-colors hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            onClick={onConfirm}
+            className={`inline-flex min-h-[44px] items-center rounded-md px-4 py-2 text-sm font-medium text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+              dangerous
+                ? 'bg-destructive hover:bg-destructive/90 focus-visible:ring-destructive'
+                : 'bg-primary hover:bg-primary/90 focus-visible:ring-primary'
+            }`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/hooks/use-is-admin.ts
+++ b/apps/web/src/hooks/use-is-admin.ts
@@ -14,8 +14,18 @@
 import { useEffect, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
-export function useIsAdmin(): boolean {
-  const [isAdmin, setIsAdmin] = useState(false);
+export interface AdminStatus {
+  isAdmin: boolean;
+  isLoaded: boolean;
+}
+
+/**
+ * Returns admin status with explicit loading state. Use this when you need to
+ * differentiate "still checking" from "confirmed not admin" (e.g. before
+ * redirecting non-admins from a guarded page).
+ */
+export function useAdminStatus(): AdminStatus {
+  const [state, setState] = useState<AdminStatus>({ isAdmin: false, isLoaded: false });
 
   useEffect(() => {
     let cancelled = false;
@@ -23,13 +33,17 @@ export function useIsAdmin(): boolean {
       const supabase = createSupabaseBrowserClient();
       const { data } = await supabase.auth.getUser();
       const user = data.user;
-      if (cancelled || !user) return;
+      if (cancelled) return;
+      if (!user) {
+        setState({ isAdmin: false, isLoaded: true });
+        return;
+      }
 
       const role = (user.app_metadata?.role ?? user.user_metadata?.role) as
         | string
         | undefined;
       if (role === 'admin') {
-        setIsAdmin(true);
+        setState({ isAdmin: true, isLoaded: true });
         return;
       }
 
@@ -38,14 +52,21 @@ export function useIsAdmin(): boolean {
         .split(',')
         .map((s) => s.trim().toLowerCase())
         .filter(Boolean);
-      if (user.email && allowed.includes(user.email.toLowerCase())) {
-        setIsAdmin(true);
-      }
+      const isAdmin = !!user.email && allowed.includes(user.email.toLowerCase());
+      setState({ isAdmin, isLoaded: true });
     })();
     return () => {
       cancelled = true;
     };
   }, []);
 
-  return isAdmin;
+  return state;
+}
+
+/**
+ * Backwards-compat boolean variant. Returns `false` during initial load — do
+ * not use for redirect guards (race condition on first paint).
+ */
+export function useIsAdmin(): boolean {
+  return useAdminStatus().isAdmin;
 }

--- a/supabase/migrations/0096_account_deletion_audit.sql
+++ b/supabase/migrations/0096_account_deletion_audit.sql
@@ -1,0 +1,20 @@
+-- Migration 0096 — audit table for RGPD account deletion requests
+-- user_id is NOT a FK to auth.users (the user will be deleted; we keep the audit row)
+
+create table if not exists public.account_deletion_audit (
+  id            uuid primary key default uuid_generate_v4(),
+  user_id       uuid not null,
+  user_email    text,
+  requested_at  timestamptz not null default now(),
+  completed_at  timestamptz,
+  ip_hash       text,          -- sha256(ip) — no raw IP stored
+  status        text not null default 'initiated'
+                check (status in ('initiated', 'completed', 'failed')),
+  error_message text
+);
+
+-- Audit is service-role only — no RLS policy = no user access
+alter table public.account_deletion_audit enable row level security;
+
+create index if not exists account_deletion_audit_user_id_idx
+  on public.account_deletion_audit (user_id);


### PR DESCRIPTION
## Summary

Rebased sur `main` (post-hotfix #165). Cette PR consolide **8 features** précédemment mergées sur l'integration branch `claude/review-repo-docs-f7qBN` qui n'avaient jamais atteint la prod, plus le rollout HelpTips final.

### Commits inclus (8 features)

| # | Commit | Feature |
|---|---|---|
| 1 | 0c9a93e | RGPD export `/me/export` + delete `/me` (PR #157) |
| 2 | f5a0d77 | Sprint 9 quick wins — BackButton + help admin gating (PR #158) |
| 3 | 7acf000 | ConfirmDialog accessible (PR #159) |
| 4 | 3e7cd7a | SVG charts a11y aria-label + table fallback (PR #160) |
| 5 | bc76781 | Settings admin gating + "Réglages avancés" (PR #161) |
| 6 | 981976e | Recharts a11y + /optimizer table abbreviations (PR #162) |
| 7 | 0928c14 | ConfirmDialog rollout — élimine 5 confirm() restants (PR #163) |
| 8 | 3626687 | HelpTips in-line sur 3 pages pilotes (cette PR) |

### Pourquoi rebase sur main

Le hotfix #165 a débloqué les builds Vercel. Le rebase sur main inclut automatiquement ce hotfix + permet de promouvoir directement les 8 features en prod sans passer par l'integration branch (qui était bloquée par le bug ESLint).

### Test plan

- [ ] CI verte (TypeScript build + Jest + Vercel Preview)
- [ ] Vercel preview accessible
- [ ] /settings/donnees répond 200 (déjà confirmé par user en prod via hotfix)
- [ ] Dashboard / portfolio / résultats : icône ℹ️ HelpTip cliquable
- [ ] Aucun `confirm()` natif restant (vérifié)

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb