### PR TITLE
feat(settings): rollout V2 information architecture (Implements ADR-003)

### DIFF
--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -17,12 +17,24 @@ import {
 } from 'lucide-react';
 import { useIsAdmin } from '@/hooks/use-is-admin';
 
-const PROFILE_SECTIONS = [
+// Implements ADR-003 — Settings V2 information architecture
+// 4 sections par axe d'impact : profil & accès / données & confidentialité /
+// stratégie & objectifs (admin) / délégation & exécution (admin).
+// Routes inchangées — pas de breaking change pour les bookmarks.
+
+interface SectionItem {
+  href: string;
+  icon: React.ElementType;
+  label: string;
+  description: string;
+}
+
+const PROFILE_ACCESS_SECTIONS: readonly SectionItem[] = [
   {
     href: '/settings/profil',
     icon: User,
     label: 'Mon profil',
-    description: 'Prénom, niveau d\'expérience, langue.',
+    description: "Prénom, niveau d'expérience, langue.",
   },
   {
     href: '/settings/securite',
@@ -42,26 +54,14 @@ const PROFILE_SECTIONS = [
     label: 'Abonnement',
     description: 'Plan actuel, limites et informations de facturation.',
   },
-  {
-    href: '/settings/donnees',
-    icon: Database,
-    label: 'Mes données',
-    description: 'Exporter ou supprimer votre compte (RGPD).',
-  },
 ] as const;
 
-const ADVANCED_SECTIONS = [
-  {
-    href: '/settings/delegation',
-    icon: Shield,
-    label: 'Délégation & Mandats',
-    description: "Garde-fous et mandats d'autonomie pour Lisa.",
-  },
+const STRATEGY_SECTIONS: readonly SectionItem[] = [
   {
     href: '/settings/strategy-mode',
     icon: Sliders,
     label: 'Mode stratégique',
-    description: "Mode d'analyse : investissement, harvest ou gainers.",
+    description: "Cadence d'analyse et intensité du risque.",
   },
   {
     href: '/settings/hyper-trading',
@@ -75,6 +75,15 @@ const ADVANCED_SECTIONS = [
     label: 'Mode sniper',
     description: 'Session courte durée pour un suivi intensif temporaire.',
   },
+] as const;
+
+const DELEGATION_EXECUTION_SECTIONS: readonly SectionItem[] = [
+  {
+    href: '/settings/delegation',
+    icon: Shield,
+    label: 'Délégation & mandats',
+    description: "Mandats d'autonomie et kill-switch pour Lisa.",
+  },
   {
     href: '/settings/brokers',
     icon: Cable,
@@ -83,26 +92,52 @@ const ADVANCED_SECTIONS = [
   },
 ] as const;
 
-function SectionList({ sections }: { sections: readonly { href: string; icon: React.ElementType; label: string; description: string }[] }) {
+function SectionList({ sections }: { sections: readonly SectionItem[] }) {
   return (
     <div className="rounded-lg border divide-y">
       {sections.map(({ href, icon: Icon, label, description }) => (
         <Link
           key={href}
           href={href as Route}
-          className="flex items-center gap-4 px-4 py-4 transition-colors hover:bg-muted/30"
+          className="flex items-center gap-4 px-4 py-4 transition-colors hover:bg-muted/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
         >
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-muted/40">
-            <Icon className="h-4 w-4 text-muted-foreground" />
+            <Icon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           </div>
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium">{label}</p>
             <p className="text-xs text-muted-foreground">{description}</p>
           </div>
-          <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+          <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
         </Link>
       ))}
     </div>
+  );
+}
+
+// Section RGPD mise en avant (ADR-003 §4 nuance 2) — card unique enrichie
+// pour compenser le faible volume (1 item) et signaler la conformité.
+function PrivacySectionCard() {
+  return (
+    <Link
+      href={'/settings/donnees' as Route}
+      className="block rounded-lg border border-blue-200 bg-blue-50/40 p-4 transition-colors hover:bg-blue-50/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 dark:border-blue-900/40 dark:bg-blue-950/10 dark:hover:bg-blue-950/20"
+    >
+      <div className="flex items-start gap-4">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-blue-200 bg-white dark:border-blue-800 dark:bg-blue-950/40">
+          <Database className="h-5 w-5 text-blue-600 dark:text-blue-400" aria-hidden="true" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium">Exporter ou supprimer mes données</p>
+          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
+            Téléchargez l'intégralité de vos données SmartVest (portefeuilles,
+            transactions, profil) au format JSON, ou demandez la suppression
+            définitive de votre compte. Conformité RGPD garantie.
+          </p>
+        </div>
+        <ChevronRight className="mt-1 h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
+      </div>
+    </Link>
   );
 }
 
@@ -111,23 +146,55 @@ export default function SettingsPage() {
 
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-6">
-      <div>
+      <header>
         <h1 className="text-xl font-semibold">Mon compte</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Configurez votre espace SmartVest.
         </p>
-      </div>
+      </header>
 
-      <section className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground px-1">Profil & préférences</p>
-        <SectionList sections={PROFILE_SECTIONS} />
+      <section className="space-y-2" aria-labelledby="settings-section-profile">
+        <h2
+          id="settings-section-profile"
+          className="px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+        >
+          Mon profil &amp; accès
+        </h2>
+        <SectionList sections={PROFILE_ACCESS_SECTIONS} />
+      </section>
+
+      <section className="space-y-2" aria-labelledby="settings-section-privacy">
+        <h2
+          id="settings-section-privacy"
+          className="px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+        >
+          Mes données &amp; confidentialité
+        </h2>
+        <PrivacySectionCard />
       </section>
 
       {isAdmin && (
-        <section className="space-y-2">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground px-1">Réglages avancés</p>
-          <SectionList sections={ADVANCED_SECTIONS} />
-        </section>
+        <>
+          <section className="space-y-2" aria-labelledby="settings-section-strategy">
+            <h2
+              id="settings-section-strategy"
+              className="px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+            >
+              Stratégie &amp; objectifs
+            </h2>
+            <SectionList sections={STRATEGY_SECTIONS} />
+          </section>
+
+          <section className="space-y-2" aria-labelledby="settings-section-delegation">
+            <h2
+              id="settings-section-delegation"
+              className="px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+            >
+              Délégation &amp; exécution
+            </h2>
+            <SectionList sections={DELEGATION_EXECUTION_SECTIONS} />
+          </section>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

**Implements ADR-003** (Settings V2 information architecture, mergé dans #167).

Refactor `/settings/page.tsx` : 2 sections plates → **4 sections par axe d'impact**.

### Avant / Après

| Avant | Après |
|---|---|
| `Profil & préférences` (5 items mélangés) | `Mon profil & accès` (4 items : identité + accès) |
| `Réglages avancés` (5 items en vrac, admin-gated) | `Mes données & confidentialité` (1 item RGPD prominent) |
| | `Stratégie & objectifs` (3 items, admin) |
| | `Délégation & exécution` (2 items, admin) |

### Section RGPD enrichie (§4 nuance 2 ADR-003)

Composant `PrivacySectionCard` dédié avec :
- Illustration (icône Database bleue sur fond clair)
- Description plus longue qui explicite le contenu de l'export et la conformité RGPD
- Bordure et fond bleus pour signaler "section sensible / contractuelle"

### A11y

- `<section aria-labelledby="...">` + `<h2 id="...">` sur chaque section → navigation screen reader
- `aria-hidden="true"` sur toutes les icônes décoratives
- `focus-visible:ring-2 ring-offset-1` sur tous les liens interactifs
- Min touch target ≥ 44px (`py-4` = 32px padding + 16px content min)
- Mobile-first : `max-w-2xl space-y-6` testé local

### No breaking change

Toutes les routes `/settings/*` restent fonctionnelles. Refactor visuel du hub uniquement.

| Sous-page | Status |
|---|---|
| `/settings/profil` | ✅ inchangée |
| `/settings/securite` | ✅ inchangée |
| `/settings/notifications` | ✅ inchangée |
| `/settings/abonnement` | ✅ inchangée |
| `/settings/donnees` | ✅ inchangée (mais accédée via card prominent) |
| `/settings/delegation` | ✅ inchangée (admin gated layout) |
| `/settings/strategy-mode` | ✅ inchangée (admin gated layout) |
| `/settings/hyper-trading` | ✅ inchangée (admin gated layout) |
| `/settings/sniper` | ✅ inchangée (admin gated layout) |
| `/settings/brokers` | ✅ inchangée (admin gated layout) |

### Validations locales

- `npm run typecheck` ✅ (tsc -b clean)
- `npm run build --workspace=@smartvest/web` ✅ (next build succeed, /settings page bundled)

## Test plan

- [ ] CI verte (typecheck + web build + Jest + Vercel)
- [ ] Vercel preview : `/settings` affiche 2 sections (user) ou 4 sections (admin)
- [ ] La card RGPD est visuellement distincte (bleu) et accessible au clic
- [ ] Tab keyboard nav passe par chaque section dans l'ordre
- [ ] Mobile <375px : sections empilées proprement

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_