### PR TITLE
feat(ux-gp): Sprint 6 polish — HelpTip + a11y mobile-first sur 4 sous-pages

### DIFF
--- a/apps/web/src/app/settings/abonnement/page.tsx
+++ b/apps/web/src/app/settings/abonnement/page.tsx
@@ -2,6 +2,7 @@ import type { Route } from 'next';
 import Link from 'next/link';
 import { BackButton } from '@/components/ui/back-button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { HelpTip } from '@/components/ui/help-tip';
 import { FlaskConical, Sparkles } from 'lucide-react';
 
 export default function AbonnementPage() {
@@ -32,18 +33,45 @@ export default function AbonnementPage() {
           </div>
 
           <ul className="space-y-2 text-sm text-muted-foreground">
-            {[
-              'Portefeuilles de simulation illimités',
-              "Analyse IA via Lisa (sous quota d'API)",
-              'Données de marché en différé (15 min)',
-              'Guides utilisateur et glossaire',
-              'Export des données (RGPD)',
-            ].map((feature) => (
-              <li key={feature} className="flex items-start gap-2">
-                <span className="mt-0.5 text-emerald-500">✓</span>
-                {feature}
-              </li>
-            ))}
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 text-emerald-500">✓</span>
+              <span className="flex-1">Portefeuilles de simulation illimités</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 text-emerald-500">✓</span>
+              <span className="flex flex-1 flex-wrap items-center gap-1">
+                Analyse IA via Lisa <span className="text-xs">(sous quota d'API)</span>
+                <HelpTip
+                  text="Chaque analyse Lisa consomme un budget LLM. Vous pouvez consulter votre consommation quotidienne dans /lisa et le plafond est paramétrable."
+                  glossarySlug="lisa"
+                  side="right"
+                />
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 text-emerald-500">✓</span>
+              <span className="flex flex-1 flex-wrap items-center gap-1">
+                Données de marché en différé (15 min)
+                <HelpTip
+                  text="Les cours affichés ont 15 minutes de retard sur les marchés temps réel. Pour le suivi long terme c'est sans impact ; pour du scalping intraday, ce délai est trop important — d'où le mode 'mode démo' sur les stratégies auto."
+                  side="right"
+                />
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 text-emerald-500">✓</span>
+              <span className="flex-1">Guides utilisateur et glossaire</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 text-emerald-500">✓</span>
+              <span className="flex flex-1 flex-wrap items-center gap-1">
+                Export des données (RGPD)
+                <HelpTip
+                  text="Le RGPD garantit votre droit à récupérer toutes vos données personnelles au format JSON, ainsi qu'à demander leur suppression définitive. Voir Mon compte → Mes données."
+                  side="right"
+                />
+              </span>
+            </li>
           </ul>
 
           <div className="border-t pt-4">

--- a/apps/web/src/app/settings/notifications/page.tsx
+++ b/apps/web/src/app/settings/notifications/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { HelpTip } from '@/components/ui/help-tip';
 import { useUserProfile } from '@/hooks/use-portfolio';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 import { useQueryClient } from '@tanstack/react-query';
@@ -14,16 +15,19 @@ const NOTIFICATION_OPTIONS = [
     key: 'email_alerts',
     label: 'Alertes de portefeuille',
     description: 'Recevez un email quand une alerte se déclenche (seuil de perte, objectif atteint).',
+    help: "Une alerte est un seuil que vous définissez (ex : prévenir si la valeur du portefeuille baisse de 5 %). Elle ne déclenche aucune action automatique — c'est juste un email d'information.",
   },
   {
     key: 'email_weekly_summary',
     label: 'Résumé hebdomadaire',
     description: 'Un récapitulatif de vos performances chaque lundi matin.',
+    help: "Performance de la semaine, top/flop positions, frais cumulés, écart vs votre objectif. Lecture rapide en moins d'une minute.",
   },
   {
     key: 'email_suggestions',
     label: 'Nouvelles suggestions Lisa',
     description: "Notification quand Lisa propose un scénario ou une analyse à valider.",
+    help: "Lisa est l'assistant IA SmartVest. Une suggestion est une proposition qui reste à valider manuellement — jamais une exécution automatique.",
   },
 ] as const;
 
@@ -95,26 +99,35 @@ export default function NotificationsPage() {
             <CardTitle className="text-sm font-medium">Préférences email</CardTitle>
           </CardHeader>
           <CardContent className="divide-y">
-            {NOTIFICATION_OPTIONS.map(({ key, label, description }) => (
+            {NOTIFICATION_OPTIONS.map(({ key, label, description, help }) => (
               <div key={key} className="flex items-start justify-between gap-4 py-3 first:pt-0 last:pb-0">
-                <div>
-                  <p className="text-sm font-medium">{label}</p>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium">{label}</p>
+                    <HelpTip text={help} side="right" />
+                  </div>
                   <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
                 </div>
+                {/* Touch target ≥44px: padding around the visible 20×36 switch */}
                 <button
                   type="button"
                   role="switch"
                   aria-checked={getChecked(key)}
+                  aria-label={label}
                   onClick={() => toggle(key)}
-                  className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ${
-                    getChecked(key) ? 'bg-primary' : 'bg-input'
-                  }`}
+                  className="inline-flex h-11 w-12 shrink-0 cursor-pointer items-center justify-center rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 >
                   <span
-                    className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-background shadow-lg transition-transform ${
-                      getChecked(key) ? 'translate-x-4' : 'translate-x-0'
+                    className={`relative inline-flex h-5 w-9 rounded-full border-2 border-transparent transition-colors ${
+                      getChecked(key) ? 'bg-primary' : 'bg-input'
                     }`}
-                  />
+                  >
+                    <span
+                      className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-background shadow-lg transition-transform ${
+                        getChecked(key) ? 'translate-x-4' : 'translate-x-0'
+                      }`}
+                    />
+                  </span>
                 </button>
               </div>
             ))}
@@ -125,7 +138,7 @@ export default function NotificationsPage() {
       {error && <p className="text-sm text-destructive">{error}</p>}
       {saved && <p className="text-sm text-emerald-600">Préférences enregistrées.</p>}
 
-      <Button onClick={handleSave} disabled={saving || isLoading}>
+      <Button size="lg" onClick={handleSave} disabled={saving || isLoading}>
         {saving ? 'Enregistrement…' : 'Enregistrer'}
       </Button>
     </div>

--- a/apps/web/src/app/settings/profil/page.tsx
+++ b/apps/web/src/app/settings/profil/page.tsx
@@ -10,6 +10,7 @@ import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 import { useQueryClient } from '@tanstack/react-query';
 import { RiskBadge } from '@/components/ui/risk-badge';
 import type { RiskProfile } from '@/components/ui/risk-badge';
+import { HelpTip } from '@/components/ui/help-tip';
 import { Skeleton } from '@/components/ui/skeleton';
 
 const EXPERIENCE_OPTIONS = [
@@ -103,7 +104,14 @@ export default function ProfilPage() {
           {profile?.risk_profile && (
             <Card>
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-medium">Profil de risque</CardTitle>
+                <CardTitle className="flex items-center gap-2 text-sm font-medium">
+                  Profil de risque
+                  <HelpTip
+                    text="Votre profil oriente les simulations proposées (allocation, drawdown toléré). Il n'est jamais une recommandation d'investissement."
+                    glossarySlug="profil-de-risque"
+                    side="right"
+                  />
+                </CardTitle>
               </CardHeader>
               <CardContent>
                 <RiskBadge
@@ -122,7 +130,13 @@ export default function ProfilPage() {
 
           <Card>
             <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium">Niveau d'expérience</CardTitle>
+              <CardTitle className="flex items-center gap-2 text-sm font-medium">
+                Niveau d'expérience
+                <HelpTip
+                  text="Cette information aide SmartVest à adapter ses explications. Elle ne change pas vos droits ni vos paramètres de simulation."
+                  side="right"
+                />
+              </CardTitle>
             </CardHeader>
             <CardContent className="space-y-2">
               {EXPERIENCE_OPTIONS.map(({ value, label, description }) => (

--- a/apps/web/src/app/settings/securite/page.tsx
+++ b/apps/web/src/app/settings/securite/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { HelpTip } from '@/components/ui/help-tip';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 import { ShieldCheck } from 'lucide-react';
 
@@ -101,7 +102,7 @@ export default function SecuritePage() {
           {error && <p className="text-sm text-destructive">{error}</p>}
           {saved && <p className="text-sm text-emerald-600">Mot de passe mis à jour.</p>}
 
-          <Button onClick={handleChangePassword} disabled={saving || !newPassword}>
+          <Button size="lg" onClick={handleChangePassword} disabled={saving || !newPassword}>
             {saving ? 'Mise à jour…' : 'Mettre à jour'}
           </Button>
         </CardContent>
@@ -109,13 +110,19 @@ export default function SecuritePage() {
 
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-sm font-medium">Sessions</CardTitle>
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            Sessions
+            <HelpTip
+              text="Une session = un appareil connecté à votre compte. Cliquer sur 'Se déconnecter partout' force une nouvelle authentification sur tous vos appareils — utile si vous avez perdu votre téléphone ou utilisé un ordinateur public."
+              side="right"
+            />
+          </CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
           <p className="text-sm text-muted-foreground">
             Déconnectez-vous de toutes les sessions actives sur tous les appareils.
           </p>
-          <Button variant="outline" onClick={handleSignOutAll}>
+          <Button variant="outline" size="lg" onClick={handleSignOutAll}>
             Se déconnecter partout
           </Button>
         </CardContent>


### PR DESCRIPTION
## Summary

Finalise le **Sprint 6 ADR-002** (sous-pages `/settings/*`). Les 4 pages sont déjà fonctionnelles ; ce PR livre uniquement le polish stashé pendant Sprint 9 :

- **HelpTip** sur les termes techniques de chaque sous-page
- **Cibles tactiles ≥ 44px** (WCAG AA, mobile-first)
- **A11y** : `aria-label` explicite, focus rings préservés

## Changements par page

### `/settings/profil`
- HelpTip sur **Profil de risque** (lien glossaire `profil-de-risque`)
- HelpTip sur **Niveau d'expérience** (rassure : pas de changement de droits)

### `/settings/securite`
- HelpTip sur **Sessions** (explique `Se déconnecter partout`)
- Boutons `size="lg"` (h-11 = 44px) — cible tactile WCAG AA

### `/settings/notifications`
- HelpTip sur les 3 toggles (alerte / résumé hebdo / suggestions Lisa)
- Toggle wrappé dans bouton 44×48px (zone tactile WCAG) sans modifier l'apparence visuelle du switch
- `aria-label` explicite + bouton "Enregistrer" `size="lg"`

### `/settings/abonnement`
- HelpTip sur **quota d'API Lisa** (lien glossaire `lisa`)
- HelpTip sur **données en différé 15 min** (explique l'impact UX)
- HelpTip sur **export RGPD** (renvoie vers Mes données)

## Implements

- ADR-002 §5 — Sprint 6 (polish phase)
- WCAG 2.1 SC 2.5.5 (Target Size) — cibles tactiles ≥ 44×44 CSS px

## Test plan

- [ ] CI : typecheck + Jest + `next build` (gating Vercel) ✅
- [ ] Visual : ouvrir chaque sous-page, vérifier HelpTip clic et tooltip clavier
- [ ] Mobile <375px : Chrome DevTools, vérifier les targets toggle ≥ 44px
- [ ] Lecteur d'écran : NVDA annonce correctement l'état des switches via `role="switch"` + `aria-checked`

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_