### PR TITLE
feat(ux-gp): Sprint 3 — AssetRiskLevel (badge risque actif/stratégie, 4 niveaux)

### DIFF
--- a/apps/web/src/app/bot-lab/page.tsx
+++ b/apps/web/src/app/bot-lab/page.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/hooks/use-bot-lab';
 import { Zap } from 'lucide-react';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { AssetRiskLevel, levelFromMaxDrawdown } from '@/components/risk/asset-risk-level';
 
 type DetailTab = 'overview' | 'metrics' | 'equity' | 'sessions' | 'trades';
 
@@ -563,6 +564,15 @@ function MetricsTab({ botId }: { botId: string }) {
 
   return (
     <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2">
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">Niveau de risque de la stratégie</span>
+        <AssetRiskLevel
+          level={levelFromMaxDrawdown(m.maxDrawdownPct)}
+          size="sm"
+          showShortHint
+        />
+      </div>
+
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         <BigMetric
           label="Net PnL"

--- a/apps/web/src/app/monte-carlo/page.tsx
+++ b/apps/web/src/app/monte-carlo/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { apiFetch } from '@/lib/api-client';
+import { AssetRiskLevel, levelFromMaxDrawdown } from '@/components/risk/asset-risk-level';
 
 interface MCStatistics {
   numPaths: number;
@@ -322,7 +323,14 @@ function ProbabilityCard({ stats, target, initial }: { stats: MCStatistics; targ
 function DistributionCard({ stats }: { stats: MCStatistics }) {
   return (
     <div className="rounded-lg border p-5">
-      <h2 className="font-medium mb-3">Distribution des résultats</h2>
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <h2 className="font-medium">Distribution des résultats</h2>
+        <AssetRiskLevel
+          level={levelFromMaxDrawdown(stats.maxDrawdownPct.p95)}
+          size="sm"
+          showShortHint
+        />
+      </div>
       <table className="w-full text-xs">
         <thead className="text-muted-foreground">
           <tr className="border-b">

--- a/apps/web/src/app/optimizer/page.tsx
+++ b/apps/web/src/app/optimizer/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { apiFetch } from '@/lib/api-client';
+import { AssetRiskLevel, levelFromMaxDrawdown } from '@/components/risk/asset-risk-level';
 
 type Mode = 'single_shot' | 'walk_forward' | 'auto_apply';
 
@@ -401,12 +402,24 @@ function ApplyDecisionCard({ decision }: { decision: ApplyDecision }) {
 
 function Leaderboard({ result, onApply }: { result: OptimizerRunResult; onApply: (c: Candidate) => void }) {
   const top = result.leaderboard.ranked.slice(0, 10);
+  const champion = result.leaderboard.best ?? top[0];
   return (
     <div className="rounded-lg border p-5">
-      <div className="flex justify-between items-baseline mb-3">
+      <div className="mb-3 flex flex-wrap items-baseline justify-between gap-3">
         <h2 className="font-medium">Leaderboard ({result.candidatesTested} configs testées)</h2>
         <span className="text-xs text-muted-foreground">Run en {(result.durationMs / 1000).toFixed(1)}s</span>
       </div>
+
+      {champion && (
+        <div className="mb-3 flex flex-wrap items-center gap-2 rounded-md bg-emerald-50 px-3 py-2 dark:bg-emerald-950/20">
+          <span className="text-xs uppercase tracking-wide text-muted-foreground">Risque de la config championne</span>
+          <AssetRiskLevel
+            level={levelFromMaxDrawdown(champion.metrics.maxDrawdownPct)}
+            size="sm"
+            showShortHint
+          />
+        </div>
+      )}
       <div className="overflow-x-auto">
         <table className="w-full text-xs">
           <caption className="sr-only">Top 10 configurations triées par score composite</caption>

--- a/apps/web/src/components/lisa/proposal-card.tsx
+++ b/apps/web/src/components/lisa/proposal-card.tsx
@@ -9,6 +9,7 @@ import {
   useRejectProposal,
   type LisaProposalRow,
 } from '@/hooks/use-lisa';
+import { AssetRiskLevel, levelFromMaxDrawdown } from '@/components/risk/asset-risk-level';
 
 interface Thesis {
   id: string;
@@ -292,6 +293,15 @@ export function LisaProposalCard({
                         </div>
                       </div>
                     )}
+
+                    <div className="flex flex-wrap items-center gap-2 rounded-md bg-muted/30 px-2 py-1.5">
+                      <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Risque de cette idée</span>
+                      <AssetRiskLevel
+                        level={levelFromMaxDrawdown(Math.abs(t.riskReward.adverseScenarioReturnPct))}
+                        size="sm"
+                        showLabel
+                      />
+                    </div>
 
                     <div className="grid grid-cols-3 gap-2 text-xs">
                       <div>

--- a/apps/web/src/components/risk/asset-risk-level.tsx
+++ b/apps/web/src/components/risk/asset-risk-level.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { HelpTip } from '@/components/ui/help-tip';
+
+// ADR-002 Sprint 3 — AssetRiskLevel : badge de risque d'actif/stratégie.
+// Distinct du <RiskBadge> profil utilisateur (prudent/équilibré/dynamique/offensif).
+// Ici : niveau de risque d'un actif ou d'une stratégie, mappé sur la
+// volatilité annualisée historique. Pour M. Tout-le-monde : 4 paliers
+// 🟢 faible / 🟡 modéré / 🟠 élevé / 🔴 extrême avec wording grand public.
+
+export type AssetRiskLevel = 'low' | 'moderate' | 'high' | 'extreme';
+
+interface LevelMeta {
+  label: string;
+  emoji: string;
+  pill: string;          // background + text + border (badge)
+  description: string;   // tooltip détaillé (vulgarisé)
+  shortHint: string;     // sous-libellé optionnel
+}
+
+export const RISK_LEVEL_META: Record<AssetRiskLevel, LevelMeta> = {
+  low: {
+    label: 'Risque faible',
+    emoji: '🟢',
+    pill: 'bg-emerald-100 text-emerald-800 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-800',
+    description:
+      'Volatilité annualisée < 8 %. Variations typiques de l\'ordre de ±5 %/an. Adapté pour un horizon court ou un capital qu\'on ne peut pas se permettre de voir baisser. Exemples : obligations d\'État, fonds monétaires.',
+    shortHint: '~5 %/an',
+  },
+  moderate: {
+    label: 'Risque modéré',
+    emoji: '🟡',
+    pill: 'bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-800',
+    description:
+      'Volatilité annualisée 8-20 %. Baisses typiques de l\'ordre de −15 %, récupérées en 2-3 ans. Standard pour un investissement long terme diversifié. Exemples : ETF World, portefeuilles équilibrés 60/40.',
+    shortHint: '~15 %, recovery 2-3 ans',
+  },
+  high: {
+    label: 'Risque élevé',
+    emoji: '🟠',
+    pill: 'bg-orange-100 text-orange-800 border-orange-200 dark:bg-orange-900/30 dark:text-orange-300 dark:border-orange-800',
+    description:
+      'Volatilité annualisée 20-40 %. Baisses possibles de 30-50 %. À éviter sur un horizon < 5 ans. Exemples : actions individuelles, secteur tech concentré, crypto majeurs (BTC/ETH).',
+    shortHint: '30-50 %, éviter <5 ans',
+  },
+  extreme: {
+    label: 'Risque extrême',
+    emoji: '🔴',
+    pill: 'bg-rose-100 text-rose-800 border-rose-200 dark:bg-rose-900/30 dark:text-rose-300 dark:border-rose-800',
+    description:
+      'Volatilité annualisée > 40 %. Perte totale possible. Réservé aux investisseurs aguerris, sur une part marginale du patrimoine. Exemples : crypto altcoins, small caps spéculatives, levier élevé.',
+    shortHint: 'perte totale possible',
+  },
+};
+
+/**
+ * Map annualized volatility (decimal fraction OR percent points) to one of
+ * the 4 risk levels. Accepts either form via heuristic: values > 1 are
+ * treated as percent points.
+ */
+export function levelFromVolatility(volAnnualized: number): AssetRiskLevel {
+  if (!Number.isFinite(volAnnualized) || volAnnualized < 0) return 'moderate';
+  const pct = volAnnualized > 1 ? volAnnualized : volAnnualized * 100;
+  if (pct < 8) return 'low';
+  if (pct < 20) return 'moderate';
+  if (pct < 40) return 'high';
+  return 'extreme';
+}
+
+/**
+ * Fallback when only the historical max drawdown is known. Drawdown is
+ * roughly 2× annualized vol on diversified equity baskets — we use this
+ * heuristic to align bands with `levelFromVolatility`.
+ *  DD < 10 %  → low
+ *  DD < 25 %  → moderate
+ *  DD < 50 %  → high
+ *  DD ≥ 50 %  → extreme
+ */
+export function levelFromMaxDrawdown(maxDrawdownPct: number): AssetRiskLevel {
+  if (!Number.isFinite(maxDrawdownPct) || maxDrawdownPct < 0) return 'moderate';
+  const pct = maxDrawdownPct;
+  if (pct < 10) return 'low';
+  if (pct < 25) return 'moderate';
+  if (pct < 50) return 'high';
+  return 'extreme';
+}
+
+interface AssetRiskLevelProps {
+  /** Volatilité annualisée — accepte fraction (0.18) ou points de % (18). */
+  volatilityAnnualized?: number;
+  /** Override manuel — prioritaire sur `volatilityAnnualized`. */
+  level?: AssetRiskLevel;
+  size?: 'sm' | 'md' | 'lg';
+  /** Affiche le label texte à côté du badge pill (par défaut visible md/lg). */
+  showLabel?: boolean;
+  /** Affiche le sous-libellé court (~5 %/an, etc.) à droite. */
+  showShortHint?: boolean;
+  /** Affiche le tooltip d'aide intégré. */
+  showTip?: boolean;
+  className?: string;
+}
+
+export function AssetRiskLevel({
+  volatilityAnnualized,
+  level,
+  size = 'md',
+  showLabel = true,
+  showShortHint = false,
+  showTip = true,
+  className,
+}: AssetRiskLevelProps) {
+  const resolvedLevel: AssetRiskLevel | null = level
+    ?? (volatilityAnnualized != null ? levelFromVolatility(volatilityAnnualized) : null);
+
+  if (!resolvedLevel) {
+    return (
+      <span
+        className={cn(
+          'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs text-muted-foreground',
+          className,
+        )}
+      >
+        Risque non évalué
+      </span>
+    );
+  }
+
+  const meta = RISK_LEVEL_META[resolvedLevel];
+
+  const sizeClasses: Record<NonNullable<AssetRiskLevelProps['size']>, string> = {
+    sm: 'text-xs px-2 py-0.5 gap-1',
+    md: 'text-sm px-2.5 py-0.5 gap-1.5',
+    lg: 'text-base px-3 py-1 gap-1.5',
+  };
+
+  return (
+    <span className={cn('inline-flex flex-wrap items-center gap-1.5', className)}>
+      <span
+        className={cn(
+          'inline-flex items-center rounded-full border font-medium',
+          sizeClasses[size],
+          meta.pill,
+        )}
+        aria-label={meta.label}
+      >
+        <span aria-hidden>{meta.emoji}</span>
+        {showLabel && meta.label}
+      </span>
+
+      {showShortHint && (
+        <span className="text-xs text-muted-foreground">{meta.shortHint}</span>
+      )}
+
+      {showTip && (
+        <HelpTip
+          text={meta.description}
+          glossarySlug="volatilite"
+          side="right"
+        />
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

Livre **ADR-002 Sprint 3** : nouveau composant `<AssetRiskLevel>` pour signaler le niveau de risque d'un actif/stratégie en 4 paliers grand public.

**Choix Option B** (validé en arbitrage utilisateur) : le `<RiskBadge>` existant (UI profil utilisateur — prudent/équilibré/dynamique/offensif) est conservé intact. Le nouveau composant a un nom distinct, un fichier dédié, une responsabilité différente.

## Composant

**Path** : `apps/web/src/components/risk/asset-risk-level.tsx`

**4 niveaux** avec wording vulgarisé conforme ADR-002 §3 :

| Niveau | Vol annualisée | Wording |
|---|---|---|
| 🟢 `low` | < 8 % | "~5 %/an" |
| 🟡 `moderate` | 8-20 % | "~15 %, recovery 2-3 ans" |
| 🟠 `high` | 20-40 % | "30-50 %, éviter <5 ans" |
| 🔴 `extreme` | ≥ 40 % | "perte totale possible" |

**Props** :
```ts
{
  volatilityAnnualized?: number;  // accepte 0.18 OU 18
  level?: 'low'|'moderate'|'high'|'extreme';  // override manuel
  size?: 'sm'|'md'|'lg';
  showLabel?: boolean;
  showShortHint?: boolean;
  showTip?: boolean;  // HelpTip intégré (lien glossaire `volatilite`)
}
```

**Helpers exportés** :
- `levelFromVolatility(volAnnualized)` — mapping vol → niveau (autorité)
- `levelFromMaxDrawdown(maxDDPct)` — fallback DD historique → niveau (utilisé sur les 4 surfaces ci-dessous puisque la vol annualisée n'est pas systématiquement exposée par les API actuelles)

## Plug — 4 surfaces

| Surface | Source du niveau | Plug |
|---|---|---|
| `/bot-lab` | `m.maxDrawdownPct` (résumé performance) | Bandeau au-dessus des métriques détaillées |
| `/optimizer` | `leaderboard.best.metrics.maxDrawdownPct` | Bandeau dans le Leaderboard |
| `/monte-carlo` | `stats.maxDrawdownPct.p95` | Badge dans en-tête "Distribution des résultats" |
| `proposal-card` (Lisa) | `abs(adverseScenarioReturnPct)` | Bandeau au-dessus du grid R/R |

## Décisions

- **Mapping drawdown → niveau** documenté (DD < 10 %/25 %/50 % aligné sur les bandes de vol via heuristique DD ≈ 2× vol historique sur paniers diversifiés).
- **HelpTip pointe vers glossaire `volatilite`** (existant) plutôt qu'un nouveau slug — cohérent avec PR #170 qui complète le glossaire à 80 termes.
- **Aucune migration DB**, **aucune nouvelle dépendance**, **aucun nouveau slug glossaire**.

## Test plan

- [ ] CI : typecheck + Jest + `next build` (ESLint Vercel parity)
- [ ] Visual : 4 surfaces affichent bien le badge selon les valeurs réelles de drawdown
- [ ] HelpTip : ouvrir tooltip → wording correct + lien glossaire fonctionne
- [ ] A11y : `aria-label` annonce "Risque faible/modéré/élevé/extrême" via NVDA
- [ ] Edge case : valeur `volAnnualized = 0` ne bug pas (resolved → low)

## Implements

- ADR-002 §5 — Sprint 3 (RiskBadge composante actif/stratégie)

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_