### PR TITLE
fix(scanner): correct EODHD exchange codes — SS→SHG, SZ→SHE, TSE→T (P20a)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
@@ -149,7 +149,8 @@ describe('fetchEodhdScreener — URL construction (P18c regression guard)', () =
     //     {"errors":{"filters.1.field":["The selected filters.1.field is invalid."]}}
     // Fix : DROP le filter 1d return pour non-US, post-filter client-side.
     const svc = makeService();
-    const exchanges = ['TSE', 'HK', 'KO', 'SS', 'SZ', 'TO', 'AS', 'NSE', 'BSE', 'AU'];
+    // P20a: corrected EODHD codes — T (Tokyo), SHG (Shanghai), SHE (Shenzhen)
+    const exchanges = ['T', 'HK', 'KO', 'SHG', 'SHE', 'TO', 'AS', 'NSE', 'BSE', 'AU'];
     for (const ex of exchanges) {
       capturedUrl = undefined;
       await (svc as any).fetchEodhdScreener(ex, 'test-key');
@@ -230,5 +231,79 @@ describe('mapEodhdRow — accepts both filter-form and legacy field names', () =
     const svc = makeService();
     const row = { code: 'BAD', adjusted_close: 0, refund_1d_p: 5 } as any;
     expect((svc as any).mapEodhdRow(row, 'US')).toBeNull();
+  });
+});
+
+// ── P20a — Exchange code registry snapshot ─────────────────────────────────
+// Guards that corrected EODHD codes (SHG/SHE/T) are in NON_EU_EXCHANGES
+// and that legacy codes (SS/SZ/TSE) are gone.
+// Source: vendor/eodhd-claude-skills/.../exchanges-list.md
+describe('P20a — NON_EU_EXCHANGES registry correctness', () => {
+  // Access the exported constant indirectly via the URL built by fetchEodhdScreener.
+  const realFetch = global.fetch;
+  let capturedUrls: string[];
+
+  beforeEach(() => {
+    capturedUrls = [];
+    global.fetch = jest.fn().mockImplementation(async (url: string) => {
+      capturedUrls.push(url as string);
+      return { ok: true, json: async () => ({ data: [] }) } as unknown as Response;
+    });
+  });
+  afterEach(() => { global.fetch = realFetch; });
+
+  function makeServiceWithApiKey(): TopGainersScannerService {
+    mockConfig.get.mockImplementation((key: string) => {
+      if (key === 'SCAN_INTERVAL_MINUTES') return '15';
+      if (key === 'EODHD_API_KEY') return 'test-key';
+      return undefined;
+    });
+    return new TopGainersScannerService(
+      mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter,
+    );
+  }
+
+  it('uses corrected EODHD codes SHG (Shanghai) and SHE (Shenzhen)', async () => {
+    const svc = makeServiceWithApiKey();
+    capturedUrls = [];
+    await (svc as any).fetchEodhdScreener('SHG', 'test-key');
+    await (svc as any).fetchEodhdScreener('SHE', 'test-key');
+    const decoded = capturedUrls.map((u) => decodeURIComponent(u));
+    expect(decoded[0]).toContain('["exchange","=","SHG"]');
+    expect(decoded[1]).toContain('["exchange","=","SHE"]');
+  });
+
+  it('uses corrected EODHD code T (Tokyo) not TSE', async () => {
+    const svc = makeServiceWithApiKey();
+    capturedUrls = [];
+    await (svc as any).fetchEodhdScreener('T', 'test-key');
+    const decoded = decodeURIComponent(capturedUrls[0]!);
+    expect(decoded).toContain('["exchange","=","T"]');
+    expect(decoded).not.toContain('"TSE"');
+  });
+
+  it('does NOT include legacy codes SS, SZ, TSE in non-EU exchange list', async () => {
+    // Simulate a full fetchAllCandidates to capture which exchanges are queried.
+    const supabaseMock = {
+      getClient: () => ({
+        from: () => ({ select: () => ({ in: async () => ({ data: [], error: null }) }) }),
+      }),
+    } as any;
+    const svc = new TopGainersScannerService(
+      supabaseMock, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter,
+    );
+    capturedUrls = [];
+    // fetchAllCandidates without EU (EU sessions closed)
+    await (svc as any).fetchAllCandidates(new Date('2026-05-01T22:00:00Z'));
+    const queried = capturedUrls.map((u) => {
+      const m = decodeURIComponent(u).match(/"exchange","=","([^"]+)"/);
+      return m ? m[1] : null;
+    }).filter(Boolean);
+    expect(queried).not.toContain('SS');
+    expect(queried).not.toContain('SZ');
+    expect(queried).not.toContain('TSE');
+    expect(queried).toContain('SHG');
+    expect(queried).toContain('SHE');
+    expect(queried).toContain('T');
   });
 });

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eu-session.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eu-session.spec.ts
@@ -123,9 +123,9 @@ describe('fetchAllCandidates — EU session gating', () => {
     expect(exchanges.has('XETRA')).toBe(true);
     expect(exchanges.has('PA')).toBe(true);
     expect(exchanges.has('AMS')).toBe(true);
-    // Non-EU still scanned
+    // Non-EU still scanned (P20a: T = Tokyo, corrected from TSE)
     expect(exchanges.has('US')).toBe(true);
-    expect(exchanges.has('TSE')).toBe(true);
+    expect(exchanges.has('T')).toBe(true);
   });
 
   it('skips EU exchanges when all 3 EU sessions closed (e.g. 22:00 UTC)', async () => {
@@ -301,8 +301,9 @@ describe('fetchAllCandidates — merge dedup', () => {
         data = [{ code: 'NVDA', last_price: 800, refund_1d_p: 6.0, volume: 50_000_000, avgvol_50d: 40_000_000, market_capitalization: 2e12 }];
       } else if (decoded.includes('"exchange","=","PA"')) {
         data = [{ code: 'AIR.PA', last_price: 150, refund_1d_p: 4.2, volume: 1_000_000, avgvol_50d: 800_000, market_capitalization: 1e11 }];
-      } else if (decoded.includes('"exchange","=","TSE"')) {
-        data = [{ code: '7203.T', last_price: 2500, refund_1d_p: 5.5, volume: 5_000_000, avgvol_50d: 4_000_000, market_capitalization: 3e11 }];
+      } else if (decoded.includes('"exchange","=","T"')) {
+        // P20a: Tokyo uses code 'T' (suffix .T), not 'TSE'
+        data = [{ code: '7203', last_price: 2500, refund_1d_p: 5.5, volume: 5_000_000, avgvol_50d: 4_000_000, market_capitalization: 3e11 }];
       }
       return { ok: true, status: 200, json: async () => ({ data }), text: async () => '' } as unknown as Response;
     });
@@ -313,12 +314,13 @@ describe('fetchAllCandidates — merge dedup', () => {
     const symbols = candidates.map((c) => c.symbol);
     expect(symbols).toContain('NVDA');
     expect(symbols).toContain('AIR.PA');
-    expect(symbols).toContain('7203.T');
+    // P20a: screener returns bare code '7203', exchange 'T' (not 'TSE')
+    expect(symbols).toContain('7203');
 
     // Verify each candidate gets the correct asset class via detectAssetClass
     const nvda = candidates.find((c) => c.symbol === 'NVDA')!;
     const air = candidates.find((c) => c.symbol === 'AIR.PA')!;
-    const toyota = candidates.find((c) => c.symbol === '7203.T')!;
+    const toyota = candidates.find((c) => c.symbol === '7203')!;
     expect(detectAssetClass(nvda.symbol, nvda.exchange, nvda.marketCap)).toBe('us_equity_large');
     expect(detectAssetClass(air.symbol, air.exchange)).toBe('eu_equity');
     expect(detectAssetClass(toyota.symbol, toyota.exchange)).toBe('asia_equity');

--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -127,9 +127,12 @@ export class EodhdIntradayService {
     const base = eodhdTicker.slice(0, lastDot);
     const suffix = eodhdTicker.slice(lastDot + 1).toUpperCase();
     switch (suffix) {
-      case 'SS':   return `${base}.SHG`;    // Shanghai Stock Exchange (scanner→EODHD)
-      case 'SZ':   return `${base}.SHE`;    // Shenzhen Stock Exchange (scanner→EODHD)
-      default:     return eodhdTicker;       // .US, .LSE, .XETRA, .PA, .HK, .TO, .NSE, .BSE, .KO (Korea), .KQ (KOSDAQ), .AU
+      // P20a backward-compat: scanner now uses SHG/SHE but legacy log entries may still carry SS/SZ.
+      case 'SS':   return `${base}.SHG`;    // Shanghai (Yahoo Finance legacy → EODHD)
+      case 'SZ':   return `${base}.SHE`;    // Shenzhen (Yahoo Finance legacy → EODHD)
+      // P20a: TSE was wrong scanner code for Tokyo; correct suffix is .T. Kept for legacy entries.
+      case 'TSE':  return `${base}.T`;      // Tokyo Stock Exchange (MIC alias → EODHD)
+      default:     return eodhdTicker;       // .US .LSE .XETRA .PA .HK .T .TO .NSE .BSE .KO .KQ .SHG .SHE .AU
     }
   }
 

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -104,7 +104,13 @@ const EU_EXCHANGES = ['LSE', 'XETRA', 'PA', 'SW', 'MI', 'MC', 'BME', 'AS', 'AMS'
 // (KOSPI .KO + KOSDAQ .KQ). Constat user dump SQL Supabase : 9/20 KO + 4/20
 // NSE + 1/20 AU = 70% des candidats Top 20 viennent d'Asie/Inde, mais KOSDAQ
 // (Kakao 035720.KQ, Naver, etc.) n'était pas scanné → trou de couverture.
-const NON_EU_EXCHANGES = ['US', 'TSE', 'HK', 'AU', 'KO', 'KQ', 'TO', 'NSE', 'BSE', 'SS', 'SZ'];
+//
+// P20a (01/05/2026) — Correction codes EODHD officiels (cf. exchanges-list doc) :
+//   SS  → SHG  (Shanghai Stock Exchange, suffix .SHG  — SS = Yahoo Finance convention)
+//   SZ  → SHE  (Shenzhen Stock Exchange, suffix .SHE  — SZ = Yahoo Finance convention)
+//   TSE → T    (Tokyo Stock Exchange,    suffix .T     — TSE était le MIC, pas le code EODHD)
+// Ref : vendor/eodhd-claude-skills/.../exchanges-list.md + symbol-format.md
+const NON_EU_EXCHANGES = ['US', 'T', 'HK', 'AU', 'KO', 'KQ', 'TO', 'NSE', 'BSE', 'SHG', 'SHE'];
 /** Watchlists EU dont la session_open_utc / session_close_utc gate l'EODHD scan. */
 const EU_WATCHLIST_NAMES = ['cac40', 'dax40', 'ftse100'];
 const CRYPTO_PAIRS = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT', 'ADAUSDT', 'AVAXUSDT', 'DOTUSDT', 'LINKUSDT', 'MATICUSDT'];

--- a/packages/ai-analyst/src/simulation/venue-fees.ts
+++ b/packages/ai-analyst/src/simulation/venue-fees.ts
@@ -194,8 +194,9 @@ function computeAsiaFees(
   } else if (v === 'T' || v === 'TSE') {
     // Tokyo — 0.05% commission, no transaction tax
     commission = notional.mul(0.0005);
-  } else if (v === 'SS' || v === 'SZ') {
-    // China A-shares — 0.025% commission + 0.10% stamp duty sell only
+  } else if (v === 'SHG' || v === 'SHE' || v === 'SS' || v === 'SZ') {
+    // China A-shares (Shanghai SHG / Shenzhen SHE) — 0.025% commission + 0.10% stamp duty sell only.
+    // SS/SZ kept as backward-compat aliases (Yahoo Finance convention, legacy log entries).
     commission = notional.mul(0.00025);
     if (side === 'sell') {
       regulatory = notional.mul(0.001);

--- a/packages/ai-analyst/src/strategies/top-gainers-filter.ts
+++ b/packages/ai-analyst/src/strategies/top-gainers-filter.ts
@@ -66,7 +66,9 @@ export function detectAssetClass(
     return 'eu_equity';
   }
   // Asia equity exchanges
-  if (['TSE', 'HK', 'AU', 'NSE', 'BSE', 'KO', 'KRX', 'T', 'HKEX'].includes(ex)) {
+  // P20a: SHG/SHE are the corrected EODHD codes for Shanghai/Shenzhen (was SS/SZ).
+  // TSE kept for backward compat with historical top_gainers_log entries.
+  if (['T', 'TSE', 'HK', 'AU', 'NSE', 'BSE', 'KO', 'KQ', 'KRX', 'HKEX', 'SHG', 'SHE'].includes(ex)) {
     return 'asia_equity';
   }
   // Default = US equity, large vs small/mid via marketCap

--- a/supabase/migrations/0097_gainers_exchange_code_fix.sql
+++ b/supabase/migrations/0097_gainers_exchange_code_fix.sql
@@ -1,0 +1,36 @@
+-- P20a (01/05/2026) — Normalize legacy market codes in top_gainers_log
+-- and gainers_persistence_log that used Yahoo Finance / wrong exchange codes:
+--   SS  → SHG  (Shanghai Stock Exchange, official EODHD code)
+--   SZ  → SHE  (Shenzhen Stock Exchange, official EODHD code)
+--   TSE → T    (Tokyo Stock Exchange, official EODHD code = suffix .T)
+--
+-- These entries are rare (scanner was paused since 30/04 and SS/SZ/TSE
+-- returned 0 EODHD screener results even before that), but the update
+-- ensures the log is internally consistent post-P20a.
+--
+-- Safe: no FK constraints on market/exchange columns; soft update only.
+
+UPDATE top_gainers_log
+SET market = CASE
+  WHEN market = 'SS'  THEN 'SHG'
+  WHEN market = 'SZ'  THEN 'SHE'
+  WHEN market = 'TSE' THEN 'T'
+  ELSE market
+END,
+detected_asset_class = CASE
+  WHEN detected_asset_class = 'SS'  THEN 'SHG'
+  WHEN detected_asset_class = 'SZ'  THEN 'SHE'
+  WHEN detected_asset_class = 'TSE' THEN 'T'
+  ELSE detected_asset_class
+END
+WHERE market IN ('SS', 'SZ', 'TSE')
+   OR detected_asset_class IN ('SS', 'SZ', 'TSE');
+
+UPDATE gainers_persistence_log
+SET market = CASE
+  WHEN market = 'SS'  THEN 'SHG'
+  WHEN market = 'SZ'  THEN 'SHE'
+  WHEN market = 'TSE' THEN 'T'
+  ELSE market
+END
+WHERE market IN ('SS', 'SZ', 'TSE');


### PR DESCRIPTION
## Summary

- **SS → SHG** (Shanghai Stock Exchange) and **SZ → SHE** (Shenzhen): were using Yahoo Finance exchange code conventions instead of the [EODHD official exchange codes](vendor/eodhd-claude-skills/skills/eodhd-api/references/endpoints/exchanges-list.md). The screener was querying `["exchange","=","SS"]` but EODHD recognizes `SHG`.
- **TSE → T** (Tokyo): EODHD suffix is `.T` (e.g. `7203.T` for Toyota). Using `TSE` caused intraday tickers to build as `7203.TSE` → 404 from EODHD intraday API.

**Impact**: these bugs caused Chinese and Japanese stocks to return 0 results from the EODHD screener / fail intraday fetch even when SCANNER_PAUSE=false. Scanner was paused since 30/04 so no regression in prod data.

## Files changed

| File | Change |
|---|---|
| `top-gainers-scanner.service.ts` | `NON_EU_EXCHANGES`: SS→SHG, SZ→SHE, TSE→T |
| `top-gainers-filter.ts` | `detectAssetClass`: adds SHG/SHE to asia_equity |
| `venue-fees.ts` | China A-shares fee: adds SHG/SHE aliases |
| `eodhd-intraday.service.ts` | Adds TSE→T normalization for legacy entries; keeps SS/SZ backward-compat |
| `top-gainers-scanner.eodhd.spec.ts` | Updated exchange list + new P20a registry snapshot test |
| `top-gainers-scanner.eu-session.spec.ts` | Updated TSE→T in merge/dedup test |
| `0097_gainers_exchange_code_fix.sql` | Soft-updates legacy market codes in top_gainers_log + gainers_persistence_log |

## Test plan

- [x] 32/32 scanner unit tests pass locally
- [x] `venue-fees` + `top-gainers-filter` tests pass
- [x] TypeScript typecheck clean
- [ ] CI GitHub Actions green

## EODHD quota impact

**Zero** — scanner remains `SCANNER_PAUSE=true`. Same number of screener calls when resumed, just different exchange codes.

## Post-merge order of battle (as agreed)

1. ✅ This PR merged
2. You verify code in prod
3. You unset SCANNER_PAUSE / MULTITF_PAUSE via Fly.io UI
4. Resume S4 → S7 → S8 ADR-002

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_