### PR TITLE
feat(ux-gp): Sprint 4 — hub Aide grand public

### DIFF
--- a/apps/web/src/app/help/contact/page.tsx
+++ b/apps/web/src/app/help/contact/page.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link';
+import { type Route } from 'next';
+import { Mail, Github, MessageCircleQuestion } from 'lucide-react';
+import { BackButton } from '@/components/ui/back-button';
+
+export default function ContactPage() {
+  return (
+    <div className="mx-auto max-w-xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Nous contacter</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Une question, un bug, une suggestion ? Voici comment nous joindre.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <a
+          href="mailto:support@smartvest.app"
+          className="flex items-start gap-4 rounded-lg border p-4 transition-colors hover:bg-muted/30"
+        >
+          <Mail className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+          <div>
+            <p className="text-sm font-medium">Email</p>
+            <p className="text-sm text-muted-foreground">support@smartvest.app</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Pour toute question sur votre compte, vos données ou un problème technique.
+            </p>
+          </div>
+        </a>
+
+        <a
+          href="https://github.com/yannicke819-max/smartvest/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-start gap-4 rounded-lg border p-4 transition-colors hover:bg-muted/30"
+        >
+          <Github className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+          <div>
+            <p className="text-sm font-medium">GitHub Issues</p>
+            <p className="text-sm text-muted-foreground">github.com/yannicke819-max/smartvest</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Pour signaler un bug ou proposer une amélioration. Réponse généralement sous 48 h.
+            </p>
+          </div>
+        </a>
+
+        <Link
+          href={'/help/faq' as Route}
+          className="flex items-start gap-4 rounded-lg border p-4 transition-colors hover:bg-muted/30"
+        >
+          <MessageCircleQuestion className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+          <div>
+            <p className="text-sm font-medium">Questions fréquentes</p>
+            <p className="text-sm text-muted-foreground">
+              Consultez notre FAQ avant d'écrire — votre réponse s'y trouve peut-être déjà.
+            </p>
+          </div>
+        </Link>
+      </div>
+
+      <div className="rounded-lg border border-dashed p-4">
+        <p className="text-xs text-muted-foreground">
+          SmartVest est un projet en beta. Votre feedback est précieux et lu avec attention.
+          Nous ne vendons pas vos données à des tiers — cf.{' '}
+          <Link href={'/legal/confidentialite' as Route} className="text-primary hover:underline underline-offset-4">
+            notre politique de confidentialité
+          </Link>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/help/faq/page.tsx
+++ b/apps/web/src/app/help/faq/page.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { type Route } from 'next';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { BackButton } from '@/components/ui/back-button';
+
+const FAQ: Array<{ q: string; a: string }> = [
+  {
+    q: "Qu'est-ce que SmartVest ?",
+    a: "SmartVest est une plateforme d'aide à la décision en investissement personnel. Elle analyse votre portefeuille, simule des scénarios et vous soumet des suggestions. Vous restez toujours décisionnaire.",
+  },
+  {
+    q: 'SmartVest passe-t-il des ordres automatiquement ?',
+    a: "Non. Par défaut, SmartVest est en mode \"analyse et suggestion\" uniquement. Aucune action n'est exécutée sans votre validation explicite. Si vous activez le mode autonome (Lisa), les paramètres sont définis par vous et peuvent être désactivés à tout moment via le bouton d'arrêt d'urgence.",
+  },
+  {
+    q: 'Mes données sont-elles en sécurité ?',
+    a: "Vos données sont stockées de manière chiffrée. SmartVest n'a pas accès à vos comptes broker sauf si vous les connectez explicitement, et uniquement en lecture seule. Vos identifiants broker ne sont jamais visibles côté application.",
+  },
+  {
+    q: 'SmartVest est-il un conseiller financier agréé ?',
+    a: "Non. SmartVest est un outil d'aide à la décision, pas un conseiller financier au sens réglementaire (MiFID). Ses analyses et suggestions sont des simulations et projections, pas des recommandations personnalisées. Pour une recommandation personnalisée, consultez un conseiller financier agréé.",
+  },
+  {
+    q: "Les performances affichées sont-elles garanties ?",
+    a: "Non. Toutes les projections sont des simulations basées sur des hypothèses. Les performances passées ne préjugent pas des performances futures. Le capital investi en bourse peut être partiellement ou totalement perdu.",
+  },
+  {
+    q: "Comment fonctionne l'assistant Lisa ?",
+    a: "Lisa est un assistant d'analyse propulsé par IA. Elle étudie votre portefeuille, les données de marché et vous propose des pistes d'optimisation ou d'action. Chaque suggestion inclut les hypothèses retenues et une estimation de l'impact.",
+  },
+  {
+    q: "Puis-je utiliser SmartVest pour gérer un PEA ou une assurance vie ?",
+    a: "SmartVest peut afficher et analyser le contenu de votre PEA ou assurance vie si vous saisissez vos positions. La gestion directe (ordres) dépend de la connexion broker disponible pour votre intermédiaire.",
+  },
+  {
+    q: "Comment signaler un problème ou une idée ?",
+    a: "Via la page Contact dans l'Aide, ou directement via les issues GitHub du projet. Nous lisons tous les retours.",
+  },
+];
+
+function FaqItem({ q, a }: { q: string; a: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border-b last:border-b-0">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center justify-between gap-4 py-4 text-left"
+        aria-expanded={open}
+      >
+        <span className="text-sm font-medium">{q}</span>
+        {open ? (
+          <ChevronUp className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+        ) : (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+        )}
+      </button>
+      {open && (
+        <p className="pb-4 text-sm text-muted-foreground">{a}</p>
+      )}
+    </div>
+  );
+}
+
+export default function FaqPage() {
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Questions fréquentes</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Les réponses aux questions les plus courantes sur SmartVest.
+        </p>
+      </div>
+
+      <div className="rounded-lg border px-4">
+        {FAQ.map((item) => (
+          <FaqItem key={item.q} q={item.q} a={item.a} />
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-3 border-t pt-4 text-sm">
+        <span className="text-muted-foreground">Vous n'avez pas trouvé votre réponse ?</span>
+        <Link
+          href={'/help/contact' as Route}
+          className="text-primary hover:underline underline-offset-4"
+        >
+          Contactez-nous →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/help/page.tsx
+++ b/apps/web/src/app/help/page.tsx
@@ -2,11 +2,52 @@
 
 import type { Route } from 'next';
 import Link from 'next/link';
-import { BookOpen, FileSearch, Wrench, Settings, BookMarked } from 'lucide-react';
+import {
+  BookOpen,
+  FileSearch,
+  Wrench,
+  Settings,
+  BookMarked,
+  Rocket,
+  CircleHelp,
+  ShieldAlert,
+  Mail,
+} from 'lucide-react';
 import { BackButton } from '@/components/ui/back-button';
 import { useIsAdmin } from '@/hooks/use-is-admin';
 import { HELP_DOCS, type HelpDocEntry } from '@/lib/help-docs';
 import { GLOSSARY_TERMS } from '@/lib/glossary-terms';
+
+// ── Grand-public hub sections ────────────────────────────────────────────────
+
+const GP_SECTIONS = [
+  {
+    href: '/help/premiers-pas',
+    Icon: Rocket,
+    label: 'Premiers pas',
+    description: 'Prise en main de SmartVest en 5 étapes simples.',
+  },
+  {
+    href: '/help/faq',
+    Icon: CircleHelp,
+    label: 'Questions fréquentes',
+    description: 'Les réponses aux questions les plus courantes.',
+  },
+  {
+    href: '/help/risques',
+    Icon: ShieldAlert,
+    label: 'Comprendre les risques',
+    description: 'Risques marché, de change, de liquidité et réglementaires.',
+  },
+  {
+    href: '/help/contact',
+    Icon: Mail,
+    label: 'Nous contacter',
+    description: 'Email, GitHub Issues — nous lisons tous les retours.',
+  },
+] as const;
+
+// ── Technical docs (existing) ────────────────────────────────────────────────
 
 const CATEGORY_META: Record<HelpDocEntry['category'], { label: string; Icon: typeof BookOpen }> = {
   audit: { label: 'Audit produit', Icon: FileSearch },
@@ -23,21 +64,64 @@ export default function HelpIndexPage() {
   const grouped = CATEGORY_ORDER.map((cat) => ({
     cat,
     items: listed.filter((d) => d.category === cat),
-  })).filter((g) => g.items.length > 0)
+  }))
+    .filter((g) => g.items.length > 0)
     .filter((g) => isAdmin || (g.cat !== 'admin' && g.cat !== 'audit'));
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 p-6">
+    <div className="mx-auto max-w-3xl space-y-8 p-6">
       <BackButton />
 
       <div>
         <h1 className="text-xl font-semibold">Aide</h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Guides utilisateur, concepts produit, audits internes. Tous les documents
-          sont versionnés dans le repo Git et synchronisés ici à chaque déploiement.
+          Guides, FAQ, risques et documentation technique.
         </p>
       </div>
 
+      {/* Grand-public hub */}
+      <section className="space-y-2">
+        <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Assistance
+        </h2>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {GP_SECTIONS.map(({ href, Icon, label, description }) => (
+            <Link
+              key={href}
+              href={href as Route}
+              className="flex items-start gap-3 rounded-lg border p-4 transition-colors hover:bg-muted/30"
+            >
+              <Icon className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+              <div>
+                <p className="text-sm font-medium">{label}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* Glossaire */}
+      <section className="space-y-2">
+        <h2 className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <BookMarked className="h-3.5 w-3.5" aria-hidden />
+          Glossaire
+        </h2>
+        <Link
+          href={'/help/glossaire' as Route}
+          className="flex items-center justify-between rounded-lg border px-4 py-3 transition-colors hover:bg-muted/30"
+        >
+          <div>
+            <p className="text-sm font-medium">Glossaire des termes</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {GLOSSARY_TERMS.length} termes financiers et concepts SmartVest expliqués en clair.
+            </p>
+          </div>
+          <span className="ml-4 shrink-0 text-xs text-muted-foreground">→</span>
+        </Link>
+      </section>
+
+      {/* Technical docs */}
       {grouped.map(({ cat, items }) => {
         const { label, Icon } = CATEGORY_META[cat];
         return (
@@ -61,38 +145,6 @@ export default function HelpIndexPage() {
           </section>
         );
       })}
-
-      {/* Glossaire */}
-      <section className="space-y-2">
-        <h2 className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          <BookMarked className="h-3.5 w-3.5" aria-hidden />
-          Glossaire
-        </h2>
-        <Link
-          href={'/help/glossaire' as Route}
-          className="flex items-center justify-between rounded-lg border px-4 py-3 transition-colors hover:bg-muted/30"
-        >
-          <div>
-            <p className="text-sm font-medium">Glossaire des termes</p>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              {GLOSSARY_TERMS.length} termes financiers et concepts SmartVest expliqués en clair.
-            </p>
-          </div>
-          <span className="ml-4 shrink-0 text-xs text-muted-foreground">→</span>
-        </Link>
-      </section>
-
-      <div className="rounded-lg border border-dashed p-4">
-        <p className="text-xs text-muted-foreground">
-          ℹ️ La documentation est en construction. La couverture exhaustive de tous
-          les champs et concepts (~80 spots identifiés en audit P4 §4.4) sera ajoutée
-          progressivement. Voir{' '}
-          <Link href={'/help/audit-2026-04' as Route} className="text-primary underline underline-offset-4">
-            l'audit produit
-          </Link>{' '}
-          pour la roadmap détaillée.
-        </p>
-      </div>
 
       {/* Légal */}
       <div className="flex flex-wrap items-center gap-4 border-t pt-4 text-xs text-muted-foreground">

--- a/apps/web/src/app/help/premiers-pas/page.tsx
+++ b/apps/web/src/app/help/premiers-pas/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import Link from 'next/link';
+import { type Route } from 'next';
+import { CheckCircle2, ChevronRight } from 'lucide-react';
+import { BackButton } from '@/components/ui/back-button';
+
+const STEPS = [
+  {
+    title: 'Créez votre portefeuille',
+    body: 'Rendez-vous dans "Mon portefeuille" et ajoutez vos positions actuelles (actions, ETF, crypto…). SmartVest calcule automatiquement votre exposition et votre diversification.',
+  },
+  {
+    title: 'Consultez votre tableau de bord',
+    body: 'La page d\'accueil résume votre situation : valeur totale, évolution récente, répartition par classe d\'actif. Tout est mis à jour à chaque chargement.',
+  },
+  {
+    title: 'Explorez les projections',
+    body: 'La section "Projections futures" simule différents scénarios pour votre portefeuille sur 1, 5 ou 10 ans. Ce sont des simulations, pas des prédictions.',
+  },
+  {
+    title: 'Activez l\'assistant Lisa',
+    body: 'Lisa analyse votre portefeuille et vous soumet des suggestions. Vous restez toujours décisionnaire : Lisa propose, vous validez ou refusez.',
+  },
+  {
+    title: 'Configurez vos notifications',
+    body: 'Dans "Mes notifications", définissez les alertes qui comptent pour vous : seuils de perte, opportunités de marché, rappels de rééquilibrage.',
+  },
+];
+
+export default function PremiersPasPage() {
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Premiers pas</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Prenez SmartVest en main en 5 étapes simples.
+        </p>
+      </div>
+
+      <ol className="space-y-4">
+        {STEPS.map((step, i) => (
+          <li key={i} className="flex gap-4 rounded-lg border p-4">
+            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+              {i + 1}
+            </div>
+            <div>
+              <p className="text-sm font-medium">{step.title}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{step.body}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <div className="flex items-start gap-3 rounded-lg border border-dashed p-4">
+        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+        <p className="text-sm text-muted-foreground">
+          SmartVest est un outil d'aide à la décision. Il ne passe aucun ordre en votre nom
+          sans votre accord explicite. Les performances passées ne préjugent pas des
+          performances futures.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-3 border-t pt-4">
+        <Link
+          href={'/help/faq' as Route}
+          className="flex items-center gap-1 text-sm text-primary hover:underline underline-offset-4"
+        >
+          Questions fréquentes <ChevronRight className="h-3.5 w-3.5" />
+        </Link>
+        <Link
+          href={'/help/risques' as Route}
+          className="flex items-center gap-1 text-sm text-primary hover:underline underline-offset-4"
+        >
+          Comprendre les risques <ChevronRight className="h-3.5 w-3.5" />
+        </Link>
+        <Link
+          href={'/help/glossaire' as Route}
+          className="flex items-center gap-1 text-sm text-primary hover:underline underline-offset-4"
+        >
+          Glossaire <ChevronRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/help/risques/page.tsx
+++ b/apps/web/src/app/help/risques/page.tsx
@@ -1,0 +1,83 @@
+import Link from 'next/link';
+import { type Route } from 'next';
+import { AlertTriangle } from 'lucide-react';
+import { BackButton } from '@/components/ui/back-button';
+
+const SECTIONS = [
+  {
+    title: 'Le capital peut être perdu',
+    body: "Tout investissement en actions, ETF, obligations ou crypto-actifs comporte un risque de perte partielle ou totale du capital investi. SmartVest ne garantit aucun rendement ni la préservation du capital.",
+  },
+  {
+    title: 'Les performances passées ne préjugent pas des performances futures',
+    body: "Les analyses et projections de SmartVest sont fondées sur des données historiques et des modèles statistiques. L'évolution future des marchés peut différer significativement des scénarios simulés.",
+  },
+  {
+    title: "SmartVest n'est pas un conseiller financier agréé",
+    body: "SmartVest est un outil d'aide à la décision, pas un service de conseil en investissement au sens de la directive MiFID II. Ses suggestions ne constituent pas des recommandations personnalisées tenant compte de votre situation patrimoniale, fiscale et de vos objectifs précis. Pour une recommandation adaptée à votre situation, consultez un conseiller financier agréé (CIF).",
+  },
+  {
+    title: 'Risque de liquidité',
+    body: "Certains actifs (petites capitalisations, crypto peu liquides) peuvent être difficiles à céder rapidement sans impact significatif sur le prix. SmartVest signale la classe d'actif concernée mais ne garantit pas la liquidité à l'exécution.",
+  },
+  {
+    title: 'Risque de change',
+    body: "Investir dans des actifs libellés en devise étrangère (USD, GBP, JPY…) expose à des fluctuations de change qui peuvent amplifier les gains ou les pertes en euros.",
+  },
+  {
+    title: 'Risque de concentration',
+    body: "Un portefeuille concentré sur un secteur, une zone géographique ou un actif unique amplifie l'impact d'un choc spécifique. La diversification réduit ce risque sans l'éliminer.",
+  },
+  {
+    title: 'Risque lié aux crypto-actifs',
+    body: "Les crypto-actifs sont des actifs hautement volatils et non régulés dans la plupart des juridictions. Leur valorisation peut varier de façon extrême sur de courtes périodes. SmartVest applique des seuils de gestion spécifiques à cette classe d'actif.",
+  },
+  {
+    title: 'Données de marché',
+    body: "SmartVest utilise des données de marché fournies par des tiers (EODHD, Binance…). Ces données peuvent être retardées, incomplètes ou temporairement indisponibles. Les décisions prises sur la base de données dégradées le sont sous la responsabilité de l'utilisateur.",
+  },
+];
+
+export default function RisquesPage() {
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Comprendre les risques</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Investir comporte des risques. Prenez connaissance des principaux avant de commencer.
+        </p>
+      </div>
+
+      <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/30">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden />
+        <p className="text-sm text-amber-800 dark:text-amber-300">
+          <strong>Avertissement :</strong> Les performances passées ne préjugent pas
+          des performances futures. Le capital investi est exposé à un risque de perte.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {SECTIONS.map((s) => (
+          <div key={s.title} className="rounded-lg border p-4">
+            <p className="text-sm font-medium">{s.title}</p>
+            <p className="mt-1.5 text-sm text-muted-foreground">{s.body}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-4 border-t pt-4 text-xs text-muted-foreground">
+        <Link href={'/legal/mentions' as Route} className="hover:text-foreground hover:underline underline-offset-4">
+          Mentions légales
+        </Link>
+        <Link href={'/legal/confidentialite' as Route} className="hover:text-foreground hover:underline underline-offset-4">
+          Politique de confidentialité
+        </Link>
+        <Link href={'/legal/cgu' as Route} className="hover:text-foreground hover:underline underline-offset-4">
+          CGU
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- **`/help` hub** revampé : section "Assistance" 2×2 grid en tête (grand-public-first), docs techniques conservées en dessous
- **`/help/premiers-pas`** — guide 5 étapes sans jargon + disclaimer capital
- **`/help/faq`** — 8 questions accordion client-side (conseiller agréé, sécurité données, mode autonome, risques)
- **`/help/risques`** — 8 sections risque + bandeau avertissement (capital, MiFID, change, liquidité, crypto, données)
- **`/help/contact`** — email + GitHub Issues + renvoi FAQ

ADR-002 : label sidebar "Aide" et route `/help` inchangés. Typechecks ✅.

## Test plan

- [ ] `/help` affiche la grille 2×2 Assistance en tête de page
- [ ] Chaque lien de la grille navigue vers la bonne sous-page
- [ ] `/help/risques` affiche le bandeau amber + 8 sections
- [ ] `/help/faq` : accordion s'ouvre/ferme au clic
- [ ] `/help/contact` : liens email et GitHub corrects
- [ ] Docs techniques (guides/audit) toujours visibles en bas

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_