### PR TITLE
feat(ux-gp): Sprint 7 — FirstRunTour + empty states

### DIFF
--- a/apps/web/src/app/bot-lab/page.tsx
+++ b/apps/web/src/app/bot-lab/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { FlaskConical, Upload, Plus, Trash2, FileText, ArrowLeft, BarChart3, RefreshCw, TrendingUp } from 'lucide-react';
+import { EmptyState } from '@/components/states/empty-state';
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine } from 'recharts';
 import {
   useBots,
@@ -136,9 +137,20 @@ function BotListView({ onSelectBot }: { onSelectBot: (botId: string) => void }) 
       )}
 
       {botsQuery.data?.bots.length === 0 && !showCreateForm && (
-        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
-          Aucun bot encore. Crée-en un et importe des trades CSV.
-        </div>
+        <EmptyState
+          icon={<FlaskConical className="h-10 w-10" />}
+          title="Aucune stratégie encore"
+          description="Créez une stratégie et importez vos trades CSV pour analyser ses performances."
+          action={
+            <button
+              type="button"
+              onClick={() => setShowCreateForm(true)}
+              className="text-sm text-primary underline underline-offset-4 hover:no-underline"
+            >
+              Créer ma première stratégie
+            </button>
+          }
+        />
       )}
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">

--- a/apps/web/src/components/dashboard/connected-dashboard.tsx
+++ b/apps/web/src/components/dashboard/connected-dashboard.tsx
@@ -12,6 +12,7 @@ import { useRecentTransactions } from '@/hooks/use-dashboard';
 import { useValuation, useAllocation, useAlerts } from '@/hooks/use-valuation';
 import { DisclaimerBanner } from '@/components/disclaimer-banner';
 import { WelcomeBanner } from '@/components/dashboard/welcome-banner';
+import { FirstRunTour } from '@/components/onboarding/first-run-tour';
 import { KpiCard } from '@/components/kpi-card';
 import { RiskProfileCard } from './risk-profile-card';
 import { AllocationDonut } from './allocation-donut';
@@ -144,6 +145,7 @@ export function ConnectedDashboard() {
 
   return (
     <div className="space-y-6">
+      <FirstRunTour />
       <DisclaimerBanner />
       {positionCount === 0 && !valuationQuery.isLoading && <WelcomeBanner />}
 

--- a/apps/web/src/components/dashboard/welcome-banner.tsx
+++ b/apps/web/src/components/dashboard/welcome-banner.tsx
@@ -4,6 +4,7 @@ import type { Route } from 'next';
 import Link from 'next/link';
 import { useState, useEffect } from 'react';
 import { X, BookOpen, FlaskConical, Sparkles, ChevronRight } from 'lucide-react';
+import { GLOSSARY_TERMS } from '@/lib/glossary-terms';
 
 const STORAGE_KEY = 'smartvest_welcome_dismissed_v1';
 
@@ -93,7 +94,7 @@ export function WelcomeBanner() {
           href={'/help/glossaire' as Route}
           className="text-[11px] text-muted-foreground underline underline-offset-2 hover:text-foreground"
         >
-          Consulter le glossaire (42 termes)
+          Consulter le glossaire ({GLOSSARY_TERMS.length} termes)
         </Link>
         <button
           type="button"

--- a/apps/web/src/components/onboarding/first-run-tour.tsx
+++ b/apps/web/src/components/onboarding/first-run-tour.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { type Route } from 'next';
+import Link from 'next/link';
+import { X, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const STORAGE_KEY = 'smartvest_first_run_tour_v1';
+
+const STEPS = [
+  {
+    title: 'Bienvenue sur SmartVest',
+    body: 'SmartVest vous aide à analyser et simuler votre portefeuille. Commençons par un tour rapide des fonctionnalités principales.',
+    action: null,
+  },
+  {
+    title: 'Mon portefeuille',
+    body: 'Ajoutez vos actifs dans "Mon portefeuille". SmartVest calcule automatiquement votre exposition, votre diversification et vos performances.',
+    action: { label: 'Aller à Mon portefeuille', href: '/portfolio' as Route },
+  },
+  {
+    title: "L'assistant Lisa",
+    body: 'Lisa analyse votre portefeuille et vous propose des pistes d\'optimisation. Vous restez toujours décisionnaire — Lisa suggère, vous validez.',
+    action: { label: 'Découvrir Lisa', href: '/lisa' as Route },
+  },
+  {
+    title: 'Simulations et projections',
+    body: '"Tester sur le passé" et "Projections futures" vous permettent de simuler des scénarios sans engager de capital réel.',
+    action: { label: 'Consulter les guides', href: '/help/premiers-pas' as Route },
+  },
+] as const;
+
+export function FirstRunTour() {
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(STORAGE_KEY)) {
+        setOpen(true);
+      }
+    } catch {
+      // localStorage indisponible (SSR, private browsing)
+    }
+  }, []);
+
+  function close() {
+    try {
+      localStorage.setItem(STORAGE_KEY, '1');
+    } catch { /* noop */ }
+    setOpen(false);
+  }
+
+  function next() {
+    if (step < STEPS.length - 1) {
+      setStep(step + 1);
+    } else {
+      close();
+    }
+  }
+
+  function prev() {
+    if (step > 0) setStep(step - 1);
+  }
+
+  if (!open) return null;
+
+  const current = STEPS[step]!;
+  const isLast = step === STEPS.length - 1;
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Tour de découverte SmartVest"
+    >
+      <div className="relative w-full max-w-sm rounded-xl border bg-background shadow-lg">
+        {/* Close */}
+        <button
+          type="button"
+          onClick={close}
+          className="absolute right-3 top-3 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Fermer le tour de découverte"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <div className="p-6">
+          {/* Step indicator */}
+          <div className="mb-4 flex items-center gap-1.5" aria-hidden>
+            {STEPS.map((_, i) => (
+              <div
+                key={i}
+                className={`h-1.5 flex-1 rounded-full transition-colors ${
+                  i <= step ? 'bg-primary' : 'bg-muted'
+                }`}
+              />
+            ))}
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Étape {step + 1} sur {STEPS.length}
+          </p>
+          <h2 className="mt-1 text-base font-semibold">{current.title}</h2>
+          <p className="mt-2 text-sm text-muted-foreground">{current.body}</p>
+
+          {current.action && (
+            <Link
+              href={current.action.href}
+              onClick={close}
+              className="mt-3 inline-block text-sm text-primary hover:underline underline-offset-4"
+            >
+              {current.action.label} →
+            </Link>
+          )}
+        </div>
+
+        {/* Navigation */}
+        <div className="flex items-center justify-between border-t px-6 py-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={prev}
+            disabled={step === 0}
+            aria-label="Étape précédente"
+          >
+            <ChevronLeft className="mr-1 h-3.5 w-3.5" />
+            Précédent
+          </Button>
+
+          <button
+            type="button"
+            onClick={close}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            Passer
+          </button>
+
+          <Button size="sm" onClick={next}>
+            {isLast ? 'Terminer' : 'Suivant'}
+            {!isLast && <ChevronRight className="ml-1 h-3.5 w-3.5" />}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé

- **`FirstRunTour`** : modal 4-étapes, localStorage-keyed (`smartvest_first_run_tour_v1`), backdrop + step indicator + prev/next/passer, wired dans `ConnectedDashboard`. Zéro dépendance externe.
- **Bot-lab `EmptyState`** : remplace le div dashed brut par `<EmptyState>` avec icon `FlaskConical` + titre + CTA contextuel "Créer ma première stratégie"
- **`WelcomeBanner` fix** : glossaire count dynamique (`GLOSSARY_TERMS.length`) au lieu du "42 termes" hardcodé

## Test plan

- [ ] Premier visit (localStorage vide) : tour s'affiche au chargement du dashboard
- [ ] Passer / Fermer / Terminer : tour disparaît, ne revient pas au reload
- [ ] Bot-lab sans bot : affiche l'EmptyState avec CTA
- [ ] WelcomeBanner glossaire : count correspond à `GLOSSARY_TERMS.length`
- [ ] Typechecks ✅

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_