### PR TITLE
feat(ux-gp): Sprint 8 — /legal/cookies + CookieBanner RGPD

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import { Providers } from './providers';
 import { AppShell } from '@/components/layout/app-shell';
+import { CookieBanner } from '@/components/cookie-banner';
 
 export const metadata: Metadata = {
   title: 'SmartVest — Assistant personnel d\'investissement',
@@ -24,6 +25,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="min-h-screen antialiased">
         <Providers>
           <AppShell>{children}</AppShell>
+          <CookieBanner />
         </Providers>
       </body>
     </html>

--- a/apps/web/src/app/legal/cgu/page.tsx
+++ b/apps/web/src/app/legal/cgu/page.tsx
@@ -87,6 +87,9 @@ export default function CguPage() {
           <Link href={'/legal/confidentialite' as Route} className="text-primary underline underline-offset-4">
             Politique de confidentialité
           </Link>
+          <Link href={'/legal/cookies' as Route} className="text-primary underline underline-offset-4">
+            Cookies
+          </Link>
         </div>
       </div>
     </div>

--- a/apps/web/src/app/legal/confidentialite/page.tsx
+++ b/apps/web/src/app/legal/confidentialite/page.tsx
@@ -96,6 +96,9 @@ export default function ConfidentialitePage() {
           <Link href={'/legal/cgu' as Route} className="text-primary underline underline-offset-4">
             Conditions générales
           </Link>
+          <Link href={'/legal/cookies' as Route} className="text-primary underline underline-offset-4">
+            Cookies
+          </Link>
         </div>
       </div>
     </div>

--- a/apps/web/src/app/legal/cookies/page.tsx
+++ b/apps/web/src/app/legal/cookies/page.tsx
@@ -1,0 +1,135 @@
+import Link from 'next/link';
+import { type Route } from 'next';
+import { BackButton } from '@/components/ui/back-button';
+
+export default function CookiesPage() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <BackButton />
+
+      <div>
+        <h1 className="text-xl font-semibold">Politique de cookies</h1>
+        <p className="mt-1 text-xs text-muted-foreground">Dernière mise à jour : 1er mai 2026</p>
+      </div>
+
+      <div className="space-y-6 text-sm">
+        <section className="space-y-2">
+          <h2 className="font-semibold">1. Qu'est-ce qu'un cookie ?</h2>
+          <p className="text-muted-foreground">
+            Un cookie est un petit fichier texte déposé sur votre appareil lors de votre visite
+            sur un site web. Il permet au site de mémoriser vos préférences ou de vous
+            reconnaître lors de visites ultérieures.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="font-semibold">2. Cookies utilisés par SmartVest</h2>
+
+          <div className="rounded-lg border overflow-hidden">
+            <table className="w-full text-xs">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="px-3 py-2 text-left font-medium">Cookie</th>
+                  <th className="px-3 py-2 text-left font-medium">Finalité</th>
+                  <th className="px-3 py-2 text-left font-medium">Durée</th>
+                  <th className="px-3 py-2 text-left font-medium">Type</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                <tr>
+                  <td className="px-3 py-2 font-mono">sb-*</td>
+                  <td className="px-3 py-2 text-muted-foreground">Session utilisateur (Supabase Auth)</td>
+                  <td className="px-3 py-2 text-muted-foreground">Session / 7 jours</td>
+                  <td className="px-3 py-2">
+                    <span className="rounded-full bg-blue-100 px-2 py-0.5 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+                      Essentiel
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td className="px-3 py-2 font-mono">smartvest_*</td>
+                  <td className="px-3 py-2 text-muted-foreground">
+                    Préférences UI (tour de bienvenue, glossaire, mode d'affichage)
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">Persistant (localStorage)</td>
+                  <td className="px-3 py-2">
+                    <span className="rounded-full bg-blue-100 px-2 py-0.5 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+                      Essentiel
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td className="px-3 py-2 font-mono">__vercel_*</td>
+                  <td className="px-3 py-2 text-muted-foreground">Routage réseau (CDN Vercel)</td>
+                  <td className="px-3 py-2 text-muted-foreground">Session</td>
+                  <td className="px-3 py-2">
+                    <span className="rounded-full bg-blue-100 px-2 py-0.5 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+                      Technique
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            SmartVest n'utilise <strong>pas</strong> de cookies publicitaires, de tracking
+            tiers (Google Analytics, Meta Pixel, etc.) ou de profilage comportemental.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="font-semibold">3. Cookies essentiels</h2>
+          <p className="text-muted-foreground">
+            Les cookies essentiels sont indispensables au fonctionnement de SmartVest
+            (authentification, sécurité de session, préférences d'interface). Ils ne peuvent
+            pas être refusés sans rendre le service inaccessible. Ils ne nécessitent pas votre
+            consentement au sens du RGPD (art. 5 §3 directive ePrivacy, exemption cookies
+            strictement nécessaires).
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="font-semibold">4. Comment gérer vos cookies ?</h2>
+          <p className="text-muted-foreground">
+            Vous pouvez à tout moment supprimer les cookies déposés par SmartVest via les
+            paramètres de votre navigateur (Paramètres → Confidentialité → Cookies). La
+            suppression des cookies de session vous déconnectera.
+          </p>
+          <p className="text-muted-foreground">
+            Les préférences UI (tour de bienvenue, etc.) sont stockées en <strong>localStorage</strong>,
+            pas dans des cookies HTTP. Vous pouvez les effacer via les outils développeur de votre
+            navigateur (Application → Local Storage).
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="font-semibold">5. Contact</h2>
+          <p className="text-muted-foreground">
+            Pour toute question relative aux cookies ou à la protection de vos données,
+            contactez-nous via la{' '}
+            <Link href={'/help/contact' as Route} className="text-primary hover:underline underline-offset-4">
+              page Contact
+            </Link>{' '}
+            ou consultez notre{' '}
+            <Link href={'/legal/confidentialite' as Route} className="text-primary hover:underline underline-offset-4">
+              politique de confidentialité
+            </Link>.
+          </p>
+        </section>
+      </div>
+
+      <div className="flex flex-wrap gap-4 border-t pt-4 text-xs text-muted-foreground">
+        <Link href={'/legal/mentions' as Route} className="hover:text-foreground hover:underline underline-offset-4">
+          Mentions légales
+        </Link>
+        <Link href={'/legal/cgu' as Route} className="hover:text-foreground hover:underline underline-offset-4">
+          CGU
+        </Link>
+        <Link href={'/legal/confidentialite' as Route} className="hover:text-foreground hover:underline underline-offset-4">
+          Confidentialité
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/cookie-banner.tsx
+++ b/apps/web/src/components/cookie-banner.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { type Route } from 'next';
+import { Cookie } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { readFeatureFlags } from '@/lib/feature-flags';
+
+const CONSENT_KEY = 'smartvest_cookie_consent_v1';
+
+export function CookieBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Only show in SAFE_PUBLIC_MODE or REGULATED_MODE — not needed in PERSONAL_MODE.
+    const flags = readFeatureFlags();
+    if (flags.PERSONAL_MODE && !flags.SAFE_PUBLIC_MODE) return;
+
+    try {
+      if (!localStorage.getItem(CONSENT_KEY)) {
+        setVisible(true);
+      }
+    } catch {
+      // localStorage indisponible
+    }
+  }, []);
+
+  function accept() {
+    try {
+      localStorage.setItem(CONSENT_KEY, 'accepted');
+    } catch { /* noop */ }
+    setVisible(false);
+  }
+
+  function refuse() {
+    try {
+      localStorage.setItem(CONSENT_KEY, 'refused');
+    } catch { /* noop */ }
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Gestion des cookies"
+      aria-live="polite"
+      className="fixed bottom-4 left-4 right-4 z-40 mx-auto max-w-xl rounded-xl border bg-background shadow-lg sm:left-auto sm:right-4 sm:w-96"
+    >
+      <div className="p-4">
+        <div className="flex items-start gap-3">
+          <Cookie className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+          <div>
+            <p className="text-sm font-medium">Cookies</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              SmartVest utilise uniquement des cookies essentiels (session, préférences d'interface).
+              Aucun tracking publicitaire, aucun cookie tiers.{' '}
+              <Link
+                href={'/legal/cookies' as Route}
+                className="text-primary hover:underline underline-offset-4"
+              >
+                En savoir plus
+              </Link>
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-3 flex justify-end gap-2">
+          <Button variant="outline" size="sm" onClick={refuse}>
+            Refuser
+          </Button>
+          <Button size="sm" onClick={accept}>
+            Accepter
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé

- **`/legal/cookies`** — page politique cookies : table des 3 cookies essentiels (`sb-*`, `smartvest_*`, `__vercel_*`), exemption RGPD art. 5§3 citée, aucun tracker tiers déclaré (exact)
- **`<CookieBanner>`** — composant client fixed-bottom right, `localStorage`-keyed (`smartvest_cookie_consent_v1`), boutons Accepter/Refuser, lien vers `/legal/cookies`. Affiché uniquement hors `PERSONAL_MODE` (conforme feature-flags §3 CLAUDE.md)
- **`layout.tsx`** — `<CookieBanner />` wired en sibling de `<AppShell>` dans `<Providers>`
- **Cross-légal** — lien "Cookies" ajouté au footer de `/legal/cgu` et `/legal/confidentialite`

## Test plan

- [ ] `/legal/cookies` s'affiche avec table + 3 cookies listés
- [ ] Banner visible au premier chargement (localStorage vide, hors PERSONAL_MODE)
- [ ] Accepter → banner disparaît, ne revient pas au reload
- [ ] Refuser → même comportement
- [ ] Lien "En savoir plus" navigue vers `/legal/cookies`
- [ ] CGU et confidentialité ont bien le lien "Cookies" dans leur footer
- [ ] Typechecks ✅

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_