### PR TITLE
fix(lisa-cache): extend source CHECK to allow eodhd_1m + eodhd_ticks

### DIFF
--- a/supabase/migrations/0099_lisa_intraday_cache_source_extend.sql
+++ b/supabase/migrations/0099_lisa_intraday_cache_source_extend.sql
@@ -1,0 +1,17 @@
+-- Extend lisa_intraday_cache.source CHECK constraint to allow 'eodhd_1m'
+-- and 'eodhd_ticks' sources introduced by P19v (1m native EODHD fetch) and
+-- P19o.3 (tick-aggregated OHLCV fallback).
+--
+-- Symptom in prod logs: repeated `new row violates check constraint
+-- "lisa_intraday_cache_source_che"` for tickers like ARHUF.US, FHRT.
+-- The TypeScript type CacheSource was extended but the DB constraint was not.
+--
+-- Safe: drop + recreate of CHECK constraint, no data migration needed
+-- (existing rows already use 'yahoo' / 'eodhd' / 'binance' which remain valid).
+
+ALTER TABLE public.lisa_intraday_cache
+  DROP CONSTRAINT IF EXISTS lisa_intraday_cache_source_check;
+
+ALTER TABLE public.lisa_intraday_cache
+  ADD CONSTRAINT lisa_intraday_cache_source_check
+  CHECK (source IN ('yahoo', 'eodhd', 'eodhd_1m', 'eodhd_ticks', 'binance'));


### PR DESCRIPTION
## Résumé

Fix des erreurs `new row violates check constraint "lisa_intraday_cache_source_check"` observées en boucle dans les logs Fly pour des tickers comme `ARHUF.US`, `FHRT`.

## Cause racine

Le type TypeScript `CacheSource` (intraday-cache.service.ts:34) déclare 5 valeurs :
```ts
type CacheSource = 'yahoo' | 'eodhd' | 'eodhd_1m' | 'eodhd_ticks' | 'binance';
```

Mais la contrainte CHECK en DB (migration `0092_lisa_intraday_cache.sql:17`) n'autorise que 3 valeurs : `'yahoo'`, `'eodhd'`, `'binance'`.

Les valeurs `'eodhd_1m'` (P19v — fetch 1m natif) et `'eodhd_ticks'` (P19o.3 — fallback tick-aggregated) sont rejetées silencieusement à l'insert. Sites concernés : `multi-tf-persistence.service.ts:344` et `:386`.

## Fix

Migration `0099` : DROP + ADD du CHECK avec les 5 valeurs alignées sur le type. Pas de migration de données (les rows existantes utilisent déjà `'yahoo'/'eodhd'/'binance'` qui restent valides).

## Pourquoi étendre plutôt que normaliser

Les 3 nouvelles sources sont des distinctions sémantiques utiles (1m natif EODHD vs 5m fallback vs ticks aggregated). Les conflater perdrait de l'observabilité côté UI/coverage badges.

## Test plan

- [ ] Migration appliquée sur staging — vérifier `\d lisa_intraday_cache` montre la nouvelle CHECK
- [ ] Nouvelle insertion avec source='eodhd_1m' réussit
- [ ] Logs Fly post-deploy : disparition de "violates check constraint" sur lisa_intraday_cache

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_