### PR TITLE
fix(gainers-scoring): off-by-rounding 4/6 threshold + warn on no active portfolio

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -206,10 +206,10 @@ export class TopGainersScannerService implements OnModuleInit {
   /**
    * P8 — Resolve config min persistence score.
    * Priority chain : DB > env > default(0.67).
-   * `lisa_session_configs.gainers_min_persistence_score` est par-portfolio
-   * mais le seuil est globalement uniforme dans v1 (1 valeur côté scanner).
-   * Le caller passe `portfolioMinScore` quand il a la row sous la main ;
-   * sinon on retombe sur env / default.
+   *
+   * Note: 0.67 est intentionnellement ≥ 4/6 (pas 5/6). La comparaison
+   * réelle utilise Math.round(minScore × availableCount) pour éviter
+   * le float off-by-one : 0.67 × 6 = 4.02 → round → 4 (= 4/6 gate).
    */
   resolveMinPersistenceScore(portfolioMinScore?: number | null): number {
     if (typeof portfolioMinScore === 'number' && Number.isFinite(portfolioMinScore)) {
@@ -426,7 +426,13 @@ export class TopGainersScannerService implements OnModuleInit {
       }
     }
 
-    if (configs.length === 0) return;
+    if (configs.length === 0) {
+      this.logger.warn(
+        '[top-gainers] no active portfolio with strategy_mode=gainers AND autopilot_enabled=true — scanner cycle skipped. ' +
+        'Activate via POST /lisa/mode/:portfolioId {mode:"gainers"} or set STRATEGY_MODE=top_gainers env.',
+      );
+      return;
+    }
 
     // Fetch global candidates UNE SEULE fois (partagé entre tous les portfolios)
     const candidates = await this.fetchAllCandidates();
@@ -1001,9 +1007,9 @@ export class TopGainersScannerService implements OnModuleInit {
         //   [0.66, 0.83) 4/6   → shadow_466 log + skip (no open)
         //   < 0.66             → skip silencieux (comportement standard)
         //
-        // NB : 4/6 = 0.66666… donc le cutoff est 0.66, PAS 0.67. Le seuil
-        // historique `gainers_min_persistence_score` default = 0.67 est en
-        // pratique strict ≥ 5/6 (0.8333 ≥ 0.67 ✓ ; 0.6667 < 0.67 ✗).
+        // Converti en entier via Math.round pour éviter l'off-by-one float :
+        // 0.67 × 6 = 4.02 → Math.round → 4 → positiveCount ≥ 4 (et non 5).
+        // Voir fix(gainers-scoring-threshold) — le bug 4/6 est corrigé ici.
         const STRICT_MODE_THRESHOLD = 0.999; // tolérance float pour 1.0
         if (minScore >= STRICT_MODE_THRESHOLD) {
           const score = persistence.persistenceScore;
@@ -1071,9 +1077,12 @@ export class TopGainersScannerService implements OnModuleInit {
           // qui pass-through (1.0 not < 1.0)
         }
 
-        if (persistence.persistenceScore < minScore) {
+        // Integer gate: Math.round avoids float off-by-one (4/6=0.6666 < 0.67 was
+        // silently excluding 4/6-TF candidates). 0.67×6=4.02 → rounds to 4.
+        const minPositive = Math.round(minScore * persistence.availableCount);
+        if (persistence.positiveCount < minPositive) {
           this.logger.log(
-            `[top-gainers] ${cand.symbol} persistenceScore=${persistence.persistenceScore.toFixed(2)} (${persistence.persistenceCount}) < min=${minScore.toFixed(2)} → skip`,
+            `[top-gainers] ${cand.symbol} ${persistence.persistenceCount} (${persistence.positiveCount}/${persistence.availableCount} TFs) < min=${minPositive}/${persistence.availableCount} → skip`,
           );
           continue;
         }


### PR DESCRIPTION
## Problème

Deux bugs distincts qui expliquent `top_gainers_log = 0 lignes` sur 24h :

### Bug 1 — Off-by-rounding sur le gate 4/6 TFs

Le seuil par défaut `gainers_min_persistence_score = 0.67` était comparé en float :
```ts
if (persistence.persistenceScore < 0.67)  // 4/6 = 0.6666... < 0.67 → SKIP toujours
```
Résultat : seuls les candidats avec **5/6 ou 6/6 TFs positifs** passaient. Les candidats 4/6 (cas majoritaire en tendance modérée) étaient silencieusement exclus.

### Bug 2 — Skip silencieux sans portfolio actif

Si aucun portfolio n'a `strategy_mode='gainers' AND autopilot_enabled=true`, le scanner retournait sans log :
```ts
if (configs.length === 0) return;  // ← pas de log → invisible dans Fly logs
```
Observé 01/05/2026 : `autopilot_enabled` mis à `false` lors de la pause matinale, mais jamais réactivé après l'unset de `SCANNER_PAUSE`. Scanner actif (cron démarré) mais ineffectif.

## Fixes

### Fix 1 — Comparaison en entier via Math.round
```ts
// Avant
if (persistence.persistenceScore < minScore)

// Après — 0.67 × 6 = 4.02 → round → 4 → positiveCount ≥ 4 gate
const minPositive = Math.round(minScore * persistence.availableCount);
if (persistence.positiveCount < minPositive)
```
Rétrocompatible : threshold float DB/env inchangé, seule la comparaison change.

Log mis à jour : `"AAPL 4/6 (4/6 TFs) < min=4/6 → skip"` lisible en clair.

### Fix 2 — Warning log quand configs vides
```
[top-gainers] no active portfolio with strategy_mode=gainers AND autopilot_enabled=true
— scanner cycle skipped. Activate via POST /lisa/mode/:portfolioId {mode:"gainers"}
```

## Impact attendu

Prochains cycles : candidats 4/6 TFs maintenant éligibles (estimation : ×3-4 candidats passant le gate). `top_gainers_log` devrait recevoir des entrées dès le premier cycle post-deploy.

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_