### PR TITLE
fix(lisa-config-overflow): widen return_target_*_pct + readable 400 error

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -274,6 +274,27 @@ export class LisaService {
       gainers_min_path_efficiency: pick('gainers_min_path_efficiency', 'gainersMinPathEfficiency', existing?.gainers_min_path_efficiency ?? 0.5),
     };
 
+    // Validation des valeurs numériques pour renvoyer une 400 lisible plutôt
+    // qu'un cryptique "numeric field overflow" venu de Postgres. La DB elle
+    // peut accepter jusqu'à numeric(8,4) = 9999.9999 après migration 0100,
+    // mais on cap côté API à des valeurs sensées (≤ 9999%) pour bloquer la
+    // saisie accidentelle de 1e9.
+    const validateReturnTarget = (key: string, value: unknown): void => {
+      if (value == null) return;
+      const n = typeof value === 'string' ? parseFloat(value) : Number(value);
+      if (!Number.isFinite(n)) {
+        throw new BadRequestException(`${key} : valeur numérique invalide.`);
+      }
+      if (n < -100 || n > 9999) {
+        throw new BadRequestException(
+          `${key} : valeur ${n} hors plage acceptée (-100 à 9999%).`,
+        );
+      }
+    };
+    validateReturnTarget('return_target_daily_pct', merged.return_target_daily_pct);
+    validateReturnTarget('return_target_monthly_pct', merged.return_target_monthly_pct);
+    validateReturnTarget('return_target_annual_pct', merged.return_target_annual_pct);
+
     // Validation : auto_approve exige uniquement un portefeuille de simulation
     // (déjà vérifié plus haut). L'expiration est suggestive côté UI mais non
     // bloquante ici — l'utilisateur peut laisser tourner sans deadline s'il

--- a/supabase/migrations/0100_lisa_config_return_target_widen.sql
+++ b/supabase/migrations/0100_lisa_config_return_target_widen.sql
@@ -1,0 +1,15 @@
+-- Fix "numeric field overflow" on PUT /lisa/config/:id when user enters
+-- annual return targets ≥ 100 (e.g. aspirational 150% annual on a high-risk
+-- scalping portfolio). Frontend convention is percentage-as-number
+-- (placeholder "ex: 25" = 25%), but numeric(6, 4) caps at 99.9999.
+--
+-- Expanding to numeric(8, 4) gives max 9999.9999 — generous headroom for
+-- absurd-but-valid values without losing the 4-decimal precision used for
+-- daily targets like 0.0500 (= 0.05%).
+--
+-- Same column shape change for monthly/annual to keep the trio consistent.
+
+ALTER TABLE public.lisa_session_configs
+  ALTER COLUMN return_target_daily_pct   TYPE numeric(8, 4),
+  ALTER COLUMN return_target_monthly_pct TYPE numeric(8, 4),
+  ALTER COLUMN return_target_annual_pct  TYPE numeric(8, 4);


### PR DESCRIPTION
## Bug

`POST /lisa/config/:portfolioId` retournait `400 numeric field overflow` quand l'utilisateur saisissait un objectif de rendement annuel ≥ 100% (ex : portfolio scalping aspirationnel à 150%/an).

## Cause racine

Migration `0050_lisa_portfolio_mission.sql` :
```sql
return_target_daily_pct   numeric(6, 4)  -- max 99.9999
return_target_monthly_pct numeric(6, 4)
return_target_annual_pct  numeric(6, 4)
```

Frontend `apps/web/src/app/lisa/page.tsx:313` envoie le nombre brut tapé dans l'input dont le placeholder dit `"ex: 25"` → convention **percentage-as-number**. Toute valeur ≥ 100 → overflow Postgres → 400 brut.

Colonnes inspectées (saines) : `gainers_min_persistence_score numeric(3,2)`, `gainers_min_path_efficiency numeric(3,2)` → fractions [0,1], pas de risque. `daily_cost_budget_usd numeric(10,2)` → max 99M, OK. `capital_usd numeric(28,2)` → OK.

## Fix

### 1. Migration `0100` — ALTER COLUMN

```sql
ALTER TABLE lisa_session_configs
  ALTER COLUMN return_target_daily_pct   TYPE numeric(8, 4),
  ALTER COLUMN return_target_monthly_pct TYPE numeric(8, 4),
  ALTER COLUMN return_target_annual_pct  TYPE numeric(8, 4);
```
Max désormais `9999.9999` — garde la précision 4 décimales utile pour les daily targets (`0.0500` = 0.05%).

### 2. Validation explicite côté service

Ajout d'une fonction `validateReturnTarget()` dans `lisa.service.ts:upsertSessionConfig` qui throw `BadRequestException` lisible (clé + valeur + plage) si la valeur est non-finite ou hors `[-100, 9999]%`. Évite le leak du message Postgres et donne à l'UI un feedback compréhensible.

## Hors scope

- DTO complet avec `class-validator` `@Max/@Min` : refacto plus large (le body est typé `Record<string, unknown>` aujourd'hui). La validation imperative dans le service couvre le cas immédiat.
- Validation côté frontend : le champ devrait avoir `max="9999"` mais c'est un cleanup UI séparé.

## Test plan

- [ ] Migration appliquée sur staging — `\d lisa_session_configs` doit montrer `numeric(8,4)` sur les 3 colonnes
- [ ] POST /lisa/config avec `return_target_annual_pct: 150` → 200 OK (avant: 400 overflow)
- [ ] POST /lisa/config avec `return_target_annual_pct: 99999` → 400 lisible
- [ ] POST /lisa/config avec `return_target_annual_pct: "abc"` → 400 lisible

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_