### PR TITLE
fix(path-quality): badge idle ⚪ pour séries plates (marché fermé / données figées)

### DIFF
--- a/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
+++ b/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
@@ -58,8 +58,8 @@ export interface PathQualityByTf {
   tf1h: PathQualityMetrics | null;
   /** Path efficiency moyenne pondérée sur les TFs disponibles. */
   overallEfficiency: number | null;
-  /** Smooth si toutes les TFs dispos sont smooth. Choppy si au moins une choppy. */
-  overallSmoothness: 'smooth' | 'mixed' | 'choppy' | null;
+  /** Smooth si tous les TFs actifs sont smooth. Choppy si ≥1 choppy. Idle si tous les TFs sont figés (données = marché fermé). */
+  overallSmoothness: 'smooth' | 'mixed' | 'choppy' | 'idle' | null;
 }
 
 /**
@@ -542,13 +542,16 @@ function summarizePathQuality(byTf: {
   const dispos = [byTf.tf5m, byTf.tf10m, byTf.tf15m, byTf.tf30m, byTf.tf1h].filter(
     (m): m is PathQualityMetrics => m !== null,
   );
-  const overallEfficiency = dispos.length > 0
-    ? dispos.reduce((s, m) => s + m.pathEfficiency, 0) / dispos.length
+  // Exclude idle TFs (flat/frozen prices) from efficiency average and smoothness logic.
+  const activeTfs = dispos.filter((m) => m.smoothnessLabel !== 'idle');
+  const overallEfficiency = activeTfs.length > 0
+    ? activeTfs.reduce((s, m) => s + m.pathEfficiency, 0) / activeTfs.length
     : null;
-  let overallSmoothness: 'smooth' | 'mixed' | 'choppy' | null = null;
+  let overallSmoothness: 'smooth' | 'mixed' | 'choppy' | 'idle' | null = null;
   if (dispos.length > 0) {
-    if (dispos.some((m) => m.smoothnessLabel === 'choppy')) overallSmoothness = 'choppy';
-    else if (dispos.every((m) => m.smoothnessLabel === 'smooth')) overallSmoothness = 'smooth';
+    if (dispos.every((m) => m.smoothnessLabel === 'idle')) overallSmoothness = 'idle';
+    else if (activeTfs.some((m) => m.smoothnessLabel === 'choppy')) overallSmoothness = 'choppy';
+    else if (activeTfs.every((m) => m.smoothnessLabel === 'smooth')) overallSmoothness = 'smooth';
     else overallSmoothness = 'mixed';
   }
   return { ...byTf, overallEfficiency, overallSmoothness };

--- a/apps/web/src/components/lisa/gainers-status-tile.tsx
+++ b/apps/web/src/components/lisa/gainers-status-tile.tsx
@@ -563,6 +563,13 @@ function PathBadge({ pq }: { pq: PathQualityByTf | null }) {
       </span>
     );
   }
+  if (pq.overallSmoothness === 'idle') {
+    return (
+      <span title="Données figées (marché fermé ou prix constant) — path quality non évaluable" className="cursor-help opacity-40">
+        ⚪
+      </span>
+    );
+  }
   const emoji =
     pq.overallSmoothness === 'smooth' ? '🟢'
     : pq.overallSmoothness === 'mixed' ? '🟡'
@@ -657,6 +664,11 @@ function PathLegend() {
       emoji: '🔴',
       label: 'Choppy',
       tooltip: 'Path bloqué — efficiency<40% OU pullback>2%. Pump-and-dump probable. Rejeté par le gate path quality.',
+    },
+    {
+      emoji: '⚪',
+      label: 'Idle',
+      tooltip: 'Données figées — marché fermé ou prix constants. Path non évaluable, exclu des statistiques.',
     },
   ];
   return (

--- a/apps/web/src/hooks/use-operating-mode.ts
+++ b/apps/web/src/hooks/use-operating-mode.ts
@@ -68,13 +68,13 @@ export interface PathQualityMetric {
   pathEfficiency: number;
   pullbackDepth: number;
   monotonicity: number;
-  smoothnessLabel: 'smooth' | 'mixed' | 'choppy';
+  smoothnessLabel: 'smooth' | 'mixed' | 'choppy' | 'idle';
   n: number;
 }
 
 export interface PathQualityByTf {
   overallEfficiency: number | null;
-  overallSmoothness: 'smooth' | 'mixed' | 'choppy' | null;
+  overallSmoothness: 'smooth' | 'mixed' | 'choppy' | 'idle' | null;
   tf5m: PathQualityMetric | null;
   tf10m: PathQualityMetric | null;
   tf15m: PathQualityMetric | null;

--- a/packages/ai-analyst/src/strategies/path-quality.ts
+++ b/packages/ai-analyst/src/strategies/path-quality.ts
@@ -21,7 +21,8 @@
  * Pure : pas d'I/O, testable en isolation.
  */
 
-export type SmoothnessLabel = 'smooth' | 'mixed' | 'choppy';
+/** 'idle' = série plate (Σ|Δp|=0) : marché fermé ou données figées — pas un jugement de qualité. */
+export type SmoothnessLabel = 'smooth' | 'mixed' | 'choppy' | 'idle';
 
 export interface PathQualityMetrics {
   pathEfficiency: number;
@@ -114,11 +115,18 @@ export function evaluatePathQuality(prices: number[]): PathQualityMetrics | null
   if (eff === null) return null;
   const pullback = computePullbackDepth(prices);
   const monotonicity = computeMonotonicity(prices);
+
+  // Flat series: Σ|Δp|=0 means all prices identical (market closed / data frozen).
+  // computePathEfficiency returns 1 for flat, which would be misclassified as 'smooth'.
+  let totalVariation = 0;
+  for (let i = 1; i < prices.length; i++) totalVariation += Math.abs(prices[i] - prices[i - 1]);
+  const isFlat = totalVariation === 0;
+
   return {
     pathEfficiency: eff,
     pullbackDepth: pullback,
     monotonicity,
-    smoothnessLabel: classifySmoothness(eff, pullback),
+    smoothnessLabel: isFlat ? 'idle' : classifySmoothness(eff, pullback),
     n: prices.length,
   };
 }


### PR DESCRIPTION
## Problème

Faux-positifs 🟢 sur symboles Asie fermés (000500, 600322, STMEF, SCBFF…) : quand tous les prix sont identiques (marché closed, données figées), `computePathEfficiency` retourne `1` et `classifySmoothness(1.0, 0.0)` classe `'smooth'`. Ce n'est pas de la qualité de path, c'est de l'absence de mouvement.

## Fix

- **`path-quality.ts`** : dans `evaluatePathQuality`, si `Σ|Δp| === 0` → `smoothnessLabel = 'idle'`. Type `SmoothnessLabel` étendu avec `'idle'`.
- **`multi-tf-persistence.service.ts`** : dans `summarizePathQuality`, les TFs `idle` sont exclus du calcul d'efficiency et de la classification. `overallSmoothness = 'idle'` ssi TOUS les TFs sont figés.
- **`use-operating-mode.ts`** : types frontend mis à jour (`'idle'` ajouté).
- **`gainers-status-tile.tsx`** : `PathBadge` retourne ⚪ avec tooltip explicatif. `PathLegend` enrichie d'une entrée Idle.

## Seuils inchangés

Les seuils smooth/choppy/mixed ne bougent pas. Seule l'entrée dans `evaluatePathQuality` est interceptée avant `classifySmoothness`.

## Test plan

- [ ] Symboles Asie (000500, 600322) affichent ⚪ quand marché fermé
- [ ] Symboles US actifs continuent d'afficher 🟢/🟡/🔴 normalement
- [ ] `overallSmoothness` d'un candidat avec ≥1 TF actif (non-idle) n'est pas `idle`

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_