### PR TITLE
fix(rr): aligne persistPaperTrade sur les stops actifs + expose tpPct/slPct/rrRatio

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -160,6 +160,21 @@ export class LisaController {
 
     const supabase = this.supabase.getClient();
 
+    // Read TP/SL and maxPositions from DB (single read, reused below).
+    const { data: cfgRow } = await supabase
+      .from('lisa_session_configs')
+      .select('gainers_default_tp_pct, gainers_default_sl_pct, max_open_positions')
+      .eq('portfolio_id', portfolioId)
+      .maybeSingle();
+    const tpPct = cfgRow?.gainers_default_tp_pct != null
+      ? Math.max(0.1, Math.min(50, Number(cfgRow.gainers_default_tp_pct)))
+      : 1.5;
+    const slPct = cfgRow?.gainers_default_sl_pct != null
+      ? Math.max(0.1, Math.min(20, Number(cfgRow.gainers_default_sl_pct)))
+      : 1.0;
+    const rrRatio = parseFloat((tpPct / slPct).toFixed(2));
+    const maxPositions: number = cfgRow?.max_open_positions ?? 3;
+
     const { count: openCount } = await supabase
       .from('lisa_positions')
       .select('*', { count: 'exact', head: true })
@@ -206,7 +221,10 @@ export class LisaController {
       nextTickInSeconds,
       intervalMinutes,
       openPositions: openCount ?? 0,
-      maxPositions: 3,
+      maxPositions,
+      tpPct,
+      slPct,
+      rrRatio,
       sessionPnlUsd,
       lastCandidates,
     };

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -1249,7 +1249,7 @@ export class TopGainersScannerService implements OnModuleInit {
       // P8 — best-effort persist du snapshot persistance dans paper_trades
       // (forward-compat avec P9 qui ajoutera features_at_entry / p_win).
       if (persistence) {
-        await this.persistPaperTrade(userId, portfolioId, cand, openedPos, persistence)
+        await this.persistPaperTrade(userId, portfolioId, cand, openedPos, persistence, effectiveTp, effectiveSl)
           .catch((e) =>
             this.logger.debug(`[top-gainers] persistPaperTrade ${cand.symbol} failed: ${String(e).slice(0, 120)}`),
           );
@@ -1265,6 +1265,8 @@ export class TopGainersScannerService implements OnModuleInit {
   /**
    * P8 — Insert append-only dans paper_trades. Ne fait pas échouer le flow
    * principal en cas de pb (best effort, table optionnelle ce PR).
+   * tpPct/slPct : valeurs effectives depuis DB (gainers_default_tp/sl_pct),
+   * alignées avec les stops actifs dans openTopGainerPosition.
    */
   private async persistPaperTrade(
     userId: string,
@@ -1272,11 +1274,13 @@ export class TopGainersScannerService implements OnModuleInit {
     cand: TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass },
     openedPos: { id: string; entryPrice?: string | number; entryNotionalUsd?: string | number },
     persistence: PersistenceResult,
+    tpPct: number,
+    slPct: number,
   ): Promise<void> {
     const entryPrice = Number(openedPos.entryPrice ?? cand.close);
     const sizeUsd = Number(openedPos.entryNotionalUsd ?? 0);
-    const stopLoss = entryPrice * (1 - 0.015);
-    const takeProfit = entryPrice * (1 + 0.03);
+    const stopLoss = entryPrice * (1 - slPct / 100);
+    const takeProfit = entryPrice * (1 + tpPct / 100);
     const tfChanges = {
       tf1m: persistence.tf1m,
       tf5m: persistence.tf5m,

--- a/apps/web/src/hooks/use-operating-mode.ts
+++ b/apps/web/src/hooks/use-operating-mode.ts
@@ -45,6 +45,10 @@ export interface GainersStatus {
   intervalMinutes: number;
   openPositions: number;
   maxPositions: number;
+  /** TP/SL effectifs lus depuis lisa_session_configs (DB), fallback 1.5/1.0 si absent. */
+  tpPct: number;
+  slPct: number;
+  rrRatio: number;
   sessionPnlUsd: number;
   lastCandidates: Array<{ symbol: string; changePct: number; score: number }>;
 }


### PR DESCRIPTION
## Problème

`persistPaperTrade` hardcodait `stopLoss = entry * (1 - 0.015)` et `takeProfit = entry * (1 + 0.03)` → R/R 1:2 stocké dans `paper_trades`.  
`openTopGainerPosition` utilisait les valeurs DB (`gainers_default_tp_pct` / `gainers_default_sl_pct`, defaults 1.5%/1.0%) → R/R 1:1.5 sur les stops actifs.

Les deux couches divergeaient silencieusement. `paper_trades` (source de vérité pour backtests P9) était pollué avec des stops fictifs.

## Fix

- **`top-gainers-scanner.service.ts`** : `persistPaperTrade` accepte désormais `tpPct` et `slPct` comme paramètres. Calcule `stopLoss = entry * (1 - slPct/100)` et `takeProfit = entry * (1 + tpPct/100)`. L'appelant `openTopGainerPosition` passe les valeurs `effectiveTp`/`effectiveSl` déjà résolues depuis la DB.
- **`lisa.controller.ts`** : `GET /lisa/gainers-status/:portfolioId` lit `gainers_default_tp_pct`, `gainers_default_sl_pct`, `max_open_positions` depuis DB. Retourne `tpPct`, `slPct`, `rrRatio` (calculé). `maxPositions` n'est plus hardcodé à `3`.
- **`use-operating-mode.ts`** : `GainersStatus` interface étendue avec `tpPct`, `slPct`, `rrRatio`.

## Prêt pour RRDisplay

L'endpoint expose désormais les valeurs nécessaires au composant `RRDisplay` (read-only dans la config gainers) — pas créé dans ce PR.

## Test plan

- [ ] `paper_trades.stop_loss` et `take_profit` cohérents avec les stops actifs (`lisa_positions`)
- [ ] `/lisa/gainers-status/:id` retourne `tpPct: 1.5`, `slPct: 1.0`, `rrRatio: 1.5` (avec valeurs DB par défaut)
- [ ] `maxPositions` reflète `max_open_positions` en DB (pas toujours 3)

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_