### PR TITLE
feat(gainers-observability): /admin/gainers/scanner-status read-only endpoint

### DIFF
--- a/apps/api/src/modules/admin/admin-gainers-status.controller.ts
+++ b/apps/api/src/modules/admin/admin-gainers-status.controller.ts
@@ -1,0 +1,47 @@
+/**
+ * GET /admin/gainers/scanner-status — observability read-only du scanner Gainers.
+ *
+ * Expose l'état diagnostique sans flyctl logs : quelle est la dernière raison
+ * d'early-return, quels exchanges ont retourné quoi, état des kill-switches,
+ * config courante des portfolios actifs, compteurs 24h.
+ *
+ * N'influence ni le scoring, ni les seuils, ni la logique d'open/close.
+ *
+ * Auth : header `x-admin-token` aligné sur le pattern AdminEodhdStatusController.
+ */
+
+import { Controller, Get, Headers, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { TopGainersScannerService } from '../lisa/services/top-gainers-scanner.service';
+
+@Controller('admin/gainers/scanner-status')
+export class AdminGainersStatusController {
+  private readonly logger = new Logger(AdminGainersStatusController.name);
+
+  constructor(
+    private readonly scanner: TopGainersScannerService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Get()
+  async getStatus(@Headers('x-admin-token') providedToken: string | undefined) {
+    this.assertAdmin(providedToken);
+    return this.scanner.getStatus();
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (providedToken !== expected) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'ADMIN_FORBIDDEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -18,6 +18,7 @@ import { AdminMigrationsController } from './admin-migrations.controller';
 import { AdminSupabaseQueryController } from './admin-supabase-query.controller';
 import { AdminLogsController } from './admin-logs.controller';
 import { AdminEodhdStatusController } from './admin-eodhd-status.controller';
+import { AdminGainersStatusController } from './admin-gainers-status.controller';
 
 @Module({
   imports: [SupabaseModule, forwardRef(() => LisaModule)],
@@ -26,6 +27,7 @@ import { AdminEodhdStatusController } from './admin-eodhd-status.controller';
     AdminSupabaseQueryController,
     AdminLogsController,
     AdminEodhdStatusController,
+    AdminGainersStatusController,
   ],
 })
 export class AdminModule {}

--- a/apps/api/src/modules/lisa/services/gainers-scanner-status.types.ts
+++ b/apps/api/src/modules/lisa/services/gainers-scanner-status.types.ts
@@ -1,0 +1,71 @@
+/**
+ * Observability — état diagnostique du scanner Gainers exposé via
+ * GET /admin/gainers/scanner-status. Strictement read-only : aucun de ces
+ * types n'influence le scoring, les seuils, ni la logique de trade.
+ */
+
+export type EarlyReturnReason =
+  | 'scanner_paused'
+  | 'configs_fetch_error'
+  | 'no_active_portfolio'
+  | 'no_candidates_fetched'
+  | 'candidates_fetched_but_none_selected'
+  | 'persist_log_failed'
+  | 'upstream_provider_error';
+
+export const EARLY_RETURN_REASONS: readonly EarlyReturnReason[] = [
+  'scanner_paused',
+  'configs_fetch_error',
+  'no_active_portfolio',
+  'no_candidates_fetched',
+  'candidates_fetched_but_none_selected',
+  'persist_log_failed',
+  'upstream_provider_error',
+] as const;
+
+export interface PerExchangeResult {
+  count: number;
+  lastError?: string;
+  at: string;
+}
+
+export interface ConfigSnapshot {
+  portfolio_id: string;
+  gainers_cycle_minutes: number | null;
+  gainers_min_persistence_score: number | null;
+  gainers_min_path_efficiency: number | null;
+  gainers_default_tp_pct: number | null;
+  gainers_default_sl_pct: number | null;
+}
+
+export interface GainersScannerStatus {
+  /** Dernier tick (succès ou skip — distingué via lastEarlyReturn). */
+  lastTickAt: string | null;
+  /** Début d'un cycle (avant tout early return). */
+  lastCycleStartedAt: string | null;
+  /** Fin d'un cycle SANS early return (pipeline complet). */
+  lastCycleCompletedAt: string | null;
+  /** Si != null, le dernier cycle s'est arrêté tôt avec cette raison. */
+  lastEarlyReturn: { reason: EarlyReturnReason; at: string; details?: string } | null;
+
+  /** État des kill-switches env qui peuvent figer le scanner sans deploy. */
+  secrets: {
+    scannerPause: boolean;
+    multiTfPause: boolean;
+    eodhdApiKeySet: boolean;
+  };
+
+  lastFetchAllCandidates: { count: number; fromCache: boolean; at: string } | null;
+  lastTopGainersSelected: { count: number; at: string } | null;
+  perExchangeLastResult: Record<string, PerExchangeResult>;
+  lastPersistLogAttempt: { count: number; at: string; error?: string } | null;
+
+  activeGainersPortfoliosCount: number;
+  activeGainersPortfolioIds: string[];
+  currentConfigSnapshot: ConfigSnapshot[];
+
+  cyclesLast24h: number;
+  earlyReturnsLast24hByReason: Record<EarlyReturnReason, number>;
+  /** Timestamp du dernier cycle qui a atteint la fin sans early return. */
+  lastSuccessfulCompleteAt: string | null;
+}

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -38,6 +38,12 @@ import {
   type PersistenceResult,
   isWithinSession,
 } from '@smartvest/ai-analyst';
+import {
+  EARLY_RETURN_REASONS,
+  type EarlyReturnReason,
+  type GainersScannerStatus,
+  type PerExchangeResult,
+} from './gainers-scanner-status.types';
 
 interface EodhdScreenerRow {
   code: string;
@@ -185,6 +191,155 @@ export class TopGainersScannerService implements OnModuleInit {
    */
   private allCandidatesCache: { candidates: TopGainerCandidate[]; asOf: number } | null = null;
   private readonly ALL_CANDIDATES_CACHE_TTL_MS = 15 * 60_000; // 15 min
+
+  // ─────────────────────────────────────────────────────────────────
+  // Observability — état diagnostique read-only exposé via
+  // GET /admin/gainers/scanner-status. N'influence pas la logique scanner.
+  // ─────────────────────────────────────────────────────────────────
+  private lastCycleStartedAt: Date | null = null;
+  private lastCycleCompletedAt: Date | null = null;
+  private lastSuccessfulCompleteAt: Date | null = null;
+  private lastEarlyReturn: { reason: EarlyReturnReason; at: Date; details?: string } | null = null;
+  private lastFetchAllCandidatesInfo: { count: number; fromCache: boolean; at: Date } | null = null;
+  private lastTopGainersSelected: { count: number; at: Date } | null = null;
+  private perExchangeLastResult = new Map<string, { count: number; lastError?: string; at: Date }>();
+  private lastPersistLogAttempt: { count: number; at: Date; error?: string } | null = null;
+  /** Ring buffer 24h des starts de cycle (pour count). */
+  private cyclesLast24h: Date[] = [];
+  /** Ring buffer 24h des early returns (pour breakdown by reason). */
+  private earlyReturnsLast24h: Array<{ reason: EarlyReturnReason; at: Date }> = [];
+
+  private recordCycleStart(): void {
+    const at = new Date();
+    this.lastCycleStartedAt = at;
+    this.cyclesLast24h.push(at);
+    this.pruneOld24h();
+  }
+
+  private recordCycleComplete(success: boolean): void {
+    const at = new Date();
+    this.lastCycleCompletedAt = at;
+    if (success) this.lastSuccessfulCompleteAt = at;
+  }
+
+  private recordEarlyReturn(reason: EarlyReturnReason, details?: string): void {
+    const at = new Date();
+    this.lastEarlyReturn = details !== undefined ? { reason, at, details } : { reason, at };
+    this.earlyReturnsLast24h.push({ reason, at });
+    this.pruneOld24h();
+  }
+
+  private recordFetchAllCandidates(count: number, fromCache: boolean): void {
+    this.lastFetchAllCandidatesInfo = { count, fromCache, at: new Date() };
+  }
+
+  private recordTopSelected(count: number): void {
+    this.lastTopGainersSelected = { count, at: new Date() };
+  }
+
+  private recordExchangeResult(exchange: string, count: number, error?: string): void {
+    const entry = error !== undefined
+      ? { count, lastError: error, at: new Date() }
+      : { count, at: new Date() };
+    this.perExchangeLastResult.set(exchange, entry);
+  }
+
+  private recordPersistLogAttempt(count: number, error?: string): void {
+    this.lastPersistLogAttempt = error !== undefined
+      ? { count, at: new Date(), error }
+      : { count, at: new Date() };
+  }
+
+  private pruneOld24h(): void {
+    const cutoff = Date.now() - 24 * 60 * 60_000;
+    this.cyclesLast24h = this.cyclesLast24h.filter((d) => d.getTime() >= cutoff);
+    this.earlyReturnsLast24h = this.earlyReturnsLast24h.filter((r) => r.at.getTime() >= cutoff);
+  }
+
+  /**
+   * Retourne le snapshot diagnostic complet pour /admin/gainers/scanner-status.
+   * Read-only. Exécute 1 SELECT light sur lisa_session_configs pour extraire
+   * la config courante des portfolios actifs.
+   */
+  async getStatus(): Promise<GainersScannerStatus> {
+    this.pruneOld24h();
+    const earlyReturnsByReason: Record<EarlyReturnReason, number> = EARLY_RETURN_REASONS
+      .reduce((acc, r) => ({ ...acc, [r]: 0 }), {} as Record<EarlyReturnReason, number>);
+    for (const r of this.earlyReturnsLast24h) {
+      earlyReturnsByReason[r.reason] = (earlyReturnsByReason[r.reason] ?? 0) + 1;
+    }
+
+    const { data: configRows } = await this.supabase
+      .getClient()
+      .from('lisa_session_configs')
+      .select('portfolio_id, gainers_cycle_minutes, gainers_min_persistence_score, gainers_min_path_efficiency, gainers_default_tp_pct, gainers_default_sl_pct')
+      .eq('strategy_mode', 'gainers')
+      .eq('autopilot_enabled', true)
+      .eq('kill_switch_active', false);
+
+    const activeIds = (configRows ?? []).map((r) => String(r.portfolio_id));
+
+    const perExchange: Record<string, PerExchangeResult> = {};
+    for (const [ex, info] of this.perExchangeLastResult.entries()) {
+      perExchange[ex] = {
+        count: info.count,
+        at: info.at.toISOString(),
+        ...(info.lastError !== undefined ? { lastError: info.lastError } : {}),
+      };
+    }
+
+    const scannerPause = (this.config.get<string>('SCANNER_PAUSE') ?? 'false').toLowerCase() === 'true';
+    const multiTfPause = (this.config.get<string>('MULTITF_PAUSE') ?? 'false').toLowerCase() === 'true';
+    const eodhdApiKeySet = !!this.config.get<string>('EODHD_API_KEY');
+
+    return {
+      lastTickAt: this.lastTickAt ? this.lastTickAt.toISOString() : null,
+      lastCycleStartedAt: this.lastCycleStartedAt ? this.lastCycleStartedAt.toISOString() : null,
+      lastCycleCompletedAt: this.lastCycleCompletedAt ? this.lastCycleCompletedAt.toISOString() : null,
+      lastEarlyReturn: this.lastEarlyReturn
+        ? {
+            reason: this.lastEarlyReturn.reason,
+            at: this.lastEarlyReturn.at.toISOString(),
+            ...(this.lastEarlyReturn.details !== undefined ? { details: this.lastEarlyReturn.details } : {}),
+          }
+        : null,
+      secrets: { scannerPause, multiTfPause, eodhdApiKeySet },
+      lastFetchAllCandidates: this.lastFetchAllCandidatesInfo
+        ? {
+            count: this.lastFetchAllCandidatesInfo.count,
+            fromCache: this.lastFetchAllCandidatesInfo.fromCache,
+            at: this.lastFetchAllCandidatesInfo.at.toISOString(),
+          }
+        : null,
+      lastTopGainersSelected: this.lastTopGainersSelected
+        ? {
+            count: this.lastTopGainersSelected.count,
+            at: this.lastTopGainersSelected.at.toISOString(),
+          }
+        : null,
+      perExchangeLastResult: perExchange,
+      lastPersistLogAttempt: this.lastPersistLogAttempt
+        ? {
+            count: this.lastPersistLogAttempt.count,
+            at: this.lastPersistLogAttempt.at.toISOString(),
+            ...(this.lastPersistLogAttempt.error !== undefined ? { error: this.lastPersistLogAttempt.error } : {}),
+          }
+        : null,
+      activeGainersPortfoliosCount: activeIds.length,
+      activeGainersPortfolioIds: activeIds,
+      currentConfigSnapshot: (configRows ?? []).map((r) => ({
+        portfolio_id: String(r.portfolio_id),
+        gainers_cycle_minutes: r.gainers_cycle_minutes != null ? Number(r.gainers_cycle_minutes) : null,
+        gainers_min_persistence_score: r.gainers_min_persistence_score != null ? Number(r.gainers_min_persistence_score) : null,
+        gainers_min_path_efficiency: r.gainers_min_path_efficiency != null ? Number(r.gainers_min_path_efficiency) : null,
+        gainers_default_tp_pct: r.gainers_default_tp_pct != null ? Number(r.gainers_default_tp_pct) : null,
+        gainers_default_sl_pct: r.gainers_default_sl_pct != null ? Number(r.gainers_default_sl_pct) : null,
+      })),
+      cyclesLast24h: this.cyclesLast24h.length,
+      earlyReturnsLast24hByReason: earlyReturnsByReason,
+      lastSuccessfulCompleteAt: this.lastSuccessfulCompleteAt ? this.lastSuccessfulCompleteAt.toISOString() : null,
+    };
+  }
 
   constructor(
     private readonly supabase: SupabaseService,
@@ -378,6 +533,7 @@ export class TopGainersScannerService implements OnModuleInit {
   }
 
   private async runScannerInner(): Promise<void> {
+    this.recordCycleStart();
     // P19v (30/04/2026 09:00 UTC) — SCANNER_PAUSE feature flag.
     // Émergency kill-switch sans deploy : `flyctl secrets set SCANNER_PAUSE=true`.
     // Pause le scanner cron + les calls EODHD screener associés. Permet d'éponger
@@ -386,6 +542,7 @@ export class TopGainersScannerService implements OnModuleInit {
     const scannerPaused = (this.config.get<string>('SCANNER_PAUSE') ?? 'false').toLowerCase() === 'true';
     if (scannerPaused) {
       this.logger.log('[top-gainers] SCANNER_PAUSE=true — cycle skipped');
+      this.recordEarlyReturn('scanner_paused');
       return;
     }
 
@@ -399,6 +556,7 @@ export class TopGainersScannerService implements OnModuleInit {
       .eq('kill_switch_active', false);
     if (dbErr) {
       this.logger.error(`[top-gainers] fetch configs (db) failed: ${dbErr.message}`);
+      this.recordEarlyReturn('configs_fetch_error', dbErr.message);
       return;
     }
 
@@ -416,6 +574,7 @@ export class TopGainersScannerService implements OnModuleInit {
         .eq('kill_switch_active', false);
       if (envErr) {
         this.logger.error(`[top-gainers] fetch configs (env fallback) failed: ${envErr.message}`);
+        this.recordEarlyReturn('configs_fetch_error', envErr.message);
         return;
       }
       configs = envConfigs ?? [];
@@ -431,6 +590,7 @@ export class TopGainersScannerService implements OnModuleInit {
         '[top-gainers] no active portfolio with strategy_mode=gainers AND autopilot_enabled=true — scanner cycle skipped. ' +
         'Activate via POST /lisa/mode/:portfolioId {mode:"gainers"} or set STRATEGY_MODE=top_gainers env.',
       );
+      this.recordEarlyReturn('no_active_portfolio');
       return;
     }
 
@@ -438,10 +598,12 @@ export class TopGainersScannerService implements OnModuleInit {
     const candidates = await this.fetchAllCandidates();
     if (candidates.length === 0) {
       this.logger.warn('[top-gainers] 0 candidate fetched — skip cycle');
+      this.recordEarlyReturn('no_candidates_fetched');
       return;
     }
 
     const top = selectTopGainers(candidates, 3);
+    this.recordTopSelected(top.length);
     this.logger.log(
       `[top-gainers] ${candidates.length} scanned → ${top.length} retained: ${top.map((t) => `${t.symbol}(${t.assetClass},${t.changePct.toFixed(1)}%,score=${t.score})`).join(', ')}`,
     );
@@ -449,7 +611,10 @@ export class TopGainersScannerService implements OnModuleInit {
     // Persist log entries pour les top retenus + filtered samples (audit)
     await this.persistLog(candidates, top);
 
-    if (top.length === 0) return;
+    if (top.length === 0) {
+      this.recordEarlyReturn('candidates_fetched_but_none_selected');
+      return;
+    }
 
     // P18 — LLM re-ranking (inert when SCANNER_LLM_ROUTER_ENABLED=false)
     const rankedTop = await this.rankCandidates(top);
@@ -473,6 +638,7 @@ export class TopGainersScannerService implements OnModuleInit {
         );
       }
     }
+    this.recordCycleComplete(true);
   }
 
   /**
@@ -558,6 +724,7 @@ export class TopGainersScannerService implements OnModuleInit {
       this.allCandidatesCache
       && now.getTime() - this.allCandidatesCache.asOf < this.ALL_CANDIDATES_CACHE_TTL_MS
     ) {
+      this.recordFetchAllCandidates(this.allCandidatesCache.candidates.length, true);
       return this.allCandidatesCache.candidates;
     }
     const apiKey = this.config.get<string>('EODHD_API_KEY');
@@ -570,10 +737,18 @@ export class TopGainersScannerService implements OnModuleInit {
       // fix UPPERCASE + change_p).
       for (const ex of NON_EU_EXCHANGES) {
         tasks.push(
-          this.fetchEodhdScreener(ex, apiKey).catch((e) => {
-            this.logger.warn(`[top-gainers] ${ex} failed: ${e?.message ?? String(e)}`);
-            return [];
-          }),
+          this.fetchEodhdScreener(ex, apiKey)
+            .then((rows) => {
+              this.recordExchangeResult(ex, rows.length);
+              return rows;
+            })
+            .catch((e) => {
+              const msg = e?.message ?? String(e);
+              this.logger.warn(`[top-gainers] ${ex} failed: ${msg}`);
+              this.recordExchangeResult(ex, 0, msg);
+              this.recordEarlyReturn('upstream_provider_error', `${ex}: ${msg.slice(0, 80)}`);
+              return [];
+            }),
         );
       }
 
@@ -601,7 +776,18 @@ export class TopGainersScannerService implements OnModuleInit {
     }
 
     // Crypto via Binance
-    tasks.push(this.fetchBinanceGainers().catch(() => []));
+    tasks.push(
+      this.fetchBinanceGainers()
+        .then((rows) => {
+          this.recordExchangeResult('BINANCE', rows.length);
+          return rows;
+        })
+        .catch((e) => {
+          const msg = e?.message ?? String(e);
+          this.recordExchangeResult('BINANCE', 0, msg);
+          return [];
+        }),
+    );
 
     const results = await Promise.allSettled(tasks);
     const merged = results
@@ -622,6 +808,7 @@ export class TopGainersScannerService implements OnModuleInit {
     // P19s++ — Cache fill (TTL 15min). Permet aux UI polls et au cron scanner
     // de partager la même fetch sans re-frapper EODHD.
     this.allCandidatesCache = { candidates: deduped, asOf: now.getTime() };
+    this.recordFetchAllCandidates(deduped.length, false);
     return deduped;
   }
 
@@ -1474,9 +1661,18 @@ export class TopGainersScannerService implements OnModuleInit {
         decision: 'filtered',
       });
     }
-    if (rows.length === 0) return;
+    if (rows.length === 0) {
+      this.recordPersistLogAttempt(0);
+      return;
+    }
     const { error } = await this.supabase.getClient().from('top_gainers_log').insert(rows);
-    if (error) this.logger.debug(`[top-gainers] persistLog failed: ${error.message}`);
+    if (error) {
+      this.logger.debug(`[top-gainers] persistLog failed: ${error.message}`);
+      this.recordPersistLogAttempt(rows.length, error.message);
+      this.recordEarlyReturn('persist_log_failed', error.message);
+    } else {
+      this.recordPersistLogAttempt(rows.length);
+    }
   }
 
   /**


### PR DESCRIPTION
## Périmètre — strictement read-only

**Aucun** changement de scoring, seuils, logique open/close, ni migration DB. L'endpoint expose uniquement de la diagnostic state déjà calculée par le scanner.

## Pourquoi

Sans `flyctl logs` accessible depuis l'environnement de session, on ne peut pas diagnostiquer pourquoi `top_gainers_log` reste vide. Cet endpoint permet d'identifier la cause exacte via un enum stable au lieu de strings libres.

## Endpoint

```
GET /admin/gainers/scanner-status
Header: x-admin-token: $ADMIN_TOKEN
```

Pattern auth aligné sur `AdminEodhdStatusController`.

## Payload `GainersScannerStatus`

| Champ | Type | Source |
|---|---|---|
| `lastTickAt` | ISO string \| null | Existant |
| `lastCycleStartedAt` / `lastCycleCompletedAt` | ISO string \| null | Nouveau tracking |
| `lastEarlyReturn.{reason,at,details?}` | enum + ISO + optional | Nouveau |
| `secrets.{scannerPause,multiTfPause,eodhdApiKeySet}` | bool | env reads |
| `lastFetchAllCandidates.{count,fromCache,at}` | tracking | Nouveau |
| `lastTopGainersSelected.{count,at}` | tracking | Nouveau |
| `perExchangeLastResult` | `Record<exchange, {count,lastError?,at}>` | Nouveau |
| `lastPersistLogAttempt.{count,at,error?}` | tracking | Nouveau |
| `activeGainersPortfoliosCount` + `activeGainersPortfolioIds` | DB read | Nouveau |
| `currentConfigSnapshot` | DB read | Nouveau (cycle, persist score, path eff, TP, SL) |
| `cyclesLast24h` | int | Ring buffer 24h |
| `earlyReturnsLast24hByReason` | `Record<reason, count>` | Ring buffer 24h |
| `lastSuccessfulCompleteAt` | ISO \| null | Nouveau |

## Enum `EarlyReturnReason` (7 valeurs stables)

```ts
| 'scanner_paused'                          // SCANNER_PAUSE env active
| 'configs_fetch_error'                     // DB error sur SELECT lisa_session_configs
| 'no_active_portfolio'                     // 0 portfolio strategy_mode='gainers' actif
| 'no_candidates_fetched'                   // fetchAllCandidates retourne 0
| 'candidates_fetched_but_none_selected'    // selectTopGainers retourne 0 sur >0 candidats
| 'persist_log_failed'                      // DB error sur INSERT top_gainers_log
| 'upstream_provider_error'                 // EODHD/Binance call failed (per-exchange)
```

## Diagnostique attendu

Une fois mergé + déployé Fly, lancer :
```bash
curl -H "x-admin-token: $ADMIN_TOKEN" https://smartvest.fly.dev/admin/gainers/scanner-status | jq
```

Lecture de `lastEarlyReturn.reason` tranche immédiatement la cause :
- `no_candidates_fetched` → regarder `perExchangeLastResult.US.lastError` (EODHD 402/422 etc.)
- `persist_log_failed` → regarder `lastPersistLogAttempt.error` (DB constraint, RLS, etc.)
- `candidates_fetched_but_none_selected` → `selectTopGainers` trop strict (filtre `changePct > 3`)
- `scanner_paused` / `no_active_portfolio` → kill-switch ou config user

## Test plan

- [ ] Endpoint retourne 403 sans `x-admin-token`
- [ ] Endpoint retourne 403 avec mauvais token
- [ ] Endpoint retourne JSON valide avec bon token
- [ ] Après 1 cycle scanner réel, `lastFetchAllCandidates.at` est récent
- [ ] Si `SCANNER_PAUSE=true`, `lastEarlyReturn.reason === 'scanner_paused'`

## Hors périmètre (séquencement utilisateur)

- ❌ UI form TP/SL gainers (PR follow-up step 2)
- ❌ Découplage module ADR (step 3+)
- ❌ Algo V1 (RVOL/VWAP/ORB) (step 6+)
- ❌ Changement de seuil `gainers_min_path_efficiency` (interdit avant diagnostic)

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_