### PR TITLE
feat(gainers): module skeleton gainers-scanner — ADR-005 Step 4

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -30,6 +30,7 @@ import { StrategyOptimizerModule } from './modules/strategy-optimizer/optimizer.
 import { MonteCarloModule } from './modules/monte-carlo/monte-carlo.module';
 import { AdminModule } from './modules/admin/admin.module';
 import { MeModule } from './modules/me/me.module';
+import { GainersModule } from './modules/gainers-scanner';
 
 @Module({
   imports: [
@@ -70,6 +71,7 @@ import { MeModule } from './modules/me/me.module';
     MonteCarloModule,
     AdminModule,
     MeModule,
+    GainersModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
@@ -5,35 +5,35 @@
 
 describe.skip('GainersBloc1 — prefilter gates', () => {
   describe('liquidity floor', () => {
-    it('rejects equity candidate below $10M median daily vol');
-    it('rejects crypto candidate below $50M 24h vol');
-    it('accepts equity candidate at exactly $10M');
+    it.todo('rejects equity candidate below $10M median daily vol');
+    it.todo('rejects crypto candidate below $50M 24h vol');
+    it.todo('accepts equity candidate at exactly $10M');
   });
 
   describe('market cap minimum', () => {
-    it('rejects equity below $300M');
-    it('rejects crypto below $500M');
-    it('accepts equity at exactly $300M');
+    it.todo('rejects equity below $300M');
+    it.todo('rejects crypto below $500M');
+    it.todo('accepts equity at exactly $300M');
   });
 
   describe('volatility clamp', () => {
-    it('rejects candidate with ATR(14)/close > 0.15');
-    it('accepts candidate with ATR(14)/close = 0.15');
+    it.todo('rejects candidate with ATR(14)/close > 0.15');
+    it.todo('accepts candidate with ATR(14)/close = 0.15');
   });
 
   describe('RVOL cumulative intraday', () => {
-    it('computes vol_open→now / avg_same_window_20_trading_days for equity');
-    it('computes vol_00:00→now for crypto');
-    it('rejects candidate below RVOL threshold');
+    it.todo('computes vol_open→now / avg_same_window_20_trading_days for equity');
+    it.todo('computes vol_00:00→now for crypto');
+    it.todo('rejects candidate below RVOL threshold');
   });
 
   describe('persistence gate', () => {
-    it('rejects candidate with persistenceScore below gainers_min_persistence_score');
-    it('accepts candidate with score >= threshold');
+    it.todo('rejects candidate with persistenceScore below gainers_min_persistence_score');
+    it.todo('accepts candidate with score >= threshold');
   });
 
   describe('composite scorer', () => {
-    it('returns compositeScore in [0, 1] for ACCEPT candidates');
-    it('returns null compositeScore for REJECT candidates');
+    it.todo('returns compositeScore in [0, 1] for ACCEPT candidates');
+    it.todo('returns null compositeScore for REJECT candidates');
   });
 });

--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * BLOC 1 — Scoring + prefilter gates.
+ * Stubs créés en PR1 skeleton. Implémentation dans PR2.
+ */
+
+describe.skip('GainersBloc1 — prefilter gates', () => {
+  describe('liquidity floor', () => {
+    it('rejects equity candidate below $10M median daily vol');
+    it('rejects crypto candidate below $50M 24h vol');
+    it('accepts equity candidate at exactly $10M');
+  });
+
+  describe('market cap minimum', () => {
+    it('rejects equity below $300M');
+    it('rejects crypto below $500M');
+    it('accepts equity at exactly $300M');
+  });
+
+  describe('volatility clamp', () => {
+    it('rejects candidate with ATR(14)/close > 0.15');
+    it('accepts candidate with ATR(14)/close = 0.15');
+  });
+
+  describe('RVOL cumulative intraday', () => {
+    it('computes vol_open→now / avg_same_window_20_trading_days for equity');
+    it('computes vol_00:00→now for crypto');
+    it('rejects candidate below RVOL threshold');
+  });
+
+  describe('persistence gate', () => {
+    it('rejects candidate with persistenceScore below gainers_min_persistence_score');
+    it('accepts candidate with score >= threshold');
+  });
+
+  describe('composite scorer', () => {
+    it('returns compositeScore in [0, 1] for ACCEPT candidates');
+    it('returns null compositeScore for REJECT candidates');
+  });
+});

--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc2.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc2.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * BLOC 2 — Baselines + spread proxy + universe guard.
+ * Stubs créés en PR1 skeleton. Implémentation dans PR3.
+ */
+
+describe.skip('GainersBloc2 — baselines & spread proxy', () => {
+  describe('spread proxy', () => {
+    it('computes HL_1M_MEDIAN = median((H-L)*0.5/close) over 5 last 1m candles');
+    it('computes HL_5M_MEDIAN for equity when 1m not available');
+    it('falls back to STATIC_CAP_FALLBACK when < 3/5 candles have vol > 0');
+    it('rejects candidate with spread proxy > 0.30%');
+    it('caps spread at 0.30% for static fallback source');
+  });
+
+  describe('trend filter EMA Golden Cross', () => {
+    it('returns EMA_GOLDEN_CROSS when EMA50 daily > EMA200 daily');
+    it('returns TREND_FILTER_FAIL rejection when EMA50 < EMA200');
+    it('returns NONE when trend filter disabled in config');
+  });
+
+  describe('volume baselines', () => {
+    it('loads medianDailyVol20d from gainers_volume_baselines table');
+    it('skips candidate when baseline missing and vol not computable live');
+  });
+
+  describe('universe guard', () => {
+    it('computes watchlist_hash = SHA256(sorted symbols)');
+    it('rejects candidate absent from non-regression universe');
+    it('emits drift warning when hash mismatch detected');
+  });
+});

--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc2.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc2.spec.ts
@@ -5,27 +5,27 @@
 
 describe.skip('GainersBloc2 — baselines & spread proxy', () => {
   describe('spread proxy', () => {
-    it('computes HL_1M_MEDIAN = median((H-L)*0.5/close) over 5 last 1m candles');
-    it('computes HL_5M_MEDIAN for equity when 1m not available');
-    it('falls back to STATIC_CAP_FALLBACK when < 3/5 candles have vol > 0');
-    it('rejects candidate with spread proxy > 0.30%');
-    it('caps spread at 0.30% for static fallback source');
+    it.todo('computes HL_1M_MEDIAN = median((H-L)*0.5/close) over 5 last 1m candles');
+    it.todo('computes HL_5M_MEDIAN for equity when 1m not available');
+    it.todo('falls back to STATIC_CAP_FALLBACK when < 3/5 candles have vol > 0');
+    it.todo('rejects candidate with spread proxy > 0.30%');
+    it.todo('caps spread at 0.30% for static fallback source');
   });
 
   describe('trend filter EMA Golden Cross', () => {
-    it('returns EMA_GOLDEN_CROSS when EMA50 daily > EMA200 daily');
-    it('returns TREND_FILTER_FAIL rejection when EMA50 < EMA200');
-    it('returns NONE when trend filter disabled in config');
+    it.todo('returns EMA_GOLDEN_CROSS when EMA50 daily > EMA200 daily');
+    it.todo('returns TREND_FILTER_FAIL rejection when EMA50 < EMA200');
+    it.todo('returns NONE when trend filter disabled in config');
   });
 
   describe('volume baselines', () => {
-    it('loads medianDailyVol20d from gainers_volume_baselines table');
-    it('skips candidate when baseline missing and vol not computable live');
+    it.todo('loads medianDailyVol20d from gainers_volume_baselines table');
+    it.todo('skips candidate when baseline missing and vol not computable live');
   });
 
   describe('universe guard', () => {
-    it('computes watchlist_hash = SHA256(sorted symbols)');
-    it('rejects candidate absent from non-regression universe');
-    it('emits drift warning when hash mismatch detected');
+    it.todo('computes watchlist_hash = SHA256(sorted symbols)');
+    it.todo('rejects candidate absent from non-regression universe');
+    it.todo('emits drift warning when hash mismatch detected');
   });
 });

--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc3.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc3.spec.ts
@@ -5,24 +5,24 @@
 
 describe.skip('GainersBloc3 — entry triggers', () => {
   describe('pullback_HL_fibo', () => {
-    it('detects swing high N=5 (Bulkowski)');
-    it('detects swing low N=5');
-    it('validates retracement within 38.2–61.8% Fibonacci range');
-    it('rejects retracement below 38.2%');
-    it('rejects retracement above 61.8%');
-    it('emits PULLBACK_HL_FIBO signal with fiboLevel, swingHigh, swingLow');
+    it.todo('detects swing high N=5 (Bulkowski)');
+    it.todo('detects swing low N=5');
+    it.todo('validates retracement within 38.2–61.8% Fibonacci range');
+    it.todo('rejects retracement below 38.2%');
+    it.todo('rejects retracement above 61.8%');
+    it.todo('emits PULLBACK_HL_FIBO signal with fiboLevel, swingHigh, swingLow');
   });
 
   describe('vwap_reclaim', () => {
-    it('detects price crossing above VWAP intraday');
-    it('confirms EMA50 daily > EMA200 daily at signal');
-    it('emits VWAP_RECLAIM signal with vwap, ema50Daily, ema200Daily');
-    it('skips signal when EMA50 < EMA200 (trend not aligned)');
+    it.todo('detects price crossing above VWAP intraday');
+    it.todo('confirms EMA50 daily > EMA200 daily at signal');
+    it.todo('emits VWAP_RECLAIM signal with vwap, ema50Daily, ema200Daily');
+    it.todo('skips signal when EMA50 < EMA200 (trend not aligned)');
   });
 
   describe('trigger priority', () => {
-    it('returns PULLBACK_HL_FIBO when both triggers valid (higher conviction)');
-    it('returns VWAP_RECLAIM when only vwap trigger detected');
-    it('emits NO_ENTRY_TRIGGER rejection when neither trigger found');
+    it.todo('returns PULLBACK_HL_FIBO when both triggers valid (higher conviction)');
+    it.todo('returns VWAP_RECLAIM when only vwap trigger detected');
+    it.todo('emits NO_ENTRY_TRIGGER rejection when neither trigger found');
   });
 });

--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc3.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc3.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * BLOC 3 — Entry triggers.
+ * Stubs créés en PR1 skeleton. Implémentation dans PR4.
+ */
+
+describe.skip('GainersBloc3 — entry triggers', () => {
+  describe('pullback_HL_fibo', () => {
+    it('detects swing high N=5 (Bulkowski)');
+    it('detects swing low N=5');
+    it('validates retracement within 38.2–61.8% Fibonacci range');
+    it('rejects retracement below 38.2%');
+    it('rejects retracement above 61.8%');
+    it('emits PULLBACK_HL_FIBO signal with fiboLevel, swingHigh, swingLow');
+  });
+
+  describe('vwap_reclaim', () => {
+    it('detects price crossing above VWAP intraday');
+    it('confirms EMA50 daily > EMA200 daily at signal');
+    it('emits VWAP_RECLAIM signal with vwap, ema50Daily, ema200Daily');
+    it('skips signal when EMA50 < EMA200 (trend not aligned)');
+  });
+
+  describe('trigger priority', () => {
+    it('returns PULLBACK_HL_FIBO when both triggers valid (higher conviction)');
+    it('returns VWAP_RECLAIM when only vwap trigger detected');
+    it('emits NO_ENTRY_TRIGGER rejection when neither trigger found');
+  });
+});

--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc4.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc4.spec.ts
@@ -5,42 +5,42 @@
 
 describe.skip('GainersBloc4 — exits & trailing', () => {
   describe('cost coverage viability', () => {
-    it('rejects trade when TP - entry < spread + fees × 2');
-    it('accepts trade when net reward covers round-trip cost');
+    it.todo('rejects trade when TP - entry < spread + fees × 2');
+    it.todo('accepts trade when net reward covers round-trip cost');
   });
 
   describe('stop-loss', () => {
-    it('triggers SL exit when price <= entry × (1 - sl_pct)');
-    it('emits ExitReason.SL with correct estimatedPnlPct');
+    it.todo('triggers SL exit when price <= entry × (1 - sl_pct)');
+    it.todo('emits ExitReason.SL with correct estimatedPnlPct');
   });
 
   describe('take-profit full', () => {
-    it('triggers TP exit when price >= entry × (1 + tp_pct)');
-    it('emits ExitReason.TP_FULL');
+    it.todo('triggers TP exit when price >= entry × (1 + tp_pct)');
+    it.todo('emits ExitReason.TP_FULL');
   });
 
   describe('trailing — breakeven at MFE 40%', () => {
-    it('raises stop to breakeven when MFE >= 40% of TP pct');
-    it('emits InvalidationReason.TRAILING_BREAKEVEN_TRIGGERED');
-    it('does not re-lower stop once at breakeven');
+    it.todo('raises stop to breakeven when MFE >= 40% of TP pct');
+    it.todo('emits InvalidationReason.TRAILING_BREAKEVEN_TRIGGERED');
+    it.todo('does not re-lower stop once at breakeven');
   });
 
   describe('trailing — lock 50% TP at MFE 70%', () => {
-    it('locks 50% of TP pct when MFE >= 70%');
-    it('emits InvalidationReason.TRAILING_LOCK_50_TRIGGERED');
-    it('emits ExitReason.TP_PARTIAL_LOCK on trigger');
+    it.todo('locks 50% of TP pct when MFE >= 70%');
+    it.todo('emits InvalidationReason.TRAILING_LOCK_50_TRIGGERED');
+    it.todo('emits ExitReason.TP_PARTIAL_LOCK on trigger');
   });
 
   describe('time limit', () => {
-    it('emits ExitReason.TIME_LIMIT after max_hold_minutes elapsed');
+    it.todo('emits ExitReason.TIME_LIMIT after max_hold_minutes elapsed');
   });
 
   describe('invalidation — persistence lost', () => {
-    it('emits InvalidationReason.PERSISTENCE_LOST when score drops post-entry');
-    it('emits ExitReason.INVALIDATION');
+    it.todo('emits InvalidationReason.PERSISTENCE_LOST when score drops post-entry');
+    it.todo('emits ExitReason.INVALIDATION');
   });
 
   describe('invalidation — spread expanded', () => {
-    it('emits InvalidationReason.SPREAD_EXPANDED when spread > cap post-entry');
+    it.todo('emits InvalidationReason.SPREAD_EXPANDED when spread > cap post-entry');
   });
 });

--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc4.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc4.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * BLOC 4 — Exits : viability, stops, invalidation, trailing 40/70.
+ * Stubs créés en PR1 skeleton. Implémentation dans PR5.
+ */
+
+describe.skip('GainersBloc4 — exits & trailing', () => {
+  describe('cost coverage viability', () => {
+    it('rejects trade when TP - entry < spread + fees × 2');
+    it('accepts trade when net reward covers round-trip cost');
+  });
+
+  describe('stop-loss', () => {
+    it('triggers SL exit when price <= entry × (1 - sl_pct)');
+    it('emits ExitReason.SL with correct estimatedPnlPct');
+  });
+
+  describe('take-profit full', () => {
+    it('triggers TP exit when price >= entry × (1 + tp_pct)');
+    it('emits ExitReason.TP_FULL');
+  });
+
+  describe('trailing — breakeven at MFE 40%', () => {
+    it('raises stop to breakeven when MFE >= 40% of TP pct');
+    it('emits InvalidationReason.TRAILING_BREAKEVEN_TRIGGERED');
+    it('does not re-lower stop once at breakeven');
+  });
+
+  describe('trailing — lock 50% TP at MFE 70%', () => {
+    it('locks 50% of TP pct when MFE >= 70%');
+    it('emits InvalidationReason.TRAILING_LOCK_50_TRIGGERED');
+    it('emits ExitReason.TP_PARTIAL_LOCK on trigger');
+  });
+
+  describe('time limit', () => {
+    it('emits ExitReason.TIME_LIMIT after max_hold_minutes elapsed');
+  });
+
+  describe('invalidation — persistence lost', () => {
+    it('emits InvalidationReason.PERSISTENCE_LOST when score drops post-entry');
+    it('emits ExitReason.INVALIDATION');
+  });
+
+  describe('invalidation — spread expanded', () => {
+    it('emits InvalidationReason.SPREAD_EXPANDED when spread > cap post-entry');
+  });
+});

--- a/apps/api/src/modules/gainers-scanner/domain/gainers-candidate.types.ts
+++ b/apps/api/src/modules/gainers-scanner/domain/gainers-candidate.types.ts
@@ -1,0 +1,105 @@
+/**
+ * ADR-005 Gainers Algo V1 — Types candidats et signaux des 4 blocs.
+ * Aucune logique de calcul ici — types purs utilisés par les services PR2-PR5.
+ */
+
+import {
+  CandidateRejectReason,
+  EntryTriggerKind,
+  ExitReason,
+  InvalidationReason,
+  SpreadProxySource,
+  TrendFilterKind,
+} from './gainers-enums';
+
+/** Données brutes d'un candidat en entrée du pipeline (avant scoring BLOC 1). */
+export interface GainersCandidateRaw {
+  symbol: string;
+  market: 'equity' | 'crypto';
+  exchange: string;
+  /** Prix de clôture ou last trade (USD). */
+  close: number;
+  open: number;
+  high: number;
+  low: number;
+  /** Volume 24h (crypto) ou volume journalier (equity) en USD. */
+  vol24hUsd: number;
+  /** Médiane du volume journalier sur 20 jours de trading, en USD. */
+  medianDailyVolUsd20d: number | null;
+  /** Market cap : equity = shares_outstanding × close ; crypto = circ_supply × price. */
+  marketCapUsd: number | null;
+  /** ATR(14, daily) / close. Volatility clamp gate. */
+  atrDailyRelative: number | null;
+  /** Variation 1m qui a placé le candidat dans le top-gainers. */
+  changePct1m: number;
+  /** Score de persistance multi-TF P8. */
+  persistenceScore: number | null;
+  /** Texte "X/N" depuis P8 (ex : "4/6"). */
+  persistenceCount: string | null;
+}
+
+/** Résultat du scoring BLOC 1 : candidat qualifié ou rejeté. */
+export interface GainersScoredCandidate {
+  raw: GainersCandidateRaw;
+  /** null si REJECT, valeur composite [0..1] si ACCEPT. */
+  compositeScore: number | null;
+  decision: 'ACCEPT' | 'REJECT';
+  rejectReason: CandidateRejectReason | null;
+  /** BLOC 2 enrichissements (null avant BLOC 2). */
+  spreadProxy: number | null;
+  spreadProxySource: SpreadProxySource | null;
+  trendFilter: TrendFilterKind | null;
+  /** RVOL cumulatif intraday calculé en BLOC 1. */
+  rvolIntraday: number | null;
+}
+
+/** Signal d'entrée produit par BLOC 3. */
+export interface GainersEntrySignal {
+  symbol: string;
+  triggerKind: EntryTriggerKind;
+  /** Prix pivot haut du swing (N=5 bougies). */
+  swingHigh: number | null;
+  /** Prix pivot bas du swing (N=5 bougies). */
+  swingLow: number | null;
+  /** Niveau de retracement Fibonacci utilisé (38.2, 50, 61.8). */
+  fiboLevel: 38.2 | 50 | 61.8 | null;
+  /** VWAP intraday au moment du signal. */
+  vwap: number | null;
+  /** EMA50 daily au moment du signal. */
+  ema50Daily: number | null;
+  /** EMA200 daily au moment du signal. */
+  ema200Daily: number | null;
+  detectedAt: string;
+}
+
+/** Signal de sortie / invalidation produit par BLOC 4. */
+export interface GainersExitSignal {
+  symbol: string;
+  exitReason: ExitReason;
+  invalidationReason: InvalidationReason | null;
+  /** Prix de sortie effectif (ou estimé pour trailing). */
+  exitPrice: number;
+  /** MFE (Maximum Favorable Excursion) en pct depuis l'entrée au moment de la sortie. */
+  mfePctAtExit: number | null;
+  /** PnL estimé en pct. */
+  estimatedPnlPct: number | null;
+  detectedAt: string;
+}
+
+/**
+ * Entrée du decision log — trace auditée par candidat et par bloc.
+ * Alignée ADR-005 §5 schema audit-trail.
+ */
+export interface GainersDecisionLogEntry {
+  candidateId: string;
+  symbol: string;
+  ts: string;
+  algoVersion: 'v1';
+  bloc: 1 | 2 | 3 | 4;
+  signalObserved: string;
+  decision: 'ACCEPT' | 'REJECT' | 'SKIP';
+  reason: CandidateRejectReason | EntryTriggerKind | ExitReason | string | null;
+  paramsCalculated: Record<string, unknown>;
+  thresholdApplied: Record<string, unknown>;
+  configSnapshot: Record<string, unknown>;
+}

--- a/apps/api/src/modules/gainers-scanner/domain/gainers-enums.ts
+++ b/apps/api/src/modules/gainers-scanner/domain/gainers-enums.ts
@@ -1,0 +1,96 @@
+/**
+ * ADR-005 Gainers Algo V1 — Enums officiels des 4 blocs.
+ * Toute la logique métier vit dans les services BLOC 1-4 (PR2-PR5).
+ */
+
+/** BLOC 1 — Raison de rejet d'un candidat à l'entrée du pipeline. */
+export enum CandidateRejectReason {
+  /** Median daily $vol 20j < $10M (equity) ou 24h $vol < $50M (crypto). */
+  LIQUIDITY_FLOOR = 'LIQUIDITY_FLOOR',
+  /** Market cap < $300M (equity) ou < $500M (crypto). */
+  MARKET_CAP_MIN = 'MARKET_CAP_MIN',
+  /** ATR(14, daily) / close > 0.15. */
+  VOLATILITY_CLAMP = 'VOLATILITY_CLAMP',
+  /** Spread proxy median (H-L)×0.5/close > 0.30%. */
+  SPREAD_TOO_WIDE = 'SPREAD_TOO_WIDE',
+  /** RVOL cumulatif intraday < seuil configuré. */
+  RVOL_INSUFFICIENT = 'RVOL_INSUFFICIENT',
+  /** Score de persistance multi-TF < gainers_min_persistence_score. */
+  PERSISTENCE_BELOW_THRESHOLD = 'PERSISTENCE_BELOW_THRESHOLD',
+  /** EMA50 daily < EMA200 daily (Golden Cross non formé). */
+  TREND_FILTER_FAIL = 'TREND_FILTER_FAIL',
+  /** Symbole absent de l'univers non-regression watchlist_hash vérifié. */
+  UNIVERSE_GUARD = 'UNIVERSE_GUARD',
+  /** Aucun trigger BLOC 3 détecté (pullback_HL_fibo ou vwap_reclaim). */
+  NO_ENTRY_TRIGGER = 'NO_ENTRY_TRIGGER',
+}
+
+/** BLOC 3 — Nature du signal déclenchant l'entrée en position. */
+export enum EntryTriggerKind {
+  /** Pullback sur pivot swing N=5, retrace Fibonacci 38.2–61.8% (Bulkowski 2021). */
+  PULLBACK_HL_FIBO = 'PULLBACK_HL_FIBO',
+  /** Prix reclaim du VWAP intraday avec EMA50 > EMA200 daily. */
+  VWAP_RECLAIM = 'VWAP_RECLAIM',
+}
+
+/** BLOC 2 — Filtre de tendance appliqué avant l'évaluation du trigger. */
+export enum TrendFilterKind {
+  /** EMA50 > EMA200 sur le daily — Golden Cross empirique (+13pp win-rate). */
+  EMA_GOLDEN_CROSS = 'EMA_GOLDEN_CROSS',
+  /** Aucun filtre de tendance (désactivé via config). */
+  NONE = 'NONE',
+}
+
+/** BLOC 2 — Source utilisée pour le calcul du spread proxy. */
+export enum SpreadProxySource {
+  /** Médiane (H-L)×0.5/close sur les 5 dernières bougies 1m avec vol > 0. */
+  HL_1M_MEDIAN = 'HL_1M_MEDIAN',
+  /** Médiane sur bougies 5m (equity EODHD sans accès 1m natif). */
+  HL_5M_MEDIAN = 'HL_5M_MEDIAN',
+  /** Cap statique 0.30% appliqué quand < 3/5 bougies avec vol > 0. */
+  STATIC_CAP_FALLBACK = 'STATIC_CAP_FALLBACK',
+}
+
+/** BLOC 4 — Raison d'invalidation d'un setup actif. */
+export enum InvalidationReason {
+  /** Stop-loss touché. */
+  SL_HIT = 'SL_HIT',
+  /** Take-profit complet atteint. */
+  TP_HIT = 'TP_HIT',
+  /** MFE ≥ 40% du TP → stop ramené au breakeven. */
+  TRAILING_BREAKEVEN_TRIGGERED = 'TRAILING_BREAKEVEN_TRIGGERED',
+  /** MFE ≥ 70% du TP → lock 50% TP. */
+  TRAILING_LOCK_50_TRIGGERED = 'TRAILING_LOCK_50_TRIGGERED',
+  /** Durée max de détention dépassée (horizon < 3h). */
+  TIME_LIMIT_EXCEEDED = 'TIME_LIMIT_EXCEEDED',
+  /** Score de persistance multi-TF tombé sous le plancher post-entrée. */
+  PERSISTENCE_LOST = 'PERSISTENCE_LOST',
+  /** Spread proxy remonté au-delà du cap post-entrée. */
+  SPREAD_EXPANDED = 'SPREAD_EXPANDED',
+}
+
+/** BLOC 4 — Raison de clôture de position. */
+export enum ExitReason {
+  /** Take-profit complet. */
+  TP_FULL = 'TP_FULL',
+  /** Lock partiel 50% du TP (MFE ≥ 70%). */
+  TP_PARTIAL_LOCK = 'TP_PARTIAL_LOCK',
+  /** Stop-loss. */
+  SL = 'SL',
+  /** Trailing stop ramené au breakeven (MFE ≥ 40%). */
+  TRAILING_BREAKEVEN = 'TRAILING_BREAKEVEN',
+  /** Trailing lock 50% TP déclenché. */
+  TRAILING_LOCK = 'TRAILING_LOCK',
+  /** Durée max de détention dépassée. */
+  TIME_LIMIT = 'TIME_LIMIT',
+  /** Invalidation générique (persistence lost, spread expanded, etc.). */
+  INVALIDATION = 'INVALIDATION',
+}
+
+/** État courant du scanner Gainers — utilisé par le module d'observabilité. */
+export enum ScannerStatus {
+  IDLE = 'IDLE',
+  RUNNING = 'RUNNING',
+  PAUSED = 'PAUSED',
+  ERROR = 'ERROR',
+}

--- a/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
+++ b/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+/**
+ * ADR-005 Gainers Algo V1 — Module NestJS découplé (ADR-006).
+ * Toute la logique métier des blocs 1-4 sera ajoutée dans PR2-PR5.
+ */
+@Module({
+  imports: [],
+  providers: [],
+  exports: [],
+})
+export class GainersModule {}

--- a/apps/api/src/modules/gainers-scanner/index.ts
+++ b/apps/api/src/modules/gainers-scanner/index.ts
@@ -1,0 +1,3 @@
+export { GainersModule } from './gainers-scanner.module';
+export * from './domain/gainers-enums';
+export * from './domain/gainers-candidate.types';


### PR DESCRIPTION
## Résumé

PR1 du chantier Gainers Algo V1 (ADR-005 + ADR-006).

Structure NestJS découplée sans aucune logique métier — fondations typage pour les blocs 1-4 (PR2-PR5).

## Contenu

- `gainers-scanner.module.ts` — `GainersModule` vide enregistré dans `AppModule`
- `domain/gainers-enums.ts` — 7 enums (CandidateRejectReason × 9, EntryTriggerKind × 2, TrendFilterKind × 2, SpreadProxySource × 3, InvalidationReason × 7, ExitReason × 7, ScannerStatus × 4)
- `domain/gainers-candidate.types.ts` — 5 interfaces (GainersCandidateRaw, GainersScoredCandidate, GainersEntrySignal, GainersExitSignal, GainersDecisionLogEntry)
- `index.ts` — barrel exports
- `__tests__/gainers-bloc{1,2,3,4}.spec.ts` — describe.skip, specs exhaustifs prêts pour PR2-PR5

## Checklist

- [x] `typecheck` ✅ 0 erreurs
- [x] ZERO logique métier
- [x] GainersModule dans AppModule
- [x] Module isolé dans `apps/api/src/modules/gainers-scanner/` (ADR-006)
- [x] Supabase : aucune migration (aucune table touchée)

## Séquence blocs

- PR2 → BLOC 1 scoring + prefilter-gates
- PR3 → BLOC 2 baselines + spread proxy + universe guard
- PR4 → BLOC 3 triggers (pullback_HL_fibo + vwap_reclaim)
- PR5 → BLOC 4 exits (viability + stop + trailing 40/70)
- PR6 → Step 9 shadow run

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_