### PR TITLE
feat(gainers): BLOC 1 scoring (prefilter-gates + trend-filter + composite-scorer)

### DIFF
--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
@@ -1,39 +1,256 @@
 /**
- * BLOC 1 — Scoring + prefilter gates.
- * Stubs créés en PR1 skeleton. Implémentation dans PR2.
+ * BLOC 1 — Scoring + prefilter gates + trend filter + composite scorer.
+ * Couvre les 4 seuils V1 officiels (ADR-005 §1bis).
  */
 
-describe.skip('GainersBloc1 — prefilter gates', () => {
+import {
+  CandidateRejectReason,
+  TrendFilterKind,
+} from '../domain/gainers-enums';
+import type { GainersCandidateRaw } from '../domain/gainers-candidate.types';
+import {
+  DEFAULT_BLOC1_CONFIG,
+  checkLiquidityFloor,
+  checkMarketCapMin,
+  checkPersistence,
+  checkVolatilityClamp,
+  runAllPrefilterGates,
+} from '../bloc1/prefilter-gates';
+import {
+  DEFAULT_TREND_FILTER_CONFIG,
+  evaluateTrendFilter,
+} from '../bloc1/trend-filter';
+import {
+  DEFAULT_COMPOSITE_SCORER_CONFIG,
+  computeCompositeScore,
+} from '../bloc1/composite-scorer';
+import { GainersBloc1Service } from '../bloc1/gainers-bloc1.service';
+
+const baseEquity = (overrides: Partial<GainersCandidateRaw> = {}): GainersCandidateRaw => ({
+  symbol: 'AAPL.US',
+  market: 'equity',
+  exchange: 'US',
+  close: 200,
+  open: 198,
+  high: 202,
+  low: 197,
+  vol24hUsd: 50_000_000,
+  medianDailyVolUsd20d: 25_000_000,
+  marketCapUsd: 3_000_000_000_000,
+  atrDailyRelative: 0.03,
+  changePct1m: 0.02,
+  persistenceScore: 0.83,
+  persistenceCount: '5/6',
+  ema50Daily: 195,
+  ema200Daily: 180,
+  ...overrides,
+});
+
+const baseCrypto = (overrides: Partial<GainersCandidateRaw> = {}): GainersCandidateRaw => ({
+  symbol: 'BTC-USD.CC',
+  market: 'crypto',
+  exchange: 'BINANCE',
+  close: 60_000,
+  open: 59_500,
+  high: 60_200,
+  low: 59_400,
+  vol24hUsd: 5_000_000_000,
+  medianDailyVolUsd20d: null,
+  marketCapUsd: 1_200_000_000_000,
+  atrDailyRelative: 0.04,
+  changePct1m: 0.015,
+  persistenceScore: 0.83,
+  persistenceCount: '5/6',
+  ema50Daily: 58_000,
+  ema200Daily: 50_000,
+  ...overrides,
+});
+
+describe('GainersBloc1 — prefilter gates', () => {
   describe('liquidity floor', () => {
-    it.todo('rejects equity candidate below $10M median daily vol');
-    it.todo('rejects crypto candidate below $50M 24h vol');
-    it.todo('accepts equity candidate at exactly $10M');
+    it('rejects equity candidate below $10M median daily vol', () => {
+      const r = checkLiquidityFloor(baseEquity({ medianDailyVolUsd20d: 9_999_999 }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(false);
+      expect(r.reason).toBe(CandidateRejectReason.LIQUIDITY_FLOOR);
+    });
+    it('rejects crypto candidate below $50M 24h vol', () => {
+      const r = checkLiquidityFloor(baseCrypto({ vol24hUsd: 49_999_999 }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(false);
+      expect(r.reason).toBe(CandidateRejectReason.LIQUIDITY_FLOOR);
+    });
+    it('accepts equity candidate at exactly $10M', () => {
+      const r = checkLiquidityFloor(baseEquity({ medianDailyVolUsd20d: 10_000_000 }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(true);
+    });
+    it('rejects equity candidate with null medianDailyVol baseline', () => {
+      const r = checkLiquidityFloor(baseEquity({ medianDailyVolUsd20d: null }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(false);
+      expect(r.observed).toBeNull();
+    });
   });
 
   describe('market cap minimum', () => {
-    it.todo('rejects equity below $300M');
-    it.todo('rejects crypto below $500M');
-    it.todo('accepts equity at exactly $300M');
+    it('rejects equity below $300M', () => {
+      const r = checkMarketCapMin(baseEquity({ marketCapUsd: 299_999_999 }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(false);
+      expect(r.reason).toBe(CandidateRejectReason.MARKET_CAP_MIN);
+    });
+    it('rejects crypto below $500M', () => {
+      const r = checkMarketCapMin(baseCrypto({ marketCapUsd: 499_999_999 }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(false);
+      expect(r.reason).toBe(CandidateRejectReason.MARKET_CAP_MIN);
+    });
+    it('accepts equity at exactly $300M', () => {
+      const r = checkMarketCapMin(baseEquity({ marketCapUsd: 300_000_000 }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(true);
+    });
+    it('rejects when marketCapUsd is null', () => {
+      const r = checkMarketCapMin(baseEquity({ marketCapUsd: null }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(false);
+    });
   });
 
   describe('volatility clamp', () => {
-    it.todo('rejects candidate with ATR(14)/close > 0.15');
-    it.todo('accepts candidate with ATR(14)/close = 0.15');
-  });
-
-  describe('RVOL cumulative intraday', () => {
-    it.todo('computes vol_open→now / avg_same_window_20_trading_days for equity');
-    it.todo('computes vol_00:00→now for crypto');
-    it.todo('rejects candidate below RVOL threshold');
+    it('rejects candidate with ATR(14)/close > 0.15', () => {
+      const r = checkVolatilityClamp(baseEquity({ atrDailyRelative: 0.151 }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(false);
+      expect(r.reason).toBe(CandidateRejectReason.VOLATILITY_CLAMP);
+    });
+    it('accepts candidate with ATR(14)/close = 0.15', () => {
+      const r = checkVolatilityClamp(baseEquity({ atrDailyRelative: 0.15 }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(true);
+    });
+    it('rejects when atrDailyRelative is null', () => {
+      const r = checkVolatilityClamp(baseEquity({ atrDailyRelative: null }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(false);
+    });
   });
 
   describe('persistence gate', () => {
-    it.todo('rejects candidate with persistenceScore below gainers_min_persistence_score');
-    it.todo('accepts candidate with score >= threshold');
+    it('rejects candidate with persistenceScore below default 0.67', () => {
+      const r = checkPersistence(baseEquity({ persistenceScore: 0.66 }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(false);
+      expect(r.reason).toBe(CandidateRejectReason.PERSISTENCE_BELOW_THRESHOLD);
+    });
+    it('accepts candidate with score >= threshold', () => {
+      const r = checkPersistence(baseEquity({ persistenceScore: 0.67 }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(true);
+    });
+    it('rejects when persistenceScore is null', () => {
+      const r = checkPersistence(baseEquity({ persistenceScore: null }), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(false);
+    });
   });
 
-  describe('composite scorer', () => {
-    it.todo('returns compositeScore in [0, 1] for ACCEPT candidates');
-    it.todo('returns null compositeScore for REJECT candidates');
+  describe('runAllPrefilterGates', () => {
+    it('returns first failed reason in order liquidity → mcap → vol → persistence', () => {
+      const r = runAllPrefilterGates(
+        baseEquity({ medianDailyVolUsd20d: 1, marketCapUsd: 1, atrDailyRelative: 0.99, persistenceScore: 0 }),
+        DEFAULT_BLOC1_CONFIG,
+      );
+      expect(r.pass).toBe(false);
+      expect(r.firstFailedReason).toBe(CandidateRejectReason.LIQUIDITY_FLOOR);
+    });
+    it('passes a healthy candidate', () => {
+      const r = runAllPrefilterGates(baseEquity(), DEFAULT_BLOC1_CONFIG);
+      expect(r.pass).toBe(true);
+      expect(r.firstFailedReason).toBeNull();
+    });
+  });
+});
+
+describe('GainersBloc1 — trend filter', () => {
+  it('returns EMA_GOLDEN_CROSS pass when EMA50 > EMA200', () => {
+    const r = evaluateTrendFilter(baseEquity({ ema50Daily: 100, ema200Daily: 90 }), DEFAULT_TREND_FILTER_CONFIG);
+    expect(r.pass).toBe(true);
+    expect(r.kind).toBe(TrendFilterKind.EMA_GOLDEN_CROSS);
+  });
+  it('returns TREND_FILTER_FAIL when EMA50 < EMA200', () => {
+    const r = evaluateTrendFilter(baseEquity({ ema50Daily: 90, ema200Daily: 100 }), DEFAULT_TREND_FILTER_CONFIG);
+    expect(r.pass).toBe(false);
+    expect(r.reason).toBe(CandidateRejectReason.TREND_FILTER_FAIL);
+  });
+  it('returns TREND_FILTER_FAIL when EMAs equal (strict greater required)', () => {
+    const r = evaluateTrendFilter(baseEquity({ ema50Daily: 100, ema200Daily: 100 }), DEFAULT_TREND_FILTER_CONFIG);
+    expect(r.pass).toBe(false);
+  });
+  it('rejects when either EMA is null', () => {
+    const r1 = evaluateTrendFilter(baseEquity({ ema50Daily: null }), DEFAULT_TREND_FILTER_CONFIG);
+    const r2 = evaluateTrendFilter(baseEquity({ ema200Daily: null }), DEFAULT_TREND_FILTER_CONFIG);
+    expect(r1.pass).toBe(false);
+    expect(r2.pass).toBe(false);
+  });
+  it('returns NONE pass when filter disabled', () => {
+    const r = evaluateTrendFilter(baseEquity({ ema50Daily: 90, ema200Daily: 100 }), { enabled: false });
+    expect(r.pass).toBe(true);
+    expect(r.kind).toBe(TrendFilterKind.NONE);
+  });
+});
+
+describe('GainersBloc1 — composite scorer', () => {
+  it('returns score in [0, 1] for healthy candidate', () => {
+    const s = computeCompositeScore(baseEquity(), DEFAULT_COMPOSITE_SCORER_CONFIG);
+    expect(s).not.toBeNull();
+    expect(s!).toBeGreaterThanOrEqual(0);
+    expect(s!).toBeLessThanOrEqual(1);
+  });
+  it('returns null when persistenceScore is null', () => {
+    const s = computeCompositeScore(baseEquity({ persistenceScore: null }), DEFAULT_COMPOSITE_SCORER_CONFIG);
+    expect(s).toBeNull();
+  });
+  it('returns null when atrDailyRelative is null', () => {
+    const s = computeCompositeScore(baseEquity({ atrDailyRelative: null }), DEFAULT_COMPOSITE_SCORER_CONFIG);
+    expect(s).toBeNull();
+  });
+  it('higher persistence ⇒ higher composite score (ceteris paribus)', () => {
+    const low = computeCompositeScore(baseEquity({ persistenceScore: 0.7 }), DEFAULT_COMPOSITE_SCORER_CONFIG);
+    const high = computeCompositeScore(baseEquity({ persistenceScore: 1.0 }), DEFAULT_COMPOSITE_SCORER_CONFIG);
+    expect(high!).toBeGreaterThan(low!);
+  });
+  it('lower volatility ⇒ higher composite score (ceteris paribus)', () => {
+    const high = computeCompositeScore(baseEquity({ atrDailyRelative: 0.01 }), DEFAULT_COMPOSITE_SCORER_CONFIG);
+    const low = computeCompositeScore(baseEquity({ atrDailyRelative: 0.14 }), DEFAULT_COMPOSITE_SCORER_CONFIG);
+    expect(high!).toBeGreaterThan(low!);
+  });
+  it('clamps negative momentum to 0', () => {
+    const s = computeCompositeScore(baseEquity({ changePct1m: -0.05 }), DEFAULT_COMPOSITE_SCORER_CONFIG);
+    expect(s).not.toBeNull();
+    expect(s!).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('GainersBloc1Service — orchestration', () => {
+  const svc = new GainersBloc1Service();
+
+  it('ACCEPT for healthy equity candidate', () => {
+    const out = svc.evaluate(baseEquity());
+    expect(out.decision).toBe('ACCEPT');
+    expect(out.rejectReason).toBeNull();
+    expect(out.compositeScore).not.toBeNull();
+    expect(out.trendFilter).toBe(TrendFilterKind.EMA_GOLDEN_CROSS);
+  });
+  it('REJECT short-circuits on first failed gate (no compositeScore)', () => {
+    const out = svc.evaluate(baseEquity({ medianDailyVolUsd20d: 1 }));
+    expect(out.decision).toBe('REJECT');
+    expect(out.rejectReason).toBe(CandidateRejectReason.LIQUIDITY_FLOOR);
+    expect(out.compositeScore).toBeNull();
+    expect(out.trendFilter).toBeNull();
+  });
+  it('REJECT on trend filter fail when prefilter passes', () => {
+    const out = svc.evaluate(baseEquity({ ema50Daily: 90, ema200Daily: 100 }));
+    expect(out.decision).toBe('REJECT');
+    expect(out.rejectReason).toBe(CandidateRejectReason.TREND_FILTER_FAIL);
+    expect(out.trendFilter).toBe(TrendFilterKind.EMA_GOLDEN_CROSS);
+  });
+  it('evaluateBatchAccepted returns only ACCEPT sorted desc by score', () => {
+    const batch = [
+      baseEquity({ symbol: 'A', persistenceScore: 0.7 }),
+      baseEquity({ symbol: 'B', persistenceScore: 1.0 }),
+      baseEquity({ symbol: 'C', medianDailyVolUsd20d: 1 }),
+    ];
+    const out = svc.evaluateBatchAccepted(batch);
+    expect(out.length).toBe(2);
+    expect(out[0].raw.symbol).toBe('B');
+    expect(out[1].raw.symbol).toBe('A');
   });
 });

--- a/apps/api/src/modules/gainers-scanner/bloc1/composite-scorer.ts
+++ b/apps/api/src/modules/gainers-scanner/bloc1/composite-scorer.ts
@@ -1,0 +1,57 @@
+/**
+ * BLOC 1 — Composite scorer (ADR-005).
+ *
+ * Combine 3 dimensions normalisées en un score [0..1] :
+ *   - Persistance multi-TF (pondération 50%)
+ *   - Momentum 1m (pondération 30%, normalisé sur 10% comme plafond)
+ *   - Volatilité inverse (pondération 20%, ATR/close ramené sur la clamp)
+ *
+ * Pas de RVOL ici — il sera inclus en BLOC 2 quand les baselines seront wirées.
+ */
+
+import type { GainersCandidateRaw } from '../domain/gainers-candidate.types';
+
+export interface CompositeScorerConfig {
+  /** Poids persistance (défaut 0.5). */
+  weightPersistence: number;
+  /** Poids momentum (défaut 0.3). */
+  weightMomentum: number;
+  /** Poids volatilité inverse (défaut 0.2). */
+  weightVolatilityInv: number;
+  /** Plafond de normalisation du momentum (défaut 0.10 = 10%). */
+  momentumNormalizationCeiling: number;
+  /** ATR clamp utilisé pour la volatilité inverse (défaut 0.15). */
+  volatilityClampMaxAtrRel: number;
+}
+
+export const DEFAULT_COMPOSITE_SCORER_CONFIG: CompositeScorerConfig = {
+  weightPersistence: 0.5,
+  weightMomentum: 0.3,
+  weightVolatilityInv: 0.2,
+  momentumNormalizationCeiling: 0.1,
+  volatilityClampMaxAtrRel: 0.15,
+};
+
+const clamp01 = (x: number): number => Math.max(0, Math.min(1, x));
+
+/**
+ * Calcule le score composite [0..1]. Retourne null si données insuffisantes
+ * (persistence ou volatilité absentes — sinon le score serait artificiellement gonflé).
+ */
+export function computeCompositeScore(
+  raw: GainersCandidateRaw,
+  cfg: CompositeScorerConfig,
+): number | null {
+  if (raw.persistenceScore === null || raw.atrDailyRelative === null) return null;
+
+  const persistenceComponent = clamp01(raw.persistenceScore);
+  const momentumComponent = clamp01(raw.changePct1m / cfg.momentumNormalizationCeiling);
+  const volatilityInvComponent = 1 - clamp01(raw.atrDailyRelative / cfg.volatilityClampMaxAtrRel);
+
+  const weighted =
+    cfg.weightPersistence * persistenceComponent +
+    cfg.weightMomentum * momentumComponent +
+    cfg.weightVolatilityInv * volatilityInvComponent;
+
+  return clamp01(weighted);
+}

--- a/apps/api/src/modules/gainers-scanner/bloc1/gainers-bloc1.service.ts
+++ b/apps/api/src/modules/gainers-scanner/bloc1/gainers-bloc1.service.ts
@@ -1,0 +1,97 @@
+/**
+ * BLOC 1 — Service NestJS orchestrant prefilter-gates + trend-filter + composite-scorer.
+ * Pas d'I/O direct : le caller fournit `GainersCandidateRaw` enrichi avec EMAs/ATR/persistence.
+ */
+
+import { Injectable } from '@nestjs/common';
+import type {
+  GainersCandidateRaw,
+  GainersScoredCandidate,
+} from '../domain/gainers-candidate.types';
+import {
+  DEFAULT_BLOC1_CONFIG,
+  GainersBloc1Config,
+  runAllPrefilterGates,
+} from './prefilter-gates';
+import {
+  DEFAULT_TREND_FILTER_CONFIG,
+  TrendFilterConfig,
+  evaluateTrendFilter,
+} from './trend-filter';
+import {
+  DEFAULT_COMPOSITE_SCORER_CONFIG,
+  CompositeScorerConfig,
+  computeCompositeScore,
+} from './composite-scorer';
+
+export interface Bloc1FullConfig {
+  prefilter: GainersBloc1Config;
+  trendFilter: TrendFilterConfig;
+  scorer: CompositeScorerConfig;
+}
+
+export const DEFAULT_BLOC1_FULL_CONFIG: Bloc1FullConfig = {
+  prefilter: DEFAULT_BLOC1_CONFIG,
+  trendFilter: DEFAULT_TREND_FILTER_CONFIG,
+  scorer: DEFAULT_COMPOSITE_SCORER_CONFIG,
+};
+
+@Injectable()
+export class GainersBloc1Service {
+  /**
+   * Évalue un candidat : prefilter-gates → trend-filter → composite-score.
+   * Premier échec = REJECT court-circuité (autres dimensions non évaluées).
+   */
+  evaluate(raw: GainersCandidateRaw, cfg: Bloc1FullConfig = DEFAULT_BLOC1_FULL_CONFIG): GainersScoredCandidate {
+    const prefilter = runAllPrefilterGates(raw, cfg.prefilter);
+    if (!prefilter.pass) {
+      return {
+        raw,
+        compositeScore: null,
+        decision: 'REJECT',
+        rejectReason: prefilter.firstFailedReason,
+        spreadProxy: null,
+        spreadProxySource: null,
+        trendFilter: null,
+        rvolIntraday: null,
+      };
+    }
+
+    const trend = evaluateTrendFilter(raw, cfg.trendFilter);
+    if (!trend.pass) {
+      return {
+        raw,
+        compositeScore: null,
+        decision: 'REJECT',
+        rejectReason: trend.reason,
+        spreadProxy: null,
+        spreadProxySource: null,
+        trendFilter: trend.kind,
+        rvolIntraday: null,
+      };
+    }
+
+    const compositeScore = computeCompositeScore(raw, cfg.scorer);
+    return {
+      raw,
+      compositeScore,
+      decision: 'ACCEPT',
+      rejectReason: null,
+      spreadProxy: null,
+      spreadProxySource: null,
+      trendFilter: trend.kind,
+      rvolIntraday: null,
+    };
+  }
+
+  /** Évalue un batch et retourne uniquement les ACCEPT triés par score décroissant. */
+  evaluateBatchAccepted(
+    raws: GainersCandidateRaw[],
+    cfg: Bloc1FullConfig = DEFAULT_BLOC1_FULL_CONFIG,
+  ): GainersScoredCandidate[] {
+    return raws
+      .map((r) => this.evaluate(r, cfg))
+      .filter((c): c is GainersScoredCandidate => c.decision === 'ACCEPT')
+      .sort((a, b) => (b.compositeScore ?? 0) - (a.compositeScore ?? 0));
+  }
+}

--- a/apps/api/src/modules/gainers-scanner/bloc1/index.ts
+++ b/apps/api/src/modules/gainers-scanner/bloc1/index.ts
@@ -1,0 +1,4 @@
+export * from './prefilter-gates';
+export * from './trend-filter';
+export * from './composite-scorer';
+export * from './gainers-bloc1.service';

--- a/apps/api/src/modules/gainers-scanner/bloc1/prefilter-gates.ts
+++ b/apps/api/src/modules/gainers-scanner/bloc1/prefilter-gates.ts
@@ -1,0 +1,122 @@
+/**
+ * BLOC 1 — Prefilter gates purs (ADR-005 §1bis).
+ *
+ * Les 4 seuils V1 officiels :
+ *   1. Liquidity floor : equity median daily $vol 20j ≥ $10M ; crypto 24h $vol ≥ $50M
+ *   2. Market cap min  : equity ≥ $300M ; crypto circ_supply×price ≥ $500M
+ *   3. Volatility clamp: ATR(14, daily)/close ≤ 0.15 (15%)
+ *   4. Persistence gate: persistenceScore ≥ gainers_min_persistence_score
+ *
+ * Toutes les fonctions sont pures et idempotentes — pas d'I/O, pas d'état.
+ */
+
+import { CandidateRejectReason } from '../domain/gainers-enums';
+import type { GainersCandidateRaw } from '../domain/gainers-candidate.types';
+
+export interface GainersBloc1Config {
+  /** Seuil liquidité equity : median daily $vol 20j (USD). Défaut $10M. */
+  liquidityFloorEquityUsd: number;
+  /** Seuil liquidité crypto : 24h $vol (USD). Défaut $50M. */
+  liquidityFloorCryptoUsd: number;
+  /** Seuil market cap minimum equity (USD). Défaut $300M. */
+  marketCapMinEquityUsd: number;
+  /** Seuil market cap minimum crypto = circ_supply × price (USD). Défaut $500M. */
+  marketCapMinCryptoUsd: number;
+  /** Volatility clamp : ATR(14, daily) / close max. Défaut 0.15. */
+  volatilityClampMaxAtrRel: number;
+  /** Score persistance minimum P8 ([0..1]). Défaut 0.67. */
+  minPersistenceScore: number;
+}
+
+export const DEFAULT_BLOC1_CONFIG: GainersBloc1Config = {
+  liquidityFloorEquityUsd: 10_000_000,
+  liquidityFloorCryptoUsd: 50_000_000,
+  marketCapMinEquityUsd: 300_000_000,
+  marketCapMinCryptoUsd: 500_000_000,
+  volatilityClampMaxAtrRel: 0.15,
+  minPersistenceScore: 0.67,
+};
+
+export interface GateResult {
+  pass: boolean;
+  reason: CandidateRejectReason | null;
+  observed: number | null;
+  threshold: number | null;
+}
+
+const FAIL = (reason: CandidateRejectReason, observed: number | null, threshold: number): GateResult => ({
+  pass: false,
+  reason,
+  observed,
+  threshold,
+});
+
+const PASS = (observed: number | null, threshold: number): GateResult => ({
+  pass: true,
+  reason: null,
+  observed,
+  threshold,
+});
+
+/** Gate 1 — Liquidity floor (equity/crypto-aware). */
+export function checkLiquidityFloor(raw: GainersCandidateRaw, cfg: GainersBloc1Config): GateResult {
+  if (raw.market === 'crypto') {
+    const threshold = cfg.liquidityFloorCryptoUsd;
+    if (raw.vol24hUsd < threshold) return FAIL(CandidateRejectReason.LIQUIDITY_FLOOR, raw.vol24hUsd, threshold);
+    return PASS(raw.vol24hUsd, threshold);
+  }
+  const threshold = cfg.liquidityFloorEquityUsd;
+  const vol = raw.medianDailyVolUsd20d;
+  if (vol === null) return FAIL(CandidateRejectReason.LIQUIDITY_FLOOR, null, threshold);
+  if (vol < threshold) return FAIL(CandidateRejectReason.LIQUIDITY_FLOOR, vol, threshold);
+  return PASS(vol, threshold);
+}
+
+/** Gate 2 — Market cap minimum. */
+export function checkMarketCapMin(raw: GainersCandidateRaw, cfg: GainersBloc1Config): GateResult {
+  const threshold = raw.market === 'crypto' ? cfg.marketCapMinCryptoUsd : cfg.marketCapMinEquityUsd;
+  const mcap = raw.marketCapUsd;
+  if (mcap === null) return FAIL(CandidateRejectReason.MARKET_CAP_MIN, null, threshold);
+  if (mcap < threshold) return FAIL(CandidateRejectReason.MARKET_CAP_MIN, mcap, threshold);
+  return PASS(mcap, threshold);
+}
+
+/** Gate 3 — Volatility clamp ATR(14, daily) / close ≤ 0.15. */
+export function checkVolatilityClamp(raw: GainersCandidateRaw, cfg: GainersBloc1Config): GateResult {
+  const threshold = cfg.volatilityClampMaxAtrRel;
+  const atrRel = raw.atrDailyRelative;
+  if (atrRel === null) return FAIL(CandidateRejectReason.VOLATILITY_CLAMP, null, threshold);
+  if (atrRel > threshold) return FAIL(CandidateRejectReason.VOLATILITY_CLAMP, atrRel, threshold);
+  return PASS(atrRel, threshold);
+}
+
+/** Gate 4 — Persistence ≥ gainers_min_persistence_score. */
+export function checkPersistence(raw: GainersCandidateRaw, cfg: GainersBloc1Config): GateResult {
+  const threshold = cfg.minPersistenceScore;
+  const score = raw.persistenceScore;
+  if (score === null) return FAIL(CandidateRejectReason.PERSISTENCE_BELOW_THRESHOLD, null, threshold);
+  if (score < threshold) return FAIL(CandidateRejectReason.PERSISTENCE_BELOW_THRESHOLD, score, threshold);
+  return PASS(score, threshold);
+}
+
+/**
+ * Évalue toutes les gates dans l'ordre et retourne le premier échec.
+ * Ordre choisi pour minimiser le coût : liquidity (cheap) → mcap → vol → persistence.
+ */
+export function runAllPrefilterGates(
+  raw: GainersCandidateRaw,
+  cfg: GainersBloc1Config,
+): { pass: boolean; firstFailedReason: CandidateRejectReason | null; gates: Record<string, GateResult> } {
+  const gates: Record<string, GateResult> = {
+    liquidity: checkLiquidityFloor(raw, cfg),
+    marketCap: checkMarketCapMin(raw, cfg),
+    volatility: checkVolatilityClamp(raw, cfg),
+    persistence: checkPersistence(raw, cfg),
+  };
+  const firstFailed = Object.values(gates).find((g) => !g.pass);
+  return {
+    pass: !firstFailed,
+    firstFailedReason: firstFailed?.reason ?? null,
+    gates,
+  };
+}

--- a/apps/api/src/modules/gainers-scanner/bloc1/trend-filter.ts
+++ b/apps/api/src/modules/gainers-scanner/bloc1/trend-filter.ts
@@ -1,0 +1,75 @@
+/**
+ * BLOC 1 — Trend filter EMA Golden Cross (ADR-005).
+ *
+ * Filtre binaire : EMA50 daily > EMA200 daily ⇒ Golden Cross établi.
+ * Empiriquement : 41% → 54% win-rate sur les setups long avec ce filtre actif.
+ */
+
+import { CandidateRejectReason, TrendFilterKind } from '../domain/gainers-enums';
+import type { GainersCandidateRaw } from '../domain/gainers-candidate.types';
+
+export interface TrendFilterConfig {
+  /** Active/désactive le filtre. Défaut true. */
+  enabled: boolean;
+}
+
+export const DEFAULT_TREND_FILTER_CONFIG: TrendFilterConfig = {
+  enabled: true,
+};
+
+export interface TrendFilterResult {
+  pass: boolean;
+  kind: TrendFilterKind;
+  reason: CandidateRejectReason | null;
+  ema50: number | null;
+  ema200: number | null;
+}
+
+/**
+ * Évalue le trend filter sur les EMAs daily du candidat.
+ * - enabled=false → pass=true, kind=NONE
+ * - EMA50 ou EMA200 manquant → reject TREND_FILTER_FAIL (data unavailable)
+ * - EMA50 > EMA200 → pass, kind=EMA_GOLDEN_CROSS
+ * - EMA50 ≤ EMA200 → reject TREND_FILTER_FAIL
+ */
+export function evaluateTrendFilter(
+  raw: GainersCandidateRaw,
+  cfg: TrendFilterConfig,
+): TrendFilterResult {
+  if (!cfg.enabled) {
+    return {
+      pass: true,
+      kind: TrendFilterKind.NONE,
+      reason: null,
+      ema50: raw.ema50Daily,
+      ema200: raw.ema200Daily,
+    };
+  }
+  const ema50 = raw.ema50Daily;
+  const ema200 = raw.ema200Daily;
+  if (ema50 === null || ema200 === null) {
+    return {
+      pass: false,
+      kind: TrendFilterKind.EMA_GOLDEN_CROSS,
+      reason: CandidateRejectReason.TREND_FILTER_FAIL,
+      ema50,
+      ema200,
+    };
+  }
+  if (ema50 > ema200) {
+    return {
+      pass: true,
+      kind: TrendFilterKind.EMA_GOLDEN_CROSS,
+      reason: null,
+      ema50,
+      ema200,
+    };
+  }
+  return {
+    pass: false,
+    kind: TrendFilterKind.EMA_GOLDEN_CROSS,
+    reason: CandidateRejectReason.TREND_FILTER_FAIL,
+    ema50,
+    ema200,
+  };
+}

--- a/apps/api/src/modules/gainers-scanner/domain/gainers-candidate.types.ts
+++ b/apps/api/src/modules/gainers-scanner/domain/gainers-candidate.types.ts
@@ -36,6 +36,10 @@ export interface GainersCandidateRaw {
   persistenceScore: number | null;
   /** Texte "X/N" depuis P8 (ex : "4/6"). */
   persistenceCount: string | null;
+  /** EMA50 daily — alimente le trend filter BLOC 1 (Golden Cross). */
+  ema50Daily: number | null;
+  /** EMA200 daily — alimente le trend filter BLOC 1 (Golden Cross). */
+  ema200Daily: number | null;
 }
 
 /** Résultat du scoring BLOC 1 : candidat qualifié ou rejeté. */

--- a/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
+++ b/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
+import { GainersBloc1Service } from './bloc1/gainers-bloc1.service';
 
 /**
  * ADR-005 Gainers Algo V1 — Module NestJS découplé (ADR-006).
- * Toute la logique métier des blocs 1-4 sera ajoutée dans PR2-PR5.
+ * BLOC 1 wired (PR2). BLOC 2-4 ajoutés dans PR3-PR5.
  */
 @Module({
   imports: [],
-  providers: [],
-  exports: [],
+  providers: [GainersBloc1Service],
+  exports: [GainersBloc1Service],
 })
 export class GainersModule {}

--- a/apps/api/src/modules/gainers-scanner/index.ts
+++ b/apps/api/src/modules/gainers-scanner/index.ts
@@ -1,3 +1,4 @@
 export { GainersModule } from './gainers-scanner.module';
 export * from './domain/gainers-enums';
 export * from './domain/gainers-candidate.types';
+export * from './bloc1';


### PR DESCRIPTION
## Résumé

PR2 du chantier Gainers Algo V1 — implémentation BLOC 1 scoring complet conformément à ADR-005 §1bis.

## Seuils V1 officiels (ADR-005)

| Gate | Equity | Crypto |
|---|---|---|
| Liquidity floor | median daily $vol 20j ≥ **$10M** | 24h $vol ≥ **$50M** |
| Market cap min | mcap ≥ **$300M** | circ_supply × price ≥ **$500M** |
| Volatility clamp | ATR(14, daily) / close ≤ **0.15** | (idem) |
| Persistence gate | score ≥ **0.67** (config par portfolio) | (idem) |
| Trend filter | **EMA50 > EMA200 daily** (Golden Cross) | (idem) |

Empirique : trend filter EMA50>EMA200 fait passer le win-rate de 41% → 54% sur les setups long.

## Architecture (pure functions)

```
apps/api/src/modules/gainers-scanner/bloc1/
├── prefilter-gates.ts    — 4 gates pures + runAllPrefilterGates orchestrator
├── trend-filter.ts       — EMA Golden Cross binaire (enabled/disabled config)
├── composite-scorer.ts   — score [0..1] = 0.5×persistence + 0.3×momentum + 0.2×vol_inv
├── gainers-bloc1.service.ts — NestJS service, court-circuite au premier reject
└── index.ts              — barrel exports
```

Court-circuit ordre : liquidity → mcap → volatility → persistence → trend filter → score composite.

## Domain enrichi

- `GainersCandidateRaw` : ajout `ema50Daily`, `ema200Daily` (alimentent le trend filter)

## Tests

- **31 specs** unitaires sur prefilter-gates, trend-filter, composite-scorer, service orchestration
- BLOC 1 unskip (les 16 todos restants sont sur BLOC 2-4)
- ✅ typecheck local clean
- ✅ jest local 31/31 pass

## Reste à faire

- PR3 → BLOC 2 baselines + spread proxy + universe guard
- PR4 → BLOC 3 triggers (pullback_HL_fibo + vwap_reclaim)
- PR5 → BLOC 4 exits (viability + stop + trailing 40/70)
- PR6 → Step 9 shadow run

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_