### PR TITLE
hotfix(migration): 0097 column 'market' didn't exist in gainers_persistence_log

### DIFF
--- a/supabase/migrations/0097_gainers_exchange_code_fix.sql
+++ b/supabase/migrations/0097_gainers_exchange_code_fix.sql
@@ -1,5 +1,4 @@
--- P20a (01/05/2026) — Normalize legacy market codes in top_gainers_log
--- and gainers_persistence_log that used Yahoo Finance / wrong exchange codes:
+-- P20a (01/05/2026) — Normalize legacy market codes used by the scanner:
 --   SS  → SHG  (Shanghai Stock Exchange, official EODHD code)
 --   SZ  → SHE  (Shenzhen Stock Exchange, official EODHD code)
 --   TSE → T    (Tokyo Stock Exchange, official EODHD code = suffix .T)
@@ -8,29 +7,67 @@
 -- returned 0 EODHD screener results even before that), but the update
 -- ensures the log is internally consistent post-P20a.
 --
+-- HOTFIX 02/05/2026 — original migration assumed gainers_persistence_log had
+-- a `market` column (it doesn't — actual columns are markets_scanned text[]
+-- and snapshot_json jsonb per migration 0086). Rewritten to:
+--   1. Idempotent column-existence guards (information_schema.columns)
+--   2. top_gainers_log update unchanged (column market exists per 0084)
+--   3. gainers_persistence_log handled via array_replace on markets_scanned
+--      (the text[] column that actually holds market codes per 0086)
+--
 -- Safe: no FK constraints on market/exchange columns; soft update only.
 
-UPDATE top_gainers_log
-SET market = CASE
-  WHEN market = 'SS'  THEN 'SHG'
-  WHEN market = 'SZ'  THEN 'SHE'
-  WHEN market = 'TSE' THEN 'T'
-  ELSE market
-END,
-detected_asset_class = CASE
-  WHEN detected_asset_class = 'SS'  THEN 'SHG'
-  WHEN detected_asset_class = 'SZ'  THEN 'SHE'
-  WHEN detected_asset_class = 'TSE' THEN 'T'
-  ELSE detected_asset_class
-END
-WHERE market IN ('SS', 'SZ', 'TSE')
-   OR detected_asset_class IN ('SS', 'SZ', 'TSE');
+-- ─── top_gainers_log : columns market + detected_asset_class exist (mig 0084) ──
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'top_gainers_log' AND column_name = 'market'
+  ) THEN
+    UPDATE public.top_gainers_log
+    SET market = CASE
+      WHEN market = 'SS'  THEN 'SHG'
+      WHEN market = 'SZ'  THEN 'SHE'
+      WHEN market = 'TSE' THEN 'T'
+      ELSE market
+    END
+    WHERE market IN ('SS', 'SZ', 'TSE');
+  END IF;
 
-UPDATE gainers_persistence_log
-SET market = CASE
-  WHEN market = 'SS'  THEN 'SHG'
-  WHEN market = 'SZ'  THEN 'SHE'
-  WHEN market = 'TSE' THEN 'T'
-  ELSE market
-END
-WHERE market IN ('SS', 'SZ', 'TSE');
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'top_gainers_log' AND column_name = 'detected_asset_class'
+  ) THEN
+    UPDATE public.top_gainers_log
+    SET detected_asset_class = CASE
+      WHEN detected_asset_class = 'SS'  THEN 'SHG'
+      WHEN detected_asset_class = 'SZ'  THEN 'SHE'
+      WHEN detected_asset_class = 'TSE' THEN 'T'
+      ELSE detected_asset_class
+    END
+    WHERE detected_asset_class IN ('SS', 'SZ', 'TSE');
+  END IF;
+END $$;
+
+-- ─── gainers_persistence_log : codes vivent dans markets_scanned text[] (mig 0086) ──
+-- array_replace remplace toutes les occurrences d'un code par un autre dans le tableau.
+-- Trois passes (une par code legacy) — idempotent : si le code n'est pas présent, NOOP.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'gainers_persistence_log' AND column_name = 'markets_scanned'
+  ) THEN
+    UPDATE public.gainers_persistence_log
+    SET markets_scanned = array_replace(markets_scanned, 'SS', 'SHG')
+    WHERE 'SS' = ANY(markets_scanned);
+
+    UPDATE public.gainers_persistence_log
+    SET markets_scanned = array_replace(markets_scanned, 'SZ', 'SHE')
+    WHERE 'SZ' = ANY(markets_scanned);
+
+    UPDATE public.gainers_persistence_log
+    SET markets_scanned = array_replace(markets_scanned, 'TSE', 'T')
+    WHERE 'TSE' = ANY(markets_scanned);
+  END IF;
+END $$;


### PR DESCRIPTION
## 🚨 Production hotfix — migration 0097 blocking pipeline

**Symptômes prod (Fly app smartvest, machine d8d4070a719018, CDG)** :
- Migration `0097_gainers_exchange_code_fix.sql` failing with `ERROR 42703: column "market" does not exist`
- Pipeline migrations : 0 appliquées · 102 ignorées · **1 échec**
- Machine 10/10 restart attempts exhausted, "Proxy not finding machines to route requests"

## Root cause

Original migration (PR P20a, 01/05) assumed `gainers_persistence_log` had a `market` column. The actual schema (migration 0086) shows :

```sql
CREATE TABLE public.gainers_persistence_log (
  id uuid PRIMARY KEY ...,
  captured_at timestamptz ...,
  top_n integer ...,
  markets_scanned text[] NOT NULL DEFAULT '{}',  ← codes vivent ici
  snapshot_json jsonb NOT NULL,
  summary jsonb NOT NULL,
  created_at timestamptz ...
);
```

Pas de colonne `market` → SQL parser échoue → toute la migration rollback → pipeline figé.

## Fix

1. **Guards `information_schema.columns`** : migration devient idempotente, safe même si schéma diverge entre envs.
2. **`top_gainers_log` UPDATE inchangé** : la table a bien `market` + `detected_asset_class` (mig 0084).
3. **`gainers_persistence_log` normalisation via `array_replace`** sur la colonne `markets_scanned text[]` (la vraie colonne qui contient les codes). Trois passes : `SS→SHG`, `SZ→SHE`, `TSE→T`. Idempotent : NOOP si code absent.

## Application post-merge

Migration n'a jamais été enregistrée dans `_smartvest_migrations` (failed last run). Le prochain `apply-migrations.mjs` réappliquera 0097 avec le nouveau contenu.

Trigger : `workflow_dispatch` sur `apply-supabase-migrations.yml` ou tag `apply-migrations-*`.

## Test plan

- [x] Diff syntactiquement valide (DO blocks, CASE branches, ANY/array_replace)
- [ ] CI green (TS build + Jest)
- [ ] Apply migrations workflow re-run → 1 nouvelle (0097) appliquée
- [ ] Fly machine recover (health check 1/1)
- [ ] Counts gainers_persistence_log unchanged sauf normalisation markets_scanned

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_