### PR TITLE
hotfix(fly): trigger redeploy via fly.toml path bump (unstuck v334 machine)

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,7 +1,10 @@
 # fly.toml — SmartVest API (NestJS)
 #
-# Last forced redeploy : 2026-04-28 — sync Fly with main HEAD (P0 hotfix
-# #52 snapshot-history-types + #53 profile-label-defensive).
+# Last forced redeploy : 2026-05-02 — unstuck v334 image after migration 0097
+# hotfix (#197). Machine d8d4070a719018 had exhausted 10 restart attempts on
+# pre-hotfix build; #197 only touched supabase/migrations/* which doesn't
+# match fly.yml `paths` filter, so no auto-deploy was triggered. This bump
+# forces fly.yml to re-deploy from main HEAD (post-#196 BLOC 4 + #197 fix).
 #
 # auto_stop_machines = 'off' : la machine reste TOUJOURS up.
 # Indispensable pour que les crons Lisa tournent sans interruption :


### PR DESCRIPTION
## 🚨 Production hotfix — Fly machine stuck on v334 image

### Symptômes (rapport ops 6h CEST)
- Machine `d8d4070a719018` (CDG) checks 0/1, banner rouge "Proxy not finding machines to route requests"
- Fly Doctor : "Machines are not listening on 0.0.0.0:3001"
- NestJS log : `[NestFactory] Starting + AppModule/HealthModule initialized` mais pas `Listening on 0.0.0.0:3001`
- 10 tentatives de restart épuisées

### Root cause découverte
Le code et la config sont **corrects** :
- `apps/api/src/main.ts:24` → `await app.listen(port, '0.0.0.0')` explicite ✅
- `fly.toml` → `internal_port = 3001`, env `PORT='3001'` + `API_PORT='3001'` ✅

Le vrai problème : **PR #197 (hotfix migration 0097) n'a touché que `supabase/migrations/*` qui n'est PAS dans le `paths` filter de `fly.yml`** :

```yaml
on:
  push:
    branches: [main]
    paths:
      - 'apps/api/**'
      - 'packages/**'
      - 'Dockerfile'
      - 'fly.toml'        ← THIS commit triggers it
      - 'package.json'
      - 'package-lock.json'
      - '.github/workflows/fly.yml'
```

Donc fly.yml ne s'est **jamais** déclenché après la merge de #197. La machine continue de tourner sur l'image **v334 pré-hotfix**, où NestJS bootstrap échouait probablement sur un appel Supabase (ETL cron, schema check) à cause des migrations cassées → exception silencieuse après "AppModule/HealthModule initialized" → `app.listen()` jamais atteint → port jamais bindé.

### Fix
Bump du commentaire d'historique dans `fly.toml` (5 lignes ajoutées, 2 modifiées) → matche le path filter → déclenche `fly.yml` qui passe les bons build args (GIT_SHA + BUILD_TIME + CACHEBUST_GIT_SHA per CLAUDE.md règle deploy P18h.2).

### Test plan post-merge
- [ ] CI green (no code change → TS/Jest fast)
- [ ] fly.yml workflow run triggered (visible dans Actions tab)
- [ ] `flyctl deploy` complete → nouvelle machine spawn / replace v334
- [ ] `GET https://smartvest.fly.dev/health` → 200 OK
- [ ] `GET https://smartvest.fly.dev/version` → `{git_sha: "8014d8d...", build_time: "..."}` (= ce commit)
- [ ] `flyctl status -a smartvest` → 1/1 healthy

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_