### PR TITLE
feat(admin): POST /admin/gainers/baseline/refresh — manual ETL trigger (Option 1)

### DIFF
--- a/apps/api/src/modules/admin/admin-gainers-baseline.controller.ts
+++ b/apps/api/src/modules/admin/admin-gainers-baseline.controller.ts
@@ -1,0 +1,68 @@
+/**
+ * POST /admin/gainers/baseline/refresh — déclenchement manuel ETL baseline volume.
+ *
+ * Bootstrap pour PR5 BLOC 4.0 : permet à l'opérateur de peupler
+ * gainers_volume_baselines sans attendre le cron 01:00 UTC. Idempotent
+ * (onConflict='symbol,exchange'), safe à re-run.
+ *
+ * Auth : header `x-admin-token` aligné sur le pattern AdminGainersStatusController.
+ *
+ * Réponse :
+ * {
+ *   totalSymbols: 215,
+ *   computed: 213,
+ *   cacheHits: 198,
+ *   cacheMisses: 12,
+ *   liveFetchSuccess: 14,
+ *   liveFetchFailures: 1,
+ *   cacheStale: false,
+ *   durationMs: 8523
+ * }
+ */
+
+import { Controller, HttpException, HttpStatus, Logger, Post, Headers } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { VolumeBaselineCalculatorService } from '../gainers-scanner/bloc2/volume-baseline-calculator.service';
+import { VolumeBaselineService } from '../gainers-scanner/bloc2/volume-baseline.service';
+
+@Controller('admin/gainers/baseline')
+export class AdminGainersBaselineController {
+  private readonly logger = new Logger(AdminGainersBaselineController.name);
+
+  constructor(
+    private readonly calculator: VolumeBaselineCalculatorService,
+    private readonly baseline: VolumeBaselineService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Post('refresh')
+  async refresh(@Headers('x-admin-token') providedToken: string | undefined) {
+    this.assertAdmin(providedToken);
+    this.logger.log('[admin] baseline ETL refresh triggered manually');
+    const result = await this.calculator.runEtl();
+    // Recharge le cache mémoire après l'upsert pour que le scanner voie
+    // immédiatement les nouvelles baselines.
+    await this.baseline.reloadCache();
+    return {
+      ...result,
+      cacheReloaded: true,
+      cacheSize: this.baseline.cacheSize,
+    };
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (providedToken !== expected) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'ADMIN_FORBIDDEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -14,20 +14,23 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { SupabaseModule } from '../supabase/supabase.module';
 import { LisaModule } from '../lisa/lisa.module';
+import { GainersModule } from '../gainers-scanner';
 import { AdminMigrationsController } from './admin-migrations.controller';
 import { AdminSupabaseQueryController } from './admin-supabase-query.controller';
 import { AdminLogsController } from './admin-logs.controller';
 import { AdminEodhdStatusController } from './admin-eodhd-status.controller';
 import { AdminGainersStatusController } from './admin-gainers-status.controller';
+import { AdminGainersBaselineController } from './admin-gainers-baseline.controller';
 
 @Module({
-  imports: [SupabaseModule, forwardRef(() => LisaModule)],
+  imports: [SupabaseModule, forwardRef(() => LisaModule), GainersModule],
   controllers: [
     AdminMigrationsController,
     AdminSupabaseQueryController,
     AdminLogsController,
     AdminEodhdStatusController,
     AdminGainersStatusController,
+    AdminGainersBaselineController,
   ],
 })
 export class AdminModule {}


### PR DESCRIPTION
## Option 1 — Endpoint admin pour bootstrap ETL baseline

Suite à la merge de PR #196 (BLOC 4.0 ETL), permet à l'opérateur de déclencher manuellement le calcul des baselines volume **sans attendre le cron 01:00 UTC** (utile post-deploy ou pour debug).

## Endpoint

```
POST /admin/gainers/baseline/refresh
Headers: x-admin-token: <ADMIN_TOKEN>
```

Réponse :
```json
{
  "totalSymbols": 215,
  "computed": 213,
  "cacheHits": 198,
  "cacheMisses": 12,
  "liveFetchSuccess": 14,
  "liveFetchFailures": 1,
  "cacheStale": false,
  "durationMs": 8523,
  "cacheReloaded": true,
  "cacheSize": 213
}
```

## Logique

1. Auth via `x-admin-token` (pattern aligné sur `AdminGainersStatusController`)
2. `VolumeBaselineCalculatorService.runEtl()` — calcule médianes 20j depuis `ohlcv_cache_daily` + fallback live EODHD/Binance per-row
3. `VolumeBaselineService.reloadCache()` — recharge cache mémoire pour que le scanner voie immédiatement les nouvelles baselines
4. Retourne metrics enrichies avec `cacheReloaded` + `cacheSize` post-reload

Idempotent (onConflict='symbol,exchange' dans `upsertBaselines()`) → safe à re-run.

## Wiring

- `AdminModule.imports` : ajout de `GainersModule` (déjà exporté `VolumeBaselineCalculatorService` + `VolumeBaselineService` via PR5)
- Controller registered dans `AdminModule.controllers`

## Test plan

- [x] Typecheck ✅
- [x] 257 gainers tests / 255 passing / 0 failures
- [ ] CI green (TS + Jest + Vercel)
- [ ] Manual call once Fly machine recovered :
  ```bash
  curl -X POST https://smartvest.fly.dev/admin/gainers/baseline/refresh \
    -H "x-admin-token: $ADMIN_TOKEN" | jq
  ```

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_