### PR TITLE
hotfix(di): export TopGainersScannerService from LisaModule (unblock app boot)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -147,6 +147,13 @@ import { ScannerLlmRouterService } from './services/scanner-llm-router.service';
     DailyProfitGovernor,
     MacroModeService,
     EodhdQuotaService,
+    // Hotfix 02/05/2026 : TopGainersScannerService était provider mais pas exporté.
+    // AdminGainersStatusController (importe LisaModule via forwardRef) crashait au
+    // boot NestJS avec "Nest can't resolve dependencies of AdminGainersStatusController
+    // (?, ConfigService). Make sure TopGainersScannerService at index [0] is available
+    // in the AdminModule context." → empêchait app.listen → port 3001 jamais bindé →
+    // Fly proxy fail. Cf. PR #200.
+    TopGainersScannerService,
   ],
 })
 export class LisaModule {}


### PR DESCRIPTION
## 🚨 Production hotfix — NestJS DI failure blocking app boot

### Symptômes (logs Fly 05:02:49 UTC après deploy v335 = SHA 65ac40b)
```
ERROR [ExceptionHandler] Nest can't resolve dependencies of the
AdminGainersStatusController (?, ConfigService). Please make sure that
the argument TopGainersScannerService at index [0] is available in the
AdminModule context.

[PR04] could not find a good candidate within 40 attempts at load balancing
[PM07] failed to change machine state: machine still active, refusing to start
```

### Root cause
`AdminGainersStatusController` (existing controller, pas nouveau) dépend de `TopGainersScannerService` via `forwardRef(LisaModule)`. Le service était **registered comme provider** dans LisaModule (`providers: [..., TopGainersScannerService, ...]` ligne 104) mais **pas exporté** (manque dans `exports: [...]` qui finit ligne 150).

### Cascade
```
DI resolve fail → app.listen() never called
                → port 3001 never bound
                → Fly proxy: "Machines are not listening on 0.0.0.0:3001"
                → 10 restart attempts exhausted
                → 502/503 prod outage
```

C'est un bug **pré-existant** non détecté plus tôt parce que :
- CI ne fait que TS build + Jest unit tests, pas de Nest module boot integration
- La machine était précédemment stuck sur v334 (image antérieure à PR #196 BLOC 4) qui peut-être n'avait pas encore la combinaison admin/lisa déclenchant le crash

### Fix
1 ligne ajoutée à `LisaModule.exports[]` :
```ts
TopGainersScannerService,
```

### Audit préventif (point 4 user) — autres controllers admin
| Controller | Deps | Status |
|---|---|---|
| `AdminGainersBaselineController` (#199) | `VolumeBaselineCalculatorService`, `VolumeBaselineService`, `ConfigService` | ✅ via `GainersModule` exports + import |
| `AdminGainersStatusController` | `TopGainersScannerService`, `ConfigService` | ❌ Fixed by this PR |
| `AdminEodhdStatusController` | `EodhdQuotaService`, `ConfigService` | ✅ déjà exporté ligne 149 LisaModule |
| `AdminLogs/Migrations/SupabaseQuery` | `ConfigService` (global) | ✅ |

**Aucun autre risque DI résiduel identifié.**

### Test plan
- [x] Typecheck ✅
- [ ] CI green (TS + Jest)
- [ ] fly.yml deploy → app.listen successful, port 3001 bound
- [ ] `curl https://smartvest.fly.dev/health` → 200 OK
- [ ] `curl https://smartvest.fly.dev/version` → `{git_sha: "1302a40..."}` matching ce commit
- [ ] `curl https://smartvest.fly.dev/admin/gainers/scanner-status -H "x-admin-token: ..."` → 200 (validation DI)

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_