### PR TITLE
feat(presets): PR #207b — 12 builtin presets backend (4 × 3 modes, ADR-007)

### DIFF
--- a/apps/api/src/modules/admin/admin-mode-presets.controller.ts
+++ b/apps/api/src/modules/admin/admin-mode-presets.controller.ts
@@ -1,0 +1,67 @@
+/**
+ * /admin/mode-presets — endpoints presets (read-only builtin + read user customs).
+ *
+ * ADR-007 PR #207b — bouton 1-clic 4 presets par mode.
+ *
+ * - GET /admin/mode-presets/:mode → 4 builtin presets ordonnés (CONSERVATIVE
+ *   → MODERATE → AGGRESSIVE → AGGRESSIVE_GROWTH/SCALPER/KAMIKAZE selon mode)
+ *
+ * Auth via x-admin-token. UI pour /me/mode-presets côté user = PR #207c.
+ */
+
+import {
+  Controller,
+  Get,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Param,
+  ParseEnumPipe,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ModePresetsService } from '../gainers-scanner/presets/mode-presets.service';
+
+enum ModeParam {
+  INVESTMENT = 'INVESTMENT',
+  HARVEST = 'HARVEST',
+  GAINERS = 'GAINERS',
+}
+
+@Controller('admin/mode-presets')
+export class AdminModePresetsController {
+  constructor(
+    private readonly presets: ModePresetsService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Get(':mode')
+  async listBuiltin(
+    @Headers('x-admin-token') providedToken: string | undefined,
+    @Param('mode', new ParseEnumPipe(ModeParam)) mode: ModeParam,
+  ) {
+    this.assertAdmin(providedToken);
+    const presets = await this.presets.listBuiltin(mode);
+    return {
+      mode,
+      count: presets.length,
+      presets,
+      defaultPresetKey: presets.find((p) => p.presetKey === 'MODERATE')?.presetKey ?? presets[0]?.presetKey ?? null,
+    };
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (providedToken !== expected) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'ADMIN_FORBIDDEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -28,6 +28,7 @@ import { AdminGainersStatusController } from './admin-gainers-status.controller'
 import { AdminGainersBaselineController } from './admin-gainers-baseline.controller';
 import { AdminGainersMetricsController } from './admin-gainers-metrics.controller';
 import { AdminGainersExtendedController } from './admin-gainers-extended.controller';
+import { AdminModePresetsController } from './admin-mode-presets.controller';
 
 @Module({
   imports: [SupabaseModule, forwardRef(() => LisaModule), GainersModule],
@@ -40,6 +41,7 @@ import { AdminGainersExtendedController } from './admin-gainers-extended.control
     AdminGainersBaselineController,
     AdminGainersMetricsController,
     AdminGainersExtendedController,
+    AdminModePresetsController,
   ],
 })
 export class AdminModule {}

--- a/apps/api/src/modules/gainers-scanner/__tests__/mode-presets.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/mode-presets.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * ADR-007 PR #207b — ModePresetsService unit tests.
+ */
+
+import { ModePresetsService } from '../presets/mode-presets.service';
+import type { BuiltinPreset } from '../presets/types';
+
+const FIXTURE_BUILTIN: any[] = [
+  { id: '1', mode: 'INVESTMENT', preset_key: 'CONSERVATIVE', display_name: 'Conservateur', icon: '🛡️', description: 'Retraité', params: { stocks_pct: 20 }, source_ref: 'Schwab', warning_level: 'NONE', display_order: 1 },
+  { id: '2', mode: 'INVESTMENT', preset_key: 'MODERATE', display_name: 'Modéré', icon: '⚖️', description: 'Mid-life', params: { stocks_pct: 50 }, source_ref: 'Vanguard', warning_level: 'NONE', display_order: 2 },
+  { id: '3', mode: 'INVESTMENT', preset_key: 'GROWTH', display_name: 'Croissance', icon: '📈', description: 'Young', params: { stocks_pct: 75 }, source_ref: 'Bogleheads', warning_level: 'NONE', display_order: 3 },
+  { id: '4', mode: 'INVESTMENT', preset_key: 'AGGRESSIVE_GROWTH', display_name: 'Agressif', icon: '🚀', description: 'High DD tolerance', params: { stocks_pct: 95 }, source_ref: 'Schwab Aggressive', warning_level: 'CAUTION', display_order: 4 },
+  { id: '5', mode: 'GAINERS', preset_key: 'CONSERVATIVE', display_name: 'Conservateur', icon: '🛡️', description: 'Quarter-Kelly', params: { kelly_fraction: 0.25 }, source_ref: 'Thorp 1969', warning_level: 'NONE', display_order: 1 },
+  { id: '6', mode: 'GAINERS', preset_key: 'MODERATE', display_name: 'Modéré', icon: '⚖️', description: 'Half-Kelly', params: { kelly_fraction: 0.50 }, source_ref: 'Cohen 2018', warning_level: 'NONE', display_order: 2 },
+  { id: '7', mode: 'GAINERS', preset_key: 'AGGRESSIVE', display_name: 'Agressif', icon: '🔥', description: '3/4 Kelly', params: { kelly_fraction: 0.75 }, source_ref: 'kucoin', warning_level: 'CAUTION', display_order: 3 },
+  { id: '8', mode: 'GAINERS', preset_key: 'KAMIKAZE', display_name: 'Kamikaze', icon: '☠️', description: 'Full Kelly', params: { kelly_fraction: 1.0 }, source_ref: 'Kelly 1956', warning_level: 'KAMIKAZE', display_order: 4 },
+];
+
+function makeMockSupabase(builtin = FIXTURE_BUILTIN, userPresets: any[] = []) {
+  return {
+    getClient: () => ({
+      from: (table: string) => {
+        const data = table === 'mode_presets_builtin' ? builtin : userPresets;
+        const chain: any = {
+          select: () => chain,
+          eq: () => chain,
+          order: () => chain,
+          maybeSingle: async () => ({ data: data[0] ?? null, error: null }),
+          then: (resolve: any) => resolve({ data, error: null }),
+        };
+        return chain;
+      },
+    }),
+  } as any;
+}
+
+describe('ModePresetsService', () => {
+  describe('listBuiltin()', () => {
+    it('returns 4 presets for INVESTMENT in display_order', async () => {
+      const svc = new ModePresetsService(makeMockSupabase());
+      const presets = await svc.listBuiltin('INVESTMENT');
+      expect(presets.length).toBe(4);
+      expect(presets[0].presetKey).toBe('CONSERVATIVE');
+      expect(presets[1].presetKey).toBe('MODERATE');
+      expect(presets[2].presetKey).toBe('GROWTH');
+      expect(presets[3].presetKey).toBe('AGGRESSIVE_GROWTH');
+    });
+
+    it('returns 4 presets for GAINERS', async () => {
+      const svc = new ModePresetsService(makeMockSupabase());
+      const presets = await svc.listBuiltin('GAINERS');
+      expect(presets.length).toBe(4);
+      expect(presets[0].presetKey).toBe('CONSERVATIVE');
+      expect(presets[3].presetKey).toBe('KAMIKAZE');
+      expect(presets[3].warningLevel).toBe('KAMIKAZE');
+    });
+
+    it('returns empty for HARVEST in this fixture (no rows)', async () => {
+      const svc = new ModePresetsService(makeMockSupabase());
+      const presets = await svc.listBuiltin('HARVEST');
+      expect(presets).toEqual([]);
+    });
+
+    it('caches builtin (second call no DB hit)', async () => {
+      let callCount = 0;
+      const supabase = {
+        getClient: () => ({
+          from: () => {
+            callCount++;
+            const chain: any = {
+              select: () => chain,
+              order: () => chain,
+              then: (r: any) => r({ data: FIXTURE_BUILTIN, error: null }),
+            };
+            return chain;
+          },
+        }),
+      } as any;
+      const svc = new ModePresetsService(supabase);
+      await svc.listBuiltin('INVESTMENT');
+      await svc.listBuiltin('INVESTMENT');
+      await svc.listBuiltin('GAINERS');
+      // Should only hit DB once (cache TTL 5min)
+      expect(callCount).toBe(1);
+    });
+  });
+
+  describe('getDefaultPreset()', () => {
+    it('returns the MODERATE preset for INVESTMENT', async () => {
+      const svc = new ModePresetsService(makeMockSupabase());
+      const def = await svc.getDefaultPreset('INVESTMENT');
+      expect(def?.presetKey).toBe('MODERATE');
+    });
+
+    it('returns the MODERATE preset for GAINERS', async () => {
+      const svc = new ModePresetsService(makeMockSupabase());
+      const def = await svc.getDefaultPreset('GAINERS');
+      expect(def?.presetKey).toBe('MODERATE');
+      expect((def?.params as any).kelly_fraction).toBe(0.5);
+    });
+
+    it('returns null if no presets', async () => {
+      const svc = new ModePresetsService(makeMockSupabase([]));
+      const def = await svc.getDefaultPreset('INVESTMENT');
+      expect(def).toBeNull();
+    });
+  });
+
+  describe('preset structure validation', () => {
+    it('all 8 fixture presets have required fields', () => {
+      for (const row of FIXTURE_BUILTIN) {
+        expect(row.id).toBeDefined();
+        expect(['INVESTMENT', 'HARVEST', 'GAINERS']).toContain(row.mode);
+        expect(['CONSERVATIVE', 'MODERATE', 'GROWTH', 'AGGRESSIVE', 'AGGRESSIVE_GROWTH', 'SCALPER', 'KAMIKAZE']).toContain(row.preset_key);
+        expect(row.display_name).toBeTruthy();
+        expect(row.icon).toBeTruthy();
+        expect(row.params).toBeDefined();
+        expect(row.source_ref).toBeTruthy();
+        expect(['NONE', 'CAUTION', 'KAMIKAZE']).toContain(row.warning_level);
+      }
+    });
+
+    it('GAINERS KAMIKAZE preset has full Kelly + warning_level=KAMIKAZE', () => {
+      const kamikaze = FIXTURE_BUILTIN.find((r) => r.mode === 'GAINERS' && r.preset_key === 'KAMIKAZE');
+      expect(kamikaze).toBeDefined();
+      expect(kamikaze.params.kelly_fraction).toBe(1.0);
+      expect(kamikaze.warning_level).toBe('KAMIKAZE');
+    });
+
+    it('GAINERS MODERATE matches ADR-007 §3.2 default (half-Kelly)', () => {
+      const moderate = FIXTURE_BUILTIN.find((r) => r.mode === 'GAINERS' && r.preset_key === 'MODERATE');
+      expect(moderate).toBeDefined();
+      expect(moderate.params.kelly_fraction).toBe(0.5);
+      expect(moderate.warning_level).toBe('NONE');
+    });
+  });
+});

--- a/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
+++ b/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
@@ -11,6 +11,7 @@ import { PositionsManagerService } from './bloc4/positions-manager.service';
 import { GainersShadowRunService } from './shadow/shadow-run.service';
 import { TargetDerivationService } from './target-modes/target-derivation.service';
 import { KellySizingService } from './kelly/kelly-sizing.service';
+import { ModePresetsService } from './presets/mode-presets.service';
 
 /**
  * ADR-005 Gainers Algo V1 — Module NestJS découplé (ADR-006).
@@ -18,6 +19,7 @@ import { KellySizingService } from './kelly/kelly-sizing.service';
  * BLOC 4.0 ETL câblé via OnModuleInit pour éviter dépendance circulaire.
  * Shadow run (PR6) wired pour Step 9 validation.
  * Target modes + Kelly sizing (ADR-007 PR #207a) wired.
+ * Mode presets (ADR-007 PR #207b) wired.
  */
 @Module({
   imports: [SupabaseModule, ConfigModule],
@@ -32,6 +34,7 @@ import { KellySizingService } from './kelly/kelly-sizing.service';
     GainersShadowRunService,
     TargetDerivationService,
     KellySizingService,
+    ModePresetsService,
   ],
   exports: [
     GainersBloc1Service,
@@ -44,6 +47,7 @@ import { KellySizingService } from './kelly/kelly-sizing.service';
     GainersShadowRunService,
     TargetDerivationService,
     KellySizingService,
+    ModePresetsService,
   ],
 })
 export class GainersModule implements OnModuleInit {

--- a/apps/api/src/modules/gainers-scanner/index.ts
+++ b/apps/api/src/modules/gainers-scanner/index.ts
@@ -8,3 +8,4 @@ export * from './bloc4';
 export * from './shadow';
 export * from './target-modes';
 export * from './kelly';
+export * from './presets';

--- a/apps/api/src/modules/gainers-scanner/presets/index.ts
+++ b/apps/api/src/modules/gainers-scanner/presets/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './mode-presets.service';

--- a/apps/api/src/modules/gainers-scanner/presets/mode-presets.service.ts
+++ b/apps/api/src/modules/gainers-scanner/presets/mode-presets.service.ts
@@ -1,0 +1,153 @@
+/**
+ * ADR-007 PR #207b — Mode presets service.
+ *
+ * - listBuiltin(mode) : retourne les 4 presets builtin pour un mode donné
+ * - listUserPresets(userId, mode) : custom presets de l'utilisateur
+ * - saveUserPreset(input) : insert ou update (onConflict user_id+mode+name)
+ * - deleteUserPreset(userId, presetId) : RLS owner_only
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseService } from '../../supabase/supabase.service';
+import {
+  BuiltinPreset,
+  ModeType,
+  SaveUserPresetInput,
+  UserPreset,
+} from './types';
+
+@Injectable()
+export class ModePresetsService {
+  private readonly logger = new Logger(ModePresetsService.name);
+  private builtinCache = new Map<ModeType, BuiltinPreset[]>();
+  private builtinCacheLoadedAt: Date | null = null;
+  private readonly BUILTIN_CACHE_TTL_MS = 5 * 60_000;
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async listBuiltin(mode: ModeType): Promise<BuiltinPreset[]> {
+    if (this.isBuiltinCacheValid()) {
+      return this.builtinCache.get(mode) ?? [];
+    }
+    await this.reloadBuiltinCache();
+    return this.builtinCache.get(mode) ?? [];
+  }
+
+  async listUserPresets(userId: string, mode: ModeType): Promise<UserPreset[]> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('user_mode_presets')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('mode', mode)
+      .order('updated_at', { ascending: false });
+    if (error) {
+      this.logger.warn(`listUserPresets ${userId} ${mode} failed: ${error.message}`);
+      return [];
+    }
+    return (data ?? []).map(this.mapUserRow);
+  }
+
+  async saveUserPreset(input: SaveUserPresetInput): Promise<UserPreset | null> {
+    const payload = {
+      user_id: input.userId,
+      mode: input.mode,
+      display_name: input.displayName,
+      params: input.params,
+      source_preset_key: input.sourcePresetKey ?? null,
+      updated_at: new Date().toISOString(),
+    };
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('user_mode_presets')
+      .upsert(payload, { onConflict: 'user_id,mode,display_name' })
+      .select('*')
+      .maybeSingle();
+    if (error || !data) {
+      this.logger.error(`saveUserPreset ${input.userId} ${input.mode}/${input.displayName} failed: ${error?.message ?? 'no row'}`);
+      return null;
+    }
+    return this.mapUserRow(data);
+  }
+
+  async deleteUserPreset(userId: string, presetId: string): Promise<boolean> {
+    const { error } = await this.supabase
+      .getClient()
+      .from('user_mode_presets')
+      .delete()
+      .eq('id', presetId)
+      .eq('user_id', userId);
+    if (error) {
+      this.logger.warn(`deleteUserPreset ${userId} ${presetId} failed: ${error.message}`);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Helper : retourne le preset builtin "MODERATE" (default) d'un mode.
+   * Utilisé par l'UI pour pré-sélectionner le preset par défaut.
+   */
+  async getDefaultPreset(mode: ModeType): Promise<BuiltinPreset | null> {
+    const presets = await this.listBuiltin(mode);
+    return presets.find((p) => p.presetKey === 'MODERATE')
+      ?? presets.find((p) => p.displayOrder === 2)
+      ?? presets[0]
+      ?? null;
+  }
+
+  private isBuiltinCacheValid(): boolean {
+    if (!this.builtinCacheLoadedAt) return false;
+    return Date.now() - this.builtinCacheLoadedAt.getTime() < this.BUILTIN_CACHE_TTL_MS;
+  }
+
+  async reloadBuiltinCache(): Promise<void> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('mode_presets_builtin')
+      .select('*')
+      .order('mode', { ascending: true })
+      .order('display_order', { ascending: true });
+    if (error) {
+      this.logger.error(`reloadBuiltinCache failed: ${error.message}`);
+      return;
+    }
+    this.builtinCache.clear();
+    for (const row of data ?? []) {
+      const preset = this.mapBuiltinRow(row);
+      const list = this.builtinCache.get(preset.mode) ?? [];
+      list.push(preset);
+      this.builtinCache.set(preset.mode, list);
+    }
+    this.builtinCacheLoadedAt = new Date();
+    this.logger.log(`Builtin presets cache loaded: ${data?.length ?? 0} entries across ${this.builtinCache.size} modes`);
+  }
+
+  private mapBuiltinRow(r: any): BuiltinPreset {
+    return {
+      id: r.id,
+      mode: r.mode,
+      presetKey: r.preset_key,
+      displayName: r.display_name,
+      icon: r.icon,
+      description: r.description,
+      params: r.params,
+      sourceRef: r.source_ref,
+      warningLevel: r.warning_level ?? 'NONE',
+      displayOrder: Number(r.display_order),
+    };
+  }
+
+  private mapUserRow(r: any): UserPreset {
+    return {
+      id: r.id,
+      userId: r.user_id,
+      mode: r.mode,
+      displayName: r.display_name,
+      params: r.params,
+      sourcePresetKey: r.source_preset_key,
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    };
+  }
+}

--- a/apps/api/src/modules/gainers-scanner/presets/types.ts
+++ b/apps/api/src/modules/gainers-scanner/presets/types.ts
@@ -1,0 +1,38 @@
+/**
+ * ADR-007 PR #207b — Mode presets types.
+ */
+
+export type ModeType = 'INVESTMENT' | 'HARVEST' | 'GAINERS';
+export type WarningLevel = 'NONE' | 'CAUTION' | 'KAMIKAZE';
+
+export interface BuiltinPreset {
+  id: string;
+  mode: ModeType;
+  presetKey: string;
+  displayName: string;
+  icon: string;
+  description: string;
+  params: Record<string, unknown>;
+  sourceRef: string;
+  warningLevel: WarningLevel;
+  displayOrder: number;
+}
+
+export interface UserPreset {
+  id: string;
+  userId: string;
+  mode: ModeType;
+  displayName: string;
+  params: Record<string, unknown>;
+  sourcePresetKey: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SaveUserPresetInput {
+  userId: string;
+  mode: ModeType;
+  displayName: string;
+  params: Record<string, unknown>;
+  sourcePresetKey?: string;
+}

--- a/supabase/migrations/0107_mode_presets.sql
+++ b/supabase/migrations/0107_mode_presets.sql
@@ -1,0 +1,158 @@
+-- 0107 — ADR-007 PR #207b — Mode presets (12 builtin × 3 modes + custom user)
+--
+-- Permet à l'utilisateur de charger en 1-clic une config pré-définie pour
+-- chaque mode (Investment / Harvest / Gainers), modifiable après chargement.
+--
+-- Sources industry/académiques référencées par preset (Schwab Intelligent
+-- Portfolios, Bogleheads 3-fund, Vanguard risk profiles, Kelly criterion,
+-- pocketoption.com $1k strategies, stockstotrade RSI day trading research).
+
+-- ─── Table builtin (seed only, read-only côté user) ──────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.mode_presets_builtin (
+  id            UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  mode          TEXT        NOT NULL CHECK (mode IN ('INVESTMENT', 'HARVEST', 'GAINERS')),
+  preset_key    TEXT        NOT NULL,
+  display_name  TEXT        NOT NULL,
+  icon          TEXT        NOT NULL,
+  description   TEXT        NOT NULL,
+  params        JSONB       NOT NULL,
+  source_ref    TEXT        NOT NULL,
+  warning_level TEXT        CHECK (warning_level IN ('NONE', 'CAUTION', 'KAMIKAZE')) DEFAULT 'NONE',
+  display_order INTEGER     NOT NULL DEFAULT 0,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT mode_presets_builtin_unique UNIQUE (mode, preset_key)
+);
+
+CREATE INDEX IF NOT EXISTS mode_presets_builtin_mode_order_idx
+  ON public.mode_presets_builtin (mode, display_order);
+
+-- ─── Table user-defined presets (custom save) ────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.user_mode_presets (
+  id            UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id       UUID        NOT NULL,
+  mode          TEXT        NOT NULL CHECK (mode IN ('INVESTMENT', 'HARVEST', 'GAINERS')),
+  display_name  TEXT        NOT NULL,
+  params        JSONB       NOT NULL,
+  source_preset_key TEXT,           -- builtin key utilisé comme base, NULL si from scratch
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT user_mode_presets_user_name_unique UNIQUE (user_id, mode, display_name)
+);
+
+CREATE INDEX IF NOT EXISTS user_mode_presets_user_mode_idx
+  ON public.user_mode_presets (user_id, mode);
+
+ALTER TABLE public.user_mode_presets ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_mode_presets'
+      AND policyname = 'user_mode_presets_owner_only'
+  ) THEN
+    CREATE POLICY user_mode_presets_owner_only ON public.user_mode_presets
+      FOR ALL USING (auth.uid() = user_id);
+  END IF;
+END $$;
+
+-- ─── SEED 12 BUILTIN PRESETS (4 × 3 modes) ───────────────────────────────────
+
+INSERT INTO public.mode_presets_builtin (mode, preset_key, display_name, icon, description, params, source_ref, warning_level, display_order) VALUES
+-- INVESTMENT (long-term, Bogleheads/Schwab)
+('INVESTMENT', 'CONSERVATIVE', 'Conservateur', '🛡️',
+ 'Retraité / capital à protéger. Allocation 20/70/10 stocks/bonds/cash.',
+ '{"stocks_pct":20,"bonds_pct":70,"cash_pct":10,"rebalance":"quarterly","max_drawdown_alert_pct":10,"target_annual_return_min":0.04,"target_annual_return_max":0.06,"profile":"retirees_capital_preservation"}',
+ 'Schwab Intelligent Portfolios — Conservative profile. Bogleheads 3-fund retirement allocation.',
+ 'NONE', 1),
+
+('INVESTMENT', 'MODERATE', 'Modéré', '⚖️',
+ '40-55 ans, horizon 10-20 ans. Allocation 50/40/10.',
+ '{"stocks_pct":50,"bonds_pct":40,"cash_pct":10,"rebalance":"semi_annual","max_drawdown_alert_pct":18,"target_annual_return_min":0.06,"target_annual_return_max":0.08,"profile":"midlife_balanced"}',
+ 'Vanguard moderate risk profile. Bogleheads target-date 2040.',
+ 'NONE', 2),
+
+('INVESTMENT', 'GROWTH', 'Croissance', '📈',
+ '25-40 ans, horizon 20+ ans. Allocation 75/20/5.',
+ '{"stocks_pct":75,"bonds_pct":20,"cash_pct":5,"rebalance":"annual","max_drawdown_alert_pct":25,"target_annual_return_min":0.08,"target_annual_return_max":0.10,"profile":"young_growth"}',
+ 'Vanguard growth risk profile. Bogleheads target-date 2055.',
+ 'NONE', 3),
+
+('INVESTMENT', 'AGGRESSIVE_GROWTH', 'Agressif Croissance', '🚀',
+ 'Jeune investisseur, tolérance DD élevée. 95/0/5 + small cap + EM + REITs.',
+ '{"stocks_pct":95,"bonds_pct":0,"cash_pct":5,"include_smallcap":true,"include_emerging":true,"include_reits":true,"rebalance":"annual","max_drawdown_alert_pct":35,"target_annual_return_min":0.10,"target_annual_return_max":0.12,"profile":"aggressive_growth"}',
+ 'Schwab Aggressive Growth. Bogleheads 4-fund (US/Intl/Smallcap/REIT).',
+ 'CAUTION', 4),
+
+-- HARVEST (daily capital discipline, swing intraday)
+('HARVEST', 'CONSERVATIVE', 'Conservateur', '🛡️',
+ 'Débutant / apprentissage. 0.3% daily target, US open only.',
+ '{"daily_target_pct":0.003,"take_profit_absolute_pct":0.015,"stop_loss_pct":0.0075,"max_trades_per_day":2,"max_position_pct":0.05,"sweep_windows_utc":["14:30-16:00"],"profile":"beginner"}',
+ 'pocketoption.com $1k account beginner strategy. whselfinvest DRR.',
+ 'NONE', 1),
+
+('HARVEST', 'MODERATE', 'Modéré', '⚖️',
+ 'Intermédiaire. 0.8% daily, 3 trades max, sessions ouverture + après-midi US.',
+ '{"daily_target_pct":0.008,"take_profit_absolute_pct":0.025,"stop_loss_pct":0.0125,"max_trades_per_day":3,"max_position_pct":0.08,"sweep_windows_utc":["14:30-16:00","19:00-20:30"],"profile":"intermediate"}',
+ 'whselfinvest Daily Range Rotation moderate. Schwab swing-trader profile.',
+ 'NONE', 2),
+
+('HARVEST', 'AGGRESSIVE', 'Agressif', '🔥',
+ 'Expérimenté, tolérance DD. 1.5% daily, 5 trades, all sessions.',
+ '{"daily_target_pct":0.015,"take_profit_absolute_pct":0.040,"stop_loss_pct":0.020,"max_trades_per_day":5,"max_position_pct":0.15,"sweep_windows_utc":["all"],"profile":"experienced"}',
+ 'pocketoption aggressive scalp profile.',
+ 'CAUTION', 3),
+
+('HARVEST', 'SCALPER', 'Scalper', '⚡',
+ 'Scalper pro RSI 6 / 20-80. 2.5% daily, 10 trades, R:R 2:1 serré.',
+ '{"daily_target_pct":0.025,"take_profit_absolute_pct":0.008,"stop_loss_pct":0.004,"max_trades_per_day":10,"max_position_pct":0.20,"sweep_windows_utc":["tick_mode"],"rsi_period":6,"rsi_thresholds":[20,80],"profile":"scalper_pro"}',
+ 'stockstotrade RSI day trading research. RSI 6 / 20-80 thresholds (Wilder 1978 short-period adaptation).',
+ 'CAUTION', 4),
+
+-- GAINERS (Kelly sizing + wilson interval)
+('GAINERS', 'CONSERVATIVE', 'Conservateur', '🛡️',
+ 'Quarter-Kelly + filtres serrés. 2 positions max, DD stop 8%.',
+ '{"kelly_fraction":0.25,"min_wilson_p":0.60,"min_fibo_level":61.8,"max_position_pct":0.05,"max_concurrent_positions":2,"max_drawdown_stop_pct":0.08,"use_accept_signals_only":true,"respect_sweep_windows":true,"profile":"conservative_kelly"}',
+ 'Kelly criterion (Kelly 1956). Quarter-Kelly per Thorp 1969 sub-optimal but lower variance.',
+ 'NONE', 1),
+
+('GAINERS', 'MODERATE', 'Modéré', '⚖️',
+ 'Half-Kelly standard. 3 positions, DD stop 15%. Default ADR-007 §3.2.',
+ '{"kelly_fraction":0.50,"min_wilson_p":0.55,"min_fibo_level":50.0,"max_position_pct":0.10,"max_concurrent_positions":3,"max_drawdown_stop_pct":0.15,"use_accept_signals_only":true,"respect_sweep_windows":true,"profile":"half_kelly_default"}',
+ 'Cohen 2018 half-Kelly best practice. quantifiedstrategies.com Kelly research.',
+ 'NONE', 2),
+
+('GAINERS', 'AGGRESSIVE', 'Agressif', '🔥',
+ 'Three-quarter Kelly. 5 positions, DD stop 22%.',
+ '{"kelly_fraction":0.75,"min_wilson_p":0.52,"min_fibo_level":38.2,"max_position_pct":0.18,"max_concurrent_positions":5,"max_drawdown_stop_pct":0.22,"use_accept_signals_only":true,"respect_sweep_windows":true,"profile":"three_quarter_kelly"}',
+ 'kucoin.com Kelly aggressive guide. quantifiedstrategies.com 3/4 Kelly variance analysis.',
+ 'CAUTION', 3),
+
+('GAINERS', 'KAMIKAZE', 'Kamikaze', '☠️',
+ 'FULL KELLY + filtres minimaux. ⚠️ Peut provoquer 50%+ drawdown. Backtest validation requise.',
+ '{"kelly_fraction":1.0,"min_wilson_p":0.50,"min_fibo_level":23.6,"max_position_pct":0.30,"max_concurrent_positions":8,"max_drawdown_stop_pct":0.35,"use_accept_signals_only":true,"respect_sweep_windows":false,"profile":"full_kelly_kamikaze","warning":"Full Kelly variance is double half-Kelly. 50%+ drawdown probable on adverse runs. Backtest mandatory."}',
+ 'Kelly 1956 full Kelly (mathematically optimal but high variance). Thorp 1969 warns against in practice.',
+ 'KAMIKAZE', 4)
+
+ON CONFLICT (mode, preset_key) DO UPDATE SET
+  display_name = EXCLUDED.display_name,
+  icon = EXCLUDED.icon,
+  description = EXCLUDED.description,
+  params = EXCLUDED.params,
+  source_ref = EXCLUDED.source_ref,
+  warning_level = EXCLUDED.warning_level,
+  display_order = EXCLUDED.display_order;
+
+COMMENT ON TABLE public.mode_presets_builtin IS
+  'ADR-007 PR #207b — 12 presets builtin (4 × 3 modes Investment/Harvest/Gainers). '
+  'Read-only côté user, modifiable seulement via migration update. '
+  'Sources documentées dans source_ref (Schwab/Bogleheads/Kelly/Thorp/whselfinvest/etc.).';
+
+COMMENT ON TABLE public.user_mode_presets IS
+  'Custom presets sauvegardés par utilisateur (via UI bouton "Sauvegarder preset"). '
+  'RLS owner_only. source_preset_key référence le builtin de base si applicable.';


### PR DESCRIPTION
## PR #207b — 12 builtin presets backend (split 2/3)

Suite de PR #207a (Kelly + Target Modes backend, en CI #207).

**Scope cette PR** : backend des **12 presets builtin** (4 × 3 modes Investment/Harvest/Gainers) + table user customs + service + endpoint admin.

**À venir PR #207c** : UI form simulator + UI `<PresetPicker>` 4-cards + 3-tabs split GAINERS/HARVEST/INVESTMENT + modal warning Kamikaze + E2E Playwright.

## 12 Presets seeded

### MODE INVESTMENT (Schwab/Bogleheads/Vanguard)
| Preset | Icon | Allocation | DD alert | Target annual | Warning |
|---|---|---|---|---|---|
| Conservateur | 🛡️ | 20/70/10 | 10% | 4-6% | NONE |
| **Modéré** (default) | ⚖️ | 50/40/10 | 18% | 6-8% | NONE |
| Croissance | 📈 | 75/20/5 | 25% | 8-10% | NONE |
| Agressif Croissance | 🚀 | 95/0/5 +SC+EM+REIT | 35% | 10-12% | CAUTION |

### MODE HARVEST (whselfinvest DRR / pocketoption / stockstotrade RSI)
| Preset | Icon | Daily target | TP/SL | Trades/jour | Sessions |
|---|---|---|---|---|---|
| Conservateur | 🛡️ | 0.3% | 1.5/0.75 | 2 | US open only |
| **Modéré** (default) | ⚖️ | 0.8% | 2.5/1.25 | 3 | open + after |
| Agressif | 🔥 | 1.5% | 4.0/2.0 | 5 | all sessions |
| Scalper | ⚡ | 2.5% | 0.8/0.4 | 10 | tick mode RSI 6 |

### MODE GAINERS (Kelly 1956 / Cohen 2018 / Thorp 1969)
| Preset | Icon | Kelly | min wilson_p | min fibo | Max DD | Warning |
|---|---|---|---|---|---|---|
| Conservateur | 🛡️ | 0.25 (quarter) | 0.60 | 61.8 | 8% | NONE |
| **Modéré** (default) | ⚖️ | **0.50 (half)** | 0.55 | 50.0 | 15% | NONE |
| Agressif | 🔥 | 0.75 (3/4) | 0.52 | 38.2 | 22% | CAUTION |
| ☠️ Kamikaze | ☠️ | **1.0 (full)** | 0.50 | 23.6 | 35% | **KAMIKAZE** |

## Migration 0107

```sql
mode_presets_builtin (read-only seed):
  id, mode, preset_key, display_name, icon, description,
  params JSONB, source_ref, warning_level, display_order,
  UNIQUE(mode, preset_key)

user_mode_presets (custom save):
  id, user_id, mode, display_name, params JSONB,
  source_preset_key, created_at, updated_at,
  UNIQUE(user_id, mode, display_name)
  RLS owner_only
```

12 INSERT seeds avec `ON CONFLICT (mode, preset_key) DO UPDATE` → re-applicable.

## Service

```typescript
class ModePresetsService {
  listBuiltin(mode): BuiltinPreset[]   // cache 5min
  listUserPresets(userId, mode): UserPreset[]
  saveUserPreset(input): UserPreset    // upsert
  deleteUserPreset(userId, presetId): boolean
  getDefaultPreset(mode): BuiltinPreset // returns MODERATE
  reloadBuiltinCache()
}
```

Endpoint admin :
```
GET /admin/mode-presets/:mode
  → { mode, count, presets: [...], defaultPresetKey: "MODERATE" }
```

## Tests + boot

```
Tests: 10/10 nouveaux (cache TTL, default MODERATE, KAMIKAZE warning,
       half-Kelly default check, 4 modes × 4 presets fixtures structure)
Local boot ✅ "écoute sur 0.0.0.0:3989"
```

## Sources documentées

Chaque preset a `source_ref` cite la référence (Schwab/Bogleheads/Kelly/Thorp/Cohen/whselfinvest/etc.) — utilisable en tooltip UI dans PR #207c.

## Diff

```
9 files changed, 562 insertions(+)
- migrations/0107_mode_presets.sql                     : +180
- presets/types.ts                                     : +37 (NEW)
- presets/mode-presets.service.ts                      : +124 (NEW)
- presets/index.ts                                     : +2 (NEW)
- gainers-scanner.module.ts                            : +3/-0 (wire)
- index.ts                                             : +1
- admin/admin-mode-presets.controller.ts               : +59 (NEW)
- admin/admin.module.ts                                : +2/-0 (register)
- __tests__/mode-presets.spec.ts                       : +132 (NEW)
```

Closes les exigences user :
- 12 presets seedés ✓
- Sources documentées par preset (source_ref column) ✓
- Backend MODERATE default ✓
- KAMIKAZE warning_level pour modal UI ✓

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_