### PR TITLE
feat(shadow): PR6.2 — daily report cron + endpoints (Phase 3.2)

### DIFF
--- a/apps/api/src/modules/admin/admin-shadow-daily-report.controller.ts
+++ b/apps/api/src/modules/admin/admin-shadow-daily-report.controller.ts
@@ -1,0 +1,96 @@
+/**
+ * /admin/gainers/shadow-daily-report — Phase 3.2 PR6.2.
+ *
+ * GET /admin/gainers/shadow-daily-report
+ *   ?days=30  → derniers N jours (max 90, default 30)
+ *
+ * POST /admin/gainers/shadow-daily-report/recompute
+ *   body { date?: 'YYYY-MM-DD' }  → backfill ou recompute manuel d'une date
+ *
+ * Auth via x-admin-token.
+ */
+
+import {
+  Body,
+  Controller,
+  Get,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ShadowDailyReportService } from '../gainers-scanner/shadow/shadow-daily-report.service';
+
+@Controller('admin/gainers/shadow-daily-report')
+export class AdminShadowDailyReportController {
+  constructor(
+    private readonly service: ShadowDailyReportService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Get()
+  async list(
+    @Headers('x-admin-token') token: string | undefined,
+    @Query('days') daysStr?: string,
+  ) {
+    this.assertAdmin(token);
+    const days = Math.min(Math.max(Number(daysStr ?? 30) || 30, 1), 90);
+    const reports = await this.service.getRecentReports(days);
+
+    // Aggregate sur la fenêtre pour quick view
+    const totalAccept = reports.reduce((s, r) => s + r.acceptCount, 0);
+    const totalClosed = reports.reduce((s, r) => s + r.closedCount, 0);
+    const totalWins = reports.reduce((s, r) => s + r.winCount, 0);
+    const anomaliesCount = reports.filter(
+      (r) => r.zeroSignalsFlag || r.highSlippageFlag || r.lowCadenceFlag,
+    ).length;
+
+    return {
+      windowDays: days,
+      reportCount: reports.length,
+      summary: {
+        totalAccept,
+        totalClosed,
+        winRate: totalClosed > 0 ? totalWins / totalClosed : null,
+        avgCadenceAcceptPerDay: reports.length > 0 ? totalAccept / reports.length : 0,
+        anomaliesCount,
+      },
+      reports,
+    };
+  }
+
+  @Post('recompute')
+  async recompute(
+    @Headers('x-admin-token') token: string | undefined,
+    @Body() body?: { date?: string },
+  ) {
+    this.assertAdmin(token);
+    const date = body?.date ?? new Date().toISOString().slice(0, 10);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      throw new HttpException(
+        { message: 'invalid date format, expected YYYY-MM-DD', code: 'BAD_DATE' },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    const result = await this.service.computeAndUpsert(date);
+    return { recomputed: date, result };
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (providedToken !== expected) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'ADMIN_FORBIDDEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -29,6 +29,7 @@ import { AdminGainersBaselineController } from './admin-gainers-baseline.control
 import { AdminGainersMetricsController } from './admin-gainers-metrics.controller';
 import { AdminGainersExtendedController } from './admin-gainers-extended.controller';
 import { AdminModePresetsController } from './admin-mode-presets.controller';
+import { AdminShadowDailyReportController } from './admin-shadow-daily-report.controller';
 
 @Module({
   imports: [SupabaseModule, forwardRef(() => LisaModule), GainersModule],
@@ -42,6 +43,7 @@ import { AdminModePresetsController } from './admin-mode-presets.controller';
     AdminGainersMetricsController,
     AdminGainersExtendedController,
     AdminModePresetsController,
+    AdminShadowDailyReportController,
   ],
 })
 export class AdminModule {}

--- a/apps/api/src/modules/gainers-scanner/__tests__/shadow-daily-report.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/shadow-daily-report.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Phase 3.2 PR6.2 — ShadowDailyReportService tests.
+ */
+
+import { ShadowDailyReportService } from '../shadow/shadow-daily-report.service';
+
+interface MockTables {
+  gainers_v1_shadow_signals?: any[];
+  gainers_shadow_daily_report?: any[];
+}
+
+function makeMockSupabase(tables: MockTables = {}) {
+  const upserts: any[] = [];
+  return {
+    upserts,
+    getClient: () => ({
+      from: (tableName: string) => {
+        const data = (tables as any)[tableName] ?? [];
+        const chain: any = {
+          select: () => chain,
+          gte: () => chain,
+          lte: () => chain,
+          lt: () => chain,
+          eq: () => chain,
+          order: () => chain,
+          limit: () => chain,
+          maybeSingle: async () => ({ data: data[0] ?? null, error: null }),
+          upsert: async (payload: any) => {
+            upserts.push({ table: tableName, payload });
+            return { error: null };
+          },
+          then: (r: any) => r({ data, error: null }),
+        };
+        return chain;
+      },
+    }),
+  } as any;
+}
+
+describe('ShadowDailyReportService', () => {
+  describe('computeAndUpsert()', () => {
+    it('returns null on fetch error and does not upsert', async () => {
+      const supabase = {
+        getClient: () => ({
+          from: () => ({
+            select: () => ({
+              gte: () => ({
+                lte: () => ({ then: (r: any) => r({ data: null, error: { message: 'boom' } }) }),
+              }),
+            }),
+          }),
+        }),
+      } as any;
+      const svc = new ShadowDailyReportService(supabase);
+      const result = await svc.computeAndUpsert('2026-05-02');
+      expect(result).toBeNull();
+    });
+
+    it('aggregates correctly with 0 signals (empty day)', async () => {
+      const mock = makeMockSupabase({ gainers_v1_shadow_signals: [] });
+      const svc = new ShadowDailyReportService(mock);
+      const result = await svc.computeAndUpsert('2026-05-02');
+      expect(result).not.toBeNull();
+      expect(result!.totalSignals).toBe(0);
+      expect(result!.acceptCount).toBe(0);
+      expect(result!.winRate).toBeNull();
+      expect(mock.upserts.length).toBe(1);
+      expect(mock.upserts[0].table).toBe('gainers_shadow_daily_report');
+    });
+
+    it('aggregates ACCEPT + REJECT + closed PnL correctly', async () => {
+      const signals = [
+        { decision: 'ACCEPT', simulated_pnl_pct: 0.012, simulated_slippage_pct: 0.001, diverges_from_legacy: false, setup_type: 'PULLBACK_HL_FIBO' },
+        { decision: 'ACCEPT', simulated_pnl_pct: -0.008, simulated_slippage_pct: -0.002, diverges_from_legacy: false, setup_type: 'VWAP_RECLAIM' },
+        { decision: 'ACCEPT', simulated_pnl_pct: 0.020, simulated_slippage_pct: 0.001, diverges_from_legacy: true, setup_type: 'PULLBACK_HL_FIBO' },
+        { decision: 'REJECT', simulated_pnl_pct: null, simulated_slippage_pct: null, diverges_from_legacy: false, setup_type: null },
+        { decision: 'REJECT', simulated_pnl_pct: null, simulated_slippage_pct: null, diverges_from_legacy: false, setup_type: null },
+      ];
+      const mock = makeMockSupabase({ gainers_v1_shadow_signals: signals });
+      const svc = new ShadowDailyReportService(mock);
+      const result = await svc.computeAndUpsert('2026-05-02');
+      expect(result!.totalSignals).toBe(5);
+      expect(result!.acceptCount).toBe(3);
+      expect(result!.rejectCount).toBe(2);
+      expect(result!.closedCount).toBe(3);
+      expect(result!.winCount).toBe(2); // pnl > 0
+      expect(result!.lossCount).toBe(1);
+      expect(result!.winRate).toBeCloseTo(2 / 3, 4);
+      expect(result!.divergenceCount).toBe(1);
+      expect(result!.divergencePct).toBeCloseTo(1 / 5, 4);
+      expect(result!.triggerBreakdown.PULLBACK_HL_FIBO).toBe(2);
+      expect(result!.triggerBreakdown.VWAP_RECLAIM).toBe(1);
+    });
+
+    it('flags high_slippage when avg > 0.6%', async () => {
+      const signals = [
+        { decision: 'ACCEPT', simulated_pnl_pct: 0.01, simulated_slippage_pct: 0.008, diverges_from_legacy: false, setup_type: 'PULLBACK_HL_FIBO' },
+        { decision: 'ACCEPT', simulated_pnl_pct: 0.01, simulated_slippage_pct: 0.007, diverges_from_legacy: false, setup_type: 'PULLBACK_HL_FIBO' },
+      ];
+      const mock = makeMockSupabase({ gainers_v1_shadow_signals: signals });
+      const svc = new ShadowDailyReportService(mock);
+      const result = await svc.computeAndUpsert('2026-05-02');
+      expect(result!.avgSlippagePct).toBeCloseTo(0.0075, 4);
+      expect(result!.highSlippageFlag).toBe(true);
+      // anomalous_fill_count counts |slip| > 1% (0.01)
+      // 0.008 and 0.007 are both BELOW 0.01 → anomalousFill = 0
+      expect(result!.anomalousFillCount).toBe(0);
+    });
+
+    it('counts anomalous_fill when |slippage| > 1%', async () => {
+      const signals = [
+        { decision: 'ACCEPT', simulated_pnl_pct: 0.01, simulated_slippage_pct: 0.012, diverges_from_legacy: false, setup_type: 'PULLBACK_HL_FIBO' },
+        { decision: 'ACCEPT', simulated_pnl_pct: -0.01, simulated_slippage_pct: -0.015, diverges_from_legacy: false, setup_type: 'VWAP_RECLAIM' },
+      ];
+      const mock = makeMockSupabase({ gainers_v1_shadow_signals: signals });
+      const svc = new ShadowDailyReportService(mock);
+      const result = await svc.computeAndUpsert('2026-05-02');
+      expect(result!.anomalousFillCount).toBe(2);
+    });
+  });
+});

--- a/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
+++ b/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
@@ -9,6 +9,7 @@ import { GainersBloc2Service } from './bloc2/gainers-bloc2.service';
 import { GainersBloc3Service } from './bloc3/gainers-bloc3.service';
 import { PositionsManagerService } from './bloc4/positions-manager.service';
 import { GainersShadowRunService } from './shadow/shadow-run.service';
+import { ShadowDailyReportService } from './shadow/shadow-daily-report.service';
 import { TargetDerivationService } from './target-modes/target-derivation.service';
 import { KellySizingService } from './kelly/kelly-sizing.service';
 import { ModePresetsService } from './presets/mode-presets.service';
@@ -32,6 +33,7 @@ import { ModePresetsService } from './presets/mode-presets.service';
     GainersBloc3Service,
     PositionsManagerService,
     GainersShadowRunService,
+    ShadowDailyReportService,
     TargetDerivationService,
     KellySizingService,
     ModePresetsService,
@@ -45,6 +47,7 @@ import { ModePresetsService } from './presets/mode-presets.service';
     GainersBloc3Service,
     PositionsManagerService,
     GainersShadowRunService,
+    ShadowDailyReportService,
     TargetDerivationService,
     KellySizingService,
     ModePresetsService,

--- a/apps/api/src/modules/gainers-scanner/shadow/index.ts
+++ b/apps/api/src/modules/gainers-scanner/shadow/index.ts
@@ -1,2 +1,3 @@
 export * from './power-analysis';
 export * from './shadow-run.service';
+export * from './shadow-daily-report.service';

--- a/apps/api/src/modules/gainers-scanner/shadow/shadow-daily-report.service.ts
+++ b/apps/api/src/modules/gainers-scanner/shadow/shadow-daily-report.service.ts
@@ -1,0 +1,237 @@
+/**
+ * ADR-005 Phase 3.2 PR6.2 — Shadow daily report service.
+ *
+ * Cron 23:30 UTC chaque jour :
+ *   - aggregate gainers_v1_shadow_signals du jour calendaire UTC
+ *   - INSERT/UPSERT 1 row dans gainers_shadow_daily_report
+ *   - calcul anomaly flags (zero_signals_48h, high_slippage_2x, low_cadence_7d)
+ *
+ * Idempotent : ON CONFLICT (report_date) DO UPDATE — safe à rerun manuel.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+export interface DailyReportRow {
+  reportDate: string;
+  totalSignals: number;
+  acceptCount: number;
+  rejectCount: number;
+  closedCount: number;
+  winCount: number;
+  lossCount: number;
+  winRate: number | null;
+  avgRealizedPnlPct: number | null;
+  cumulativePnlPct: number | null;
+  avgSlippagePct: number | null;
+  anomalousFillCount: number;
+  divergenceCount: number;
+  divergencePct: number | null;
+  triggerBreakdown: Record<string, number>;
+  zeroSignalsFlag: boolean;
+  highSlippageFlag: boolean;
+  lowCadenceFlag: boolean;
+}
+
+const HIGH_SLIPPAGE_THRESHOLD = 0.006; // 2× ADR §11.3 cap 0.30%
+const LOW_CADENCE_THRESHOLD = 0.5; // < 0.5 accept/jour sur 7j → risque ETA
+
+@Injectable()
+export class ShadowDailyReportService {
+  private readonly logger = new Logger(ShadowDailyReportService.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  /** Cron quotidien 23:30 UTC — aggregate du jour courant. */
+  @Cron('30 23 * * *')
+  async runDailyReport(): Promise<void> {
+    const today = this.todayUtcDateStr();
+    try {
+      await this.computeAndUpsert(today);
+      this.logger.log(`[shadow-daily-report] computed ${today}`);
+    } catch (e) {
+      this.logger.error(`[shadow-daily-report] ${today} failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  /**
+   * Calcule + UPSERT le report d'une date donnée. Public pour permettre
+   * recompute manuel (admin endpoint follow-up) ou backfill.
+   */
+  async computeAndUpsert(reportDate: string): Promise<DailyReportRow | null> {
+    const dayStart = `${reportDate}T00:00:00Z`;
+    const dayEnd = `${reportDate}T23:59:59.999Z`;
+
+    const { data: signals, error } = await this.supabase
+      .getClient()
+      .from('gainers_v1_shadow_signals')
+      .select('decision, simulated_pnl_pct, simulated_slippage_pct, diverges_from_legacy, setup_type')
+      .gte('created_at', dayStart)
+      .lte('created_at', dayEnd);
+
+    if (error) {
+      this.logger.warn(`fetch signals ${reportDate} failed: ${error.message}`);
+      return null;
+    }
+
+    const rows = signals ?? [];
+    let acceptCount = 0;
+    let rejectCount = 0;
+    let closedCount = 0;
+    let winCount = 0;
+    let lossCount = 0;
+    let divergenceCount = 0;
+    const pnls: number[] = [];
+    const slippages: number[] = [];
+    let anomalousFillCount = 0;
+    const triggerBreakdown: Record<string, number> = {};
+
+    for (const row of rows) {
+      const r = row as any;
+      if (r.decision === 'ACCEPT') {
+        acceptCount++;
+        if (r.setup_type) {
+          triggerBreakdown[r.setup_type] = (triggerBreakdown[r.setup_type] ?? 0) + 1;
+        }
+      } else {
+        rejectCount++;
+      }
+      if (r.simulated_pnl_pct !== null && r.simulated_pnl_pct !== undefined) {
+        const pnl = Number(r.simulated_pnl_pct);
+        closedCount++;
+        pnls.push(pnl);
+        if (pnl > 0) winCount++;
+        else if (pnl < 0) lossCount++;
+      }
+      if (r.simulated_slippage_pct !== null && r.simulated_slippage_pct !== undefined) {
+        const slip = Number(r.simulated_slippage_pct);
+        slippages.push(slip);
+        if (Math.abs(slip) > 0.01) anomalousFillCount++;
+      }
+      if (r.diverges_from_legacy === true) divergenceCount++;
+    }
+
+    const totalSignals = rows.length;
+    const winRate = closedCount > 0 ? winCount / closedCount : null;
+    const avgPnl = pnls.length > 0 ? pnls.reduce((s, n) => s + n, 0) / pnls.length : null;
+    const cumPnl = pnls.length > 0 ? pnls.reduce((s, n) => s + n, 0) : null;
+    const avgSlip = slippages.length > 0 ? slippages.reduce((s, n) => s + n, 0) / slippages.length : null;
+    const divergencePct = totalSignals > 0 ? divergenceCount / totalSignals : null;
+
+    // Anomaly flags
+    const zeroSignalsFlag = await this.checkZeroSignals48h(reportDate, acceptCount);
+    const highSlippageFlag = avgSlip !== null && Math.abs(avgSlip) > HIGH_SLIPPAGE_THRESHOLD;
+    const lowCadenceFlag = await this.checkLowCadence7d(reportDate);
+
+    const payload = {
+      report_date: reportDate,
+      total_signals: totalSignals,
+      accept_count: acceptCount,
+      reject_count: rejectCount,
+      closed_count: closedCount,
+      win_count: winCount,
+      loss_count: lossCount,
+      win_rate: winRate,
+      avg_realized_pnl_pct: avgPnl,
+      cumulative_pnl_pct: cumPnl,
+      avg_slippage_pct: avgSlip,
+      anomalous_fill_count: anomalousFillCount,
+      divergence_count: divergenceCount,
+      divergence_pct: divergencePct,
+      trigger_breakdown: triggerBreakdown,
+      zero_signals_flag: zeroSignalsFlag,
+      high_slippage_flag: highSlippageFlag,
+      low_cadence_flag: lowCadenceFlag,
+      computed_at: new Date().toISOString(),
+    };
+
+    const { error: upErr } = await this.supabase
+      .getClient()
+      .from('gainers_shadow_daily_report')
+      .upsert(payload, { onConflict: 'report_date' });
+
+    if (upErr) {
+      this.logger.error(`upsert ${reportDate} failed: ${upErr.message}`);
+      return null;
+    }
+
+    if (zeroSignalsFlag || highSlippageFlag || lowCadenceFlag) {
+      this.logger.warn(`[shadow-daily-report] ${reportDate} ANOMALY zero=${zeroSignalsFlag} highSlip=${highSlippageFlag} lowCadence=${lowCadenceFlag}`);
+    }
+
+    return this.mapRowToDto(payload);
+  }
+
+  async getRecentReports(days: number = 30): Promise<DailyReportRow[]> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('gainers_shadow_daily_report')
+      .select('*')
+      .order('report_date', { ascending: false })
+      .limit(days);
+    if (error || !data) return [];
+    return data.map((r) => this.mapRowToDto(r));
+  }
+
+  /** Anomaly check 1 : zero_signals_48h. */
+  private async checkZeroSignals48h(reportDate: string, todayAccept: number): Promise<boolean> {
+    if (todayAccept > 0) return false;
+    const yesterday = this.dateOffset(reportDate, -1);
+    const { data } = await this.supabase
+      .getClient()
+      .from('gainers_shadow_daily_report')
+      .select('accept_count')
+      .eq('report_date', yesterday)
+      .maybeSingle();
+    if (!data) return false; // pas de baseline hier → ne pas flag
+    return Number((data as any).accept_count) === 0;
+  }
+
+  /** Anomaly check 2 : low_cadence_7d. */
+  private async checkLowCadence7d(reportDate: string): Promise<boolean> {
+    const sevenDaysAgo = this.dateOffset(reportDate, -7);
+    const { data } = await this.supabase
+      .getClient()
+      .from('gainers_shadow_daily_report')
+      .select('accept_count')
+      .gte('report_date', sevenDaysAgo)
+      .lt('report_date', reportDate);
+    if (!data || data.length < 7) return false; // baseline insuffisante
+    const total = data.reduce((s, r) => s + Number((r as any).accept_count), 0);
+    return total / 7 < LOW_CADENCE_THRESHOLD;
+  }
+
+  private todayUtcDateStr(): string {
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  private dateOffset(dateStr: string, days: number): string {
+    const d = new Date(`${dateStr}T00:00:00Z`);
+    d.setUTCDate(d.getUTCDate() + days);
+    return d.toISOString().slice(0, 10);
+  }
+
+  private mapRowToDto(r: any): DailyReportRow {
+    return {
+      reportDate: r.report_date,
+      totalSignals: Number(r.total_signals ?? 0),
+      acceptCount: Number(r.accept_count ?? 0),
+      rejectCount: Number(r.reject_count ?? 0),
+      closedCount: Number(r.closed_count ?? 0),
+      winCount: Number(r.win_count ?? 0),
+      lossCount: Number(r.loss_count ?? 0),
+      winRate: r.win_rate !== null ? Number(r.win_rate) : null,
+      avgRealizedPnlPct: r.avg_realized_pnl_pct !== null ? Number(r.avg_realized_pnl_pct) : null,
+      cumulativePnlPct: r.cumulative_pnl_pct !== null ? Number(r.cumulative_pnl_pct) : null,
+      avgSlippagePct: r.avg_slippage_pct !== null ? Number(r.avg_slippage_pct) : null,
+      anomalousFillCount: Number(r.anomalous_fill_count ?? 0),
+      divergenceCount: Number(r.divergence_count ?? 0),
+      divergencePct: r.divergence_pct !== null ? Number(r.divergence_pct) : null,
+      triggerBreakdown: r.trigger_breakdown ?? {},
+      zeroSignalsFlag: !!r.zero_signals_flag,
+      highSlippageFlag: !!r.high_slippage_flag,
+      lowCadenceFlag: !!r.low_cadence_flag,
+    };
+  }
+}

--- a/supabase/migrations/0108_gainers_shadow_daily_report.sql
+++ b/supabase/migrations/0108_gainers_shadow_daily_report.sql
@@ -1,0 +1,71 @@
+-- 0108 — ADR-005 Phase 3.2 PR6.2 — table gainers_shadow_daily_report
+--
+-- Aggregation quotidienne du shadow run pour monitoring sans hammering la table
+-- gainers_v1_shadow_signals append-only à chaque appel dashboard.
+--
+-- Cron 23:30 UTC chaque jour : INSERT 1 row par jour calendaire UTC.
+-- Si rerun (idempotence) : ON CONFLICT (report_date) DO UPDATE.
+--
+-- Notification automatique (à wirer) si :
+--   - 0 signaux ACCEPT pendant 48h (cadence trop faible pour atteindre 30 en 28j)
+--   - avg_slippage_pct > 2× expected (anomalie fill systématique)
+--   - cadence < 0.5 ACCEPT/jour sur fenêtre 7j (idem)
+
+CREATE TABLE IF NOT EXISTS public.gainers_shadow_daily_report (
+  id            UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  report_date   DATE        NOT NULL UNIQUE,
+
+  -- Counts
+  total_signals INT         NOT NULL DEFAULT 0,
+  accept_count  INT         NOT NULL DEFAULT 0,
+  reject_count  INT         NOT NULL DEFAULT 0,
+  closed_count  INT         NOT NULL DEFAULT 0,
+  win_count     INT         NOT NULL DEFAULT 0,
+  loss_count    INT         NOT NULL DEFAULT 0,
+
+  -- Stats win-rate / PnL
+  win_rate          NUMERIC(5,4),     -- wins / closed_with_pnl, NULL si closed=0
+  avg_realized_pnl_pct NUMERIC(8,5),
+  cumulative_pnl_pct   NUMERIC(8,5),
+
+  -- Slippage (lien ADR-005 §11.3)
+  avg_slippage_pct      NUMERIC(7,5),
+  anomalous_fill_count  INT NOT NULL DEFAULT 0,
+
+  -- Divergence legacy
+  divergence_count INT NOT NULL DEFAULT 0,
+  divergence_pct   NUMERIC(5,4),
+
+  -- Trigger breakdown JSON: { "PULLBACK_HL_FIBO": N, "VWAP_RECLAIM": M }
+  trigger_breakdown JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Anomaly flags pour notification (à read par alerting)
+  zero_signals_flag        BOOLEAN NOT NULL DEFAULT FALSE,  -- TRUE si accept_count=0 ET aucun signal hier non plus
+  high_slippage_flag       BOOLEAN NOT NULL DEFAULT FALSE,  -- TRUE si avg_slippage > 0.6%
+  low_cadence_flag         BOOLEAN NOT NULL DEFAULT FALSE,  -- TRUE si avg accept/jour 7j < 0.5
+
+  computed_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS gainers_shadow_daily_report_date_desc_idx
+  ON public.gainers_shadow_daily_report (report_date DESC);
+
+CREATE INDEX IF NOT EXISTS gainers_shadow_daily_report_anomaly_idx
+  ON public.gainers_shadow_daily_report (report_date DESC)
+  WHERE zero_signals_flag = TRUE OR high_slippage_flag = TRUE OR low_cadence_flag = TRUE;
+
+COMMENT ON TABLE public.gainers_shadow_daily_report IS
+  'ADR-005 Phase 3.2 PR6.2 — aggregation quotidienne du shadow run. '
+  'Cron 23:30 UTC. Idempotent (UNIQUE report_date). Source : gainers_v1_shadow_signals.';
+
+COMMENT ON COLUMN public.gainers_shadow_daily_report.zero_signals_flag IS
+  'TRUE si accept_count=0 sur ce jour ET hier (= 48h sans signal). '
+  'Notification opérateur : cadence trop faible, risque de ne pas atteindre 30 ACCEPT en 28j.';
+
+COMMENT ON COLUMN public.gainers_shadow_daily_report.high_slippage_flag IS
+  'TRUE si avg_slippage_pct > 0.006 (= 2× expected ADR-005 §11.3 cap 0.30%). '
+  'Notification : anomalie fill systématique.';
+
+COMMENT ON COLUMN public.gainers_shadow_daily_report.low_cadence_flag IS
+  'TRUE si moyenne accept/jour sur fenêtre 7j < 0.5. '
+  'Notification : risque ETA bascule live > 28j.';


### PR DESCRIPTION
## Phase 3.2 — Daily report cron + endpoints (PR6.2 ADR-005)

Cron quotidien aggregating shadow run signals → 1 row par jour calendaire UTC dans `gainers_shadow_daily_report`. Trois anomaly flags pour notification opérateur (cadence, slippage, zero signals).

## Migration 0108

```sql
CREATE TABLE gainers_shadow_daily_report (
  id UUID PK,
  report_date DATE UNIQUE,
  -- counts
  total_signals, accept_count, reject_count, closed_count, win_count, loss_count,
  -- stats
  win_rate, avg_realized_pnl_pct, cumulative_pnl_pct,
  avg_slippage_pct, anomalous_fill_count,
  divergence_count, divergence_pct,
  trigger_breakdown JSONB,
  -- anomaly flags
  zero_signals_flag, high_slippage_flag, low_cadence_flag,
  computed_at
);
```

3 indexes : date desc, anomaly partial, default.

## Service `ShadowDailyReportService`

- `@Cron('30 23 * * *')` daily 23:30 UTC
- `computeAndUpsert(date)` public (recompute manuel + backfill)
- `getRecentReports(days)` lecture pour dashboard
- 3 anomaly checks :
  - `zero_signals_flag` : accept=0 today AND yesterday (48h sans signal)
  - `high_slippage_flag` : avg |slippage| > 0.006 (2× cap ADR §11.3)
  - `low_cadence_flag` : avg accept/jour 7j < 0.5 (= risque ETA bascule > 28j)

## Endpoints admin

| Endpoint | Description |
|---|---|
| `GET /admin/gainers/shadow-daily-report?days=N` | derniers N jours (max 90) + summary aggregé |
| `POST /admin/gainers/shadow-daily-report/recompute` body `{date?}` | backfill ou recompute manuel idempotent |

Auth x-admin-token.

## Tests + boot

```
shadow-daily-report.spec : 5 unit tests
- empty day → totalSignals=0, winRate=null
- 3 ACCEPT (2 wins, 1 loss) + 2 REJECT → winRate 2/3, divergence 1/5
- avg_slippage > 0.6% → high_slippage_flag=true
- |slippage| > 1% → anomalous_fill_count counted

Suite gainers : ~347 / 0 failures
Local boot ✅ "écoute sur 0.0.0.0:3987"
```

## Préparation Phase 3 shadow run

Avec PR6.2, dès flip `GAINERS_V1_SHADOW=true` :
- Premier daily report ce soir 23:30 UTC
- Anomaly flags actifs J+2 (need historique 48h pour zero_signals)
- low_cadence flag actif J+8 (need 7j historique)
- Dashboard admin live via `GET /admin/gainers/shadow-daily-report?days=30`

## Out of scope follow-up

- Notification opérateur (Slack/email/push) sur les flags
- Backfill historique pré-flip (cron only à partir de J+1)
- Wiring du `simulated_pnl_pct` post-hoc (worker exit-simulator) — PR6.3

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_