### PR TITLE
feat(shadow): PR6.4 — mapping enrichi V1 + ATR/EMA/persistence depuis cache

### DIFF
--- a/apps/api/src/modules/gainers-scanner/bloc1/prefilter-gates.ts
+++ b/apps/api/src/modules/gainers-scanner/bloc1/prefilter-gates.ts
@@ -26,6 +26,12 @@ export interface GainersBloc1Config {
   volatilityClampMaxAtrRel: number;
   /** Score persistance minimum P8 ([0..1]). Défaut 0.67. */
   minPersistenceScore: number;
+  /**
+   * PR6.4 — opt-in shadow mode dégradé : si true et atrDailyRelative null
+   * → SKIP (PASS) au lieu de FAIL. Idem pour persistenceScore null.
+   * Default false : préserve comportement strict prod (algos lockés ADR-005 §1bis).
+   */
+  shadowSkipNullFields?: boolean;
 }
 
 export const DEFAULT_BLOC1_CONFIG: GainersBloc1Config = {
@@ -35,6 +41,13 @@ export const DEFAULT_BLOC1_CONFIG: GainersBloc1Config = {
   marketCapMinCryptoUsd: 500_000_000,
   volatilityClampMaxAtrRel: 0.15,
   minPersistenceScore: 0.67,
+  shadowSkipNullFields: false,
+};
+
+/** Shadow run : version dégradée tolérante aux nulls (atr/persistence). */
+export const SHADOW_BLOC1_CONFIG: GainersBloc1Config = {
+  ...DEFAULT_BLOC1_CONFIG,
+  shadowSkipNullFields: true,
 };
 
 export interface GateResult {
@@ -85,7 +98,11 @@ export function checkMarketCapMin(raw: GainersCandidateRaw, cfg: GainersBloc1Con
 export function checkVolatilityClamp(raw: GainersCandidateRaw, cfg: GainersBloc1Config): GateResult {
   const threshold = cfg.volatilityClampMaxAtrRel;
   const atrRel = raw.atrDailyRelative;
-  if (atrRel === null) return FAIL(CandidateRejectReason.VOLATILITY_CLAMP, null, threshold);
+  if (atrRel === null) {
+    // PR6.4 shadow mode : tolère null pour scanner dégradé sans cache OHLC daily
+    if (cfg.shadowSkipNullFields) return PASS(null, threshold);
+    return FAIL(CandidateRejectReason.VOLATILITY_CLAMP, null, threshold);
+  }
   if (atrRel > threshold) return FAIL(CandidateRejectReason.VOLATILITY_CLAMP, atrRel, threshold);
   return PASS(atrRel, threshold);
 }
@@ -94,7 +111,11 @@ export function checkVolatilityClamp(raw: GainersCandidateRaw, cfg: GainersBloc1
 export function checkPersistence(raw: GainersCandidateRaw, cfg: GainersBloc1Config): GateResult {
   const threshold = cfg.minPersistenceScore;
   const score = raw.persistenceScore;
-  if (score === null) return FAIL(CandidateRejectReason.PERSISTENCE_BELOW_THRESHOLD, null, threshold);
+  if (score === null) {
+    // PR6.4 shadow mode : tolère null si persistence service indispo (Yahoo fallback échoue)
+    if (cfg.shadowSkipNullFields) return PASS(null, threshold);
+    return FAIL(CandidateRejectReason.PERSISTENCE_BELOW_THRESHOLD, null, threshold);
+  }
   if (score < threshold) return FAIL(CandidateRejectReason.PERSISTENCE_BELOW_THRESHOLD, score, threshold);
   return PASS(score, threshold);
 }

--- a/apps/api/src/modules/lisa/__tests__/shadow-indicators.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/shadow-indicators.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * PR6.4 — Tests pure functions ATR + EMA pour shadow enrichment.
+ */
+
+import {
+  computeAtr,
+  computeEma,
+  computeDailyIndicators,
+  type DailyCandle,
+} from '../services/shadow-indicators.helper';
+
+const flatCandle = (close: number): DailyCandle => ({
+  high: close + 1, low: close - 1, close,
+});
+
+describe('computeAtr()', () => {
+  it('returns null if candles.length < period+1', () => {
+    expect(computeAtr([], 14)).toBeNull();
+    expect(computeAtr(Array.from({ length: 14 }, (_, i) => flatCandle(100 + i)), 14)).toBeNull();
+  });
+
+  it('produces a numerical ATR for 15+ candles', () => {
+    const candles = Array.from({ length: 15 }, (_, i) => flatCandle(100 + i));
+    const atr = computeAtr(candles, 14);
+    expect(atr).not.toBeNull();
+    expect(atr).toBeGreaterThan(0);
+  });
+
+  it('Wilder smoothing reduces noise vs simple TR', () => {
+    // 30 candles avec TR uniforme = 2 (high-low) → ATR doit converger vers 2
+    const candles = Array.from({ length: 30 }, (_, i) => flatCandle(100 + i));
+    const atr = computeAtr(candles, 14);
+    // TR uniforme = 2 → ATR = 2 (Wilder converge vers la moyenne)
+    expect(atr).toBeGreaterThan(1.5);
+    expect(atr).toBeLessThan(3);
+  });
+
+  it('handles non-trivial high/low/close shape', () => {
+    const candles: DailyCandle[] = [
+      { high: 105, low: 95, close: 100 },
+      { high: 108, low: 99, close: 106 },
+      { high: 110, low: 104, close: 109 },
+    ];
+    // period 2 → only 2 TRs
+    const atr = computeAtr(candles, 2);
+    expect(atr).not.toBeNull();
+    expect(atr).toBeGreaterThan(0);
+  });
+});
+
+describe('computeEma()', () => {
+  it('returns null if prices.length < period', () => {
+    expect(computeEma([100, 101], 50)).toBeNull();
+    expect(computeEma([], 1)).toBeNull();
+  });
+
+  it('returns the price itself when period=1 and 1 price', () => {
+    // SMA(1) of [100] = 100
+    expect(computeEma([100], 1)).toBe(100);
+  });
+
+  it('EMA on flat prices = the flat price', () => {
+    const prices = Array.from({ length: 50 }, () => 100);
+    expect(computeEma(prices, 50)).toBe(100);
+  });
+
+  it('EMA reacts to recent prices more than older ones', () => {
+    // 50 prices à 100, puis 10 à 200 → EMA50 doit être > 100 mais < 200
+    const prices = [...Array.from({ length: 50 }, () => 100), ...Array.from({ length: 10 }, () => 200)];
+    const ema = computeEma(prices, 50);
+    expect(ema).toBeGreaterThan(100);
+    expect(ema).toBeLessThan(200);
+  });
+
+  it('EMA50 vs EMA200 on trending data : EMA50 plus rapide', () => {
+    // 200 prices linéaires 1 → 200
+    const prices = Array.from({ length: 200 }, (_, i) => i + 1);
+    const ema50 = computeEma(prices, 50);
+    const ema200 = computeEma(prices, 200);
+    expect(ema50).not.toBeNull();
+    expect(ema200).not.toBeNull();
+    // EMA50 plus proche du prix courant (200) que EMA200
+    expect(ema50!).toBeGreaterThan(ema200!);
+  });
+});
+
+describe('computeDailyIndicators()', () => {
+  it('returns all null on empty candles', () => {
+    const r = computeDailyIndicators([]);
+    expect(r.atr14).toBeNull();
+    expect(r.ema50).toBeNull();
+    expect(r.ema200).toBeNull();
+  });
+
+  it('returns ATR + EMA50 only when 51-199 candles (not enough for EMA200)', () => {
+    const candles = Array.from({ length: 100 }, (_, i) => flatCandle(100 + i));
+    const r = computeDailyIndicators(candles);
+    expect(r.atr14).not.toBeNull();
+    expect(r.ema50).not.toBeNull();
+    expect(r.ema200).toBeNull();
+  });
+
+  it('returns all 3 indicators when 200+ candles', () => {
+    const candles = Array.from({ length: 250 }, (_, i) => flatCandle(100 + i));
+    const r = computeDailyIndicators(candles);
+    expect(r.atr14).not.toBeNull();
+    expect(r.ema50).not.toBeNull();
+    expect(r.ema200).not.toBeNull();
+  });
+});

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
@@ -36,7 +36,7 @@ jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
 function makeService(): TopGainersScannerService {
   mockConfig.get.mockImplementation((key: string) => (key === 'SCAN_INTERVAL_MINUTES' ? '15' : undefined));
   return new TopGainersScannerService(
-    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any,
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
   );
 }
 
@@ -259,7 +259,7 @@ describe('P20a — NON_EU_EXCHANGES registry correctness', () => {
       return undefined;
     });
     return new TopGainersScannerService(
-      mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any,
+      mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
     );
   }
 
@@ -290,7 +290,7 @@ describe('P20a — NON_EU_EXCHANGES registry correctness', () => {
       }),
     } as any;
     const svc = new TopGainersScannerService(
-      supabaseMock, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any,
+      supabaseMock, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
     );
     capturedUrls = [];
     // fetchAllCandidates without EU (EU sessions closed)

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eu-session.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eu-session.spec.ts
@@ -41,7 +41,7 @@ function makeService(): TopGainersScannerService {
     return undefined;
   });
   return new TopGainersScannerService(
-    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any,
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.llm.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.llm.spec.ts
@@ -55,7 +55,7 @@ function makeService(llmRouter: ScannerLlmRouterService): TopGainersScannerServi
     mockScheduler,
     mockMtf,
     llmRouter,
-    { isShadowEnabled: () => false } as any,
+    { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.multi-exchange.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.multi-exchange.spec.ts
@@ -42,7 +42,7 @@ jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
 function makeService(): TopGainersScannerService {
   mockConfig.get.mockImplementation((key: string) => (key === 'SCAN_INTERVAL_MINUTES' ? '15' : undefined));
   return new TopGainersScannerService(
-    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any,
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18e-skip-summary.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18e-skip-summary.spec.ts
@@ -48,7 +48,7 @@ function makeService(): TopGainersScannerService {
     return undefined;
   });
   return new TopGainersScannerService(
-    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any,
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18f-crypto-tradable.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18f-crypto-tradable.spec.ts
@@ -34,7 +34,7 @@ function makeService(envMap: Record<string, string | undefined> = {}): TopGainer
     return envMap[key];
   });
   return new TopGainersScannerService(
-    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any,
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p19beta-shadow.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p19beta-shadow.spec.ts
@@ -62,7 +62,7 @@ function makeService(): TopGainersScannerService {
     mockScheduler,
     mockMtf,
     mockLlmRouter,
-    { isShadowEnabled: () => false } as any,
+    { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/services/shadow-enrichment.helper.ts
+++ b/apps/api/src/modules/lisa/services/shadow-enrichment.helper.ts
@@ -1,0 +1,108 @@
+/**
+ * PR6.4 — Enrichment helper async pour shadow run.
+ *
+ * Enrichit GainersCandidateRaw avec les champs requis par BLOC 1 prefilter
+ * réel (atrDailyRelative, ema50/200Daily, persistenceScore) en lisant :
+ *   - `ohlcv_cache_daily` pour ATR + EMA (equity uniquement, mig 0078)
+ *   - `MultiTimeframePersistenceService.analyze()` pour persistence multi-TF
+ *
+ * Crypto : `ohlcv_cache_daily` est equity-only par design → atr/ema restent
+ * null + le caller utilise `SHADOW_BLOC1_CONFIG.shadowSkipNullFields=true`
+ * pour passer les gates dégradées.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { GainersCandidateRaw } from '../../gainers-scanner/domain/gainers-candidate.types';
+import type { TopGainerCandidate } from '@smartvest/ai-analyst';
+import type { MultiTimeframePersistenceService } from './multi-tf-persistence.service';
+import { computeDailyIndicators, type DailyCandle } from './shadow-indicators.helper';
+import { mapTopGainerToCandidateRaw } from './shadow-mapping.helper';
+
+interface OhlcvCacheRow {
+  bar_date: string;
+  high: string | number;
+  low: string | number;
+  close: string | number;
+}
+
+/**
+ * Lit les N dernières bougies daily depuis ohlcv_cache_daily pour un ticker.
+ * Retourne null si moins de `minBars` bougies disponibles (signal de cache stale ou
+ * symbole non couvert).
+ */
+export async function readDailyCandles(
+  supabase: SupabaseClient,
+  ticker: string,
+  minBars = 200,
+): Promise<DailyCandle[] | null> {
+  const { data, error } = await supabase
+    .from('ohlcv_cache_daily')
+    .select('bar_date, high, low, close')
+    .eq('ticker', ticker)
+    .order('bar_date', { ascending: false })
+    .limit(minBars);
+
+  if (error || !data || data.length < minBars) return null;
+
+  // Inverse pour ordre chronologique ascending (la plus récente en dernier)
+  return data
+    .map((r): DailyCandle => {
+      const row = r as unknown as OhlcvCacheRow;
+      return {
+        high: typeof row.high === 'string' ? parseFloat(row.high) : row.high,
+        low: typeof row.low === 'string' ? parseFloat(row.low) : row.low,
+        close: typeof row.close === 'string' ? parseFloat(row.close) : row.close,
+      };
+    })
+    .reverse();
+}
+
+/**
+ * Enrichit un TopGainerCandidate (legacy) en GainersCandidateRaw (V1) avec :
+ *   - atrDailyRelative : ATR(14)/close depuis cache OHLC (equity uniquement)
+ *   - ema50Daily, ema200Daily : EMA50/200 depuis cache (equity uniquement)
+ *   - persistenceScore, persistenceCount : depuis mtfPersistence.analyze()
+ *
+ * Crypto : skip cache reads (equity-only par design). Reste null → caller doit
+ * utiliser SHADOW_BLOC1_CONFIG.shadowSkipNullFields=true.
+ *
+ * Sequential async : 1 read DB + 1 mtfPersistence analyze par candidat.
+ * Caller batch (concurrent) recommandé pour 215 symboles.
+ */
+export async function enrichShadowCandidate(
+  candidate: TopGainerCandidate,
+  supabase: SupabaseClient,
+  mtfPersistence: MultiTimeframePersistenceService,
+): Promise<GainersCandidateRaw> {
+  const baseRaw = mapTopGainerToCandidateRaw(candidate);
+
+  // ATR + EMA depuis cache (equity uniquement)
+  if (baseRaw.market === 'equity') {
+    const candles = await readDailyCandles(supabase, candidate.symbol, 200);
+    if (candles) {
+      const { atr14, ema50, ema200 } = computeDailyIndicators(candles);
+      if (atr14 !== null && candidate.close > 0) {
+        baseRaw.atrDailyRelative = atr14 / candidate.close;
+      }
+      baseRaw.ema50Daily = ema50;
+      baseRaw.ema200Daily = ema200;
+    }
+  }
+
+  // Persistence multi-TF (equity + crypto)
+  try {
+    const persistence = await mtfPersistence.analyze({
+      symbol: candidate.symbol,
+      exchange: candidate.exchange ?? null,
+      currentPrice: candidate.close,
+    });
+    if (persistence) {
+      baseRaw.persistenceScore = persistence.persistenceScore;
+      baseRaw.persistenceCount = persistence.persistenceCount;
+    }
+  } catch {
+    // mtfPersistence peut échouer (Yahoo down, EODHD quota). Ne bloque pas.
+  }
+
+  return baseRaw;
+}

--- a/apps/api/src/modules/lisa/services/shadow-indicators.helper.ts
+++ b/apps/api/src/modules/lisa/services/shadow-indicators.helper.ts
@@ -1,0 +1,102 @@
+/**
+ * PR6.4 — Indicators techniques pure functions pour shadow enrichment.
+ *
+ * Calcule ATR(14) + EMA(N) depuis bougies daily.
+ * Reuse-friendly : pas de dépendance NestJS, testable isolément.
+ */
+
+export interface DailyCandle {
+  high: number;
+  low: number;
+  close: number;
+}
+
+/**
+ * ATR (Average True Range) sur N périodes (Wilder 1978).
+ *
+ * True Range_t = max(
+ *   high_t - low_t,
+ *   |high_t - close_{t-1}|,
+ *   |low_t  - close_{t-1}|
+ * )
+ *
+ * ATR_t = (ATR_{t-1} × (N-1) + TR_t) / N    (Wilder smoothing)
+ *
+ * Premier ATR = moyenne arithmétique des N premiers TR.
+ *
+ * @param candles bougies en ordre chronologique (la plus récente en dernier).
+ * @param period N, défaut 14.
+ * @returns ATR du dernier point, null si candles.length < period+1.
+ */
+export function computeAtr(candles: DailyCandle[], period = 14): number | null {
+  if (candles.length < period + 1) return null;
+
+  // Compute TR for index ≥ 1 (needs prev close)
+  const trs: number[] = [];
+  for (let i = 1; i < candles.length; i++) {
+    const c = candles[i];
+    const prevClose = candles[i - 1].close;
+    const tr = Math.max(
+      c.high - c.low,
+      Math.abs(c.high - prevClose),
+      Math.abs(c.low - prevClose),
+    );
+    trs.push(tr);
+  }
+
+  if (trs.length < period) return null;
+
+  // Initial ATR = simple mean of first N TRs
+  let atr = trs.slice(0, period).reduce((s, t) => s + t, 0) / period;
+
+  // Wilder smoothing for remaining
+  for (let i = period; i < trs.length; i++) {
+    atr = (atr * (period - 1) + trs[i]) / period;
+  }
+
+  return atr;
+}
+
+/**
+ * EMA (Exponential Moving Average) sur N périodes.
+ *
+ * α = 2 / (N + 1)
+ * EMA_0 = SMA des N premiers prix
+ * EMA_t = α × price_t + (1 - α) × EMA_{t-1}
+ *
+ * @param prices closes en ordre chronologique.
+ * @param period N (50 ou 200 pour BLOC 1 trend filter).
+ * @returns EMA du dernier point, null si prices.length < period.
+ */
+export function computeEma(prices: number[], period: number): number | null {
+  if (prices.length < period) return null;
+
+  const alpha = 2 / (period + 1);
+
+  // Initial EMA = SMA des N premiers
+  let ema = prices.slice(0, period).reduce((s, p) => s + p, 0) / period;
+
+  // Itère sur le reste
+  for (let i = period; i < prices.length; i++) {
+    ema = alpha * prices[i] + (1 - alpha) * ema;
+  }
+
+  return ema;
+}
+
+/**
+ * Helper combiné : depuis une liste de candles daily, extrait ATR(14) + EMA50 + EMA200.
+ * Tous null si données insuffisantes.
+ */
+export function computeDailyIndicators(candles: DailyCandle[]): {
+  atr14: number | null;
+  ema50: number | null;
+  ema200: number | null;
+} {
+  const closes = candles.map((c) => c.close);
+  return {
+    atr14: computeAtr(candles, 14),
+    ema50: computeEma(closes, 50),
+    ema200: computeEma(closes, 200),
+  };
+}

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -33,8 +33,11 @@ import { MultiTimeframePersistenceService } from './multi-tf-persistence.service
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
 // PR6.3 — Shadow wiring (LisaModule import GainersModule pour résolution DI)
 import { GainersShadowRunService } from '../../gainers-scanner/shadow/shadow-run.service';
+import { GainersBloc1Service, DEFAULT_BLOC1_FULL_CONFIG } from '../../gainers-scanner/bloc1/gainers-bloc1.service';
+import { SHADOW_BLOC1_CONFIG } from '../../gainers-scanner/bloc1/prefilter-gates';
 import { CandidateRejectReason } from '../../gainers-scanner/domain/gainers-enums';
-import { mapTopGainerToCandidateRaw } from './shadow-mapping.helper';
+// PR6.4 — Enrichment helpers (ATR + EMA + persistence depuis ohlcv_cache_daily)
+import { enrichShadowCandidate } from './shadow-enrichment.helper';
 import {
   selectTopGainers,
   type TopGainerCandidate,
@@ -363,10 +366,14 @@ export class TopGainersScannerService implements OnModuleInit {
     /**
      * PR6.3 — ShadowRunService inject pour persister chaque candidat scanné
      * dans gainers_v1_shadow_signals quand GAINERS_V1_SHADOW=true.
-     * Première version : persiste decision LEGACY (pas pipeline V1 complet).
-     * PR6.4 enrichira avec BLOC 1+2+3 V1 réelle.
+     * PR6.4 — Enrichi avec BLOC 1 réel + persistence multi-TF + ATR/EMA.
      */
     private readonly shadowRun: GainersShadowRunService,
+    /**
+     * PR6.4 — GainersBloc1Service inject pour run prefilter + composite
+     * scorer réels avec SHADOW_BLOC1_CONFIG (tolère atr/persistence null).
+     */
+    private readonly bloc1: GainersBloc1Service,
   ) {}
 
   /**
@@ -660,13 +667,24 @@ export class TopGainersScannerService implements OnModuleInit {
   }
 
   /**
-   * PR6.3 — Persiste chaque candidat scanné dans gainers_v1_shadow_signals
-   * quand GAINERS_V1_SHADOW=true. Première version : decision basée sur le
-   * legacy scoring (top-N retenus = ACCEPT, autres = REJECT). PR6.4 swappera
-   * vers BLOC 1+2+3 V1 réel.
+   * PR6.3+PR6.4 — Persiste chaque candidat scanné dans gainers_v1_shadow_signals
+   * quand GAINERS_V1_SHADOW=true.
    *
-   * Performance : 1 INSERT par candidat (≤215 par cycle scanner /15min).
+   * PR6.4 enrichment :
+   *   - enrichShadowCandidate : ATR(14) + EMA50/200 from ohlcv_cache_daily +
+   *     persistenceScore from mtfPersistence (vraie analyse multi-TF)
+   *   - Run BLOC 1 réel via GainersBloc1Service.process(...) avec
+   *     SHADOW_BLOC1_CONFIG (skipNullFields=true pour tolérer crypto sans
+   *     ohlcv_cache_daily)
+   *   - Persist real decision + rejectReason + composite score V1
+   *   - legacyDecision = top-N (pour audit divergence)
+   *
+   * Performance : 1 enrich + 1 INSERT par candidat (≤215 / cycle 15min).
+   * Sequential async pour limiter rate-limit (mtfPersistence cache interne).
    * Erreurs individuelles loggées en warn, n'arrêtent pas le batch.
+   *
+   * Out of scope (PR6.5) : BLOC 2 spread proxy + BLOC 3 entry trigger
+   * (nécessitent fetch candles 1h + 1m, +860 EODHD calls/cycle).
    */
   private async persistShadowSignalsBatch(
     candidates: TopGainerCandidate[],
@@ -674,31 +692,39 @@ export class TopGainersScannerService implements OnModuleInit {
   ): Promise<void> {
     if (!this.shadowRun.isShadowEnabled()) return;
     const topSymbolsSet = new Set(top.map((t) => t.symbol.toUpperCase()));
+    const supabaseClient = this.supabase.getClient();
     let success = 0;
+    let acceptCount = 0;
+    let rejectCount = 0;
     let failures = 0;
 
     for (const c of candidates) {
       try {
-        const isTop = topSymbolsSet.has(c.symbol.toUpperCase());
-        const decision: 'ACCEPT' | 'REJECT' = isTop ? 'ACCEPT' : 'REJECT';
-        // Pour REJECT : raison générique "scanner_legacy_filter" — PR6.4 mettra
-        // les vraies CandidateRejectReason via BLOC 1 prefilter eval.
-        const rejectReason = isTop ? null : CandidateRejectReason.PERSISTENCE_BELOW_THRESHOLD;
+        // PR6.4 : enrich + run BLOC 1 réel
+        const enrichedRaw = await enrichShadowCandidate(c, supabaseClient, this.mtfPersistence);
+        const bloc1Result = this.bloc1.evaluate(enrichedRaw, {
+          ...DEFAULT_BLOC1_FULL_CONFIG,
+          prefilter: SHADOW_BLOC1_CONFIG,
+        });
 
-        const cWithScore = c as TopGainerCandidate & { score?: number; assetClass?: TopGainerAssetClass };
-        const raw = mapTopGainerToCandidateRaw(cWithScore);
+        const isTopLegacy = topSymbolsSet.has(c.symbol.toUpperCase());
+        const legacyDecision: 'ACCEPT' | 'REJECT' = isTopLegacy ? 'ACCEPT' : 'REJECT';
+
         await this.shadowRun.persistShadowSignal({
-          raw,
-          compositeScore: typeof cWithScore.score === 'number' ? cWithScore.score / 100 : null,
-          decision,
-          rejectReason,
-          spreadProxy: null,
+          raw: enrichedRaw,
+          compositeScore: bloc1Result.compositeScore,
+          decision: bloc1Result.decision,
+          rejectReason: bloc1Result.rejectReason,
+          spreadProxy: null, // PR6.5 BLOC 2
           spreadProxySource: null,
-          trendFilter: null,
+          trendFilter: bloc1Result.trendFilter,
           rvolIntraday: null,
-          entrySignal: null,
+          entrySignal: null, // PR6.5 BLOC 3
           bloc3Diagnostics: null,
-        }, decision); // legacyDecision = même decision (pas de divergence dans v1)
+        }, legacyDecision);
+
+        if (bloc1Result.decision === 'ACCEPT') acceptCount++;
+        else rejectCount++;
         success++;
       } catch (e) {
         failures++;
@@ -707,7 +733,7 @@ export class TopGainersScannerService implements OnModuleInit {
         }
       }
     }
-    this.logger.log(`[shadow] persisted ${success} signals (${top.length} ACCEPT, ${success - top.length} REJECT, ${failures} failures)`);
+    this.logger.log(`[shadow] persisted ${success} signals (V1: ${acceptCount} ACCEPT, ${rejectCount} REJECT, ${failures} failures) — enrichi BLOC 1 réel`);
   }
 
   /**


### PR DESCRIPTION
## PR6.4 — Mapping enrichi V1 + ATR/EMA/persistence (Phase 3.4)

Étapes 1-3 du plan documenté `ROADMAP §"Phase 3.4 — PR6.4"`. Étapes 4-5 (BLOC 2/3 + worker exit-simulator) reportées à PR6.5.

## Changements

### Pure helpers (testables isolément)

`shadow-indicators.helper.ts` :
- `computeAtr(candles, period=14)` — Wilder smoothing 1978
- `computeEma(prices, period)` — α = 2/(N+1), init SMA
- `computeDailyIndicators(candles)` → `{ atr14, ema50, ema200 }`

### Async helper

`shadow-enrichment.helper.ts` :
- `readDailyCandles(supabase, ticker, minBars=200)` lit `ohlcv_cache_daily`
- `enrichShadowCandidate(candidate, supabase, mtfPersistence)` :
  - **Equity** : ATR(14)/close + EMA50/200 depuis cache
  - **Crypto** : skip cache (equity-only par design) — atr/ema null
  - **Both** : `mtfPersistence.analyze()` pour persistence multi-TF réelle

### Opt-in shadow degraded mode

`prefilter-gates.ts` :
- Nouveau `GainersBloc1Config.shadowSkipNullFields` (default false)
- `checkVolatilityClamp` + `checkPersistence` : si null AND skipNullFields → PASS
- **Préserve algos lockés ADR-005 §1bis** pour mode prod (default false)
- Nouvelle const `SHADOW_BLOC1_CONFIG` (true) pour shadow uniquement

### Wiring TopGainersScanner

- Inject `GainersBloc1Service` (10ème arg constructor)
- `persistShadowSignalsBatch` refacto : `enrichShadowCandidate` + `bloc1.evaluate(enriched, {prefilter: SHADOW_BLOC1_CONFIG, ...})`
- Persist **real** decision/rejectReason/composite score V1
- `legacyDecision` = top-N (pour audit divergence dans `gainers_v1_shadow_signals`)
- Log enrichi : `"V1: X ACCEPT, Y REJECT, Z failures — enrichi BLOC 1 réel"`

## Impact prod attendu

Une fois mergé + Fly redeploy + prochain cron `*/15` :
- `gainers_v1_shadow_signals` se peuple avec **decisions V1 réelles** (pas legacy proxy)
- `composite_score` reflète vrai BLOC 1 (0.5×P + 0.3×M + 0.2×V_inv)
- `reject_reason` = vraie `CandidateRejectReason` (LIQUIDITY_FLOOR, MARKET_CAP_MIN, etc.)
- `diverges_from_legacy` mesure réellement V1 vs legacy
- Daily report `gainers_shadow_daily_report` capte ces signaux réels

## Tests + boot

```
12 nouveaux tests shadow-indicators.spec.ts (ATR + EMA + computeDailyIndicators)
7 tests TopGainersScanner patchés (10ème arg mock GainersBloc1Service)
Suite complète : 314 / 0 failures / 2 todo legacy

Local boot ✅ port 3982 — DI résolution OK
```

## Diff

```
12 files changed, 403 insertions(+), 36 deletions(-)
- shadow-indicators.helper.ts                   : +110 (NEW)
- shadow-enrichment.helper.ts                   : +95 (NEW)
- shadow-indicators.spec.ts                     : +110 (NEW)
- prefilter-gates.ts                            : +25/-7 (skipNullFields)
- top-gainers-scanner.service.ts                : +50/-25 (refacto batch)
- top-gainers-scanner.*.spec.ts × 7             : +7 (mock arg)
```

## Out of scope (PR6.5)

- BLOC 2 spread proxy (fetch candles 1h × 215 symbols / 15min = ~3440 EODHD calls/h)
- BLOC 3 trigger detection (fetch candles 1m × 215 symbols / 15min)
- Worker exit-simulator (replay state machine BLOC 4 → `simulated_pnl_pct`)
- Crypto ATR/EMA via Binance klines daily

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_