### PR TITLE
feat(shadow): PR6.5 — exit-simulator worker + enrichi persist (TP/SL/path_eff)

### DIFF
--- a/apps/api/src/modules/gainers-scanner/shadow/shadow-run.service.ts
+++ b/apps/api/src/modules/gainers-scanner/shadow/shadow-run.service.ts
@@ -56,6 +56,11 @@ export class GainersShadowRunService {
   /**
    * Persiste un signal V1 (ACCEPT ou REJECT) dans la table shadow.
    * Idempotent côté DB (pas d'unique constraint sur ce flux append-only).
+   *
+   * PR6.5 — enrichi avec entry_path_eff + tp_price + sl_price calculés via
+   * BLOC 4 §11.1 pour permettre le worker exit-simulator de replay la state
+   * machine. path_eff par défaut = 0.5 (= 0.5% mouvement attendu, conservateur)
+   * tant que P9-UX path efficiency n'est pas wired pour shadow.
    */
   async persistShadowSignal(
     candidate: GainersScoredCandidate,
@@ -65,6 +70,17 @@ export class GainersShadowRunService {
 
     const { raw, decision, rejectReason, compositeScore, entrySignal, bloc3Diagnostics } = candidate;
 
+    // BLOC 4 §11.1 : equity TP=×1.5/SL=×1.0, crypto TP=×2.0/SL=×0.8
+    // path_eff default 0.5 (% conservateur). PR6.6 enrichira avec P9-UX réel.
+    const PATH_EFF_DEFAULT = 0.5;
+    const tpMul = raw.market === 'crypto' ? 2.0 : 1.5;
+    const slMul = raw.market === 'crypto' ? 0.8 : 1.0;
+    const tpPct = (PATH_EFF_DEFAULT * tpMul) / 100;
+    const slPct = (PATH_EFF_DEFAULT * slMul) / 100;
+    const entryPrice = entrySignal ? raw.close : (decision === 'ACCEPT' ? raw.close : null);
+    const tpPrice = entryPrice !== null ? entryPrice * (1 + tpPct) : null;
+    const slPrice = entryPrice !== null ? entryPrice * (1 - slPct) : null;
+
     const payload: Record<string, unknown> = {
       symbol: raw.symbol,
       exchange: raw.exchange,
@@ -73,10 +89,10 @@ export class GainersShadowRunService {
       composite_score: compositeScore,
       decision,
       reject_reason: rejectReason,
-      entry_price: entrySignal ? raw.close : null,
-      entry_path_eff: null,
-      tp_price: null,
-      sl_price: null,
+      entry_price: entryPrice,
+      entry_path_eff: entryPrice !== null ? PATH_EFF_DEFAULT : null,
+      tp_price: tpPrice,
+      sl_price: slPrice,
       fibo_level: entrySignal?.fiboLevel ?? null,
       spread_proxy: bloc3Diagnostics?.spreadProxy ?? null,
       volume_ratio: bloc3Diagnostics?.volumeRatio ?? null,

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -45,6 +45,7 @@ import { ReboundMonitorService } from './services/rebound-monitor.service';
 import { ReboundScannerService } from './services/rebound-scanner.service';
 import { OhlcvCacheService } from './services/ohlcv-cache.service';
 import { TopGainersScannerService } from './services/top-gainers-scanner.service';
+import { ShadowExitSimulatorService } from './services/shadow-exit-simulator.service';
 import { OperatingModeService } from './services/operating-mode.service';
 import { MultiTimeframePersistenceService } from './services/multi-tf-persistence.service';
 import { EodhdQuotaService } from './services/eodhd-quota.service';
@@ -104,6 +105,8 @@ import { ScannerLlmRouterService } from './services/scanner-llm-router.service';
     OhlcvCacheService,
     // P5-PIVOT-TOP-GAINERS — scanner momentum cross-asset (gated par STRATEGY_MODE=top_gainers)
     TopGainersScannerService,
+    // PR6.5 — Worker exit-simulator : replay BLOC 4 state machine sur shadow signals ACCEPT
+    ShadowExitSimulatorService,
     // P7-MODE-GAINERS-BADGE — toggle 3-modes opératoires (UI badge → DB strategy_mode)
     OperatingModeService,
     // P8-MULTI-TIMEFRAME-PERSISTENCE — fetch + score multi-TF (1m/5m/10m/15m/30m/1h)

--- a/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
@@ -1,0 +1,212 @@
+/**
+ * PR6.5 — Shadow exit-simulator worker (Phase 3.4 étape 5).
+ *
+ * Cron 5min : pour chaque shadow signal ACCEPT non encore exit-simulated et
+ * dont l'âge dépasse 5 min (donne du temps pour 1+ candle 1m), replay la
+ * state machine BLOC 4 (TP/SL/trailing 20/50) sur les candles intraday
+ * fetchées depuis EodhdIntradayService (equity) ou BinanceMarketService (crypto).
+ *
+ * Update :
+ *   simulated_exit_price, simulated_exit_at, simulated_exit_reason,
+ *   simulated_pnl_pct, simulated_slippage_pct
+ *
+ * Permet le calcul win-rate dans gainers_shadow_daily_report et la
+ * validation Phase 4 des critères ADR-005 §5 Step 9.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { SupabaseService } from '../../supabase/supabase.service';
+import {
+  applyTick,
+  PositionSnapshot,
+} from '../../gainers-scanner/bloc4/trailing-engine';
+import { PositionState, ExitReason } from '../../gainers-scanner/domain/gainers-enums';
+import { EodhdIntradayService } from './eodhd-intraday.service';
+import { BinanceMarketService } from './binance-market.service';
+
+interface ShadowSignalRow {
+  id: string;
+  symbol: string;
+  exchange: string;
+  asset_class: 'equity' | 'crypto';
+  entry_price: number;
+  entry_path_eff: number;
+  tp_price: number;
+  sl_price: number;
+  created_at: string;
+}
+
+interface SimResult {
+  exitPrice: number;
+  exitAt: string;
+  exitReason: string;
+  pnlPct: number;
+  slippagePct: number | null;
+}
+
+const MIN_AGE_MIN_BEFORE_REPLAY = 5;
+const MAX_HOLD_HOURS = 3; // ADR-005 §2.4 time-stop
+
+@Injectable()
+export class ShadowExitSimulatorService {
+  private readonly logger = new Logger(ShadowExitSimulatorService.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly eodhd: EodhdIntradayService,
+    private readonly binance: BinanceMarketService,
+  ) {}
+
+  /** Cron 5 min — replay state machine pour signals ACCEPT non encore simulés. */
+  @Cron('*/5 * * * *')
+  async runExitSimulator(): Promise<void> {
+    try {
+      await this.runInner();
+    } catch (e) {
+      this.logger.error(`[exit-sim] cron failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  private async runInner(): Promise<void> {
+    const minAgeMs = MIN_AGE_MIN_BEFORE_REPLAY * 60_000;
+    const cutoff = new Date(Date.now() - minAgeMs).toISOString();
+
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('gainers_v1_shadow_signals')
+      .select('id, symbol, exchange, asset_class, entry_price, entry_path_eff, tp_price, sl_price, created_at')
+      .eq('decision', 'ACCEPT')
+      .is('simulated_exit_at', null)
+      .not('entry_price', 'is', null)
+      .lte('created_at', cutoff)
+      .order('created_at', { ascending: true })
+      .limit(50);
+
+    if (error || !data || data.length === 0) return;
+
+    let processed = 0;
+    let succeeded = 0;
+    for (const r of data as ShadowSignalRow[]) {
+      processed++;
+      try {
+        const sim = await this.simulateOne(r);
+        if (!sim) continue;
+        const { error: upErr } = await this.supabase
+          .getClient()
+          .from('gainers_v1_shadow_signals')
+          .update({
+            simulated_exit_price: sim.exitPrice,
+            simulated_exit_at: sim.exitAt,
+            simulated_exit_reason: sim.exitReason,
+            simulated_pnl_pct: sim.pnlPct,
+            simulated_slippage_pct: sim.slippagePct,
+          })
+          .eq('id', r.id);
+        if (upErr) this.logger.warn(`[exit-sim] update ${r.id} failed: ${upErr.message}`);
+        else succeeded++;
+      } catch (e) {
+        this.logger.warn(`[exit-sim] sim ${r.symbol} (${r.id}) failed: ${String(e).slice(0, 80)}`);
+      }
+    }
+    this.logger.log(`[exit-sim] processed ${processed} signals, ${succeeded} simulated`);
+  }
+
+  /**
+   * Simule un signal : fetch candles 1m depuis entry_at, replay BLOC 4 state
+   * machine. Retourne null si pas assez de candles ou MAX_HOLD_HOURS atteint
+   * sans hit (TIME_LIMIT).
+   */
+  private async simulateOne(row: ShadowSignalRow): Promise<SimResult | null> {
+    const entryTime = new Date(row.created_at).getTime();
+    const ageMin = (Date.now() - entryTime) / 60_000;
+    const replayCount = Math.min(60 * MAX_HOLD_HOURS, Math.ceil(ageMin));
+    if (replayCount < 5) return null;
+
+    const candles = await this.fetchCandles(row, replayCount);
+    if (!candles || candles.length === 0) return null;
+
+    // Build PositionSnapshot from BLOC 4 contract
+    const initial: PositionSnapshot = {
+      state: PositionState.OPEN,
+      entryPrice: row.entry_price,
+      pathEff: row.entry_path_eff,
+      tpPrice: row.tp_price,
+      initialSlPrice: row.sl_price,
+      currentStopPrice: row.sl_price,
+      mfePrice: row.entry_price,
+    };
+
+    let snap = { ...initial };
+    let exitTickIdx = -1;
+    let exitReason: ExitReason | null = null;
+
+    for (let i = 0; i < candles.length; i++) {
+      const c = candles[i];
+      // Use close as the tick price (simplification). Could test high/low for
+      // intra-candle stop hits — kept simple for PR6.5.
+      const r = applyTick({ position: snap, currentPrice: c.close });
+      snap = {
+        ...snap,
+        state: r.newState,
+        currentStopPrice: r.newStopPrice,
+        mfePrice: r.newMfePrice,
+      };
+      if (r.exitReason) {
+        exitReason = r.exitReason;
+        exitTickIdx = i;
+        break;
+      }
+    }
+
+    // Aucun exit dans la fenêtre : check TIME_LIMIT
+    if (exitTickIdx === -1) {
+      if (ageMin >= MAX_HOLD_HOURS * 60) {
+        exitReason = ExitReason.TIME_LIMIT;
+        exitTickIdx = candles.length - 1;
+      } else {
+        return null; // pas encore time-limit, attendre prochain cron
+      }
+    }
+
+    const exitCandle = candles[exitTickIdx];
+    const exitTime = new Date(entryTime + (exitTickIdx + 1) * 60_000).toISOString();
+    const exitPrice = exitCandle.close;
+    const pnlPct = (exitPrice - row.entry_price) / row.entry_price;
+    const theoretical =
+      exitReason === ExitReason.TP_FULL ? row.tp_price :
+      exitReason === ExitReason.SL ? row.sl_price :
+      snap.currentStopPrice;
+    const slippagePct = theoretical !== null
+      ? (exitPrice - theoretical) / row.entry_price
+      : null;
+
+    return {
+      exitPrice,
+      exitAt: exitTime,
+      exitReason: String(exitReason),
+      pnlPct,
+      slippagePct,
+    };
+  }
+
+  /** Fetch intraday 1m candles depuis le ticker (EODHD ou Binance). */
+  private async fetchCandles(
+    row: ShadowSignalRow,
+    count: number,
+  ): Promise<Array<{ close: number }> | null> {
+    if (row.asset_class === 'crypto') {
+      const binanceSymbol = this.toBinanceSymbol(row.symbol);
+      if (!binanceSymbol) return null;
+      const candles = await this.binance.getKlines(binanceSymbol, '1m', count);
+      return candles ? candles.map((c) => ({ close: c.close })) : null;
+    }
+    const series = await this.eodhd.getCandles(row.symbol, '1m', count);
+    return series ? series.candles.map((c) => ({ close: c.close })) : null;
+  }
+
+  private toBinanceSymbol(eodhdSymbol: string): string | null {
+    const m = eodhdSymbol.match(/^([A-Z0-9]+)-USD\.CC$/);
+    return m ? `${m[1]}USDT` : null;
+  }
+}


### PR DESCRIPTION
## PR6.5 — Worker exit-simulator (Phase 3.4 étape 5)

Replay BLOC 4 state machine sur shadow signals ACCEPT pour calculer `simulated_pnl_pct`. Permet aux daily reports de calculer win-rate et de valider les critères Phase 4 ADR-005 §5 Step 9.

## Changements

### `shadow-run.service.ts.persistShadowSignal` enrichi

Calcule à la volée :
- `entry_path_eff` (default 0.5% — PR6.6 mettra P9-UX réel)
- `tp_price` = entry × (1 + path_eff × tp_mul / 100)
- `sl_price` = entry × (1 - path_eff × sl_mul / 100)

Multipliers BLOC 4 §11.1 :
- equity : TP=×1.5 / SL=×1.0
- crypto : TP=×2.0 / SL=×0.8

Sans ces 3 champs, l'exit-simulator ne peut pas instancier `PositionSnapshot` pour le replay.

### `shadow-exit-simulator.service.ts` (NEW)

```
@Cron('*/5 * * * *')
1. SELECT shadow signals (decision='ACCEPT', simulated_exit_at IS NULL,
   age >= 5min, ORDER created_at, LIMIT 50)
2. Pour chaque : fetch candles 1m (EodhdIntradayService equity / Binance crypto)
3. replayTicks(initial, closes) → state machine BLOC 4
4. UPDATE simulated_exit_price/at/reason + simulated_pnl_pct + slippage
5. TIME_LIMIT après MAX_HOLD_HOURS = 3h (ADR-005 §2.4)
```

### LisaModule

`ShadowExitSimulatorService` inject providers entre `TopGainersScannerService` et `OperatingModeService`.

## Tests + boot

```
Suite gainers : 326 / 0 failures / 2 todo legacy
Local boot ✅ port 3981 — DI chains OK
```

Pas de nouveaux tests pour le worker (logique repose sur `applyTick` exhaustivement testé en BLOC 4 trailing-engine).

## Impact prod attendu après merge + Fly redeploy

- Cron `*/5min` actif
- Premier batch dès qu'un shadow signal ACCEPT est âgé >5min (= 1 cron `*/15` du scanner après cycle)
- `gainers_shadow_daily_report` cron 23:30 UTC capte les `simulated_pnl_pct`
- Métriques win-rate / avg_pnl / anomalous_fill_count se peuplent
- Validation Phase 4 (≥30 ACCEPT, win-rate ≥45%, divergence ≤20%) devient mesurable

## Out of scope (PR6.6)

- BLOC 2 spread proxy (fetch candles 1h × 215 symbols / 15min)
- BLOC 3 trigger detection (fetch candles 1m × 215 symbols / 15min)
- Crypto enrichment ATR/EMA via Binance klines daily 200
- Path efficiency P9-UX réel (path_eff default 0.5 actuellement)

## Diff

```
3 files changed, 235 insertions(+), 4 deletions(-)
- shadow-run.service.ts                : +24/-4 (TP/SL/path_eff enrichi)
- shadow-exit-simulator.service.ts     : +207 (NEW worker)
- lisa.module.ts                       : +4 (import + provider register)
```

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_