### PR TITLE
feat(shadow): PR6.6 — crypto enrichment Binance + path_eff réel P9-UX

### DIFF
--- a/apps/api/src/modules/gainers-scanner/shadow/shadow-run.service.ts
+++ b/apps/api/src/modules/gainers-scanner/shadow/shadow-run.service.ts
@@ -59,24 +59,28 @@ export class GainersShadowRunService {
    *
    * PR6.5 — enrichi avec entry_path_eff + tp_price + sl_price calculés via
    * BLOC 4 §11.1 pour permettre le worker exit-simulator de replay la state
-   * machine. path_eff par défaut = 0.5 (= 0.5% mouvement attendu, conservateur)
-   * tant que P9-UX path efficiency n'est pas wired pour shadow.
+   * machine.
+   * PR6.6 — accepte pathEffOverride (P9-UX réel) ; default 0.5% si absent.
    */
   async persistShadowSignal(
     candidate: GainersScoredCandidate,
     legacyDecision: 'ACCEPT' | 'REJECT' | null = null,
+    pathEffOverride: number | null = null,
   ): Promise<void> {
     if (!this.isShadowEnabled()) return;
 
     const { raw, decision, rejectReason, compositeScore, entrySignal, bloc3Diagnostics } = candidate;
 
     // BLOC 4 §11.1 : equity TP=×1.5/SL=×1.0, crypto TP=×2.0/SL=×0.8
-    // path_eff default 0.5 (% conservateur). PR6.6 enrichira avec P9-UX réel.
-    const PATH_EFF_DEFAULT = 0.5;
+    // PR6.6 : pathEffOverride (mtfPersistence.pathQuality) si dispo, else 0.5%
+    // pathEff est un % (0.5 = 0.5% mouvement attendu)
+    const pathEffRaw = pathEffOverride !== null && pathEffOverride > 0
+      ? Math.min(pathEffOverride * 100, 5) // overallEfficiency [0,1] → cap 5% mvt
+      : 0.5;
     const tpMul = raw.market === 'crypto' ? 2.0 : 1.5;
     const slMul = raw.market === 'crypto' ? 0.8 : 1.0;
-    const tpPct = (PATH_EFF_DEFAULT * tpMul) / 100;
-    const slPct = (PATH_EFF_DEFAULT * slMul) / 100;
+    const tpPct = (pathEffRaw * tpMul) / 100;
+    const slPct = (pathEffRaw * slMul) / 100;
     const entryPrice = entrySignal ? raw.close : (decision === 'ACCEPT' ? raw.close : null);
     const tpPrice = entryPrice !== null ? entryPrice * (1 + tpPct) : null;
     const slPrice = entryPrice !== null ? entryPrice * (1 - slPct) : null;
@@ -90,7 +94,7 @@ export class GainersShadowRunService {
       decision,
       reject_reason: rejectReason,
       entry_price: entryPrice,
-      entry_path_eff: entryPrice !== null ? PATH_EFF_DEFAULT : null,
+      entry_path_eff: entryPrice !== null ? pathEffRaw : null,
       tp_price: tpPrice,
       sl_price: slPrice,
       fibo_level: entrySignal?.fiboLevel ?? null,

--- a/apps/api/src/modules/lisa/services/shadow-enrichment.helper.ts
+++ b/apps/api/src/modules/lisa/services/shadow-enrichment.helper.ts
@@ -1,20 +1,22 @@
 /**
- * PR6.4 — Enrichment helper async pour shadow run.
+ * PR6.4 + PR6.6 — Enrichment helper async pour shadow run.
  *
  * Enrichit GainersCandidateRaw avec les champs requis par BLOC 1 prefilter
  * réel (atrDailyRelative, ema50/200Daily, persistenceScore) en lisant :
- *   - `ohlcv_cache_daily` pour ATR + EMA (equity uniquement, mig 0078)
+ *   - `ohlcv_cache_daily` pour ATR + EMA (equity, mig 0078)
+ *   - `BinanceMarketService.getKlines(symbol, '1d', 200)` pour ATR + EMA (crypto, PR6.6)
  *   - `MultiTimeframePersistenceService.analyze()` pour persistence multi-TF
+ *     + pathQuality.overallEfficiency utilisé comme path_eff réel (PR6.6)
  *
- * Crypto : `ohlcv_cache_daily` est equity-only par design → atr/ema restent
- * null + le caller utilise `SHADOW_BLOC1_CONFIG.shadowSkipNullFields=true`
- * pour passer les gates dégradées.
+ * Retourne `{ raw, pathEff }` où pathEff vient de mtfPersistence (P9-UX) ou
+ * null si pas dispo (caller utilise default 0.5%).
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { GainersCandidateRaw } from '../../gainers-scanner/domain/gainers-candidate.types';
 import type { TopGainerCandidate } from '@smartvest/ai-analyst';
 import type { MultiTimeframePersistenceService } from './multi-tf-persistence.service';
+import type { BinanceMarketService } from './binance-market.service';
 import { computeDailyIndicators, type DailyCandle } from './shadow-indicators.helper';
 import { mapTopGainerToCandidateRaw } from './shadow-mapping.helper';
 
@@ -23,6 +25,12 @@ interface OhlcvCacheRow {
   high: string | number;
   low: string | number;
   close: string | number;
+}
+
+export interface EnrichResult {
+  raw: GainersCandidateRaw;
+  /** Path efficiency P9-UX overall ∈ [0, 1] ; null si pas dispo. */
+  pathEff: number | null;
 }
 
 /**
@@ -58,38 +66,61 @@ export async function readDailyCandles(
 }
 
 /**
+ * PR6.6 — Lit 200 bougies daily Binance pour un symbole crypto.
+ * Format eodhd → binance : BTC-USD.CC → BTCUSDT.
+ */
+export async function readBinanceDailyCandles(
+  binance: BinanceMarketService,
+  cryptoSymbol: string,
+  minBars = 200,
+): Promise<DailyCandle[] | null> {
+  const m = cryptoSymbol.match(/^([A-Z0-9]+)-USD\.CC$/);
+  if (!m) return null;
+  const binanceSymbol = `${m[1]}USDT`;
+  const candles = await binance.getKlines(binanceSymbol, '1d', minBars);
+  if (!candles || candles.length < minBars) return null;
+  return candles.map((c): DailyCandle => ({ high: c.high, low: c.low, close: c.close }));
+}
+
+/**
  * Enrichit un TopGainerCandidate (legacy) en GainersCandidateRaw (V1) avec :
- *   - atrDailyRelative : ATR(14)/close depuis cache OHLC (equity uniquement)
- *   - ema50Daily, ema200Daily : EMA50/200 depuis cache (equity uniquement)
+ *   - atrDailyRelative : ATR(14)/close depuis cache OHLC equity OU Binance klines crypto
+ *   - ema50Daily, ema200Daily : EMA50/200 idem
  *   - persistenceScore, persistenceCount : depuis mtfPersistence.analyze()
  *
- * Crypto : skip cache reads (equity-only par design). Reste null → caller doit
- * utiliser SHADOW_BLOC1_CONFIG.shadowSkipNullFields=true.
+ * PR6.6 : crypto enrichi via BinanceMarketService.getKlines (1d × 200).
+ * PR6.6 : path_eff réel = mtfPersistence.pathQuality.overallEfficiency.
  *
- * Sequential async : 1 read DB + 1 mtfPersistence analyze par candidat.
+ * Sequential async : 1 read DB/Binance + 1 mtfPersistence analyze par candidat.
  * Caller batch (concurrent) recommandé pour 215 symboles.
  */
 export async function enrichShadowCandidate(
   candidate: TopGainerCandidate,
   supabase: SupabaseClient,
   mtfPersistence: MultiTimeframePersistenceService,
-): Promise<GainersCandidateRaw> {
+  binance?: BinanceMarketService,
+): Promise<EnrichResult> {
   const baseRaw = mapTopGainerToCandidateRaw(candidate);
 
-  // ATR + EMA depuis cache (equity uniquement)
+  // ATR + EMA depuis cache (equity) ou Binance klines (crypto, PR6.6)
+  let dailyCandles: DailyCandle[] | null = null;
   if (baseRaw.market === 'equity') {
-    const candles = await readDailyCandles(supabase, candidate.symbol, 200);
-    if (candles) {
-      const { atr14, ema50, ema200 } = computeDailyIndicators(candles);
-      if (atr14 !== null && candidate.close > 0) {
-        baseRaw.atrDailyRelative = atr14 / candidate.close;
-      }
-      baseRaw.ema50Daily = ema50;
-      baseRaw.ema200Daily = ema200;
-    }
+    dailyCandles = await readDailyCandles(supabase, candidate.symbol, 200);
+  } else if (baseRaw.market === 'crypto' && binance) {
+    dailyCandles = await readBinanceDailyCandles(binance, candidate.symbol, 200);
   }
 
-  // Persistence multi-TF (equity + crypto)
+  if (dailyCandles) {
+    const { atr14, ema50, ema200 } = computeDailyIndicators(dailyCandles);
+    if (atr14 !== null && candidate.close > 0) {
+      baseRaw.atrDailyRelative = atr14 / candidate.close;
+    }
+    baseRaw.ema50Daily = ema50;
+    baseRaw.ema200Daily = ema200;
+  }
+
+  // Persistence multi-TF (equity + crypto) + path_eff réel
+  let pathEff: number | null = null;
   try {
     const persistence = await mtfPersistence.analyze({
       symbol: candidate.symbol,
@@ -99,10 +130,13 @@ export async function enrichShadowCandidate(
     if (persistence) {
       baseRaw.persistenceScore = persistence.persistenceScore;
       baseRaw.persistenceCount = persistence.persistenceCount;
+      // PR6.6 : extract overall path efficiency for shadow path_eff réel
+      pathEff = persistence.pathQuality?.overallEfficiency ?? null;
     }
   } catch {
     // mtfPersistence peut échouer (Yahoo down, EODHD quota). Ne bloque pas.
   }
 
-  return baseRaw;
+  return { raw: baseRaw, pathEff };
 }
+

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -700,9 +700,10 @@ export class TopGainersScannerService implements OnModuleInit {
 
     for (const c of candidates) {
       try {
-        // PR6.4 : enrich + run BLOC 1 réel
-        const enrichedRaw = await enrichShadowCandidate(c, supabaseClient, this.mtfPersistence);
-        const bloc1Result = this.bloc1.evaluate(enrichedRaw, {
+        // PR6.4 : enrich BLOC 1 réel
+        // PR6.6 : enrich crypto via Binance + pathEff réel via mtfPersistence
+        const enriched = await enrichShadowCandidate(c, supabaseClient, this.mtfPersistence, this.binanceMarket);
+        const bloc1Result = this.bloc1.evaluate(enriched.raw, {
           ...DEFAULT_BLOC1_FULL_CONFIG,
           prefilter: SHADOW_BLOC1_CONFIG,
         });
@@ -711,17 +712,17 @@ export class TopGainersScannerService implements OnModuleInit {
         const legacyDecision: 'ACCEPT' | 'REJECT' = isTopLegacy ? 'ACCEPT' : 'REJECT';
 
         await this.shadowRun.persistShadowSignal({
-          raw: enrichedRaw,
+          raw: enriched.raw,
           compositeScore: bloc1Result.compositeScore,
           decision: bloc1Result.decision,
           rejectReason: bloc1Result.rejectReason,
-          spreadProxy: null, // PR6.5 BLOC 2
+          spreadProxy: null, // PR6.7 BLOC 2
           spreadProxySource: null,
           trendFilter: bloc1Result.trendFilter,
           rvolIntraday: null,
           entrySignal: null, // PR6.5 BLOC 3
           bloc3Diagnostics: null,
-        }, legacyDecision);
+        }, legacyDecision, enriched.pathEff);
 
         if (bloc1Result.decision === 'ACCEPT') acceptCount++;
         else rejectCount++;


### PR DESCRIPTION
## PR6.6 — Crypto enrichment Binance + path_eff réel P9-UX

Phase 3.4 enrichissements complémentaires. BLOC 2/3 spread+trigger restent en PR6.7.

## Changements

### `shadow-enrichment.helper.ts`

**Nouveau** `readBinanceDailyCandles(binance, symbol, 200)` :
- Fetch klines `1d` × 200 depuis Binance pour symboles crypto
- Parse `BTC-USD.CC → BTCUSDT` mapping standard

**`enrichShadowCandidate`** signature change :
- Nouveau 4ème param optionnel `binance?: BinanceMarketService`
- Crypto : fetch daily candles via Binance (au lieu de skip vide)
- ATR(14) + EMA50/200 calculés depuis ces candles (mêmes formules pure helper)
- **Retour API change** : `{ raw: GainersCandidateRaw, pathEff: number | null }`
- `pathEff` = `mtfPersistence.pathQuality.overallEfficiency` (P9-UX réel)

### `shadow-run.service.ts.persistShadowSignal`

- Nouveau 3ème param optionnel `pathEffOverride: number | null = null`
- Si fourni : utilisé comme `path_eff` (cap à 5% mvt max via `Math.min(× 100, 5)`)
- Sinon : default `0.5%` (baseline PR6.5)
- `entry_path_eff` persisté = valeur effectivement utilisée pour TP/SL calc
- TP/SL recalc avec path_eff réel → impacte précision Kelly + exit-simulator

### `top-gainers-scanner.service.ts.persistShadowSignalsBatch`

- `enrichShadowCandidate(c, supabase, mtfPersistence, this.binanceMarket)` (4ème arg)
- Destructuring : `enriched.raw + enriched.pathEff`
- `persistShadowSignal(candidate, legacyDecision, enriched.pathEff)` (3ème arg)

## Impact prod attendu

| Avant PR6.6 | Après PR6.6 |
|---|---|
| Crypto : ATR/EMA = null → skip gates | **Crypto : ATR/EMA réels via Binance klines** |
| `path_eff` = 0.5% défaut arbitraire | **path_eff = P9-UX overallEfficiency réel** (cap 5%) |
| TP/SL approximatifs | **TP/SL calibrés** sur dynamique réelle du symbole |
| BLOC 1 trend filter skip crypto | **BLOC 1 trend filter actif** sur crypto |

→ exit-simulator replay plus représentatif, Kelly sizing plus précis.

## Tests + boot

```
Suite gainers : 326 / 0 failures / 2 todo legacy
Local boot ✅ port 3979 — DI résolution OK
```

## Reste pour Phase 4 bascule live (PR6.7)

- BLOC 2 spread proxy (fetch candles 1h × 215 symbols / 15min)
- BLOC 3 entry trigger PULLBACK_HL_FIBO + VWAP_RECLAIM (fetch candles 1m × 215 symbols)
- Spread / fibo level / pivots persistés dans shadow signals

## Diff

```
3 files changed, 74 insertions(+), 35 deletions(-)
- shadow-enrichment.helper.ts          : +52/-22 (Binance + EnrichResult)
- top-gainers-scanner.service.ts       : +6/-5 (enriched destructuring + 4th arg)
- shadow-run.service.ts                : +13/-7 (pathEffOverride 3rd arg)
```

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_