### PR TITLE
fix(shadow): PR6.6.1 — shadow run pipeline-agnostic (decouple from active portfolios)

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -609,6 +609,26 @@ export class TopGainersScannerService implements OnModuleInit {
         'Activate via POST /lisa/mode/:portfolioId {mode:"gainers"} or set STRATEGY_MODE=top_gainers env.',
       );
       this.recordEarlyReturn('no_active_portfolio');
+
+      // PR6.6.1 — Shadow run est pipeline-agnostic (ADR-005 §5 Step 9).
+      // Même sans portfolio actif, on persiste les shadow signals pour valider
+      // le pipeline V1 (BLOC 1 enrichi + crypto Binance + path_eff réel).
+      // Sans ce bypass, aucun signal n'est persisté tant qu'aucun portfolio
+      // n'est en strategy_mode='gainers' — ce qui bloque la Phase 4 bascule.
+      if (this.shadowRun.isShadowEnabled()) {
+        try {
+          const candidates = await this.fetchAllCandidates();
+          if (candidates.length > 0) {
+            const top = selectTopGainers(candidates, 3);
+            await this.persistShadowSignalsBatch(candidates, top);
+            this.logger.log(
+              `[top-gainers] shadow-only: ${candidates.length} scanned → ${top.length} top, persisted to gainers_v1_shadow_signals`,
+            );
+          }
+        } catch (e) {
+          this.logger.warn(`[top-gainers] shadow-only persist failed: ${String(e).slice(0, 200)}`);
+        }
+      }
       return;
     }
 


### PR DESCRIPTION
## Diagnostic

Post-deploy `705ff2c` (PR6.6) : 0 shadow signal persisté en 30j malgré `GAINERS_V1_SHADOW=true` + 4 cycles cron */15 par jour fetchant 186 candidats (incl. 10 Binance crypto).

## Root cause

`runScannerInner` faisait un early return `no_active_portfolio` AVANT l'appel à `persistShadowSignalsBatch` (L606 vs L634), couplant le shadow run aux portfolios utilisateur. Sans portfolio en `strategy_mode='gainers'` ni env `STRATEGY_MODE=top_gainers`, le shadow batch n'était jamais exécuté → PR6.4/6.5/6.6 enrichments shippés mais jamais validés en prod.

## Fix

Quand `shadowRun.isShadowEnabled()` et qu'aucun portfolio n'est actif, fetch + select top + persist shadow batch quand même, puis early return. Conforme à l'intent ADR-005 §5 Step 9 (le shadow run est un test du pipeline V1, indépendant des portfolios).

## Changes

- `apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts` (+20 LoC)

## Tests

- ✅ Typecheck OK
- ✅ Jest 73/73 top-gainers-scanner specs (pas de constructor change → pas de test à patcher)
- ✅ Boot local port 3979 (DI resolved, routes mapped, cron scheduled)

## Risk

Faible :
- Shadow only — aucun impact legacy decisioning
- Comportement nominal (configs > 0) inchangé
- Pas de dépendance ajoutée, pas de constructor arg modifié

## Effet attendu post-deploy

Au prochain cron `*/15` :
- Logs : `[top-gainers] shadow-only: 186 scanned → 3 top, persisted to gainers_v1_shadow_signals`
- `gainers_v1_shadow_signals` se remplit avec `entry_path_eff` réel + crypto Binance enrichi
- `/admin/gainers/shadow-daily-report` reflète `acceptCount > 0`

## Bloquait

Phase 4 bascule live (validation empirique cadence + win-rate impossible sans signaux persistés).

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_