### PR TITLE
fix(shadow): PR6.6.2 — crypto asset_class propagation (Binance + EODHD)

### DIFF
--- a/apps/api/src/modules/lisa/services/shadow-mapping.helper.ts
+++ b/apps/api/src/modules/lisa/services/shadow-mapping.helper.ts
@@ -18,13 +18,27 @@
  *   - BLOC 3 trigger detection sur candles 1m intraday
  */
 
-import type { TopGainerCandidate, TopGainerAssetClass } from '@smartvest/ai-analyst';
+import { detectAssetClass, type TopGainerCandidate, type TopGainerAssetClass } from '@smartvest/ai-analyst';
 import type { GainersCandidateRaw } from '../../gainers-scanner/domain/gainers-candidate.types';
 
-/** Mappe TopGainerAssetClass → 'equity' | 'crypto' attendu par V1. */
-function mapAssetClass(legacyAssetClass: TopGainerAssetClass | undefined): 'equity' | 'crypto' {
-  if (!legacyAssetClass) return 'equity';
-  if (legacyAssetClass === 'crypto_major' || legacyAssetClass === 'crypto_alt') return 'crypto';
+/**
+ * Mappe TopGainerAssetClass → 'equity' | 'crypto' attendu par V1.
+ *
+ * PR6.6.2 — Fallback sur detectAssetClass(symbol, exchange, marketCap) quand
+ * `legacyAssetClass` est undefined. Cas critique : les raw candidates produits
+ * par fetchBinanceGainers/mapEodhdRow ne set jamais `assetClass` (seul
+ * selectTopGainers le fait downstream pour les top-N qui passent le filtre).
+ * Sans ce fallback, BTCUSDT/ETHUSDT/etc. tombaient en `equity` → fail
+ * LIQUIDITY_FLOOR alors que crypto majors devraient passer.
+ */
+function mapAssetClass(
+  legacyAssetClass: TopGainerAssetClass | undefined,
+  symbol: string,
+  exchange: string | null | undefined,
+  marketCap: number | null,
+): 'equity' | 'crypto' {
+  const cls = legacyAssetClass ?? detectAssetClass(symbol, exchange, marketCap);
+  if (cls === 'crypto_major' || cls === 'crypto_alt') return 'crypto';
   return 'equity';
 }
 
@@ -38,7 +52,12 @@ export function mapTopGainerToCandidateRaw(
 ): GainersCandidateRaw {
   return {
     symbol: candidate.symbol,
-    market: mapAssetClass(candidate.assetClass),
+    market: mapAssetClass(
+      candidate.assetClass,
+      candidate.symbol,
+      candidate.exchange,
+      candidate.marketCap ?? null,
+    ),
     exchange: candidate.exchange ?? 'UNKNOWN',
     close: candidate.close,
     open: candidate.close, // single-tick fallback

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -39,6 +39,7 @@ import { CandidateRejectReason } from '../../gainers-scanner/domain/gainers-enum
 // PR6.4 — Enrichment helpers (ATR + EMA + persistence depuis ohlcv_cache_daily)
 import { enrichShadowCandidate } from './shadow-enrichment.helper';
 import {
+  detectAssetClass,
   selectTopGainers,
   type TopGainerCandidate,
   type TopGainerAssetClass,
@@ -1032,6 +1033,10 @@ export class TopGainersScannerService implements OnModuleInit {
     return {
       symbol,
       exchange,
+      // PR6.6.2 — pré-classifie pour que les raw candidates exposent assetClass
+      // correctement (consommé par persistShadowSignalsBatch sans passer par
+      // selectTopGainers qui re-calcule).
+      assetClass: detectAssetClass(symbol, exchange, marketCap),
       close,
       high,
       changePct,
@@ -1054,6 +1059,10 @@ export class TopGainersScannerService implements OnModuleInit {
         out.push({
           symbol: pair,
           exchange: 'BINANCE',
+          // PR6.6.2 — set assetClass upstream (whitelisted CRYPTO_PAIRS = majors).
+          // Sans ça, persistShadowSignalsBatch tombait en fallback equity sur les
+          // 10 paires Binance et fail LIQUIDITY_FLOOR à tort.
+          assetClass: 'crypto_major',
           close: t.lastPrice,
           high: t.high ?? t.lastPrice,
           changePct: t.priceChangePct,


### PR DESCRIPTION
## Diagnostic post-PR6.6.1

372 shadow signals persistés (✅ wiring OK), mais :
- **0 ACCEPT** sur 372 (~50% rejected pour `LIQUIDITY_FLOOR`)
- **BTCUSDT, ETHUSDT, BNBUSDT, SOLUSDT, XRPUSDT, ADAUSDT, AVAXUSDT, DOTUSDT, LINKUSDT, MATICUSDT** étiquetés `asset_class='equity'` au lieu de `crypto`
- Crypto majors avec ~$20B/jour de volume **ne devraient pas fail liquidity floor**

## Root cause

```
mapEodhdRow + fetchBinanceGainers
  → TopGainerCandidate sans assetClass
selectTopGainers
  → calcule assetClass via detectAssetClass MAIS uniquement pour top-N
persistShadowSignalsBatch
  → itère sur tous les raw candidates → assetClass undefined
mapAssetClass(undefined) 
  → fallback 'equity' (ligne 26 shadow-mapping.helper.ts)
  → BTCUSDT évalué comme equity → fail LIQUIDITY_FLOOR
```

## Fix (a) — defensive in mapping helper

`mapTopGainerToCandidateRaw` appelle `detectAssetClass(symbol, exchange, marketCap)` quand `legacyAssetClass` est undefined. Garde-fou même si l'upstream oublie de set.

## Fix (b) — upstream classification

- `fetchBinanceGainers`: ajoute `assetClass: 'crypto_major'` (whitelist `CRYPTO_PAIRS` = top 10 majors)
- `mapEodhdRow`: ajoute `assetClass: detectAssetClass(symbol, exchange, marketCap)` pour propager upstream

Les 2 fixes sont **complémentaires** — (a) protège même si futurs paths oublient, (b) corrige la source.

## Files

- `apps/api/src/modules/lisa/services/shadow-mapping.helper.ts` (+25/-6)
- `apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts` (+9)

## Tests

- ✅ Typecheck OK
- ✅ Jest 105/105 top-gainers-scanner + shadow specs (suites élargies inclues)
- ✅ Boot port 3979 OK (DI resolved, cron scheduled)

## Effet attendu post-deploy

Au prochain cron `*/15` :
- BTCUSDT/ETHUSDT etc. → `market='crypto'` dans `gainers_v1_shadow_signals`
- Crypto majors devraient passer LIQUIDITY_FLOOR (volume Binance live = milliards $)
- 1er ACCEPT crypto attendu si persistence ≥ 5/6 TF (threshold 0.67 inchangé)

## Risk

Faible — shadow only, pas d'impact legacy ni execution. Ajoute juste un calcul `detectAssetClass` par candidat dans le shadow batch (~µs).

## Limitations connues

- Données weekend (samedi 02/05) : equity markets fermés → prix figés vendredi → REJECT légitimes pour majorité du panier non-crypto
- Validation complète attendra Monday open + 4h pour évaluer cadence ACCEPT réelle

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_