### PR TITLE
fix(shadow): PR6.6.3 — crypto vol24hUsd correct + marketCap from CRYPTO_MARKET_CAP_USD

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/shadow-mapping.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/shadow-mapping.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * PR6.6.3 — Unit tests pour shadow-mapping.helper.
+ *
+ * Verifie :
+ *   - Crypto vol24hUsd : pas de × close (volume Binance déjà USDT)
+ *   - Equity vol24hUsd : × close (volume EODHD = nb shares)
+ *   - asset_class detection upstream (PR6.6.2 fallback) reste OK
+ */
+
+import { mapTopGainerToCandidateRaw } from '../services/shadow-mapping.helper';
+
+describe('mapTopGainerToCandidateRaw — PR6.6.3 vol24hUsd correctness', () => {
+  it('crypto: vol24hUsd = volume (no × close)', () => {
+    const raw = mapTopGainerToCandidateRaw({
+      symbol: 'BTCUSDT',
+      exchange: 'BINANCE',
+      assetClass: 'crypto_major',
+      close: 60_000,
+      high: 61_000,
+      changePct: 2.5,
+      volume: 20_000_000_000, // $20B quoteVolume Binance (already USD)
+      avgVol50d: 25_000_000_000,
+      marketCap: 1_300_000_000_000,
+    });
+    expect(raw.market).toBe('crypto');
+    expect(raw.vol24hUsd).toBe(20_000_000_000); // not × close
+    expect(raw.medianDailyVolUsd20d).toBe(25_000_000_000);
+    expect(raw.marketCapUsd).toBe(1_300_000_000_000);
+  });
+
+  it('equity: vol24hUsd = volume × close (volume = nb shares)', () => {
+    const raw = mapTopGainerToCandidateRaw({
+      symbol: 'AAPL',
+      exchange: 'US',
+      assetClass: 'us_equity_large',
+      close: 200,
+      high: 205,
+      changePct: 3,
+      volume: 50_000_000, // 50M shares
+      avgVol50d: 60_000_000,
+      marketCap: 3_000_000_000_000,
+    });
+    expect(raw.market).toBe('equity');
+    expect(raw.vol24hUsd).toBe(50_000_000 * 200); // 10B USD
+    expect(raw.medianDailyVolUsd20d).toBe(60_000_000 * 200);
+  });
+
+  it('crypto without legacyAssetClass: detectAssetClass fallback recognizes BTCUSDT', () => {
+    const raw = mapTopGainerToCandidateRaw({
+      symbol: 'BTCUSDT',
+      exchange: 'BINANCE',
+      // assetClass undefined — simule raw candidate from fetchBinanceGainers pre-PR6.6.2
+      close: 60_000,
+      high: 61_000,
+      changePct: 2.5,
+      volume: 20_000_000_000,
+      avgVol50d: 0,
+      marketCap: 1_300_000_000_000,
+    } as any);
+    expect(raw.market).toBe('crypto'); // PR6.6.2 fallback works
+    expect(raw.vol24hUsd).toBe(20_000_000_000); // PR6.6.3 correct formula
+  });
+
+  it('crypto with low volume (ADA-like) does not get artificially inflated', () => {
+    const raw = mapTopGainerToCandidateRaw({
+      symbol: 'ADAUSDT',
+      exchange: 'BINANCE',
+      assetClass: 'crypto_major',
+      close: 0.4,
+      high: 0.42,
+      changePct: 5,
+      volume: 200_000_000, // $200M quoteVolume
+      avgVol50d: 200_000_000,
+      marketCap: 15_000_000_000,
+    });
+    expect(raw.vol24hUsd).toBe(200_000_000); // not 200M × 0.4 = 80M
+    // Pre-fix: 80M < 50M crypto floor → fail liquidity. Post-fix: 200M > 50M → pass.
+  });
+});

--- a/apps/api/src/modules/lisa/services/shadow-mapping.helper.ts
+++ b/apps/api/src/modules/lisa/services/shadow-mapping.helper.ts
@@ -46,25 +46,33 @@ function mapAssetClass(
  * Convertit un TopGainerCandidate (legacy scanner) en GainersCandidateRaw (V1).
  * Champs manquants → null/défauts pour permettre BLOC 1 prefilter d'évaluer
  * en mode dégradé (skip gates basés sur null).
+ *
+ * PR6.6.3 — Volume USD :
+ *   - Equity (EODHD) : `volume` = nombre de shares → × close → USD ✅
+ *   - Crypto (Binance) : `volume` = `t.quoteVolume` qui est DÉJÀ en USDT (≈USD).
+ *     Multiplier par close donne un nombre absurde (USD²). Fix : skip × close
+ *     pour crypto.
  */
 export function mapTopGainerToCandidateRaw(
   candidate: TopGainerCandidate & { score?: number; assetClass?: TopGainerAssetClass },
 ): GainersCandidateRaw {
+  const market = mapAssetClass(
+    candidate.assetClass,
+    candidate.symbol,
+    candidate.exchange,
+    candidate.marketCap ?? null,
+  );
+  const isCrypto = market === 'crypto';
   return {
     symbol: candidate.symbol,
-    market: mapAssetClass(
-      candidate.assetClass,
-      candidate.symbol,
-      candidate.exchange,
-      candidate.marketCap ?? null,
-    ),
+    market,
     exchange: candidate.exchange ?? 'UNKNOWN',
     close: candidate.close,
     open: candidate.close, // single-tick fallback
     high: candidate.high,
     low: candidate.close, // fallback
-    vol24hUsd: candidate.volume * candidate.close,
-    medianDailyVolUsd20d: candidate.avgVol50d * candidate.close,
+    vol24hUsd: isCrypto ? candidate.volume : candidate.volume * candidate.close,
+    medianDailyVolUsd20d: isCrypto ? candidate.avgVol50d : candidate.avgVol50d * candidate.close,
     marketCapUsd: candidate.marketCap,
     atrDailyRelative: null,
     changePct1m: candidate.changePct,

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -130,6 +130,33 @@ const EU_WATCHLIST_NAMES = ['cac40', 'dax40', 'ftse100'];
 const CRYPTO_PAIRS = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT', 'ADAUSDT', 'AVAXUSDT', 'DOTUSDT', 'LINKUSDT', 'MATICUSDT'];
 
 /**
+ * PR6.6.3 — Market cap approximatif pour les 10 Binance majors whitelistés.
+ *
+ * Binance ticker24hr ne renvoie pas market cap (OHLCV-only). Sans valeur réelle,
+ * BLOC 1 V1 gate `MARKET_CAP_MIN` (seuil 500M crypto) fail systématiquement avec
+ * marketCap=0. Les 10 majors actuels ont tous un cap entre 8B et 1.3T (>>500M),
+ * la gate est de fait redondante pour cette whitelist contrôlée.
+ *
+ * Valeurs au 02/05/2026 (approximatives, conservatrices). La marge vs seuil 500M
+ * tolère ×10 dérive avant fail.
+ *
+ * Long-term : intégration CoinGecko/CMC pour caps live (cron quotidien). Out of
+ * scope PR6.6.3.
+ */
+const CRYPTO_MARKET_CAP_USD: Record<string, number> = {
+  BTCUSDT:  1_300_000_000_000,
+  ETHUSDT:    400_000_000_000,
+  BNBUSDT:     90_000_000_000,
+  SOLUSDT:    100_000_000_000,
+  XRPUSDT:     60_000_000_000,
+  ADAUSDT:     15_000_000_000,
+  AVAXUSDT:    15_000_000_000,
+  DOTUSDT:      8_000_000_000,
+  LINKUSDT:    10_000_000_000,
+  MATICUSDT:    8_000_000_000,
+};
+
+/**
  * P18f (29/04/2026, autonomous) — `crypto_tradable` concept : whitelist
  * opt-in via env var `CRYPTO_TRADABLE_WHITELIST=BTCUSDT,ETHUSDT,...` qui
  * RESTREINT les ouvertures de positions crypto à ces symboles.
@@ -1067,8 +1094,10 @@ export class TopGainersScannerService implements OnModuleInit {
           high: t.high ?? t.lastPrice,
           changePct: t.priceChangePct,
           volume: t.quoteVolume ?? 0,
-          avgVol50d: 0,
-          marketCap: 0, // Crypto major filter ne nécessite pas marketCap si on whitelist top pairs
+          avgVol50d: t.quoteVolume ?? 0, // PR6.6.3 — fallback sur 24h volume (pas de 50d Binance ticker24hr)
+          // PR6.6.3 — marketCap depuis table CRYPTO_MARKET_CAP_USD (Binance ne renvoie
+          // pas market cap, et BLOC 1 V1 gate MARKET_CAP_MIN check ce field).
+          marketCap: CRYPTO_MARKET_CAP_USD[pair] ?? 0,
         });
       } catch (e) {
         this.logger.debug(`[top-gainers] binance ${pair} error: ${String(e).slice(0, 80)}`);


### PR DESCRIPTION
## Diagnostic post-PR6.6.2

`asset_class='crypto'` OK ✅ mais 100% REJECT crypto avec **2 reject_reasons** :
- 7× `MARKET_CAP_MIN` (BTC, ETH, BNB, SOL, XRP, AVAX, LINK)
- 3× `LIQUIDITY_FLOOR` (ADA, DOT, MATIC)

Absurde pour top 10 majors avec caps $8B-$1.3T et volumes $0.2-20B/jour.

## Root causes

### Bug A — `vol24hUsd` cassé pour crypto (`shadow-mapping.helper.ts`)
```ts
vol24hUsd: candidate.volume * candidate.close  // FAUX pour crypto
```
Pour Binance, `volume = quoteVolume` qui est **déjà en USDT**. Multiplier par `close` donne `USD²` absurde.
- ADA : 200M × 0.4 = 80M (sous seuil crypto 50M weekend) → fail liquidity à tort

### Bug B — `marketCap: 0` hardcodé (`fetchBinanceGainers` L1062)
Binance `ticker24hr` ne renvoie pas market cap. Le commentaire prétendait "pas nécessaire" mais BLOC 1 V1 gate `MARKET_CAP_MIN` check ce field (seuil 500M crypto). 10/10 majors fail.

## Fix

### (1) `vol24hUsd` correct selon market
```ts
vol24hUsd: isCrypto ? candidate.volume : candidate.volume * candidate.close
```
Idem `medianDailyVolUsd20d`.

### (2) Table `CRYPTO_MARKET_CAP_USD` (whitelist)
```ts
const CRYPTO_MARKET_CAP_USD = {
  BTCUSDT: 1_300_000_000_000,  // ~1.3T
  ETHUSDT:   400_000_000_000,
  BNBUSDT:    90_000_000_000,
  SOLUSDT:   100_000_000_000,
  XRPUSDT:    60_000_000_000,
  ADAUSDT:    15_000_000_000,
  AVAXUSDT:   15_000_000_000,
  DOTUSDT:     8_000_000_000,
  LINKUSDT:   10_000_000_000,
  MATICUSDT:   8_000_000_000,
};
```
Tous >> seuil 500M. **Marge ×10 vs dérive marché** avant que la moindre fail. ADR-005 §1bis seuils non touchés.

## Files

- `apps/api/src/modules/lisa/services/shadow-mapping.helper.ts` (+13/-7)
- `apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts` (+30/-3)
- `apps/api/src/modules/lisa/__tests__/shadow-mapping.spec.ts` (+79 new)

## Tests

- ✅ 4 nouveaux specs `shadow-mapping.spec.ts`
- ✅ 363/363 tests scanner+shadow+gainers
- ✅ Typecheck OK
- ✅ Boot port 3979 OK (DI resolved, cron scheduled)

## Effet attendu post-deploy

Au prochain cron `*/15` :
- Les 10 crypto majors devraient passer `LIQUIDITY_FLOOR` + `MARKET_CAP_MIN`
- Reste à vérifier `VOLATILITY_CLAMP` + `TREND_FILTER` (EMA50/200 daily Binance, déjà PR6.6) + `PERSISTENCE_BELOW_THRESHOLD` (multi-TF)
- 1ers ACCEPT crypto attendus si persistence ≥ 5/6 TF (threshold 0.67 inchangé)

## Validation success criteria

Après deploy + cron :
- ✅ aucun MARKET_CAP_MIN sur les 10 crypto majors
- ✅ aucun LIQUIDITY_FLOOR sur les 10 crypto majors
- ⏳ ≥ 3-5 ACCEPT sur le top 10 (sinon analyse VOLATILITY/TREND/PERSISTENCE)

## TODO long-term (out of scope)

Intégration CoinGecko ou CMC pour caps live (cron quotidien). Brittle approach hardcoded acceptable hotfix.

## Risk

Faible — shadow only, pas d'impact legacy ni execution.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_