### PR TITLE
feat(shadow): PR6.7 — BLOC 2 spread proxy + BLOC 3 entry triggers wired in shadow batch [DRAFT - gated weekday validation]

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
@@ -36,7 +36,7 @@ jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
 function makeService(): TopGainersScannerService {
   mockConfig.get.mockImplementation((key: string) => (key === 'SCAN_INTERVAL_MINUTES' ? '15' : undefined));
   return new TopGainersScannerService(
-    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any, { enrich: (i: any) => i.candidate } as any, { evaluate: (i: any) => i.candidate } as any, { getCandles: () => Promise.resolve(null) } as any,
   );
 }
 
@@ -259,7 +259,7 @@ describe('P20a — NON_EU_EXCHANGES registry correctness', () => {
       return undefined;
     });
     return new TopGainersScannerService(
-      mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+      mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any, { enrich: (i: any) => i.candidate } as any, { evaluate: (i: any) => i.candidate } as any, { getCandles: () => Promise.resolve(null) } as any,
     );
   }
 
@@ -290,7 +290,7 @@ describe('P20a — NON_EU_EXCHANGES registry correctness', () => {
       }),
     } as any;
     const svc = new TopGainersScannerService(
-      supabaseMock, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+      supabaseMock, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any, { enrich: (i: any) => i.candidate } as any, { evaluate: (i: any) => i.candidate } as any, { getCandles: () => Promise.resolve(null) } as any,
     );
     capturedUrls = [];
     // fetchAllCandidates without EU (EU sessions closed)

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eu-session.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eu-session.spec.ts
@@ -41,7 +41,7 @@ function makeService(): TopGainersScannerService {
     return undefined;
   });
   return new TopGainersScannerService(
-    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any, { enrich: (i: any) => i.candidate } as any, { evaluate: (i: any) => i.candidate } as any, { getCandles: () => Promise.resolve(null) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.llm.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.llm.spec.ts
@@ -55,7 +55,7 @@ function makeService(llmRouter: ScannerLlmRouterService): TopGainersScannerServi
     mockScheduler,
     mockMtf,
     llmRouter,
-    { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any, { enrich: (i: any) => i.candidate } as any, { evaluate: (i: any) => i.candidate } as any, { getCandles: () => Promise.resolve(null) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.multi-exchange.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.multi-exchange.spec.ts
@@ -42,7 +42,7 @@ jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
 function makeService(): TopGainersScannerService {
   mockConfig.get.mockImplementation((key: string) => (key === 'SCAN_INTERVAL_MINUTES' ? '15' : undefined));
   return new TopGainersScannerService(
-    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any, { enrich: (i: any) => i.candidate } as any, { evaluate: (i: any) => i.candidate } as any, { getCandles: () => Promise.resolve(null) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18e-skip-summary.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18e-skip-summary.spec.ts
@@ -48,7 +48,7 @@ function makeService(): TopGainersScannerService {
     return undefined;
   });
   return new TopGainersScannerService(
-    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any, { enrich: (i: any) => i.candidate } as any, { evaluate: (i: any) => i.candidate } as any, { getCandles: () => Promise.resolve(null) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18f-crypto-tradable.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18f-crypto-tradable.spec.ts
@@ -34,7 +34,7 @@ function makeService(envMap: Record<string, string | undefined> = {}): TopGainer
     return envMap[key];
   });
   return new TopGainersScannerService(
-    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any, { enrich: (i: any) => i.candidate } as any, { evaluate: (i: any) => i.candidate } as any, { getCandles: () => Promise.resolve(null) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p19beta-shadow.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p19beta-shadow.spec.ts
@@ -62,7 +62,7 @@ function makeService(): TopGainersScannerService {
     mockScheduler,
     mockMtf,
     mockLlmRouter,
-    { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any, { enrich: (i: any) => i.candidate } as any, { evaluate: (i: any) => i.candidate } as any, { getCandles: () => Promise.resolve(null) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -34,10 +34,15 @@ import { ScannerLlmRouterService } from './scanner-llm-router.service';
 // PR6.3 — Shadow wiring (LisaModule import GainersModule pour résolution DI)
 import { GainersShadowRunService } from '../../gainers-scanner/shadow/shadow-run.service';
 import { GainersBloc1Service, DEFAULT_BLOC1_FULL_CONFIG } from '../../gainers-scanner/bloc1/gainers-bloc1.service';
+import { GainersBloc2Service, DEFAULT_BLOC2_CONFIG } from '../../gainers-scanner/bloc2/gainers-bloc2.service';
+import { GainersBloc3Service, DEFAULT_BLOC3_CONFIG } from '../../gainers-scanner/bloc3/gainers-bloc3.service';
 import { SHADOW_BLOC1_CONFIG } from '../../gainers-scanner/bloc1/prefilter-gates';
 import { CandidateRejectReason } from '../../gainers-scanner/domain/gainers-enums';
+import type { CandleOHLCV } from '../../gainers-scanner/bloc2/spread-proxy';
 // PR6.4 — Enrichment helpers (ATR + EMA + persistence depuis ohlcv_cache_daily)
 import { enrichShadowCandidate } from './shadow-enrichment.helper';
+// PR6.7 — Intraday candles for BLOC 2 spread + BLOC 3 entry triggers
+import { EodhdIntradayService } from './eodhd-intraday.service';
 import {
   detectAssetClass,
   selectTopGainers,
@@ -402,6 +407,21 @@ export class TopGainersScannerService implements OnModuleInit {
      * scorer réels avec SHADOW_BLOC1_CONFIG (tolère atr/persistence null).
      */
     private readonly bloc1: GainersBloc1Service,
+    /**
+     * PR6.7 — BLOC 2 enrich (spread proxy + RVOL) sur les BLOC 1 ACCEPT.
+     * Inject pour pipeline shadow complet.
+     */
+    private readonly bloc2: GainersBloc2Service,
+    /**
+     * PR6.7 — BLOC 3 entry trigger detection (PULLBACK_HL_FIBO + VWAP_RECLAIM).
+     * Inject pour pipeline shadow complet.
+     */
+    private readonly bloc3: GainersBloc3Service,
+    /**
+     * PR6.7 — Intraday candles fetcher pour equity (BLOC 2 1h + BLOC 3 1m).
+     * Crypto utilise binanceMarket déjà inject.
+     */
+    private readonly eodhdIntraday: EodhdIntradayService,
   ) {}
 
   /**
@@ -746,33 +766,68 @@ export class TopGainersScannerService implements OnModuleInit {
     let rejectCount = 0;
     let failures = 0;
 
+    let bloc2RejectCount = 0;
+    let bloc3RejectCount = 0;
+    let triggerHitCount = 0;
+
     for (const c of candidates) {
       try {
         // PR6.4 : enrich BLOC 1 réel
         // PR6.6 : enrich crypto via Binance + pathEff réel via mtfPersistence
         const enriched = await enrichShadowCandidate(c, supabaseClient, this.mtfPersistence, this.binanceMarket);
-        const bloc1Result = this.bloc1.evaluate(enriched.raw, {
+        let scored = this.bloc1.evaluate(enriched.raw, {
           ...DEFAULT_BLOC1_FULL_CONFIG,
           prefilter: SHADOW_BLOC1_CONFIG,
         });
+
+        // PR6.7 — Pipeline BLOC 1 → 2 → 3 sur les ACCEPT seulement (cost guard).
+        // Skip BLOC 2/3 si BLOC 1 a déjà REJECT (court-circuit ADR-005 §1bis.5).
+        if (scored.decision === 'ACCEPT') {
+          // BLOC 2 — fetch 1h candles, enrich spread proxy
+          const candles1h = await this.fetchOhlcvForBloc23(enriched.raw, '1h', 20);
+          scored = this.bloc2.enrich({
+            candidate: scored,
+            candles: candles1h,
+            resolution: '1h',
+            intradayVolUsd: null, // RVOL désactivé par défaut (DEFAULT_BLOC2_CONFIG.rvolEnabled=false)
+          }, DEFAULT_BLOC2_CONFIG);
+
+          if (scored.decision === 'ACCEPT') {
+            // BLOC 3 — fetch 1m candles, evaluate entry triggers
+            const candles1m = await this.fetchOhlcvForBloc23(enriched.raw, '1m', 60);
+            const candles1mForBloc3 = candles1m ?? [];
+            scored = this.bloc3.evaluate({
+              candidate: scored,
+              candles: candles1mForBloc3,
+              volumeBaseline: null, // surge check disabled in shadow (baseline lookup = follow-up)
+              detectedAt: new Date().toISOString(),
+              resolution: '1m',
+            }, DEFAULT_BLOC3_CONFIG);
+
+            if (scored.decision === 'REJECT') bloc3RejectCount++;
+            else if (scored.entrySignal) triggerHitCount++;
+          } else {
+            bloc2RejectCount++;
+          }
+        }
 
         const isTopLegacy = topSymbolsSet.has(c.symbol.toUpperCase());
         const legacyDecision: 'ACCEPT' | 'REJECT' = isTopLegacy ? 'ACCEPT' : 'REJECT';
 
         await this.shadowRun.persistShadowSignal({
           raw: enriched.raw,
-          compositeScore: bloc1Result.compositeScore,
-          decision: bloc1Result.decision,
-          rejectReason: bloc1Result.rejectReason,
-          spreadProxy: null, // PR6.7 BLOC 2
-          spreadProxySource: null,
-          trendFilter: bloc1Result.trendFilter,
-          rvolIntraday: null,
-          entrySignal: null, // PR6.5 BLOC 3
-          bloc3Diagnostics: null,
+          compositeScore: scored.compositeScore,
+          decision: scored.decision,
+          rejectReason: scored.rejectReason,
+          spreadProxy: scored.spreadProxy ?? null,
+          spreadProxySource: scored.spreadProxySource ?? null,
+          trendFilter: scored.trendFilter,
+          rvolIntraday: scored.rvolIntraday ?? null,
+          entrySignal: scored.entrySignal ?? null,
+          bloc3Diagnostics: scored.bloc3Diagnostics ?? null,
         }, legacyDecision, enriched.pathEff);
 
-        if (bloc1Result.decision === 'ACCEPT') acceptCount++;
+        if (scored.decision === 'ACCEPT') acceptCount++;
         else rejectCount++;
         success++;
       } catch (e) {
@@ -782,7 +837,46 @@ export class TopGainersScannerService implements OnModuleInit {
         }
       }
     }
-    this.logger.log(`[shadow] persisted ${success} signals (V1: ${acceptCount} ACCEPT, ${rejectCount} REJECT, ${failures} failures) — enrichi BLOC 1 réel`);
+    this.logger.log(
+      `[shadow] persisted ${success} signals (V1: ${acceptCount} ACCEPT, ${rejectCount} REJECT, ` +
+      `BLOC2 reject=${bloc2RejectCount}, BLOC3 reject=${bloc3RejectCount}, trigger hits=${triggerHitCount}, ` +
+      `${failures} failures) — pipeline BLOC 1+2+3 réel (PR6.7)`,
+    );
+  }
+
+  /**
+   * PR6.7 — Helper fetch OHLCV candles pour BLOC 2 (1h) ou BLOC 3 (1m).
+   *
+   * Equity → EodhdIntradayService.getCandles
+   * Crypto → BinanceMarketService.getKlines (eodhd → binance symbol mapping)
+   *
+   * Retourne null si fetch échoue ou si interval non supporté pour le market.
+   * Le caller (BLOC 2/3) gère le null en fallback (STATIC_CAP_FALLBACK pour
+   * spread, REJECT NO_ENTRY_TRIGGER pour bloc3 si <5 candles).
+   */
+  private async fetchOhlcvForBloc23(
+    raw: import('../../gainers-scanner/domain/gainers-candidate.types').GainersCandidateRaw,
+    interval: '1m' | '1h',
+    count: number,
+  ): Promise<CandleOHLCV[] | null> {
+    try {
+      if (raw.market === 'crypto') {
+        // eodhd format BTC-USD.CC → binance BTCUSDT (PR6.5/6.6 helper)
+        const m = raw.symbol.match(/^([A-Z0-9]+)-USD\.CC$/);
+        const binanceSymbol = m ? `${m[1]}USDT` : raw.symbol;
+        const klines = await this.binanceMarket.getKlines(binanceSymbol, interval, count);
+        return klines ? klines.map((k) => ({
+          open: k.open, high: k.high, low: k.low, close: k.close, volume: k.volume,
+        })) : null;
+      }
+      const series = await this.eodhdIntraday.getCandles(raw.symbol, interval, count);
+      return series ? series.candles.map((c) => ({
+        open: c.open, high: c.high, low: c.low, close: c.close, volume: c.volume,
+      })) : null;
+    } catch (e) {
+      // Fail soft : caller (BLOC 2/3) handle null en fallback gracieux
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
## ⚠️ DRAFT — Gated sur bilan weekday lundi

Cette PR pre-stage le code de PR6.7 mais **ne doit pas être mergée avant validation lundi 09:00+4h UTC** (cf. roadmap Task #1) :
- ≥ 3-5 ACCEPT crypto sur top 10 majors weekday
- ≤ 2 LIQUIDITY_FLOOR (volumes weekday > 50M sur la majorité)
- 0 MARKET_CAP_MIN (déjà OK PR6.6.3)

## Phase 3.5 — Pipeline V1 complet

Extension de `persistShadowSignalsBatch` :

```
BLOC 1 (existant) → BLOC 2 (nouveau) → BLOC 3 (nouveau) → persist
```

### BLOC 2 — Spread proxy enrich

Sur ACCEPT BLOC 1 uniquement (court-circuit ADR-005 §1bis.5) :
- Fetch 1h candles via `fetchOhlcvForBloc23(symbol, '1h', 20)`
- `bloc2.enrich(input, DEFAULT_BLOC2_CONFIG)` → `spreadProxy + spreadProxySource`
- REJECT `SPREAD_TOO_WIDE` court-circuite avant BLOC 3
- RVOL désactivé par défaut (DEFAULT_BLOC2_CONFIG.rvolEnabled=false) jusqu'à ETL baseline peuplé

### BLOC 3 — Entry trigger detection

Sur ACCEPT BLOC 2 uniquement :
- Fetch 1m candles via `fetchOhlcvForBloc23(symbol, '1m', 60)`
- `bloc3.evaluate(input, DEFAULT_BLOC3_CONFIG)` → `entrySignal + bloc3Diagnostics`
- Triggers : `PULLBACK_HL_FIBO` + `VWAP_RECLAIM`
- REJECT `NO_ENTRY_TRIGGER` si aucun trigger ne matche

### Helper fetch routing

`fetchOhlcvForBloc23(raw, interval, count)` :
- Equity → `eodhdIntraday.getCandles(symbol, '1m'|'1h', count)`
- Crypto → `binanceMarket.getKlines(binanceSymbol, interval, count)`
- Mapping eodhd→binance : `BTC-USD.CC` → `BTCUSDT`
- Fail soft : null sur échec, caller fallback gracieux (STATIC_CAP_FALLBACK / REJECT NO_ENTRY_TRIGGER)

## Coût performance

- THÉORIQUE : 215 symbols × (1h + 1m) = ~860 calls/cycle
- RÉEL : BLOC 2/3 only sur ACCEPT BLOC 1 (~5-20% pass rate) → 22-86 calls/cycle
- Soit 88-344/h × 24h = **2-8k/jour**
- Quota EODHD ALL-IN-ONE = 100k/jour → **marge ×12-50** ✅

## Files

- `apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts` (+118/-15)
- 7 test files patchés (mocks `bloc2`/`bloc3`/`eodhdIntraday`)

## Tests

- ✅ Typecheck OK
- ✅ Jest 231/231 specs scanner+shadow+gainers
- ✅ Boot port 3979 OK (DI resolved, cron scheduled, no errors)

## Effet attendu post-deploy

- Shadow signals avec `setup_type` renseigné (PULLBACK_HL_FIBO / VWAP_RECLAIM)
- `spread_proxy` calculé via Bloc2 réel (pas null)
- `bloc3Diagnostics` avec session + spread + volume_ratio + pivots
- Daily report `triggerBreakdown` alimenté (préférence trigger pipeline V1)

## Constructor args

10 → 13 :
- `bloc2: GainersBloc2Service`
- `bloc3: GainersBloc3Service`
- `eodhdIntraday: EodhdIntradayService`

GainersModule exporte déjà bloc2/bloc3. EodhdIntradayService déjà provider LisaModule.

## Risk

Modéré :
- Augmente I/O par cycle (BLOC 2/3 fetch candles), mais court-circuit garde le coût en main
- Pas d'impact legacy decisioning (shadow only)
- Tests boot OK = pas de DI failure régression

## Validation success criteria post-merge

- Shadow signals affichent `setup_type` non-null
- Spread proxy values < 0.40% (equity) / 0.60% (crypto) sur ACCEPT
- Bloc3 diagnostics renseignent `pivotsDetected > 0` sur la majorité

## Suite

PR6.7 mergée → Phase 3.5 OK → préparer Phase 4 bascule live + canary 10% (T0+30j shadow stable).

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_