### PR TITLE
feat(insights): Phase A — gainers_insights_log for self-learning model

### DIFF
--- a/apps/api/src/modules/admin/admin-gainers-insights.controller.ts
+++ b/apps/api/src/modules/admin/admin-gainers-insights.controller.ts
@@ -1,0 +1,165 @@
+/**
+ * /admin/gainers/insights — Phase A insights log endpoints.
+ *
+ * GET /admin/gainers/insights
+ *   ?type=...&status=...&severity=...&source=...&since_days=30&limit=50
+ *
+ * GET /admin/gainers/insights/stats
+ *   Aggregates par type/status/severity sur les 30 derniers jours.
+ *
+ * POST /admin/gainers/insights
+ *   body { type, source, summary, payload, severity?, context? }
+ *
+ * PATCH /admin/gainers/insights/:id
+ *   body { status, resolution?, resolution_pr?, resolved_by? }
+ *
+ * Auth via x-admin-token.
+ */
+
+import {
+  Body,
+  Controller,
+  Get,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  GainersInsightsService,
+  type InsightSeverity,
+  type InsightSource,
+  type InsightStatus,
+  type InsightType,
+} from '../gainers-scanner/insights/gainers-insights.service';
+
+@Controller('admin/gainers/insights')
+export class AdminGainersInsightsController {
+  constructor(
+    private readonly service: GainersInsightsService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Get()
+  async list(
+    @Headers('x-admin-token') token: string | undefined,
+    @Query('type') type?: InsightType,
+    @Query('status') status?: InsightStatus,
+    @Query('severity') severity?: InsightSeverity,
+    @Query('source') source?: InsightSource,
+    @Query('since_days') sinceDaysStr?: string,
+    @Query('limit') limitStr?: string,
+  ) {
+    this.assertAdmin(token);
+    const sinceDays = Math.min(Math.max(Number(sinceDaysStr ?? 30) || 30, 1), 365);
+    const limit = Math.min(Math.max(Number(limitStr ?? 50) || 50, 1), 500);
+    const q: Parameters<GainersInsightsService['queryInsights']>[0] = { sinceDays, limit };
+    if (type) q.type = type;
+    if (status) q.status = status;
+    if (severity) q.severity = severity;
+    if (source) q.source = source;
+    const insights = await this.service.queryInsights(q);
+    return { count: insights.length, insights };
+  }
+
+  @Get('stats')
+  async stats(
+    @Headers('x-admin-token') token: string | undefined,
+    @Query('since_days') sinceDaysStr?: string,
+  ) {
+    this.assertAdmin(token);
+    const sinceDays = Math.min(Math.max(Number(sinceDaysStr ?? 30) || 30, 1), 365);
+    return this.service.getStats(sinceDays);
+  }
+
+  @Post()
+  async create(
+    @Headers('x-admin-token') token: string | undefined,
+    @Body() body: {
+      type: InsightType;
+      source: InsightSource;
+      summary: string;
+      payload: Record<string, unknown>;
+      severity?: InsightSeverity;
+      context?: Record<string, unknown>;
+    },
+  ) {
+    this.assertAdmin(token);
+    if (!body || !body.type || !body.source || !body.summary || !body.payload) {
+      throw new HttpException(
+        { message: 'missing required fields: type, source, summary, payload', code: 'BAD_INPUT' },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    const logInput: Parameters<GainersInsightsService['logInsight']>[0] = {
+      type: body.type,
+      source: body.source,
+      summary: body.summary,
+      payload: body.payload,
+    };
+    if (body.severity) logInput.severity = body.severity;
+    if (body.context) logInput.context = body.context;
+    const id = await this.service.logInsight(logInput);
+    if (!id) {
+      throw new HttpException(
+        { message: 'log failed (db error)', code: 'DB_ERROR' },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+    return { id };
+  }
+
+  @Patch(':id')
+  async resolve(
+    @Headers('x-admin-token') token: string | undefined,
+    @Param('id') id: string,
+    @Body() body: {
+      status: 'investigating' | 'actioned' | 'dismissed';
+      resolution?: string;
+      resolution_pr?: string;
+      resolved_by?: string;
+    },
+  ) {
+    this.assertAdmin(token);
+    if (!body || !body.status) {
+      throw new HttpException(
+        { message: 'missing field: status', code: 'BAD_INPUT' },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    const resolveInput: Parameters<GainersInsightsService['resolveInsight']>[1] = {
+      status: body.status,
+    };
+    if (body.resolution) resolveInput.resolution = body.resolution;
+    if (body.resolution_pr) resolveInput.resolutionPr = body.resolution_pr;
+    if (body.resolved_by) resolveInput.resolvedBy = body.resolved_by;
+    const ok = await this.service.resolveInsight(id, resolveInput);
+    if (!ok) {
+      throw new HttpException(
+        { message: 'resolve failed', code: 'DB_ERROR' },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+    return { id, status: body.status };
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (providedToken !== expected) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'ADMIN_FORBIDDEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -31,6 +31,7 @@ import { AdminGainersExtendedController } from './admin-gainers-extended.control
 import { AdminModePresetsController } from './admin-mode-presets.controller';
 import { AdminShadowDailyReportController } from './admin-shadow-daily-report.controller';
 import { AdminGainersSeedUniverseController } from './admin-gainers-seed-universe.controller';
+import { AdminGainersInsightsController } from './admin-gainers-insights.controller';
 
 @Module({
   imports: [SupabaseModule, forwardRef(() => LisaModule), GainersModule],
@@ -46,6 +47,7 @@ import { AdminGainersSeedUniverseController } from './admin-gainers-seed-univers
     AdminModePresetsController,
     AdminShadowDailyReportController,
     AdminGainersSeedUniverseController,
+    AdminGainersInsightsController,
   ],
 })
 export class AdminModule {}

--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-insights.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-insights.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * Phase A — GainersInsightsService specs.
+ *
+ * Mock SupabaseClient avec un fake table store en mémoire.
+ */
+
+import { GainersInsightsService } from '../insights/gainers-insights.service';
+
+function makeMockSupabase() {
+  const rows: any[] = [];
+  let nextId = 0;
+
+  const builder = (tableName: string): any => {
+    let _filters: Array<{ field: string; op: string; value: unknown }> = [];
+    let _patch: Record<string, unknown> | null = null;
+    let _select: string | null = null;
+    let _limit: number | null = null;
+    let _orderBy: { field: string; ascending: boolean } | null = null;
+    let _gteValue: { field: string; value: string } | null = null;
+    let _insert: Record<string, unknown> | null = null;
+    let _operation: 'select' | 'insert' | 'update' | null = null;
+
+    const obj: any = {
+      select(s: string) { _select = s; _operation = _operation ?? 'select'; return obj; },
+      insert(payload: Record<string, unknown>) { _insert = { ...payload }; _operation = 'insert'; return obj; },
+      update(patch: Record<string, unknown>) { _patch = patch; _operation = 'update'; return obj; },
+      eq(field: string, value: unknown) { _filters.push({ field, op: 'eq', value }); return obj; },
+      gte(field: string, value: string) { _gteValue = { field, value }; return obj; },
+      order(field: string, opts: { ascending: boolean }) { _orderBy = { field, ascending: opts.ascending }; return obj; },
+      limit(n: number) { _limit = n; return obj; },
+      single() {
+        if (_operation === 'insert' && _insert) {
+          const row = { id: `id-${nextId++}`, created_at: new Date().toISOString(), ..._insert };
+          rows.push(row);
+          return Promise.resolve({ data: row, error: null });
+        }
+        return Promise.resolve({ data: null, error: { message: 'unexpected single()' } });
+      },
+      then(resolve: any) {
+        // For await on update or select chain
+        if (_operation === 'update' && _patch) {
+          for (const r of rows) {
+            const matches = _filters.every((f) => r[f.field] === f.value);
+            if (matches) Object.assign(r, _patch);
+          }
+          return resolve({ data: null, error: null });
+        }
+        if (_operation === 'select') {
+          let out = rows.slice();
+          if (_gteValue) out = out.filter((r) => r[_gteValue!.field] >= _gteValue!.value);
+          for (const f of _filters) out = out.filter((r) => r[f.field] === f.value);
+          if (_orderBy) {
+            out.sort((a, b) => (a[_orderBy!.field] < b[_orderBy!.field] ? 1 : -1) * (_orderBy!.ascending ? -1 : 1));
+          }
+          if (_limit !== null) out = out.slice(0, _limit);
+          return resolve({ data: out, error: null });
+        }
+        return resolve({ data: null, error: null });
+      },
+    };
+    return obj;
+  };
+
+  return {
+    getClient: () => ({
+      from: (table: string) => builder(table),
+    }),
+    _rows: rows,
+  } as any;
+}
+
+describe('GainersInsightsService', () => {
+  it('logs an insight and returns id', async () => {
+    const supabase = makeMockSupabase();
+    const svc = new GainersInsightsService(supabase);
+    const id = await svc.logInsight({
+      type: 'divergence_analysis',
+      source: 'session_chat',
+      summary: 'V1 plus prudente que legacy sur 3 cas Asia weekend',
+      payload: { divergence_count: 3, symbols: ['059120', '000783', 'DWARKESH'] },
+      severity: 'info',
+    });
+    expect(id).toBeTruthy();
+    expect(supabase._rows.length).toBe(1);
+    expect(supabase._rows[0].insight_type).toBe('divergence_analysis');
+    expect(supabase._rows[0].status).toBe('open');
+    expect(supabase._rows[0].severity).toBe('info');
+  });
+
+  it('clamps summary to 500 chars', async () => {
+    const supabase = makeMockSupabase();
+    const svc = new GainersInsightsService(supabase);
+    const longSummary = 'x'.repeat(800);
+    await svc.logInsight({
+      type: 'manual_observation',
+      source: 'manual',
+      summary: longSummary,
+      payload: {},
+    });
+    expect(supabase._rows[0].summary.length).toBe(500);
+  });
+
+  it('queries with filters', async () => {
+    const supabase = makeMockSupabase();
+    const svc = new GainersInsightsService(supabase);
+    await svc.logInsight({ type: 'divergence_analysis', source: 'session_chat', summary: 's1', payload: {} });
+    await svc.logInsight({ type: 'cadence_drift', source: 'auto_drift_detector', summary: 's2', payload: {}, severity: 'high' });
+    await svc.logInsight({ type: 'divergence_analysis', source: 'manual', summary: 's3', payload: {} });
+
+    const all = await svc.queryInsights({ sinceDays: 30 });
+    expect(all.length).toBe(3);
+
+    const divergences = await svc.queryInsights({ type: 'divergence_analysis' });
+    expect(divergences.length).toBe(2);
+
+    const high = await svc.queryInsights({ severity: 'high' });
+    expect(high.length).toBe(1);
+    expect(high[0].insight_type).toBe('cadence_drift');
+  });
+
+  it('resolveInsight updates status + resolution metadata', async () => {
+    const supabase = makeMockSupabase();
+    const svc = new GainersInsightsService(supabase);
+    const id = await svc.logInsight({ type: 'pipeline_bug', source: 'manual', summary: 'BTC mislabeled', payload: {} });
+    const ok = await svc.resolveInsight(id!, {
+      status: 'actioned',
+      resolution: 'PR6.6.2 wired asset_class',
+      resolutionPr: 'yannicke819-max/smartvest#218',
+      resolvedBy: 'session-chat',
+    });
+    expect(ok).toBe(true);
+    expect(supabase._rows[0].status).toBe('actioned');
+    expect(supabase._rows[0].resolution_pr).toBe('yannicke819-max/smartvest#218');
+    expect(supabase._rows[0].resolved_at).toBeTruthy();
+  });
+
+  it('getStats aggregates by type/status/severity', async () => {
+    const supabase = makeMockSupabase();
+    const svc = new GainersInsightsService(supabase);
+    await svc.logInsight({ type: 'divergence_analysis', source: 'session_chat', summary: 's1', payload: {}, severity: 'info' });
+    await svc.logInsight({ type: 'divergence_analysis', source: 'session_chat', summary: 's2', payload: {}, severity: 'low' });
+    await svc.logInsight({ type: 'pipeline_bug', source: 'manual', summary: 's3', payload: {}, severity: 'critical' });
+
+    const stats = await svc.getStats(30);
+    expect(stats.total).toBe(3);
+    expect(stats.byType.divergence_analysis).toBe(2);
+    expect(stats.byType.pipeline_bug).toBe(1);
+    expect(stats.byStatus.open).toBe(3);
+    expect(stats.bySeverity.critical).toBe(1);
+  });
+});

--- a/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
+++ b/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
@@ -13,6 +13,7 @@ import { ShadowDailyReportService } from './shadow/shadow-daily-report.service';
 import { TargetDerivationService } from './target-modes/target-derivation.service';
 import { KellySizingService } from './kelly/kelly-sizing.service';
 import { ModePresetsService } from './presets/mode-presets.service';
+import { GainersInsightsService } from './insights/gainers-insights.service';
 
 /**
  * ADR-005 Gainers Algo V1 — Module NestJS découplé (ADR-006).
@@ -37,6 +38,7 @@ import { ModePresetsService } from './presets/mode-presets.service';
     TargetDerivationService,
     KellySizingService,
     ModePresetsService,
+    GainersInsightsService,
   ],
   exports: [
     GainersBloc1Service,
@@ -51,6 +53,7 @@ import { ModePresetsService } from './presets/mode-presets.service';
     TargetDerivationService,
     KellySizingService,
     ModePresetsService,
+    GainersInsightsService,
   ],
 })
 export class GainersModule implements OnModuleInit {

--- a/apps/api/src/modules/gainers-scanner/insights/gainers-insights.service.ts
+++ b/apps/api/src/modules/gainers-scanner/insights/gainers-insights.service.ts
@@ -1,0 +1,184 @@
+/**
+ * Phase A — Insights log service.
+ *
+ * CRUD service pour gainers_insights_log (migration 0110). Sert de mémoire
+ * persistante pour toute observation/divergence/drift collectée par :
+ *   - opérateur humain (manual / session_chat)
+ *   - cron drift detector (Phase B)
+ *   - threshold auto-tuner (Phase C)
+ *   - ML refit weekly (P9)
+ *
+ * Append-only : pas de DELETE exposé. Status évolue via UPDATE seulement.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+export type InsightType =
+  | 'divergence_analysis'
+  | 'cadence_drift'
+  | 'reject_pattern'
+  | 'champion_observed'
+  | 'threshold_proposal'
+  | 'pipeline_bug'
+  | 'data_quality'
+  | 'ml_refit'
+  | 'manual_observation';
+
+export type InsightSource =
+  | 'manual'
+  | 'session_chat'
+  | 'auto_drift_detector'
+  | 'auto_threshold_tuner'
+  | 'auto_ml_refit'
+  | 'auto_anomaly_detector';
+
+export type InsightStatus = 'open' | 'investigating' | 'actioned' | 'dismissed';
+export type InsightSeverity = 'info' | 'low' | 'medium' | 'high' | 'critical';
+
+export interface InsightRow {
+  id: string;
+  created_at: string;
+  insight_type: InsightType;
+  source: InsightSource;
+  status: InsightStatus;
+  severity: InsightSeverity;
+  summary: string;
+  payload: Record<string, unknown>;
+  context?: Record<string, unknown> | null;
+  resolution?: string | null;
+  resolution_pr?: string | null;
+  resolved_at?: string | null;
+  resolved_by?: string | null;
+}
+
+export interface LogInsightInput {
+  type: InsightType;
+  source: InsightSource;
+  summary: string;
+  payload: Record<string, unknown>;
+  severity?: InsightSeverity;
+  context?: Record<string, unknown>;
+}
+
+export interface QueryInsightsInput {
+  type?: InsightType;
+  status?: InsightStatus;
+  severity?: InsightSeverity;
+  source?: InsightSource;
+  sinceDays?: number;
+  limit?: number;
+}
+
+@Injectable()
+export class GainersInsightsService {
+  private readonly logger = new Logger(GainersInsightsService.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  /** Log un insight (append-only). Retourne l'id créé. */
+  async logInsight(input: LogInsightInput): Promise<string | null> {
+    const { type, source, summary, payload, severity = 'info', context } = input;
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('gainers_insights_log')
+      .insert({
+        insight_type: type,
+        source,
+        status: 'open',
+        severity,
+        summary: summary.slice(0, 500),
+        payload,
+        context: context ?? null,
+      })
+      .select('id')
+      .single();
+
+    if (error || !data) {
+      this.logger.warn(`[insights] log failed: ${error?.message ?? 'no data'}`);
+      return null;
+    }
+    return (data as { id: string }).id;
+  }
+
+  /** Query insights avec filtres optionnels. Default: 50 derniers, tous types. */
+  async queryInsights(input: QueryInsightsInput = {}): Promise<InsightRow[]> {
+    const { type, status, severity, source, sinceDays = 30, limit = 50 } = input;
+    const since = new Date(Date.now() - sinceDays * 24 * 3600_000).toISOString();
+
+    let q = this.supabase
+      .getClient()
+      .from('gainers_insights_log')
+      .select('*')
+      .gte('created_at', since)
+      .order('created_at', { ascending: false })
+      .limit(Math.min(limit, 500));
+
+    if (type) q = q.eq('insight_type', type);
+    if (status) q = q.eq('status', status);
+    if (severity) q = q.eq('severity', severity);
+    if (source) q = q.eq('source', source);
+
+    const { data, error } = await q;
+    if (error || !data) {
+      this.logger.warn(`[insights] query failed: ${error?.message ?? 'no data'}`);
+      return [];
+    }
+    return data as InsightRow[];
+  }
+
+  /**
+   * Update status + resolution metadata. Idempotent — si déjà actioned, no-op.
+   */
+  async resolveInsight(
+    id: string,
+    input: {
+      status: 'investigating' | 'actioned' | 'dismissed';
+      resolution?: string;
+      resolutionPr?: string;
+      resolvedBy?: string;
+    },
+  ): Promise<boolean> {
+    const { status, resolution, resolutionPr, resolvedBy } = input;
+    const patch: Record<string, unknown> = { status };
+    if (status === 'actioned' || status === 'dismissed') {
+      patch.resolved_at = new Date().toISOString();
+      if (resolution) patch.resolution = resolution;
+      if (resolutionPr) patch.resolution_pr = resolutionPr;
+      if (resolvedBy) patch.resolved_by = resolvedBy;
+    }
+    const { error } = await this.supabase
+      .getClient()
+      .from('gainers_insights_log')
+      .update(patch)
+      .eq('id', id);
+
+    if (error) {
+      this.logger.warn(`[insights] resolve ${id} failed: ${error.message}`);
+      return false;
+    }
+    return true;
+  }
+
+  /** Aggregate counts par type/status pour dashboard. */
+  async getStats(sinceDays = 30): Promise<{
+    total: number;
+    byType: Record<string, number>;
+    byStatus: Record<string, number>;
+    bySeverity: Record<string, number>;
+  }> {
+    const rows = await this.queryInsights({ sinceDays, limit: 500 });
+    const stats = {
+      total: rows.length,
+      byType: {} as Record<string, number>,
+      byStatus: {} as Record<string, number>,
+      bySeverity: {} as Record<string, number>,
+    };
+    for (const r of rows) {
+      stats.byType[r.insight_type] = (stats.byType[r.insight_type] ?? 0) + 1;
+      stats.byStatus[r.status] = (stats.byStatus[r.status] ?? 0) + 1;
+      stats.bySeverity[r.severity] = (stats.bySeverity[r.severity] ?? 0) + 1;
+    }
+    return stats;
+  }
+}

--- a/apps/api/src/modules/gainers-scanner/insights/index.ts
+++ b/apps/api/src/modules/gainers-scanner/insights/index.ts
@@ -1,0 +1,1 @@
+export * from './gainers-insights.service';

--- a/supabase/migrations/0110_gainers_insights_log.sql
+++ b/supabase/migrations/0110_gainers_insights_log.sql
@@ -1,0 +1,88 @@
+-- Migration 0110 — Phase A : insights log structuré pour modèle auto-apprenant.
+--
+-- Stocke toute observation, divergence, drift, ou proposition d'ajustement
+-- (humaine ou automatique) avec payload JSONB pour analyse rétrospective et
+-- training de futurs auto-tuners (Phase B/C).
+--
+-- Append-only : pas de DELETE, status évolue via UPDATE seulement.
+
+CREATE TABLE IF NOT EXISTS gainers_insights_log (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Catégorie de l'insight (extensible)
+  --   'divergence_analysis'  : legacy ACCEPT vs V1 REJECT (ou vice versa)
+  --   'cadence_drift'        : ACCEPT/cycle change vs baseline
+  --   'reject_pattern'       : reject_reason concentration anormale
+  --   'champion_observed'    : symbol récurrent avec near-miss
+  --   'threshold_proposal'   : suggestion d'ajustement seuil ADR-005 §1bis
+  --   'pipeline_bug'         : bug identifié (ex PR6.6.x trilogy)
+  --   'data_quality'         : provider down, fallback, stale data
+  --   'ml_refit'             : nouveau modèle P9 fitté avec metrics
+  --   'manual_observation'   : observation libre humaine
+  insight_type  TEXT NOT NULL,
+
+  -- Origine de l'insight
+  --   'manual'                  : opérateur humain via API/UI
+  --   'session_chat'            : agent IA (ex Claude Code)
+  --   'auto_drift_detector'     : cron Phase B
+  --   'auto_threshold_tuner'    : cron Phase C
+  --   'auto_ml_refit'           : weekly P9 cron
+  --   'auto_anomaly_detector'   : daily report flags
+  source        TEXT NOT NULL,
+
+  -- Cycle de vie
+  --   'open'         : nouveau, à investiguer
+  --   'investigating' : en cours d'analyse
+  --   'actioned'     : action prise (PR mergée, threshold ajusté, etc.)
+  --   'dismissed'    : faux positif ou non-actionable
+  status        TEXT NOT NULL DEFAULT 'open',
+
+  -- Severity (pour dashboard/alertes)
+  --   'info'      : observation neutre
+  --   'low'       : à examiner sans urgence
+  --   'medium'    : nécessite décision sous 7j
+  --   'high'      : action requise sous 24h
+  --   'critical'  : bug bloquant, hotfix requis
+  severity      TEXT NOT NULL DEFAULT 'info',
+
+  -- Résumé human-readable (≤500 chars)
+  summary       TEXT NOT NULL,
+
+  -- Données structurées : varie par type
+  --   divergence_analysis : { symbol, asset_class, legacy_decision, v1_decision, reject_reason, count }
+  --   cadence_drift       : { window_days, accept_count_w1, accept_count_w2, drift_pct }
+  --   threshold_proposal  : { threshold_name, current_value, proposed_value, expected_roi, sample_size, auc }
+  --   ...
+  payload       JSONB NOT NULL,
+
+  -- Contexte additionnel
+  -- live SHA, fly_machine_id, etc. au moment de la capture
+  context       JSONB,
+
+  -- Résolution (rempli quand status passe à 'actioned' / 'dismissed')
+  resolution      TEXT,
+  resolution_pr   TEXT,        -- ex 'yannicke819-max/smartvest#221'
+  resolved_at     TIMESTAMPTZ,
+  resolved_by     TEXT,        -- email/identifier opérateur
+
+  CONSTRAINT chk_status CHECK (status IN ('open', 'investigating', 'actioned', 'dismissed')),
+  CONSTRAINT chk_severity CHECK (severity IN ('info', 'low', 'medium', 'high', 'critical'))
+);
+
+-- Index pour queries fréquentes
+CREATE INDEX IF NOT EXISTS idx_gainers_insights_type_created ON gainers_insights_log (insight_type, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gainers_insights_open ON gainers_insights_log (status) WHERE status = 'open';
+CREATE INDEX IF NOT EXISTS idx_gainers_insights_severity ON gainers_insights_log (severity, created_at DESC) WHERE severity IN ('high', 'critical');
+
+-- RLS : admin-only, jamais exposé user
+ALTER TABLE gainers_insights_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service_role_insights_full_access"
+  ON gainers_insights_log
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE gainers_insights_log IS 'Phase A — log structuré pour modèle V1 auto-apprenant. Stocke observations + divergences + drifts + propositions ajustements (human + auto). Append-only.';


### PR DESCRIPTION
## Phase A — Storage layer pour modèle V1 auto-apprenant

Pierre angulaire du modèle "intelligent qui apprend toujours" demandé : couche de **mémoire persistante structurée** pour toute observation, divergence, drift ou proposition d'ajustement (humaine ou automatique).

## Why

Aujourd'hui les analyses (ex : 3 divergences Asia, 20 champions weekend, PR6.6.x diagnoses) sont **dans le chat session, pas en DB**. Si on ferme la session = perdu. Cette PR crée la persistance pour permettre :
- Rétrospective : "qu'est-ce qu'on a appris depuis 30 jours ?"
- Auto-tuning futur : Phase B/C lit ces insights pour proposer ajustements
- Audit trail : trace complète des décisions algo

## What

### Migration 0110 — `gainers_insights_log`

Table append-only avec :
- 9 `insight_type` extensibles (divergence_analysis, cadence_drift, threshold_proposal, pipeline_bug, ml_refit, ...)
- 6 `source` (manual, session_chat, auto_drift_detector, auto_threshold_tuner, auto_ml_refit, auto_anomaly_detector)
- 5 `status` (open → investigating → actioned/dismissed)
- 5 `severity` (info/low/medium/high/critical)
- `payload` JSONB structuré + `context` JSONB
- `resolution` + `resolution_pr` + `resolved_at` + `resolved_by`
- RLS service_role only (pas exposé user)

### `GainersInsightsService`

```typescript
logInsight({ type, source, summary, payload, severity?, context? })
queryInsights({ type?, status?, severity?, source?, sinceDays, limit })
resolveInsight(id, { status, resolution?, resolutionPr?, resolvedBy? })
getStats(sinceDays)  // aggregates par type/status/severity
```

### 4 endpoints admin (token gated)

```
GET    /admin/gainers/insights         (filtres + pagination)
GET    /admin/gainers/insights/stats   (aggregates)
POST   /admin/gainers/insights         (log)
PATCH  /admin/gainers/insights/:id     (resolve)
```

## Tests

- ✅ 5/5 specs `gainers-insights.spec.ts` (log + clamp summary 500c + filters + resolve + stats)
- ✅ Typecheck OK (avec exactOptionalPropertyTypes)
- ✅ Boot port 3979 OK, 4 routes mapped

## Roadmap continuité

**Phase A (cette PR)** : Storage layer ✅
**Phase B (next session)** : Auto-detection
- Wire P9 weekly refit cron (`@Cron('0 2 * * 0')` — Sunday 02:00 UTC)
- `DriftDetectorService` cron daily (cadence ACCEPT trend, divergence% trend)
- `CadenceAlertService` — log auto si `acceptCount/24h < 0.5` sur 7j
**Phase C (post-Phase 4 + 30j outcomes)** : Auto-tuning
- `ThresholdAutoTunerService` weekly — analyse `paper_trades` outcomes
- Calc P(win) par bucket, propose `threshold_proposal` insights avec ROI
- **Pas de flip auto** — propose insights qu'humain valide via PATCH `/insights/:id` status=actioned

## Files

- `supabase/migrations/0110_gainers_insights_log.sql` (+88)
- `apps/api/src/modules/gainers-scanner/insights/` (service + index)
- `apps/api/src/modules/gainers-scanner/__tests__/gainers-insights.spec.ts` (+151)
- `apps/api/src/modules/admin/admin-gainers-insights.controller.ts` (+165)
- `apps/api/src/modules/admin/admin.module.ts` (+2)
- `apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts` (+3)

## Risk

Faible :
- Nouveau service + table additive, aucun impact sur scanner ou shadow batch
- RLS service_role only, pas d'exposition user
- Append-only = pas de risque corruption data existante

## Post-merge

Retroactive log des 6 insights majeurs session 02-03/05 :
1. PR6.6.1 fix shadow pipeline-agnostic
2. PR6.6.2 crypto asset_class bug
3. PR6.6.3 crypto vol+marketCap bug
4. Weekend findings : LIQUIDITY_FLOOR légitime, gates fonctionnent comme spec
5. 20 champions weekend identifiés (Asia heavy)
6. 3 divergences legacy/V1 (059120, 000783, DWARKESH)

Via `curl POST /admin/gainers/insights` avec payload structuré pour bootstrapper la mémoire.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_