### PR TITLE
feat(insights): Phase B — auto-detection (DriftDetector + P9 weekly refit cron)

### DIFF
--- a/apps/api/src/modules/gainers-scanner/__tests__/drift-detector.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/drift-detector.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Phase B — DriftDetectorService specs.
+ */
+
+import { DriftDetectorService } from '../automations/drift-detector.service';
+
+function makeMockSupabase(rowsByQuery: Array<Array<{
+  decision: string;
+  reject_reason: string | null;
+  diverges_from_legacy: boolean | null;
+  created_at: string;
+}>>) {
+  let callIdx = 0;
+  const builder: any = {
+    select() { return builder; },
+    gte() { return builder; },
+    lt() { return builder; },
+    limit() {
+      const data = rowsByQuery[callIdx++] ?? [];
+      return Promise.resolve({ data, error: null });
+    },
+  };
+  return {
+    getClient: () => ({
+      from: () => builder,
+    }),
+  } as any;
+}
+
+function makeMockInsights() {
+  const logged: any[] = [];
+  return {
+    logInsight: jest.fn(async (input: any) => {
+      logged.push(input);
+      return 'mock-id';
+    }),
+    _logged: logged,
+  } as any;
+}
+
+describe('DriftDetectorService', () => {
+  it('logs cadence_drift insight when ACCEPT count drops > 30% W-1 vs W-2', async () => {
+    // W-1 (most recent): 5 ACCEPT, 50 total
+    // W-2: 20 ACCEPT, 100 total → cadence ratio = 5/20 = 0.25 (75% drop) → trigger
+    const w1 = Array.from({ length: 50 }, (_, i) => ({
+      decision: i < 5 ? 'ACCEPT' : 'REJECT',
+      reject_reason: i < 5 ? null : 'PERSISTENCE_BELOW_THRESHOLD',
+      diverges_from_legacy: false,
+      created_at: '2026-05-02T00:00:00Z',
+    }));
+    const w2 = Array.from({ length: 100 }, (_, i) => ({
+      decision: i < 20 ? 'ACCEPT' : 'REJECT',
+      reject_reason: i < 20 ? null : 'PERSISTENCE_BELOW_THRESHOLD',
+      diverges_from_legacy: false,
+      created_at: '2026-04-25T00:00:00Z',
+    }));
+    const supabase = makeMockSupabase([w1, w2]);
+    const insights = makeMockInsights();
+    const svc = new DriftDetectorService(supabase, insights);
+
+    await (svc as any).runInner();
+
+    expect(insights.logInsight).toHaveBeenCalled();
+    const cadenceLog = insights._logged.find((l: any) => l.type === 'cadence_drift' && l.summary.includes('chute'));
+    expect(cadenceLog).toBeTruthy();
+    expect(cadenceLog.severity).toBe('high'); // 75% drop > 50%
+    expect(cadenceLog.payload.cadence_ratio).toBeCloseTo(0.25);
+  });
+
+  it('logs reject_pattern when one reason concentrates > 60%', async () => {
+    // W-1: 100 signals, 70× LIQUIDITY_FLOOR = 70% concentration
+    const w1 = Array.from({ length: 100 }, (_, i) => ({
+      decision: 'REJECT',
+      reject_reason: i < 70 ? 'LIQUIDITY_FLOOR' : 'TREND_FILTER_FAIL',
+      diverges_from_legacy: false,
+      created_at: '2026-05-02T00:00:00Z',
+    }));
+    const supabase = makeMockSupabase([w1, []]);
+    const insights = makeMockInsights();
+    const svc = new DriftDetectorService(supabase, insights);
+
+    await (svc as any).runInner();
+
+    const concentrationLog = insights._logged.find((l: any) => l.type === 'reject_pattern');
+    expect(concentrationLog).toBeTruthy();
+    expect(concentrationLog.payload.reject_reason).toBe('LIQUIDITY_FLOOR');
+    expect(concentrationLog.payload.concentration_pct).toBeCloseTo(0.70);
+  });
+
+  it('logs zero_accept_7d when no ACCEPT in 7 days with > 100 signals', async () => {
+    const w1 = Array.from({ length: 200 }, () => ({
+      decision: 'REJECT',
+      reject_reason: 'PERSISTENCE_BELOW_THRESHOLD',
+      diverges_from_legacy: false,
+      created_at: '2026-05-02T00:00:00Z',
+    }));
+    const supabase = makeMockSupabase([w1, []]);
+    const insights = makeMockInsights();
+    const svc = new DriftDetectorService(supabase, insights);
+
+    await (svc as any).runInner();
+
+    const zeroLog = insights._logged.find((l: any) =>
+      l.type === 'cadence_drift' && l.summary.includes('Aucun ACCEPT')
+    );
+    expect(zeroLog).toBeTruthy();
+    expect(zeroLog.severity).toBe('high');
+  });
+
+  it('does not log if cadence stable and no concentration', async () => {
+    // W-1: 10 ACCEPT, 50 total
+    // W-2: 11 ACCEPT, 50 total → ratio 0.91 (9% drop) → no trigger
+    const w1 = Array.from({ length: 50 }, (_, i) => ({
+      decision: i < 10 ? 'ACCEPT' : 'REJECT',
+      reject_reason: i < 10 ? null : i < 30 ? 'PERSISTENCE_BELOW_THRESHOLD' : 'TREND_FILTER_FAIL',
+      diverges_from_legacy: false,
+      created_at: '2026-05-02T00:00:00Z',
+    }));
+    const w2 = Array.from({ length: 50 }, (_, i) => ({
+      decision: i < 11 ? 'ACCEPT' : 'REJECT',
+      reject_reason: i < 11 ? null : i < 30 ? 'PERSISTENCE_BELOW_THRESHOLD' : 'TREND_FILTER_FAIL',
+      diverges_from_legacy: false,
+      created_at: '2026-04-25T00:00:00Z',
+    }));
+    const supabase = makeMockSupabase([w1, w2]);
+    const insights = makeMockInsights();
+    const svc = new DriftDetectorService(supabase, insights);
+
+    await (svc as any).runInner();
+
+    expect(insights.logInsight).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/gainers-scanner/automations/drift-detector.service.ts
+++ b/apps/api/src/modules/gainers-scanner/automations/drift-detector.service.ts
@@ -1,0 +1,194 @@
+/**
+ * Phase B — DriftDetectorService.
+ *
+ * Cron daily 23:50 UTC qui scanne le shadow pour détecter automatiquement :
+ *   1. Cadence drift  : ACCEPT/24h chute vs W-1 → log cadence_drift insight
+ *   2. Divergence drift : V1 vs legacy disagreement % en hausse → log
+ *   3. Reject concentration : > 60% des rejects sur même reason → log reject_pattern
+ *   4. Zero ACCEPT 7d : aucun ACCEPT 7 jours consécutifs → log severity=high
+ *
+ * Tous les insights logués via GainersInsightsService (Phase A) avec
+ * source='auto_drift_detector'. Pas de flip auto sur les seuils — propose
+ * uniquement à l'opérateur via insights pour validation humaine.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { GainersInsightsService } from '../insights/gainers-insights.service';
+
+const CADENCE_DROP_THRESHOLD_PCT = 0.30; // 30% drop W-1 vs W-2
+const DIVERGENCE_RISE_THRESHOLD_PCT = 0.10; // +10pp rise W-1 vs W-2
+const REJECT_CONCENTRATION_THRESHOLD = 0.60; // > 60% same reject_reason
+const ZERO_ACCEPT_DAYS_THRESHOLD = 7;
+
+interface ShadowSignalRow {
+  decision: string;
+  reject_reason: string | null;
+  diverges_from_legacy: boolean | null;
+  created_at: string;
+}
+
+@Injectable()
+export class DriftDetectorService {
+  private readonly logger = new Logger(DriftDetectorService.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly insights: GainersInsightsService,
+  ) {}
+
+  /** Cron daily 23:50 UTC. */
+  @Cron('50 23 * * *')
+  async runDriftDetection(): Promise<void> {
+    try {
+      await this.runInner();
+    } catch (e) {
+      this.logger.error(`[drift] cron failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  private async runInner(): Promise<void> {
+    const now = Date.now();
+    const w1Start = new Date(now - 7 * 24 * 3600_000).toISOString();
+    const w2Start = new Date(now - 14 * 24 * 3600_000).toISOString();
+    const nowIso = new Date(now).toISOString();
+
+    const w1 = await this.fetchSignals(w1Start, nowIso);
+    const w2 = await this.fetchSignals(w2Start, w1Start);
+
+    const w1Stats = this.computeStats(w1);
+    const w2Stats = this.computeStats(w2);
+
+    let insightsLogged = 0;
+
+    // 1. Cadence drift
+    if (w2Stats.acceptCount > 0) {
+      const cadenceRatio = w1Stats.acceptCount / w2Stats.acceptCount;
+      if (cadenceRatio < 1 - CADENCE_DROP_THRESHOLD_PCT) {
+        await this.insights.logInsight({
+          type: 'cadence_drift',
+          source: 'auto_drift_detector',
+          severity: cadenceRatio < 0.5 ? 'high' : 'medium',
+          summary: `Cadence ACCEPT chute de ${((1 - cadenceRatio) * 100).toFixed(0)}% W-1 vs W-2 (${w1Stats.acceptCount} vs ${w2Stats.acceptCount})`,
+          payload: {
+            window_w1: { start: w1Start, end: nowIso, accept: w1Stats.acceptCount, total: w1Stats.total },
+            window_w2: { start: w2Start, end: w1Start, accept: w2Stats.acceptCount, total: w2Stats.total },
+            cadence_ratio: cadenceRatio,
+            threshold_pct: CADENCE_DROP_THRESHOLD_PCT,
+          },
+        });
+        insightsLogged++;
+      }
+    }
+
+    // 2. Divergence rise
+    if (w1Stats.total > 0 && w2Stats.total > 0) {
+      const divW1 = w1Stats.divergenceCount / w1Stats.total;
+      const divW2 = w2Stats.divergenceCount / w2Stats.total;
+      const divRise = divW1 - divW2;
+      if (divRise > DIVERGENCE_RISE_THRESHOLD_PCT) {
+        await this.insights.logInsight({
+          type: 'cadence_drift',
+          source: 'auto_drift_detector',
+          severity: divRise > 0.20 ? 'high' : 'medium',
+          summary: `Divergence legacy vs V1 monte de +${(divRise * 100).toFixed(1)}pp (W-1=${(divW1 * 100).toFixed(1)}% vs W-2=${(divW2 * 100).toFixed(1)}%)`,
+          payload: {
+            divergence_w1_pct: divW1,
+            divergence_w2_pct: divW2,
+            rise_pp: divRise,
+            threshold_pp: DIVERGENCE_RISE_THRESHOLD_PCT,
+          },
+        });
+        insightsLogged++;
+      }
+    }
+
+    // 3. Reject concentration anormale
+    if (w1Stats.total > 30) {
+      const topReject = Object.entries(w1Stats.rejectReasons)
+        .sort((a, b) => b[1] - a[1])[0];
+      if (topReject) {
+        const concentration = topReject[1] / w1Stats.total;
+        if (concentration > REJECT_CONCENTRATION_THRESHOLD) {
+          await this.insights.logInsight({
+            type: 'reject_pattern',
+            source: 'auto_drift_detector',
+            severity: concentration > 0.80 ? 'medium' : 'low',
+            summary: `${topReject[0]} concentre ${(concentration * 100).toFixed(0)}% des rejects W-1 (${topReject[1]}/${w1Stats.total})`,
+            payload: {
+              reject_reason: topReject[0],
+              count: topReject[1],
+              total: w1Stats.total,
+              concentration_pct: concentration,
+              threshold_pct: REJECT_CONCENTRATION_THRESHOLD,
+              all_reasons: w1Stats.rejectReasons,
+            },
+          });
+          insightsLogged++;
+        }
+      }
+    }
+
+    // 4. Zero ACCEPT 7 jours
+    if (w1Stats.acceptCount === 0 && w1Stats.total > 100) {
+      await this.insights.logInsight({
+        type: 'cadence_drift',
+        source: 'auto_drift_detector',
+        severity: 'high',
+        summary: `Aucun ACCEPT V1 sur ${ZERO_ACCEPT_DAYS_THRESHOLD} jours (${w1Stats.total} signals évalués)`,
+        payload: {
+          window_days: ZERO_ACCEPT_DAYS_THRESHOLD,
+          total_signals: w1Stats.total,
+          reject_breakdown: w1Stats.rejectReasons,
+        },
+      });
+      insightsLogged++;
+    }
+
+    if (insightsLogged > 0) {
+      this.logger.log(`[drift] detected ${insightsLogged} new insight(s) — written to gainers_insights_log`);
+    }
+  }
+
+  private async fetchSignals(start: string, end: string): Promise<ShadowSignalRow[]> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('gainers_v1_shadow_signals')
+      .select('decision, reject_reason, diverges_from_legacy, created_at')
+      .gte('created_at', start)
+      .lt('created_at', end)
+      .limit(50_000);
+
+    if (error || !data) {
+      this.logger.warn(`[drift] fetch failed: ${error?.message ?? 'no data'}`);
+      return [];
+    }
+    return data as ShadowSignalRow[];
+  }
+
+  private computeStats(rows: ShadowSignalRow[]): {
+    total: number;
+    acceptCount: number;
+    rejectCount: number;
+    divergenceCount: number;
+    rejectReasons: Record<string, number>;
+  } {
+    const stats = {
+      total: rows.length,
+      acceptCount: 0,
+      rejectCount: 0,
+      divergenceCount: 0,
+      rejectReasons: {} as Record<string, number>,
+    };
+    for (const r of rows) {
+      if (r.decision === 'ACCEPT') stats.acceptCount++;
+      else stats.rejectCount++;
+      if (r.diverges_from_legacy === true) stats.divergenceCount++;
+      if (r.reject_reason) {
+        stats.rejectReasons[r.reject_reason] = (stats.rejectReasons[r.reject_reason] ?? 0) + 1;
+      }
+    }
+    return stats;
+  }
+}

--- a/apps/api/src/modules/gainers-scanner/automations/index.ts
+++ b/apps/api/src/modules/gainers-scanner/automations/index.ts
@@ -1,0 +1,2 @@
+export * from './drift-detector.service';
+export * from './probability-refit-cron.service';

--- a/apps/api/src/modules/gainers-scanner/automations/probability-refit-cron.service.ts
+++ b/apps/api/src/modules/gainers-scanner/automations/probability-refit-cron.service.ts
@@ -1,0 +1,88 @@
+/**
+ * Phase B — ProbabilityRefitCronService.
+ *
+ * Cron weekly Sunday 02:00 UTC qui re-fit le modèle P9 logistic regression
+ * (P(win) sur features persistence) depuis paper_trades fermés.
+ *
+ * Documente CLAUDE.md §P9 :
+ *   "Out of scope ce PR (deferred follow-up): Cron Sunday 02:00 UTC (à wirer
+ *    dans LisaAutopilotService ou nouveau service ProbabilityRefitCron)"
+ *
+ * Cette PR (Phase B) wire ce cron + auto-log un `ml_refit` insight avec
+ * metrics (AUC, accuracy, sample size, accepté/rejeté) pour traçabilité
+ * complète des évolutions du modèle.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { PersistenceProbabilityService } from '../../lisa/services/persistence-probability.service';
+import { GainersInsightsService } from '../insights/gainers-insights.service';
+
+@Injectable()
+export class ProbabilityRefitCronService {
+  private readonly logger = new Logger(ProbabilityRefitCronService.name);
+
+  constructor(
+    private readonly probability: PersistenceProbabilityService,
+    private readonly insights: GainersInsightsService,
+  ) {}
+
+  /** Cron Sunday 02:00 UTC — refit hebdomadaire. */
+  @Cron('0 2 * * 0')
+  async runWeeklyRefit(): Promise<void> {
+    try {
+      await this.runInner();
+    } catch (e) {
+      this.logger.error(`[ml-refit] cron failed: ${String(e).slice(0, 200)}`);
+      // Auto-log error insight
+      await this.insights.logInsight({
+        type: 'ml_refit',
+        source: 'auto_ml_refit',
+        severity: 'medium',
+        summary: `Weekly P9 refit cron failed: ${String(e).slice(0, 200)}`,
+        payload: { error: String(e).slice(0, 500), timestamp: new Date().toISOString() },
+      });
+    }
+  }
+
+  private async runInner(): Promise<void> {
+    this.logger.log('[ml-refit] starting weekly P9 logistic regression refit');
+    const result = await this.probability.trainAndPersist({ lookbackDays: 30 });
+
+    // Log insight quel que soit le résultat (accepted/rejected/insufficient)
+    const accepted = (result as { accepted?: boolean }).accepted ?? false;
+    const auc = (result as { aucRoc?: number }).aucRoc ?? null;
+    const accuracy = (result as { accuracy?: number }).accuracy ?? null;
+    const sampleSize = (result as { sampleSize?: number }).sampleSize ?? 0;
+    const version = (result as { modelVersion?: string }).modelVersion ?? null;
+    const reason = (result as { reason?: string }).reason ?? null;
+
+    const severity = accepted
+      ? 'info'
+      : sampleSize < 30 ? 'low' : 'medium';
+
+    await this.insights.logInsight({
+      type: 'ml_refit',
+      source: 'auto_ml_refit',
+      severity,
+      summary: accepted
+        ? `P9 refit accepté — version ${version} (AUC ${auc?.toFixed(3) ?? 'n/a'}, accuracy ${accuracy?.toFixed(3) ?? 'n/a'}, n=${sampleSize})`
+        : `P9 refit rejeté — ${reason ?? 'unknown'} (sample n=${sampleSize}, AUC ${auc?.toFixed(3) ?? 'n/a'})`,
+      payload: {
+        accepted,
+        model_version: version,
+        auc_roc: auc,
+        accuracy,
+        sample_size: sampleSize,
+        reason,
+        lookback_days: 30,
+        cron_at: new Date().toISOString(),
+      },
+    });
+
+    this.logger.log(
+      `[ml-refit] ${accepted ? 'accepted' : 'rejected'} — ` +
+      `version=${version ?? 'n/a'} auc=${auc?.toFixed(3) ?? 'n/a'} n=${sampleSize}`,
+    );
+  }
+}

--- a/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
+++ b/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
@@ -14,6 +14,7 @@ import { TargetDerivationService } from './target-modes/target-derivation.servic
 import { KellySizingService } from './kelly/kelly-sizing.service';
 import { ModePresetsService } from './presets/mode-presets.service';
 import { GainersInsightsService } from './insights/gainers-insights.service';
+import { DriftDetectorService } from './automations/drift-detector.service';
 
 /**
  * ADR-005 Gainers Algo V1 — Module NestJS découplé (ADR-006).
@@ -22,6 +23,7 @@ import { GainersInsightsService } from './insights/gainers-insights.service';
  * Shadow run (PR6) wired pour Step 9 validation.
  * Target modes + Kelly sizing (ADR-007 PR #207a) wired.
  * Mode presets (ADR-007 PR #207b) wired.
+ * Insights log (Phase A) + DriftDetector (Phase B) wired.
  */
 @Module({
   imports: [SupabaseModule, ConfigModule],
@@ -39,6 +41,8 @@ import { GainersInsightsService } from './insights/gainers-insights.service';
     KellySizingService,
     ModePresetsService,
     GainersInsightsService,
+    // Phase B — cron daily 23:50 UTC qui auto-log drifts/anomalies
+    DriftDetectorService,
   ],
   exports: [
     GainersBloc1Service,

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -53,6 +53,8 @@ import { YahooIntradayService } from './services/yahoo-intraday.service';
 import { IntradayCacheService } from './services/intraday-cache.service';
 import { PersistenceProbabilityService } from './services/persistence-probability.service';
 import { ScannerLlmRouterService } from './services/scanner-llm-router.service';
+// Phase B — Weekly P9 ML refit cron auto-logging insights
+import { ProbabilityRefitCronService } from '../gainers-scanner/automations/probability-refit-cron.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule, BotLabModule, GainersModule],
@@ -121,6 +123,9 @@ import { ScannerLlmRouterService } from './services/scanner-llm-router.service';
     ScannerLlmRouterService,
     // P19v (30/04/2026) — Quota service centralisé EODHD (cost map + auto-throttle)
     EodhdQuotaService,
+    // Phase B — Cron Sunday 02:00 UTC qui refit P9 logistic regression et auto-log
+    // un insight `ml_refit` avec metrics (AUC, accuracy, sample_size, accepted/rejected).
+    ProbabilityRefitCronService,
   ],
   exports: [
     LisaService,


### PR DESCRIPTION
## Phase B — Auto-detection (suite Phase A #222)

Couche d'**automation** qui auto-log insights via `GainersInsightsService` (Phase A) sans intervention humaine. Implémente la moitié de la roadmap "modèle qui apprend toujours" demandée par l'utilisateur.

## Services nouveaux

### `DriftDetectorService` (cron daily 23:50 UTC)

Scan shadow signals + détection auto de 4 types d'anomalies :

| # | Détection | Threshold | Insight type | Severity |
|---|---|---|---|---|
| 1 | Cadence drift | ACCEPT/24h chute > 30% W-1 vs W-2 | `cadence_drift` | high si > 50% drop, sinon medium |
| 2 | Divergence drift | V1 vs legacy disagreement +10pp W-1 vs W-2 | `cadence_drift` | high si > +20pp, sinon medium |
| 3 | Reject concentration | > 60% des rejects sur même reason | `reject_pattern` | medium si >80%, sinon low |
| 4 | Zero ACCEPT 7d | aucun ACCEPT sur 7j > 100 signals | `cadence_drift` | high |

Tous les insights logués via `GainersInsightsService` avec `source='auto_drift_detector'`.

### `ProbabilityRefitCronService` (cron Sunday 02:00 UTC)

Wire le **P9 logistic regression weekly refit** documenté dans CLAUDE.md (`Out of scope ce PR (deferred follow-up): Cron Sunday 02:00 UTC`).

```typescript
@Cron('0 2 * * 0')
async runWeeklyRefit() {
  const result = await probability.trainAndPersist({ lookbackDays: 30 });
  await insights.logInsight({
    type: 'ml_refit',
    source: 'auto_ml_refit',
    severity: accepted ? 'info' : 'medium',
    summary: ...,
    payload: { auc, accuracy, sample_size, modelVersion, ... },
  });
}
```

Auto-log `ml_refit` insight avec metrics complètes — traçabilité totale des évolutions du modèle ML.

## Architecture

- `apps/api/src/modules/gainers-scanner/automations/`
  - `drift-detector.service.ts` (+194)
  - `probability-refit-cron.service.ts` (+88)
  - `index.ts` (+2)
- `DriftDetectorService` wired dans `GainersModule` (uses Supabase + Insights)
- `ProbabilityRefitCronService` wired dans `LisaModule` (uses P9 + Insights via GainersModule import)

## Tests

- ✅ 4/4 specs `drift-detector.spec.ts` (cadence drop / reject concentration / zero accept / no false positive)
- ✅ 9 specs Phase A+B totaux passent
- ✅ Typecheck OK
- ✅ Boot port 3979 OK (DI resolved, crons schedulés)

## Effet attendu post-deploy

- **Daily 23:50 UTC** : DriftDetector tourne, logs anomalies dans `gainers_insights_log`
- **Sunday 02:00 UTC** : P9 refit + log `ml_refit` insight
- **`GET /admin/gainers/insights`** expose l'historique pour analyse rétrospective
- **Graceful degradation** : si refit fail, error est aussi logué comme insight (pas silent fail)

## Files

| File | Lines |
|---|---|
| `apps/api/src/modules/gainers-scanner/automations/drift-detector.service.ts` | +194 |
| `apps/api/src/modules/gainers-scanner/automations/probability-refit-cron.service.ts` | +88 |
| `apps/api/src/modules/gainers-scanner/automations/index.ts` | +2 |
| `apps/api/src/modules/gainers-scanner/__tests__/drift-detector.spec.ts` | +133 |
| `apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts` | +4 |
| `apps/api/src/modules/lisa/lisa.module.ts` | +5 |

## Risk

Faible :
- Cron services additifs, aucun impact sur scanner ou shadow batch
- Crons graceful : try/catch + log erreur dans insight (pas crash)
- Pas de modification de seuils ADR-005 §1bis (insights = propositions, pas auto-flip)

## Phase C suite (post-Phase 4 + 30j outcomes)

`ThresholdAutoTunerService` weekly analysera `paper_trades` fermés + propose `threshold_proposal` insights avec ROI estimé. **Pas de flip auto** — humain valide via `PATCH /admin/gainers/insights/:id` status=actioned.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_