### PR TITLE
feat(rcft): PR6.8.1 — status field + inclusive thresholds + env vars + TTL 90j + per-row env_tag hook + cron TZ UTC

### DIFF
--- a/apps/api/src/modules/gainers-scanner/__tests__/rejected-insights.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/rejected-insights.spec.ts
@@ -30,10 +30,11 @@ describe('RejectedInsightsService', () => {
     expect(result.global_fp_rate).toBeNull();
     expect(result.global_failure_rate).toBeNull();
     expect(result.accept_stats.fp_rate).toBeNull();
+    expect(result.accept_stats.status).toBe('insufficient_data');
     expect(Object.keys(result.by_reason).length).toBe(0);
   });
 
-  it('returns fp_rate=null when sample < min_samples (anti FP-rate sur 3 datapoints)', async () => {
+  it('returns fp_rate=null AND status=insufficient_data when sample < min_samples', async () => {
     // 5 REJECT LIQUIDITY_FLOOR avec outcome computed, min_samples=20 default
     const rows = Array.from({ length: 5 }, (_, i) => ({
       symbol: `SYM${i}`,
@@ -49,9 +50,11 @@ describe('RejectedInsightsService', () => {
     const result = await svc.getFalsePositiveRate({ minSamples: 20 });
     expect(result.by_reason.LIQUIDITY_FLOOR.total).toBe(5);
     expect(result.by_reason.LIQUIDITY_FLOOR.fp_rate).toBeNull(); // < min_samples
+    // PR6.8.1 — explicit status field
+    expect(result.by_reason.LIQUIDITY_FLOOR.status).toBe('insufficient_data');
   });
 
-  it('computes fp_rate correctly when sample >= min_samples', async () => {
+  it('computes fp_rate AND status=ok when sample >= min_samples', async () => {
     // 30 REJECT LIQUIDITY_FLOOR : 9 champions, 21 neutral → fp_rate = 30%
     const rows = Array.from({ length: 30 }, (_, i) => ({
       symbol: `SYM${i}`,
@@ -68,6 +71,8 @@ describe('RejectedInsightsService', () => {
     expect(result.by_reason.LIQUIDITY_FLOOR.total).toBe(30);
     expect(result.by_reason.LIQUIDITY_FLOOR.champions).toBe(9);
     expect(result.by_reason.LIQUIDITY_FLOOR.fp_rate).toBeCloseTo(0.30);
+    // PR6.8.1 — explicit status='ok' when computed
+    expect(result.by_reason.LIQUIDITY_FLOOR.status).toBe('ok');
   });
 
   it('computes ACCEPT failure_rate symmetrically', async () => {

--- a/apps/api/src/modules/gainers-scanner/__tests__/signal-forward-tracker.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/signal-forward-tracker.spec.ts
@@ -133,6 +133,67 @@ describe('SignalForwardTrackerService', () => {
     expect((svc as any).envTag).toBe('shadow');
   });
 
+  // PR6.8.1 — Default env_tag regression check
+  it('default env_tag stays "shadow" when GAINERS_ENV_TAG unset', () => {
+    const config = { get: () => undefined } as any;
+    const svc = new SignalForwardTrackerService(
+      makeMockSupabase(),
+      makeMockBinance(),
+      makeMockEodhd(),
+      makeMockInsights(),
+      config,
+    );
+    expect((svc as any).envTag).toBe('shadow');
+  });
+
+  // PR6.8.1 — resolveEnvTag hook callable, returns process-level envTag today
+  it('resolveEnvTag returns process-level envTag (canary-ready hook)', () => {
+    const svc = new SignalForwardTrackerService(
+      makeMockSupabase(),
+      makeMockBinance(),
+      makeMockEodhd(),
+      makeMockInsights(),
+      makeMockConfig('canary'),
+    );
+    const fakeRow = { id: 'x', symbol: 'BTCUSDT', asset_class: 'crypto', decision: 'REJECT',
+      reject_reason: null, created_at: '2026-05-04T00:00:00Z', entry_price: 60000 };
+    expect((svc as any).resolveEnvTag(fakeRow)).toBe('canary');
+  });
+
+  // PR6.8.1 — env vars override outcome thresholds at compute time
+  it('resolveOutcomeThresholds uses env vars over row defaults', () => {
+    const config = {
+      get: (key: string) => {
+        if (key === 'CHAMPION_RET_PCT') return '0.10';
+        if (key === 'FAILURE_RET_PCT') return '-0.05';
+        return undefined;
+      },
+    } as any;
+    const svc = new SignalForwardTrackerService(
+      makeMockSupabase(),
+      makeMockBinance(),
+      makeMockEodhd(),
+      makeMockInsights(),
+      config,
+    );
+    const result = (svc as any).resolveOutcomeThresholds(0.05, -0.02);
+    expect(result.champion).toBe(0.10);  // env override
+    expect(result.failure).toBe(-0.05);  // env override
+  });
+
+  it('resolveOutcomeThresholds falls back to row values when env unset', () => {
+    const svc = new SignalForwardTrackerService(
+      makeMockSupabase(),
+      makeMockBinance(),
+      makeMockEodhd(),
+      makeMockInsights(),
+      makeMockConfig(),
+    );
+    const result = (svc as any).resolveOutcomeThresholds(0.05, -0.02);
+    expect(result.champion).toBe(0.05); // row default
+    expect(result.failure).toBe(-0.02); // row default
+  });
+
   it('skips equity weekend rejects (Saturday/Sunday)', () => {
     const svc = new SignalForwardTrackerService(
       makeMockSupabase(),

--- a/apps/api/src/modules/gainers-scanner/automations/drift-detector.service.ts
+++ b/apps/api/src/modules/gainers-scanner/automations/drift-detector.service.ts
@@ -38,8 +38,8 @@ export class DriftDetectorService {
     private readonly insights: GainersInsightsService,
   ) {}
 
-  /** Cron daily 23:50 UTC. */
-  @Cron('50 23 * * *')
+  /** Cron daily 23:50 UTC strict (PR6.8.1 timezone explicite). */
+  @Cron('50 23 * * *', { timeZone: 'UTC' })
   async runDriftDetection(): Promise<void> {
     try {
       await this.runInner();

--- a/apps/api/src/modules/gainers-scanner/automations/probability-refit-cron.service.ts
+++ b/apps/api/src/modules/gainers-scanner/automations/probability-refit-cron.service.ts
@@ -27,8 +27,8 @@ export class ProbabilityRefitCronService {
     private readonly insights: GainersInsightsService,
   ) {}
 
-  /** Cron Sunday 02:00 UTC — refit hebdomadaire. */
-  @Cron('0 2 * * 0')
+  /** Cron Sunday 02:00 UTC strict (PR6.8.1 timezone explicite). */
+  @Cron('0 2 * * 0', { timeZone: 'UTC' })
   async runWeeklyRefit(): Promise<void> {
     try {
       await this.runInner();

--- a/apps/api/src/modules/gainers-scanner/automations/rejected-insights.service.ts
+++ b/apps/api/src/modules/gainers-scanner/automations/rejected-insights.service.ts
@@ -13,6 +13,7 @@
  */
 
 import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
 
 export interface FpRateStats {
@@ -29,6 +30,10 @@ export interface FpRateStats {
     return_72h: number;
     rejected_at: string;
   }>;
+  // PR6.8.1 — Status explicite pour AutoTuner V2 (anti décision sur 3 datapoints)
+  // 'ok' : evaluated >= min_samples, fp_rate/failure_rate calculables
+  // 'insufficient_data' : evaluated < min_samples, fp_rate=null en sortie
+  status: 'ok' | 'insufficient_data';
 }
 
 export interface RejectedInsightsQuery {
@@ -51,7 +56,10 @@ interface SignalForwardAggRow {
 export class RejectedInsightsService {
   private readonly logger = new Logger(RejectedInsightsService.name);
 
-  constructor(private readonly supabase: SupabaseService) {}
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly config?: ConfigService,
+  ) {}
 
   async getFalsePositiveRate(query: RejectedInsightsQuery = {}): Promise<{
     by_reason: Record<string, FpRateStats>;
@@ -137,6 +145,7 @@ export class RejectedInsightsService {
       failure_rate: null,
       avg_return_72h: null,
       samples_top_missed: [],
+      status: 'insufficient_data',
     };
 
     const evaluated: SignalForwardAggRow[] = [];
@@ -162,6 +171,10 @@ export class RejectedInsightsService {
     if (evaluated.length >= minSamples) {
       stats.fp_rate = stats.champions / evaluated.length;
       stats.failure_rate = stats.failures / evaluated.length;
+      stats.status = 'ok';
+    } else {
+      // PR6.8.1 — explicit status field pour AutoTuner V2 lecture
+      stats.status = 'insufficient_data';
     }
     if (returnCount > 0) {
       stats.avg_return_72h = returnSum / returnCount;
@@ -192,6 +205,7 @@ export class RejectedInsightsService {
       failure_rate: null,
       avg_return_72h: null,
       samples_top_missed: [],
+      status: 'insufficient_data',
     };
   }
 }

--- a/apps/api/src/modules/gainers-scanner/automations/signal-forward-tracker.service.ts
+++ b/apps/api/src/modules/gainers-scanner/automations/signal-forward-tracker.service.ts
@@ -94,8 +94,8 @@ export class SignalForwardTrackerService {
     this.envTag = ['shadow', 'canary', 'prod'].includes(tag) ? tag : 'shadow';
   }
 
-  /** Cron daily 00:30 UTC. */
-  @Cron('30 0 * * *')
+  /** Cron daily 00:30 UTC strict (PR6.8.1 timezone explicite, anti drift Europe/Paris). */
+  @Cron('30 0 * * *', { timeZone: 'UTC' })
   async runForwardTracking(): Promise<void> {
     try {
       const stats = await this.runInner();
@@ -171,7 +171,8 @@ export class SignalForwardTrackerService {
           decision: r.decision,
           reject_reason: r.reject_reason,
           gate_passed_until: gateBeforeReject(r.reject_reason, r.decision),
-          env_tag: this.envTag,
+          // PR6.8.1 — Per-row env_tag via resolveEnvTag hook (canary-ready)
+          env_tag: this.resolveEnvTag(r),
           rejected_at: r.created_at,
           price_at_signal: r.entry_price ?? 0,
           source: r.asset_class === 'crypto' ? 'binance' : 'eodhd',
@@ -192,6 +193,51 @@ export class SignalForwardTrackerService {
       }
     }
     return seeded;
+  }
+
+  /**
+   * PR6.8.1 — Resolve thresholds at compute time : env vars override migration
+   * defaults (CHAMPION_RET_PCT / FAILURE_RET_PCT). Permet ajustement runtime
+   * sans ALTER TABLE.
+   *
+   * Default flow : utilise les valeurs stockées sur la row (champion=0.05,
+   * failure=-0.02 from migration 0111).
+   *
+   * Override flow : si env var set ET parsable as number, l'utilise prioritaire.
+   */
+  private resolveOutcomeThresholds(
+    rowChampionPct: number,
+    rowFailurePct: number,
+  ): { champion: number; failure: number } {
+    const envChampion = parseFloat(this.config.get<string>('CHAMPION_RET_PCT') ?? '');
+    const envFailure = parseFloat(this.config.get<string>('FAILURE_RET_PCT') ?? '');
+    return {
+      champion: Number.isFinite(envChampion) ? envChampion : rowChampionPct,
+      failure: Number.isFinite(envFailure) ? envFailure : rowFailurePct,
+    };
+  }
+
+  /**
+   * PR6.8.1 — Hook per-row env_tag injection (canary-ready).
+   *
+   * Aujourd'hui : retourne le process-level envTag (lit GAINERS_ENV_TAG env var
+   * au constructor, défaut 'shadow').
+   *
+   * TODO Phase 4 canary 10% routing : quand le routing intra-process canary est
+   * implémenté (#224 V2 ou subsequent), cette méthode doit lookup le contexte
+   * du signal (e.g., portfolios.execution_mode='canary' OU
+   * gainers_v1_shadow_signals.env_tag column si ajoutée) pour distinguer shadow
+   * vs canary vs prod. Single point of change pour passer de process-level à
+   * per-row tagging.
+   *
+   * Le call site `seedNewSignals.upsertRows[].env_tag = this.resolveEnvTag(r)`
+   * est PRÊT pour ce switch sans changer le rest du flow.
+   */
+  private resolveEnvTag(_signalRow: ShadowSignalSeed): string {
+    // TODO 2026-Q2 canary routing : lookup `_signalRow.portfolio_id` (à ajouter
+    // dans select query) puis lire `lisa_session_configs.execution_mode` ou un
+    // futur champ `env_tag` sur shadow_signals. Pour l'instant, process-level.
+    return this.envTag;
   }
 
   /**
@@ -304,6 +350,11 @@ export class SignalForwardTrackerService {
   /**
    * Step 4 — compute outcome (champion/failure/neutral) sur rows avec
    * price_t_plus_72h non null mais outcome null.
+   *
+   * PR6.8.1 :
+   *  - Inclusivité boundaries : >= et <= (cas exact +5% ou -2% labellé)
+   *  - Env vars CHAMPION_RET_PCT + FAILURE_RET_PCT override migration default
+   *    AT COMPUTE TIME (no ALTER TABLE needed pour ajuster seuils)
    */
   private async computeOutcomes(): Promise<{ computed: number; champions: number; failures: number }> {
     const { data, error } = await this.supabase
@@ -326,11 +377,17 @@ export class SignalForwardTrackerService {
       champion_threshold_pct: number;
       failure_threshold_pct: number;
     }>) {
+      // PR6.8.1 — env var override at compute time (pas migration ALTER)
+      const { champion: championPct, failure: failurePct } = this.resolveOutcomeThresholds(
+        Number(r.champion_threshold_pct),
+        Number(r.failure_threshold_pct),
+      );
       let outcome: 'champion' | 'failure' | 'neutral' = 'neutral';
-      if (r.decision === 'REJECT' && r.return_72h > Number(r.champion_threshold_pct)) {
+      // PR6.8.1 — inclusivité (>= et <=) au lieu de strict (> et <)
+      if (r.decision === 'REJECT' && r.return_72h >= championPct) {
         outcome = 'champion';
         champions++;
-      } else if (r.decision === 'ACCEPT' && r.return_72h < Number(r.failure_threshold_pct)) {
+      } else if (r.decision === 'ACCEPT' && r.return_72h <= failurePct) {
         outcome = 'failure';
         failures++;
       }

--- a/supabase/migrations/0112_bump_signal_forward_ttl_90d.sql
+++ b/supabase/migrations/0112_bump_signal_forward_ttl_90d.sql
@@ -1,0 +1,23 @@
+-- Migration 0112 — PR6.8.1 patch : bump RCFT TTL 30j → 90j.
+--
+-- Justification : AutoTuner V2 #224 voudra des FP-rate longitudinaux pour gates
+-- à faible cadence (rare reject_reason). 30j trop court — bump à 90j donne marge
+-- pour analyses trimestrielles.
+--
+-- Impact stockage : 1000 rows/day × 90j = ~90k rows steady state (vs 30k avant).
+-- Acceptable pour Postgres.
+--
+-- Idempotente : ALTER ... SET DEFAULT est idempotent. UPDATE WHERE backfill rows
+-- existantes (créées avec ancien default 30j) vers 90j.
+
+-- Step 1 : modifie le default pour les futures inserts
+ALTER TABLE gainers_signal_forward
+  ALTER COLUMN expires_at SET DEFAULT (NOW() + INTERVAL '90 days');
+
+-- Step 2 : backfill rows existantes encore actives (créées avec default 30j)
+-- Migration idempotente : ne touche que rows où le calcul donnerait > expires_at actuel.
+UPDATE gainers_signal_forward
+SET expires_at = created_at + INTERVAL '90 days'
+WHERE expires_at < created_at + INTERVAL '90 days';
+
+COMMENT ON COLUMN gainers_signal_forward.expires_at IS 'TTL 90j (PR6.8.1 bump). Cleanup via cron daily 00:30 UTC DELETE WHERE expires_at < NOW().';


### PR DESCRIPTION
## Patch RCFT post-revue utilisateur — 6 améliorations

Suite à la revue de PR6.8 (#225), 6 ajustements qui durcissent garde-fous ML + ouvrent canary same-deploy mix.

## 1. STATUS field explicite

`FpRateStats` expose désormais `status: 'ok' | 'insufficient_data'`. AutoTuner V2 lit ce field au lieu d'inférer "fp_rate=null = insufficient_data".

```typescript
export interface FpRateStats {
  // ...
  fp_rate: number | null;
  status: 'ok' | 'insufficient_data';  // ← NEW PR6.8.1
}
```

## 2. INCLUSIVITÉ boundaries

```typescript
// AVANT (strict)
if (r.return_72h > championPct) outcome = 'champion';

// APRÈS PR6.8.1 (inclusif)
if (r.return_72h >= championPct) outcome = 'champion';
```

Cas exact `return_72h = +5.00%` désormais labellé `'champion'` au lieu de `'neutral'`.

## 3. ENV VARS override at compute time

```typescript
private resolveOutcomeThresholds(rowChampion, rowFailure) {
  const envChampion = parseFloat(this.config.get('CHAMPION_RET_PCT') ?? '');
  const envFailure = parseFloat(this.config.get('FAILURE_RET_PCT') ?? '');
  return {
    champion: Number.isFinite(envChampion) ? envChampion : rowChampion,  // env override
    failure: Number.isFinite(envFailure) ? envFailure : rowFailure,
  };
}
```

Permet ajustement runtime via Fly secrets (`fly secrets set CHAMPION_RET_PCT=0.07`) sans ALTER TABLE migration.

## 4. TTL BUMP 30j → 90j (migration 0112)

```sql
ALTER TABLE gainers_signal_forward
  ALTER COLUMN expires_at SET DEFAULT (NOW() + INTERVAL '90 days');

UPDATE gainers_signal_forward
SET expires_at = created_at + INTERVAL '90 days'
WHERE expires_at < created_at + INTERVAL '90 days';
```

Permet AutoTuner V2 analyses longitudinales (gates à faible cadence). Stockage steady state ~90k rows.

**Idempotente** : ALTER SET DEFAULT + UPDATE WHERE → re-run no-op.

## 5. PER-ROW env_tag HOOK (canary-ready)

```typescript
private resolveEnvTag(_signalRow: ShadowSignalSeed): string {
  // TODO 2026-Q2 canary routing : lookup _signalRow.portfolio_id puis
  // lire lisa_session_configs.execution_mode pour distinguer canary.
  return this.envTag;  // process-level today
}

// Call site : seedNewSignals.upsertRows[].env_tag = this.resolveEnvTag(r);
```

Aujourd'hui retourne process-level envTag (default 'shadow'). Quand canary 10% intra-process démarrera, **un seul point de change** dans `resolveEnvTag` pour switch vers per-row tagging.

## 6. CRON TIMEZONE UTC explicite

```typescript
// AVANT
@Cron('30 0 * * *')                          // system TZ ambiguous

// APRÈS PR6.8.1
@Cron('30 0 * * *', { timeZone: 'UTC' })     // strict UTC
```

Appliqué aux 3 crons : `DriftDetectorService`, `ProbabilityRefitCronService`, `SignalForwardTrackerService`. Anti drift Europe/Paris si Fly machine TZ change accidentellement.

## Tests

- ✅ **19/19 specs** Phase B + RCFT + nouveaux PR6.8.1 :
  - `status='insufficient_data'` si COUNT < min_samples
  - `status='ok'` si computed
  - default env_tag = 'shadow' (regression)
  - `resolveEnvTag` retourne process-level (canary-ready hook)
  - `resolveOutcomeThresholds` env override / fallback row
- ✅ Typecheck OK
- ✅ Boot port 3979 OK
- ✅ Migration 0112 idempotente

## Files

| File | Lines |
|---|---|
| `supabase/migrations/0112_bump_signal_forward_ttl_90d.sql` | +23 |
| `automations/signal-forward-tracker.service.ts` | +50/-3 |
| `automations/rejected-insights.service.ts` | +15/-3 |
| `automations/drift-detector.service.ts` | +1/-1 |
| `automations/probability-refit-cron.service.ts` | +1/-1 |
| `__tests__/rejected-insights.spec.ts` | +5 |
| `__tests__/signal-forward-tracker.spec.ts` | +58 |

**Total : +172 LoC**

## Risk

Faible :
- Migration 0112 idempotente (ALTER SET DEFAULT + UPDATE WHERE)
- Rétrocompat : status='ok' = comportement existant, status='insufficient_data' = nouveau signal optionnel
- Inclusivité boundaries : edge-case rare (exact value at threshold)
- TZ explicit : déjà UTC en prod (vérifié), juste lock for safety
- env_tag hook : retourne même valeur qu'avant (process-level)

## Phase C V2 readiness

PR6.8.1 prépare le terrain pour Phase C V2 (#224 rewrite) :
- `status='ok'` field consumable directly
- `env_tag` filter cloisonne shadow/canary outcomes
- Env vars permettent A/B test thresholds sans deploy

Prêt pour activation post-Phase 4.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_