### PR TITLE
feat(insights): PR6.8.2 — DriftDetector détecte fetch instability top 5 crypto (data_quality insight)

### DIFF
--- a/apps/api/src/modules/gainers-scanner/__tests__/drift-detector.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/drift-detector.spec.ts
@@ -5,6 +5,7 @@
 import { DriftDetectorService } from '../automations/drift-detector.service';
 
 function makeMockSupabase(rowsByQuery: Array<Array<{
+  symbol?: string;
   decision: string;
   reject_reason: string | null;
   diverges_from_legacy: boolean | null;
@@ -111,12 +112,14 @@ describe('DriftDetectorService', () => {
     // W-1: 10 ACCEPT, 50 total
     // W-2: 11 ACCEPT, 50 total → ratio 0.91 (9% drop) → no trigger
     const w1 = Array.from({ length: 50 }, (_, i) => ({
+      symbol: `SYM${i}`,
       decision: i < 10 ? 'ACCEPT' : 'REJECT',
       reject_reason: i < 10 ? null : i < 30 ? 'PERSISTENCE_BELOW_THRESHOLD' : 'TREND_FILTER_FAIL',
       diverges_from_legacy: false,
       created_at: '2026-05-02T00:00:00Z',
     }));
     const w2 = Array.from({ length: 50 }, (_, i) => ({
+      symbol: `SYM${i}`,
       decision: i < 11 ? 'ACCEPT' : 'REJECT',
       reject_reason: i < 11 ? null : i < 30 ? 'PERSISTENCE_BELOW_THRESHOLD' : 'TREND_FILTER_FAIL',
       diverges_from_legacy: false,
@@ -129,5 +132,93 @@ describe('DriftDetectorService', () => {
     await (svc as any).runInner();
 
     expect(insights.logInsight).not.toHaveBeenCalled();
+  });
+
+  // PR6.8.2 — TREND_FILTER_FAIL anormalement élevé sur top 5 crypto = fetch flaky
+  describe('PR6.8.2 — top 5 crypto fetch instability detection', () => {
+    it('logs data_quality insight when > 20% top 5 crypto fail TREND_FILTER', async () => {
+      // 25 cycles top 5 crypto, 10 fail TREND_FILTER (40% > 20% threshold)
+      const top5 = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT'];
+      const w1 = Array.from({ length: 25 }, (_, i) => ({
+        symbol: top5[i % 5],
+        decision: 'REJECT',
+        reject_reason: i < 10 ? 'TREND_FILTER_FAIL' : 'PERSISTENCE_BELOW_THRESHOLD',
+        diverges_from_legacy: false,
+        created_at: '2026-05-03T00:00:00Z',
+      }));
+      const supabase = makeMockSupabase([w1, []]);
+      const insights = makeMockInsights();
+      const svc = new DriftDetectorService(supabase, insights);
+
+      await (svc as any).runInner();
+
+      const dataQualityLog = insights._logged.find(
+        (l: any) => l.type === 'data_quality' && l.summary.includes('Binance daily klines flaky'),
+      );
+      expect(dataQualityLog).toBeTruthy();
+      expect(dataQualityLog.severity).toBe('medium'); // 40% < 40% threshold for high
+      expect(dataQualityLog.payload.top5_trend_fail_count).toBe(10);
+      expect(dataQualityLog.payload.top5_trend_fail_rate).toBeCloseTo(0.40);
+    });
+
+    it('does NOT log if < 20 top 5 crypto cycles (anti FP-rate sur petit sample)', async () => {
+      // Seulement 10 cycles top 5 (< 20 min_samples)
+      const top5 = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT'];
+      const w1 = Array.from({ length: 10 }, (_, i) => ({
+        symbol: top5[i % 5],
+        decision: 'REJECT',
+        reject_reason: 'TREND_FILTER_FAIL', // 100% trend fail mais < 20 samples
+        diverges_from_legacy: false,
+        created_at: '2026-05-03T00:00:00Z',
+      }));
+      const supabase = makeMockSupabase([w1, []]);
+      const insights = makeMockInsights();
+      const svc = new DriftDetectorService(supabase, insights);
+
+      await (svc as any).runInner();
+
+      const dataQualityLog = insights._logged.find((l: any) => l.type === 'data_quality');
+      expect(dataQualityLog).toBeFalsy(); // pas assez de samples
+    });
+
+    it('high severity if > 40% trend fail rate', async () => {
+      const top5 = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT'];
+      // 25 cycles, 15 fail TREND (60% > 40%)
+      const w1 = Array.from({ length: 25 }, (_, i) => ({
+        symbol: top5[i % 5],
+        decision: 'REJECT',
+        reject_reason: i < 15 ? 'TREND_FILTER_FAIL' : 'PERSISTENCE_BELOW_THRESHOLD',
+        diverges_from_legacy: false,
+        created_at: '2026-05-03T00:00:00Z',
+      }));
+      const supabase = makeMockSupabase([w1, []]);
+      const insights = makeMockInsights();
+      const svc = new DriftDetectorService(supabase, insights);
+
+      await (svc as any).runInner();
+
+      const dataQualityLog = insights._logged.find((l: any) => l.type === 'data_quality');
+      expect(dataQualityLog.severity).toBe('high'); // 60% > 40%
+    });
+
+    it('does NOT log when top 5 fail TREND legitimately at low rate (< 20%)', async () => {
+      const top5 = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT'];
+      // 25 cycles, 3 fail TREND (12% < 20% threshold)
+      const w1 = Array.from({ length: 25 }, (_, i) => ({
+        symbol: top5[i % 5],
+        decision: 'REJECT',
+        reject_reason: i < 3 ? 'TREND_FILTER_FAIL' : 'PERSISTENCE_BELOW_THRESHOLD',
+        diverges_from_legacy: false,
+        created_at: '2026-05-03T00:00:00Z',
+      }));
+      const supabase = makeMockSupabase([w1, []]);
+      const insights = makeMockInsights();
+      const svc = new DriftDetectorService(supabase, insights);
+
+      await (svc as any).runInner();
+
+      const dataQualityLog = insights._logged.find((l: any) => l.type === 'data_quality');
+      expect(dataQualityLog).toBeFalsy();
+    });
   });
 });

--- a/apps/api/src/modules/gainers-scanner/automations/drift-detector.service.ts
+++ b/apps/api/src/modules/gainers-scanner/automations/drift-detector.service.ts
@@ -21,8 +21,13 @@ const CADENCE_DROP_THRESHOLD_PCT = 0.30; // 30% drop W-1 vs W-2
 const DIVERGENCE_RISE_THRESHOLD_PCT = 0.10; // +10pp rise W-1 vs W-2
 const REJECT_CONCENTRATION_THRESHOLD = 0.60; // > 60% same reject_reason
 const ZERO_ACCEPT_DAYS_THRESHOLD = 7;
+// PR6.8.2 — Fetch instability detection (BTC/ETH/etc TREND_FAIL anomalous)
+const TOP5_TREND_FAIL_RATE_THRESHOLD = 0.20;  // > 20% des top 5 fail TREND = fetch flaky suspected
+const TOP5_TREND_MIN_SAMPLES = 20;            // anti FP-rate sur 3 datapoints
+const TOP5_CRYPTO_SYMBOLS = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT'];
 
 interface ShadowSignalRow {
+  symbol: string;
   decision: string;
   reject_reason: string | null;
   diverges_from_legacy: boolean | null;
@@ -146,6 +151,44 @@ export class DriftDetectorService {
       insightsLogged++;
     }
 
+    // 5. PR6.8.2 — TREND_FILTER_FAIL anormalement élevé sur top 5 crypto (fetch instability)
+    //
+    // Heuristique : BTC/ETH/BNB/SOL/XRP sont en uptrend long-terme structurel
+    // (EMA50 > EMA200 daily depuis des années). Un TREND_FILTER_FAIL sur ces
+    // 5 majors révèle quasi-toujours un fetch Binance daily klines flaky
+    // (rate-limit, network, < 200 candles dispo) → EMA null → REJECT à tort.
+    //
+    // Si > 20% des cycles top 5 fail TREND → log insight 'data_quality' pour
+    // alerter ops avant que AutoTuner V2 ne propose à tort de relâcher TREND
+    // (soigner symptôme au lieu de la maladie).
+    const top5W1 = w1.filter((r) => TOP5_CRYPTO_SYMBOLS.includes(r.symbol));
+    const top5TrendFail = top5W1.filter((r) => r.reject_reason === 'TREND_FILTER_FAIL').length;
+    const top5TrendFailRate = top5W1.length > 0 ? top5TrendFail / top5W1.length : 0;
+    if (top5W1.length >= TOP5_TREND_MIN_SAMPLES && top5TrendFailRate > TOP5_TREND_FAIL_RATE_THRESHOLD) {
+      await this.insights.logInsight({
+        type: 'data_quality',
+        source: 'auto_drift_detector',
+        severity: top5TrendFailRate > 0.40 ? 'high' : 'medium',
+        summary: `Fetch Binance daily klines flaky suspecté : ${(top5TrendFailRate * 100).toFixed(0)}% des top 5 crypto fail TREND_FILTER (${top5TrendFail}/${top5W1.length} cycles 7j)`,
+        payload: {
+          top5_symbols: TOP5_CRYPTO_SYMBOLS,
+          top5_total_cycles: top5W1.length,
+          top5_trend_fail_count: top5TrendFail,
+          top5_trend_fail_rate: top5TrendFailRate,
+          threshold_pct: TOP5_TREND_FAIL_RATE_THRESHOLD,
+          hypothesis: 'Binance getKlines(\'1d\', 200) échoue intermittemment → EMA50/EMA200 null → trend-filter REJECT à tort. Ces 5 cryptos sont structurellement en uptrend long-terme.',
+          action_items: [
+            'Vérifier timeout AbortSignal dans BinanceMarketService.getKlines',
+            'Vérifier rate-limit usage Binance (1200 weight/min)',
+            'Ajouter retry logic avec exponential backoff si absent',
+            'Vérifier que getKlines retourne bien 200 candles (sinon trend EMA200 = NaN)',
+            'AVANT de relâcher seuil TREND : fix le fetch — sinon AutoTuner V2 corrompu',
+          ],
+        },
+      });
+      insightsLogged++;
+    }
+
     if (insightsLogged > 0) {
       this.logger.log(`[drift] detected ${insightsLogged} new insight(s) — written to gainers_insights_log`);
     }
@@ -155,7 +198,8 @@ export class DriftDetectorService {
     const { data, error } = await this.supabase
       .getClient()
       .from('gainers_v1_shadow_signals')
-      .select('decision, reject_reason, diverges_from_legacy, created_at')
+      // PR6.8.2 — `symbol` ajouté pour filtrer top 5 crypto fetch instability
+      .select('symbol, decision, reject_reason, diverges_from_legacy, created_at')
       .gte('created_at', start)
       .lt('created_at', end)
       .limit(50_000);


### PR DESCRIPTION
## Garde-fou ML : distinguer faux REJECT (bug fetch) vs vrai REJECT (algo)

**Insight observé aujourd'hui** : sur les 5 crypto majors (BTC/ETH/BNB/SOL/XRP), 40% des cycles fail `TREND_FILTER_FAIL`. Mais ces cryptos sont **structurellement en uptrend long-terme** (EMA50 > EMA200 daily depuis 2023+). Le TREND fail révèle quasi-toujours un **fetch Binance daily klines flaky** (rate-limit, timeout, < 200 candles dispo) → EMA null → REJECT à tort.

**Risque sans cette détection** : AutoTuner V2 (Phase C) verrait "TREND fail high" et proposerait de relâcher le seuil TREND. Mais la cause n'est PAS un seuil trop strict — c'est un bug fetch. Relâcher le seuil = soigner symptôme au lieu de la maladie = corruption algo.

## Détection ajoutée

Nouvelle règle #5 dans `DriftDetectorService` (cron daily 23:50 UTC) :

```typescript
const top5W1 = w1.filter(r => TOP5_CRYPTO_SYMBOLS.includes(r.symbol));
const trendFailRate = top5TrendFail / top5W1.length;

if (top5W1.length >= 20 && trendFailRate > 0.20) {
  await insights.logInsight({
    type: 'data_quality',
    source: 'auto_drift_detector',
    severity: trendFailRate > 0.40 ? 'high' : 'medium',
    summary: `Fetch Binance daily klines flaky suspecté : X% des top 5 crypto fail TREND_FILTER`,
    payload: {
      top5_trend_fail_rate, hypothesis, action_items: [...]
    },
  });
}
```

Insight payload contient **action items concrets** pour ops :
- Vérifier timeout `AbortSignal` dans `BinanceMarketService.getKlines`
- Vérifier rate-limit usage Binance (1200 weight/min)
- Ajouter retry logic exponential backoff si absent
- **AVANT de relâcher seuil TREND : fix le fetch d'abord**

## Tests

- ✅ 4 nouveaux specs PR6.8.2
  - 40% trend fail → log medium severity
  - < 20 samples → no log (anti FP-rate sur 3 datapoints)
  - 60% trend fail → log high severity
  - 12% trend fail (légitime) → no log
- ✅ Total 8/8 drift-detector specs
- ✅ Typecheck OK
- ✅ Boot port 3979 OK

## Files

| File | Lines |
|---|---|
| `automations/drift-detector.service.ts` | +50/-2 |
| `__tests__/drift-detector.spec.ts` | +78/-2 |

## Comment ça marche en pratique

Demain matin (lundi 23:50 UTC), le cron tournera et :
1. Lit les 7 derniers jours de signals (incl. dimanche soir actuel)
2. Filter top 5 crypto rows
3. Si trend_fail rate > 20% → log dans `gainers_insights_log`
4. **Toi tu vois l'insight** via `GET /admin/gainers/insights?type=data_quality&since_days=7`
5. Tu débugges Binance fetch AVANT que AutoTuner ne touche aux seuils

## Risk

Faible :
- Pas de modification d'algo, ajout pur observabilité
- Anti FP-rate via min_samples threshold
- Pas de flip auto, juste log

## Continuité chantier auto-learning

| Brique | Status |
|---|---|
| Phase A storage | ✅ #222 |
| Phase B detection | ✅ #223 |
| **Phase B+ data_quality** | 🟡 **this PR** |
| RCFT signal_forward | ✅ #225 |
| RCFT patch | ✅ #227 |
| Phase C V2 (gated Phase 4) | DRAFT #224 |

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_