### PR TITLE
fix(scanner): PR6.6.5 — TREND_FILTER respecte shadowSkipNullFields (shadow only, prod inchangée)

### DIFF
--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '../bloc1/prefilter-gates';
 import {
   DEFAULT_TREND_FILTER_CONFIG,
+  SHADOW_TREND_FILTER_CONFIG,
   evaluateTrendFilter,
 } from '../bloc1/trend-filter';
 import {
@@ -224,6 +225,71 @@ describe('GainersBloc1 — trend filter', () => {
     const r = evaluateTrendFilter(baseEquity({ ema50Daily: 90, ema200Daily: 100 }), { enabled: false });
     expect(r.pass).toBe(true);
     expect(r.kind).toBe(TrendFilterKind.NONE);
+  });
+
+  // PR6.6.5 — Shadow tolérance EMA null
+  describe('PR6.6.5 — shadowSkipNullFields', () => {
+    it('Cas 1 : EMAs présents, shadowSkipNullFields=false → strict identique', () => {
+      const r = evaluateTrendFilter(
+        baseEquity({ ema50Daily: 100, ema200Daily: 90 }),
+        DEFAULT_TREND_FILTER_CONFIG,
+      );
+      expect(r.pass).toBe(true);
+      expect(r.kind).toBe(TrendFilterKind.EMA_GOLDEN_CROSS);
+    });
+
+    it('Cas 1bis : EMAs présents bear (50<200), shadowSkipNullFields=true → REJECT (skip seulement null)', () => {
+      const r = evaluateTrendFilter(
+        baseEquity({ ema50Daily: 90, ema200Daily: 100 }),
+        SHADOW_TREND_FILTER_CONFIG,
+      );
+      expect(r.pass).toBe(false);
+      expect(r.reason).toBe(CandidateRejectReason.TREND_FILTER_FAIL);
+    });
+
+    it('Cas 2 : EMAs null, shadowSkipNullFields=false → REJECT TREND_FILTER_FAIL (prod strict)', () => {
+      const r1 = evaluateTrendFilter(baseEquity({ ema50Daily: null }), DEFAULT_TREND_FILTER_CONFIG);
+      const r2 = evaluateTrendFilter(baseEquity({ ema200Daily: null }), DEFAULT_TREND_FILTER_CONFIG);
+      const r3 = evaluateTrendFilter(
+        baseEquity({ ema50Daily: null, ema200Daily: null }),
+        DEFAULT_TREND_FILTER_CONFIG,
+      );
+      expect(r1.pass).toBe(false);
+      expect(r1.reason).toBe(CandidateRejectReason.TREND_FILTER_FAIL);
+      expect(r2.pass).toBe(false);
+      expect(r3.pass).toBe(false);
+    });
+
+    it('Cas 3 : EMAs null, shadowSkipNullFields=true → PASS kind=NONE', () => {
+      const r1 = evaluateTrendFilter(
+        baseEquity({ ema50Daily: null }),
+        SHADOW_TREND_FILTER_CONFIG,
+      );
+      const r2 = evaluateTrendFilter(
+        baseEquity({ ema200Daily: null }),
+        SHADOW_TREND_FILTER_CONFIG,
+      );
+      const r3 = evaluateTrendFilter(
+        baseEquity({ ema50Daily: null, ema200Daily: null }),
+        SHADOW_TREND_FILTER_CONFIG,
+      );
+      expect(r1.pass).toBe(true);
+      expect(r1.kind).toBe(TrendFilterKind.NONE);
+      expect(r1.reason).toBeNull();
+      expect(r2.pass).toBe(true);
+      expect(r2.kind).toBe(TrendFilterKind.NONE);
+      expect(r3.pass).toBe(true);
+      expect(r3.kind).toBe(TrendFilterKind.NONE);
+    });
+
+    it('Régression prod : DEFAULT_TREND_FILTER_CONFIG.shadowSkipNullFields = false', () => {
+      expect(DEFAULT_TREND_FILTER_CONFIG.shadowSkipNullFields).toBe(false);
+    });
+
+    it('Shadow config : SHADOW_TREND_FILTER_CONFIG.shadowSkipNullFields = true', () => {
+      expect(SHADOW_TREND_FILTER_CONFIG.shadowSkipNullFields).toBe(true);
+      expect(SHADOW_TREND_FILTER_CONFIG.enabled).toBe(true);
+    });
   });
 });
 

--- a/apps/api/src/modules/gainers-scanner/bloc1/gainers-bloc1.service.ts
+++ b/apps/api/src/modules/gainers-scanner/bloc1/gainers-bloc1.service.ts
@@ -10,11 +10,13 @@ import type {
 } from '../domain/gainers-candidate.types';
 import {
   DEFAULT_BLOC1_CONFIG,
+  SHADOW_BLOC1_CONFIG,
   GainersBloc1Config,
   runAllPrefilterGates,
 } from './prefilter-gates';
 import {
   DEFAULT_TREND_FILTER_CONFIG,
+  SHADOW_TREND_FILTER_CONFIG,
   TrendFilterConfig,
   evaluateTrendFilter,
 } from './trend-filter';
@@ -33,6 +35,17 @@ export interface Bloc1FullConfig {
 export const DEFAULT_BLOC1_FULL_CONFIG: Bloc1FullConfig = {
   prefilter: DEFAULT_BLOC1_CONFIG,
   trendFilter: DEFAULT_TREND_FILTER_CONFIG,
+  scorer: DEFAULT_COMPOSITE_SCORER_CONFIG,
+};
+
+/**
+ * PR6.6.5 — Bloc1 full config pour shadow run.
+ * Tolère null fields à la fois sur prefilter (PR6.4) et trend filter (PR6.6.5).
+ * Prod garde DEFAULT_BLOC1_FULL_CONFIG strict (ADR-005 §1bis lock).
+ */
+export const SHADOW_BLOC1_FULL_CONFIG: Bloc1FullConfig = {
+  prefilter: SHADOW_BLOC1_CONFIG,
+  trendFilter: SHADOW_TREND_FILTER_CONFIG,
   scorer: DEFAULT_COMPOSITE_SCORER_CONFIG,
 };
 

--- a/apps/api/src/modules/gainers-scanner/bloc1/trend-filter.ts
+++ b/apps/api/src/modules/gainers-scanner/bloc1/trend-filter.ts
@@ -15,10 +15,42 @@ import type { GainersCandidateRaw } from '../domain/gainers-candidate.types';
 export interface TrendFilterConfig {
   /** Active/désactive le filtre. Défaut true. */
   enabled: boolean;
+  /**
+   * PR6.6.5 — Shadow mode tolérance : si true ET ema50/ema200 daily est null
+   * (cache OHLCV partiel pour equity hors-watchlist, OU fetch Binance flaky
+   * intermittent crypto), retourne pass=true kind=NONE au lieu de
+   * TREND_FILTER_FAIL.
+   *
+   * Default false : préserve comportement strict prod ADR-005 §1bis (algos
+   * lockés). Activable uniquement via SHADOW_TREND_FILTER_CONFIG ou
+   * SHADOW_BLOC1_FULL_CONFIG dans le pipeline shadow run.
+   *
+   * Justification : pour equity, le cron `ohlcv_cache_daily` (21:30 UTC)
+   * ne couvre pas tous les tickers remontés par EODHD screener. Tickers
+   * hors-cache → EMAs null → REJECT TREND systématique → corruption shadow
+   * stats (100% trend_fail observé lundi 04/05 sur 1041 cycles). Cohérent
+   * avec philosophie SHADOW_BLOC1_CONFIG (PR6.4 shadowSkipNullFields=true
+   * sur ATR + persistence) — ce flag étend la tolérance au trend filter.
+   *
+   * Note ML : un kind=NONE résultant signal à AutoTuner V2 que ce signal n'a
+   * pas été filtré sur trend, donc ne doit PAS être considéré comme
+   * "validation trend filter" dans les stats post-Phase 4.
+   */
+  shadowSkipNullFields?: boolean;
 }
 
 export const DEFAULT_TREND_FILTER_CONFIG: TrendFilterConfig = {
   enabled: true,
+  shadowSkipNullFields: false,
+};
+
+/**
+ * PR6.6.5 — Config trend filter pour shadow run.
+ * Identique à DEFAULT mais avec shadowSkipNullFields=true → tolère EMAs null.
+ */
+export const SHADOW_TREND_FILTER_CONFIG: TrendFilterConfig = {
+  ...DEFAULT_TREND_FILTER_CONFIG,
+  shadowSkipNullFields: true,
 };
 
 export interface TrendFilterResult {
@@ -32,7 +64,9 @@ export interface TrendFilterResult {
 /**
  * Évalue le trend filter sur les EMAs daily du candidat.
  * - enabled=false → pass=true, kind=NONE
- * - EMA50 ou EMA200 manquant → reject TREND_FILTER_FAIL (data unavailable)
+ * - EMA50 ou EMA200 manquant :
+ *     - shadowSkipNullFields=true (shadow mode) → pass=true, kind=NONE (PR6.6.5)
+ *     - sinon → reject TREND_FILTER_FAIL (data unavailable, prod strict)
  * - EMA50 > EMA200 → pass, kind=EMA_GOLDEN_CROSS
  * - EMA50 ≤ EMA200 → reject TREND_FILTER_FAIL
  */
@@ -52,6 +86,17 @@ export function evaluateTrendFilter(
   const ema50 = raw.ema50Daily;
   const ema200 = raw.ema200Daily;
   if (ema50 === null || ema200 === null) {
+    // PR6.6.5 — shadow tolère EMA null (cache OHLCV partiel equity, fetch
+    // Binance flaky crypto). Prod strict (cfg.shadowSkipNullFields !== true).
+    if (cfg.shadowSkipNullFields) {
+      return {
+        pass: true,
+        kind: TrendFilterKind.NONE,
+        reason: null,
+        ema50,
+        ema200,
+      };
+    }
     return {
       pass: false,
       kind: TrendFilterKind.EMA_GOLDEN_CROSS,

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -33,7 +33,7 @@ import { MultiTimeframePersistenceService } from './multi-tf-persistence.service
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
 // PR6.3 — Shadow wiring (LisaModule import GainersModule pour résolution DI)
 import { GainersShadowRunService } from '../../gainers-scanner/shadow/shadow-run.service';
-import { GainersBloc1Service, DEFAULT_BLOC1_FULL_CONFIG } from '../../gainers-scanner/bloc1/gainers-bloc1.service';
+import { GainersBloc1Service, SHADOW_BLOC1_FULL_CONFIG } from '../../gainers-scanner/bloc1/gainers-bloc1.service';
 import { SHADOW_BLOC1_CONFIG } from '../../gainers-scanner/bloc1/prefilter-gates';
 import { CandidateRejectReason } from '../../gainers-scanner/domain/gainers-enums';
 // PR6.4 — Enrichment helpers (ATR + EMA + persistence depuis ohlcv_cache_daily)
@@ -750,11 +750,10 @@ export class TopGainersScannerService implements OnModuleInit {
       try {
         // PR6.4 : enrich BLOC 1 réel
         // PR6.6 : enrich crypto via Binance + pathEff réel via mtfPersistence
+        // PR6.6.5 : SHADOW_BLOC1_FULL_CONFIG tolère null sur prefilter ET trend filter
+        // (cache OHLCV partiel equity, fetch Binance flaky crypto). Prod inchangée.
         const enriched = await enrichShadowCandidate(c, supabaseClient, this.mtfPersistence, this.binanceMarket);
-        const bloc1Result = this.bloc1.evaluate(enriched.raw, {
-          ...DEFAULT_BLOC1_FULL_CONFIG,
-          prefilter: SHADOW_BLOC1_CONFIG,
-        });
+        const bloc1Result = this.bloc1.evaluate(enriched.raw, SHADOW_BLOC1_FULL_CONFIG);
 
         const isTopLegacy = topSymbolsSet.has(c.symbol.toUpperCase());
         const legacyDecision: 'ACCEPT' | 'REJECT' = isTopLegacy ? 'ACCEPT' : 'REJECT';


### PR DESCRIPTION
## Diagnostic lundi 04/05 13:30+ UTC US open

**0 ACCEPT sur 3441 equity weekday actifs**. Math :
- 1346 fail LIQUIDITY (39%) → reste 2095
- 39 fail MARKET_CAP → reste 2056
- 1015 fail PERSISTENCE → reste 1041
- **1041 fail TREND → reste 0 ACCEPT (100% trend fail !)**

100% trend fail systémique = **bug, pas algo strict**.

## Cause racine

`evaluateTrendFilter` ne respecte PAS `shadowSkipNullFields`. Si EMAs daily null → REJECT systématique.

- **Equity** : cache `ohlcv_cache_daily` ne couvre pas tous les tickers EODHD screener → EMAs null → 100% trend fail
- **Crypto** : fetch Binance daily flaky (rate-limit, timeout) → EMAs null intermittent → trend fail sporadique

## Fix — scope strictement shadow

| # | Modif | Fichier |
|---|---|---|
| 1 | `TrendFilterConfig` + `shadowSkipNullFields?: boolean` (default false) | `trend-filter.ts` |
| 2 | `evaluateTrendFilter` : si null + flag=true → pass=true kind=NONE | `trend-filter.ts` |
| 3 | `SHADOW_TREND_FILTER_CONFIG` nouveau export | `trend-filter.ts` |
| 4 | `SHADOW_BLOC1_FULL_CONFIG` nouveau export combine prefilter + trend shadow | `gainers-bloc1.service.ts` |
| 5 | Scanner `persistShadowSignalsBatch` utilise `SHADOW_BLOC1_FULL_CONFIG` au lieu d'inline build | `top-gainers-scanner.service.ts` |

## Diff complet

### `trend-filter.ts` (+38/-7)

```typescript
export interface TrendFilterConfig {
  enabled: boolean;
  shadowSkipNullFields?: boolean;  // PR6.6.5 — default false (prod strict)
}

export const SHADOW_TREND_FILTER_CONFIG: TrendFilterConfig = {
  ...DEFAULT_TREND_FILTER_CONFIG,
  shadowSkipNullFields: true,
};

// evaluateTrendFilter :
if (ema50 === null || ema200 === null) {
  // PR6.6.5 — shadow tolère null
  if (cfg.shadowSkipNullFields) {
    return { pass: true, kind: TrendFilterKind.NONE, reason: null, ema50, ema200 };
  }
  return { pass: false, reason: TREND_FILTER_FAIL, ... };  // prod strict
}
```

### `gainers-bloc1.service.ts` (+13)

```typescript
export const SHADOW_BLOC1_FULL_CONFIG: Bloc1FullConfig = {
  prefilter: SHADOW_BLOC1_CONFIG,
  trendFilter: SHADOW_TREND_FILTER_CONFIG,
  scorer: DEFAULT_COMPOSITE_SCORER_CONFIG,
};
```

### `top-gainers-scanner.service.ts` (+5/-4)

```typescript
// AVANT
const bloc1Result = this.bloc1.evaluate(enriched.raw, {
  ...DEFAULT_BLOC1_FULL_CONFIG,
  prefilter: SHADOW_BLOC1_CONFIG,
});

// APRÈS PR6.6.5
const bloc1Result = this.bloc1.evaluate(enriched.raw, SHADOW_BLOC1_FULL_CONFIG);
```

## Garde-fou prod ADR-005 §1bis

| Check | Status |
|---|---|
| `DEFAULT_TREND_FILTER_CONFIG.shadowSkipNullFields = false` | ✅ regression test explicit |
| `SHADOW_TREND_FILTER_CONFIG` isolé, n'apparaît que dans `SHADOW_BLOC1_FULL_CONFIG` | ✅ |
| `SHADOW_BLOC1_FULL_CONFIG` n'apparaît que dans `persistShadowSignalsBatch` | ✅ vérifié grep |
| Aucune autre logique métier touchée (persistence, liquidity, composite, BLOC 2/3) | ✅ |

**Audit fuite shadowSkipNullFields** : le flag n'est lu QUE dans `evaluateTrendFilter` (line 56 if branch). Pas d'autre site dans le code qui interroge ce flag. Pas de fuite vers prod.

## Tests

✅ **42/42 specs gainers-bloc1**, dont **6 nouveaux PR6.6.5** :

| Cas | EMAs | Flag | Résultat attendu |
|---|---|---|---|
| 1 | présents (50>200) | false | PASS GOLDEN_CROSS strict |
| 1bis | présents bear (50<200) | **true** | REJECT TREND_FILTER_FAIL (skip null seulement, pas bear) |
| 2 | null | false | REJECT prod strict |
| 3 | null | **true** | PASS kind=NONE shadow tolère |
| Reg | check `DEFAULT_TREND_FILTER_CONFIG.shadowSkipNullFields = false` | ✅ |
| Cfg | check `SHADOW_TREND_FILTER_CONFIG.shadowSkipNullFields = true` | ✅ |

Typecheck OK, boot port 3979 OK (DI resolved, cron scheduled).

## Comportement avant/après

| Cas | Avant | Après |
|---|---|---|
| Prod equity hors cache OHLC | REJECT TREND systématique | (inchangé) REJECT prod strict |
| Prod crypto fetch flaky | REJECT TREND intermittent | (inchangé) REJECT prod strict |
| **Shadow equity hors cache OHLC** | REJECT TREND systématique → **0 ACCEPT** | **PASS kind=NONE → continue pipeline → ACCEPT possible** |
| **Shadow crypto fetch flaky** | REJECT TREND intermittent ~30% | **PASS kind=NONE quand fetch fail → continue** |
| Shadow EMAs présents bear (50<200) | REJECT TREND | (inchangé) REJECT TREND (skip null seulement) |

## Effet attendu post-deploy

- ~1041 equity rejets/jour qui fail TREND vont passer au gate suivant (composite score) → **1ers ACCEPT equity attendus dès cron 18:15 UTC**
- Crypto top 5 (déjà bypass LIQUIDITY via PR6.6.4) auront moins de TREND fail intermittent
- DriftDetector PR6.8.2 continuera d'observer fetch instability (insight data_quality si > 20% trend_fail) — détection orthogonale, le voyant reste utile pour identifier la cause racine fetch

## Risk

Faible :
- Strictement scoped shadow path (1 call site)
- Prod ADR-005 §1bis 100% inchangée
- Test régression explicite default flag false
- Comportement shadow nouveau bien circonscrit (null EMAs only)

## Roadmap continuité

| PR | Objectif |
|---|---|
| ✅ PR6.6.4 | Bypass LIQUIDITY top 5 crypto |
| ✅ PR6.8.1 | RCFT patch (status, env vars, TTL) |
| ✅ PR6.8.2 | DriftDetector fetch instability |
| 🟡 **this PR6.6.5** | TREND_FILTER tolère null shadow |
| ⏳ Cron weekday data | Lundi 18:15+ UTC = 1ers ACCEPT attendus |
| ⏳ DRAFT #221 | PR6.7 BLOC 2/3 mergeable post 1er ACCEPT |

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_