### PR TITLE
fix(scanner): PR6.6.6 — composite_score best-effort partial scoring (shadow only) (Yaya #1)

### DIFF
--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
@@ -23,6 +23,7 @@ import {
 } from '../bloc1/trend-filter';
 import {
   DEFAULT_COMPOSITE_SCORER_CONFIG,
+  SHADOW_COMPOSITE_SCORER_CONFIG,
   computeCompositeScore,
 } from '../bloc1/composite-scorer';
 import { GainersBloc1Service } from '../bloc1/gainers-bloc1.service';
@@ -322,6 +323,76 @@ describe('GainersBloc1 — composite scorer', () => {
     const s = computeCompositeScore(baseEquity({ changePct1m: -0.05 }), DEFAULT_COMPOSITE_SCORER_CONFIG);
     expect(s).not.toBeNull();
     expect(s!).toBeGreaterThanOrEqual(0);
+  });
+
+  // PR6.6.6 — shadowAllowPartialScore : best-effort scoring with null fields
+  describe('PR6.6.6 — shadowAllowPartialScore', () => {
+    it('Cas 1 : tous fields présents, shadowAllowPartialScore=false → strict identique', () => {
+      const s = computeCompositeScore(baseEquity(), DEFAULT_COMPOSITE_SCORER_CONFIG);
+      const sShadow = computeCompositeScore(baseEquity(), SHADOW_COMPOSITE_SCORER_CONFIG);
+      expect(s).toBeCloseTo(sShadow!);
+    });
+
+    it('Cas 2 : persistence null, shadowAllowPartialScore=false → null (prod strict)', () => {
+      const s = computeCompositeScore(
+        baseEquity({ persistenceScore: null }),
+        DEFAULT_COMPOSITE_SCORER_CONFIG,
+      );
+      expect(s).toBeNull();
+    });
+
+    it('Cas 3 : persistence null, shadowAllowPartialScore=true → score partiel non-null', () => {
+      const s = computeCompositeScore(
+        baseEquity({ persistenceScore: null }),
+        SHADOW_COMPOSITE_SCORER_CONFIG,
+      );
+      expect(s).not.toBeNull();
+      expect(s!).toBeGreaterThanOrEqual(0);
+      expect(s!).toBeLessThanOrEqual(1);
+    });
+
+    it('Cas 4 : atr null, shadowAllowPartialScore=true → score partiel non-null', () => {
+      const s = computeCompositeScore(
+        baseEquity({ atrDailyRelative: null }),
+        SHADOW_COMPOSITE_SCORER_CONFIG,
+      );
+      expect(s).not.toBeNull();
+      expect(s!).toBeGreaterThanOrEqual(0);
+      expect(s!).toBeLessThanOrEqual(1);
+    });
+
+    it('Cas 5 : persistence ET atr null, shadowAllowPartialScore=true → score basé momentum only', () => {
+      const s = computeCompositeScore(
+        baseEquity({ persistenceScore: null, atrDailyRelative: null, changePct1m: 0.05 }),
+        SHADOW_COMPOSITE_SCORER_CONFIG,
+      );
+      expect(s).not.toBeNull();
+      // changePct1m=0.05 / 0.10 ceiling = 0.5 momentum component
+      // Re-normalized weight = 0.3/0.3 = 1.0 → score = 0.5
+      expect(s!).toBeCloseTo(0.5);
+    });
+
+    it('Cas 6 : Régression prod default — shadowAllowPartialScore=false', () => {
+      expect(DEFAULT_COMPOSITE_SCORER_CONFIG.shadowAllowPartialScore).toBe(false);
+    });
+
+    it('Cas 7 : Shadow config = true', () => {
+      expect(SHADOW_COMPOSITE_SCORER_CONFIG.shadowAllowPartialScore).toBe(true);
+    });
+
+    it('Cas 8 : score partiel reflète proportionnellement les composants présents', () => {
+      // baseEquity : persistence=0.83, momentum=0.02 (changePct1m), atr=0.03
+      // Strict score : 0.5*0.83 + 0.3*0.2 + 0.2*0.8 = 0.415 + 0.06 + 0.16 = 0.635
+      const strict = computeCompositeScore(baseEquity(), DEFAULT_COMPOSITE_SCORER_CONFIG);
+
+      // Shadow partiel sans persistence : (0.3*0.2 + 0.2*0.8) / (0.3+0.2) = 0.22/0.5 = 0.44
+      const partial = computeCompositeScore(
+        baseEquity({ persistenceScore: null }),
+        SHADOW_COMPOSITE_SCORER_CONFIG,
+      );
+      expect(strict).toBeCloseTo(0.635);
+      expect(partial).toBeCloseTo(0.44);
+    });
   });
 });
 

--- a/apps/api/src/modules/gainers-scanner/bloc1/composite-scorer.ts
+++ b/apps/api/src/modules/gainers-scanner/bloc1/composite-scorer.ts
@@ -22,6 +22,22 @@ export interface CompositeScorerConfig {
   momentumNormalizationCeiling: number;
   /** ATR clamp utilisé pour la volatilité inverse (défaut 0.15). */
   volatilityClampMaxAtrRel: number;
+  /**
+   * PR6.6.6 — Shadow mode best-effort scoring : si true ET persistenceScore
+   * ou atrDailyRelative null, calcule un score partiel basé uniquement sur
+   * les composants disponibles (renormalisation des poids).
+   *
+   * Default false : préserve comportement strict prod (ADR-005 §1bis : un
+   * score partiel pourrait être trompeur). Activable uniquement via
+   * SHADOW_BLOC1_FULL_CONFIG (PR6.6.5).
+   *
+   * Effet : composite_score n'est plus null pour les ACCEPT shadow → ranking
+   * possible + AutoTuner V2 a un score à analyser. Le score est marqué
+   * "partial" via la convention que persistence ou atr étaient null
+   * (audit via gainers_v1_shadow_signals.composite_score IS NOT NULL +
+   * raw fields stored elsewhere si needed).
+   */
+  shadowAllowPartialScore?: boolean;
 }
 
 export const DEFAULT_COMPOSITE_SCORER_CONFIG: CompositeScorerConfig = {
@@ -30,28 +46,84 @@ export const DEFAULT_COMPOSITE_SCORER_CONFIG: CompositeScorerConfig = {
   weightVolatilityInv: 0.2,
   momentumNormalizationCeiling: 0.1,
   volatilityClampMaxAtrRel: 0.15,
+  shadowAllowPartialScore: false,
+};
+
+/**
+ * PR6.6.6 — Composite scorer config pour shadow run.
+ * Identique à DEFAULT mais shadowAllowPartialScore=true → calcule score
+ * best-effort même avec persistence ou atr null.
+ */
+export const SHADOW_COMPOSITE_SCORER_CONFIG: CompositeScorerConfig = {
+  ...DEFAULT_COMPOSITE_SCORER_CONFIG,
+  shadowAllowPartialScore: true,
 };
 
 const clamp01 = (x: number): number => Math.max(0, Math.min(1, x));
 
 /**
- * Calcule le score composite [0..1]. Retourne null si données insuffisantes
- * (persistence ou volatilité absentes — sinon le score serait artificiellement gonflé).
+ * Calcule le score composite [0..1].
+ *
+ * Mode strict (default) : retourne null si persistence ou atr absents
+ * (ADR-005 §1bis prod : score partiel = trompeur).
+ *
+ * Mode shadow PR6.6.6 (cfg.shadowAllowPartialScore=true) :
+ *   - Calcule le score sur les composants disponibles uniquement
+ *   - Re-normalise les poids (somme = 1.0) sur les composants présents
+ *   - Si AUCUN composant n'est calculable (momentum est toujours dispo via
+ *     changePct1m donc ce cas est rare) → fallback 0
+ *
+ * Note : changePct1m (momentum) est TOUJOURS disponible (vient du screener).
+ * Donc en mode shadow, on a au minimum momentum component → score non-null.
  */
 export function computeCompositeScore(
   raw: GainersCandidateRaw,
   cfg: CompositeScorerConfig,
 ): number | null {
-  if (raw.persistenceScore === null || raw.atrDailyRelative === null) return null;
+  const persistenceAvail = raw.persistenceScore !== null;
+  const atrAvail = raw.atrDailyRelative !== null;
 
-  const persistenceComponent = clamp01(raw.persistenceScore);
+  // Mode strict : null si features manquantes
+  if (!cfg.shadowAllowPartialScore && (!persistenceAvail || !atrAvail)) {
+    return null;
+  }
+
   const momentumComponent = clamp01(raw.changePct1m / cfg.momentumNormalizationCeiling);
-  const volatilityInvComponent = 1 - clamp01(raw.atrDailyRelative / cfg.volatilityClampMaxAtrRel);
 
-  const weighted =
-    cfg.weightPersistence * persistenceComponent +
-    cfg.weightMomentum * momentumComponent +
-    cfg.weightVolatilityInv * volatilityInvComponent;
+  // Mode strict : tous composants présents
+  if (persistenceAvail && atrAvail) {
+    const persistenceComponent = clamp01(raw.persistenceScore!);
+    const volatilityInvComponent = 1 - clamp01(raw.atrDailyRelative! / cfg.volatilityClampMaxAtrRel);
+    const weighted =
+      cfg.weightPersistence * persistenceComponent +
+      cfg.weightMomentum * momentumComponent +
+      cfg.weightVolatilityInv * volatilityInvComponent;
+    return clamp01(weighted);
+  }
 
-  return clamp01(weighted);
+  // Mode shadow partial : renormalize weights sur composants présents
+  let weightedSum = 0;
+  let totalWeight = 0;
+
+  // Momentum (toujours dispo via changePct1m)
+  weightedSum += cfg.weightMomentum * momentumComponent;
+  totalWeight += cfg.weightMomentum;
+
+  if (persistenceAvail) {
+    const persistenceComponent = clamp01(raw.persistenceScore!);
+    weightedSum += cfg.weightPersistence * persistenceComponent;
+    totalWeight += cfg.weightPersistence;
+  }
+
+  if (atrAvail) {
+    const volatilityInvComponent = 1 - clamp01(raw.atrDailyRelative! / cfg.volatilityClampMaxAtrRel);
+    weightedSum += cfg.weightVolatilityInv * volatilityInvComponent;
+    totalWeight += cfg.weightVolatilityInv;
+  }
+
+  // Garde-fou : si totalWeight = 0 (impossible vu momentum), fallback 0
+  if (totalWeight === 0) return 0;
+
+  // Renormalize : score = weightedSum / totalWeight (équivalent ramener somme poids à 1.0)
+  return clamp01(weightedSum / totalWeight);
 }

--- a/apps/api/src/modules/gainers-scanner/bloc1/gainers-bloc1.service.ts
+++ b/apps/api/src/modules/gainers-scanner/bloc1/gainers-bloc1.service.ts
@@ -22,6 +22,7 @@ import {
 } from './trend-filter';
 import {
   DEFAULT_COMPOSITE_SCORER_CONFIG,
+  SHADOW_COMPOSITE_SCORER_CONFIG,
   CompositeScorerConfig,
   computeCompositeScore,
 } from './composite-scorer';
@@ -39,14 +40,17 @@ export const DEFAULT_BLOC1_FULL_CONFIG: Bloc1FullConfig = {
 };
 
 /**
- * PR6.6.5 — Bloc1 full config pour shadow run.
- * Tolère null fields à la fois sur prefilter (PR6.4) et trend filter (PR6.6.5).
+ * PR6.6.5 + PR6.6.6 — Bloc1 full config pour shadow run.
+ * Tolère null fields sur prefilter (PR6.4), trend filter (PR6.6.5),
+ * et composite scorer best-effort partial (PR6.6.6 — composite_score
+ * calculé même avec persistence/atr null, renormalize weights sur
+ * composants présents).
  * Prod garde DEFAULT_BLOC1_FULL_CONFIG strict (ADR-005 §1bis lock).
  */
 export const SHADOW_BLOC1_FULL_CONFIG: Bloc1FullConfig = {
   prefilter: SHADOW_BLOC1_CONFIG,
   trendFilter: SHADOW_TREND_FILTER_CONFIG,
-  scorer: DEFAULT_COMPOSITE_SCORER_CONFIG,
+  scorer: SHADOW_COMPOSITE_SCORER_CONFIG,
 };
 
 @Injectable()


### PR DESCRIPTION
## Yaya obligation résultats — Fix #1/3

**Diagnostic Supabase 04:16 UTC** : 2096 ACCEPT shadow MAIS `composite_score = NULL` pour TOUS. Cause : `computeCompositeScore()` retourne null si `persistenceScore` ou `atrDailyRelative` est null. En shadow mode degraded → score impossible → ranking impossible → AutoTuner V2 bloqué.

## Fix — best-effort partial scoring (shadow only)

```typescript
// PR6.6.6 — Shadow mode renormalize weights
if (cfg.shadowAllowPartialScore && (persistenceNull || atrNull)) {
  // Calcule sur composants présents avec poids re-normalisés à 1.0
  let weightedSum = momentum * weightMomentum;  // toujours dispo
  let totalWeight = weightMomentum;
  if (!persistenceNull) { weightedSum += persistence * w; totalWeight += w; }
  if (!atrNull) { weightedSum += volInv * w; totalWeight += w; }
  return weightedSum / totalWeight;
}
```

**Garde-fou prod** : `DEFAULT_COMPOSITE_SCORER_CONFIG.shadowAllowPartialScore = false` (test régression). Activé uniquement via `SHADOW_BLOC1_FULL_CONFIG.scorer = SHADOW_COMPOSITE_SCORER_CONFIG`.

## Tests

50/50 specs gainers-bloc1, **8 nouveaux PR6.6.6** :
- Cas 1 tous présents → strict identique
- Cas 2 persistence null + strict → null
- Cas 3 persistence null + shadow → non-null
- Cas 4 atr null + shadow → non-null
- Cas 5 ET atr null + shadow → score basé momentum (valeur exacte 0.5)
- Cas 6 régression default false ✅
- Cas 7 shadow config true ✅
- Cas 8 valeurs exactes 0.635 strict vs 0.44 partial

## Effet attendu post-deploy

- 100% ACCEPT shadow auront `composite_score` non-null
- Ranking utilisable pour AutoTuner V2
- Audit RCFT enrichi

## Files

- `bloc1/composite-scorer.ts` (+62/-13)
- `bloc1/gainers-bloc1.service.ts` (+5/-3)
- `__tests__/gainers-bloc1.spec.ts` (+76)

## Risk

Faible — strictement scoped shadow, prod ADR-005 §1bis 100% inchangée.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_