### PR TITLE
fix(insights): PR6.6.7 — Migration 0113 repair gainers_insights_log + Sniper trajectory targets doc (Yaya #2 #3)

### DIFF
--- a/docs/SNIPER_TRAJECTORY_TARGETS.md
+++ b/docs/SNIPER_TRAJECTORY_TARGETS.md
@@ -1,0 +1,79 @@
+# Cibles Trajectoire — Profil Sniper SmartVest
+
+**Yaya obligation résultats #3** : configurer cibles daily/monthly/annual sur `lisa_session_configs.daily_harvest_config` JSONB pour permettre à Lisa de moduler `trajectory_status` (EN_AVANCE / DANS_LE_PLAN / EN_RETARD / HORS_TRAJECTOIRE).
+
+## Profil Sniper actif
+
+- $10k sim
+- 60% deploy max
+- max position 25%
+- anti-consensus 8/10
+
+## Cibles proposées (cohérentes avec profil Sniper)
+
+| Horizon | Target | Justification |
+|---|---|---|
+| **Daily** | **0.15%** | $15/jour sur $10k = conservateur sniper (vs 0.30% beginner, 0.80% intermediate, 1.50% experienced, 2.50% scalper_pro) |
+| **Monthly** | **3.5%** | $350/mois — compounded ~21 trading days |
+| **Annual** | **25%** | $2500/an — top decile retail performance |
+
+Coherence math :
+- Daily 0.15% × 21 jours/mois = ~3.2% (proche 3.5% target)
+- Monthly 3.5% × 12 mois compounded = ~51% — donc on lisse à 25% annuel pour anti-volatilité
+
+## SQL UPDATE — à coller dans Supabase SQL editor
+
+### Si tu connais l'email user
+
+```sql
+UPDATE lisa_session_configs
+SET daily_harvest_config = COALESCE(daily_harvest_config, '{}'::jsonb) || jsonb_build_object(
+  'daily_target_pct', 0.0015,
+  'monthly_target_pct', 0.035,
+  'annual_target_pct', 0.25,
+  'profile', 'sniper',
+  'target_mode', 'ANNUAL_COMPOUND',
+  'target_value', 0.25
+)
+WHERE user_id = (SELECT id FROM auth.users WHERE email = 'TON_EMAIL@example.com' LIMIT 1);
+```
+
+### Apply sur tous les portfolios actifs (simple)
+
+```sql
+UPDATE lisa_session_configs
+SET daily_harvest_config = COALESCE(daily_harvest_config, '{}'::jsonb) || jsonb_build_object(
+  'daily_target_pct', 0.0015,
+  'monthly_target_pct', 0.035,
+  'annual_target_pct', 0.25,
+  'profile', 'sniper',
+  'target_mode', 'ANNUAL_COMPOUND',
+  'target_value', 0.25
+)
+WHERE autopilot_enabled = true;
+
+-- Vérification
+SELECT
+  user_id,
+  daily_harvest_config->>'daily_target_pct' AS daily,
+  daily_harvest_config->>'monthly_target_pct' AS monthly,
+  daily_harvest_config->>'annual_target_pct' AS annual,
+  daily_harvest_config->>'profile' AS profile
+FROM lisa_session_configs
+WHERE autopilot_enabled = true;
+```
+
+## Effet attendu
+
+Une fois inséré, l'agent mécanique (cron 1 min) lira `lisa_mechanical_directives.trajectory_status` calculé par Lisa toutes les 30 min et pourra moduler :
+- `EN_AVANCE` : élargir sélectivité (compositeScore ≥ 0.7)
+- `DANS_LE_PLAN` : sélectivité standard (compositeScore ≥ 0.6)
+- `EN_RETARD` : resserrer sélectivité (compositeScore ≥ 0.55)
+- `HORS_TRAJECTOIRE` : STOP+DIAGNOSTIC (CLAUDE.md §1bis lock)
+
+## Roadmap continuité
+
+- ✅ Migrations 0051/0052 déjà appliquées
+- 🟡 Migration 0110 partiellement appliquée → fix par migration 0113 (PR6.6.7)
+- ⏳ SQL UPDATE manuel ci-dessus pour activer cibles
+- ⏳ Lisa cycle suivant (~30 min) lira config + écrira `lisa_mechanical_directives` avec `trajectory_status` calculé

--- a/supabase/migrations/0113_repair_gainers_insights_log.sql
+++ b/supabase/migrations/0113_repair_gainers_insights_log.sql
@@ -1,0 +1,96 @@
+-- Migration 0113 — Repair Phase A gainers_insights_log (PR6.6.6 / Yaya #2).
+--
+-- Diagnostic : 0110 a créé la table partiellement (vraisemblablement sans
+-- toutes les colonnes severity/context/resolution_*) lors d'une exécution
+-- antérieure échouée. CREATE TABLE IF NOT EXISTS skip alors qu'il manque
+-- des colonnes → indexes 0110 fail "column severity does not exist".
+--
+-- Fix : ALTER TABLE ADD COLUMN IF NOT EXISTS pour TOUTES les colonnes 0110,
+-- puis re-créer les indexes manquants. Idempotente.
+
+-- ─── Step 1 : Ajouter colonnes manquantes (si absentes) ───────────────────
+
+ALTER TABLE public.gainers_insights_log
+  ADD COLUMN IF NOT EXISTS insight_type   TEXT,
+  ADD COLUMN IF NOT EXISTS source         TEXT,
+  ADD COLUMN IF NOT EXISTS status         TEXT DEFAULT 'open',
+  ADD COLUMN IF NOT EXISTS severity       TEXT DEFAULT 'info',
+  ADD COLUMN IF NOT EXISTS summary        TEXT,
+  ADD COLUMN IF NOT EXISTS payload        JSONB,
+  ADD COLUMN IF NOT EXISTS context        JSONB,
+  ADD COLUMN IF NOT EXISTS resolution     TEXT,
+  ADD COLUMN IF NOT EXISTS resolution_pr  TEXT,
+  ADD COLUMN IF NOT EXISTS resolved_at    TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS resolved_by    TEXT;
+
+-- ─── Step 2 : NOT NULL constraints (sur colonnes critiques uniquement) ─────
+-- (skip si elles ont des rows sans valeur — Supabase / Postgres bloquerait)
+DO $$
+BEGIN
+  -- Seulement si table vide (sinon skip pour préserver rows existants)
+  IF (SELECT COUNT(*) FROM public.gainers_insights_log) = 0 THEN
+    BEGIN
+      ALTER TABLE public.gainers_insights_log
+        ALTER COLUMN insight_type SET NOT NULL,
+        ALTER COLUMN source SET NOT NULL,
+        ALTER COLUMN status SET NOT NULL,
+        ALTER COLUMN severity SET NOT NULL,
+        ALTER COLUMN summary SET NOT NULL,
+        ALTER COLUMN payload SET NOT NULL;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'NOT NULL constraints skip (existing rows): %', SQLERRM;
+    END;
+  END IF;
+END$$;
+
+-- ─── Step 3 : CHECK constraints (idempotent via DROP + ADD) ────────────────
+DO $$
+BEGIN
+  -- chk_status
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'chk_status'
+      AND conrelid = 'public.gainers_insights_log'::regclass
+  ) THEN
+    ALTER TABLE public.gainers_insights_log DROP CONSTRAINT chk_status;
+  END IF;
+  ALTER TABLE public.gainers_insights_log
+    ADD CONSTRAINT chk_status CHECK (status IN ('open', 'investigating', 'actioned', 'dismissed'));
+
+  -- chk_severity
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'chk_severity'
+      AND conrelid = 'public.gainers_insights_log'::regclass
+  ) THEN
+    ALTER TABLE public.gainers_insights_log DROP CONSTRAINT chk_severity;
+  END IF;
+  ALTER TABLE public.gainers_insights_log
+    ADD CONSTRAINT chk_severity CHECK (severity IN ('info', 'low', 'medium', 'high', 'critical'));
+END$$;
+
+-- ─── Step 4 : Indexes (re-créer ceux qui ont fail dans 0110) ───────────────
+
+CREATE INDEX IF NOT EXISTS idx_gainers_insights_type_created
+  ON public.gainers_insights_log (insight_type, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_gainers_insights_open
+  ON public.gainers_insights_log (status) WHERE status = 'open';
+
+CREATE INDEX IF NOT EXISTS idx_gainers_insights_severity
+  ON public.gainers_insights_log (severity, created_at DESC)
+  WHERE severity IN ('high', 'critical');
+
+-- ─── Step 5 : RLS policy (idempotent) ──────────────────────────────────────
+
+ALTER TABLE public.gainers_insights_log ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_insights_full_access" ON public.gainers_insights_log;
+CREATE POLICY "service_role_insights_full_access"
+  ON public.gainers_insights_log
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE public.gainers_insights_log IS 'Phase A — log structuré pour modèle V1 auto-apprenant. Réparé 0113 après 0110 partial apply.';


### PR DESCRIPTION
## Yaya obligation résultats — Fixes #2 et #3

## #2 Migration 0110 partiellement appliquée — repair via 0113

**Diagnostic** : `POST /admin/migrations/apply-missing` returned :
```
failed: [{ filename: '0110_gainers_insights_log.sql',
  error: 'column "severity" does not exist' }]
```

Table existe (créée par exécution antérieure) mais SANS `severity`. `CREATE TABLE IF NOT EXISTS` skip → indexes 0110 fail.

**Migration 0113 idempotente** :
- `ALTER TABLE ADD COLUMN IF NOT EXISTS` pour TOUTES colonnes 0110
- NOT NULL constraints conditionnel (skip si rows existants)
- DROP+CREATE CHECK constraints
- `CREATE INDEX IF NOT EXISTS` pour indexes manquants
- RLS policy DROP+CREATE idempotent

## #3 Cibles trajectoire profil Sniper — doc

`docs/SNIPER_TRAJECTORY_TARGETS.md` propose :

| Horizon | Target | Justification |
|---|---|---|
| Daily | 0.15% | $15/jour sur $10k |
| Monthly | 3.5% | $350/mois |
| Annual | 25% | $2500/an |

SQL UPDATE prêt pour Supabase editor.

## Files

- `supabase/migrations/0113_repair_gainers_insights_log.sql` (+86)
- `docs/SNIPER_TRAJECTORY_TARGETS.md` (+82)

## Risk faible
ALTER TABLE IF NOT EXISTS, DROP+CREATE idempotents, doc-only pour SQL.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_