### PR TITLE
fix(scanner): PR6.6.6.1 — composite_score missing-penalty (replaces renormalize, fixes score=1.000 artifact)

### DIFF
--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
@@ -361,15 +361,27 @@ describe('GainersBloc1 — composite scorer', () => {
       expect(s!).toBeLessThanOrEqual(1);
     });
 
-    it('Cas 5 : persistence ET atr null, shadowAllowPartialScore=true → score basé momentum only', () => {
+    it('Cas 5 : persistence ET atr null, shadowAllowPartialScore=true → missing-penalty (PR6.6.6.1)', () => {
       const s = computeCompositeScore(
         baseEquity({ persistenceScore: null, atrDailyRelative: null, changePct1m: 0.05 }),
         SHADOW_COMPOSITE_SCORER_CONFIG,
       );
       expect(s).not.toBeNull();
-      // changePct1m=0.05 / 0.10 ceiling = 0.5 momentum component
-      // Re-normalized weight = 0.3/0.3 = 1.0 → score = 0.5
-      expect(s!).toBeCloseTo(0.5);
+      // PR6.6.6.1 missing-penalty (PAS renormalize) :
+      // momentumComp = 0.05 / 0.10 = 0.5
+      // weightedSum = 0.3 × 0.5 = 0.15 (persistence + atr absents → max 0.3)
+      expect(s!).toBeCloseTo(0.15);
+    });
+
+    it('Cas 5bis : PR6.6.6.1 — changePct1m=20% (max momentum) + tous null → score plafonné à 0.3', () => {
+      const s = computeCompositeScore(
+        baseEquity({ persistenceScore: null, atrDailyRelative: null, changePct1m: 0.20 }),
+        SHADOW_COMPOSITE_SCORER_CONFIG,
+      );
+      // momentum clamp à 1.0 (changePct >= ceiling 0.10)
+      // weightedSum = 0.3 × 1.0 = 0.3 (max possible avec seul momentum)
+      // Sans renormalize → 0.3 (vs ancien 1.0 = artifact bilan smoke test)
+      expect(s).toBeCloseTo(0.3);
     });
 
     it('Cas 6 : Régression prod default — shadowAllowPartialScore=false', () => {
@@ -380,18 +392,40 @@ describe('GainersBloc1 — composite scorer', () => {
       expect(SHADOW_COMPOSITE_SCORER_CONFIG.shadowAllowPartialScore).toBe(true);
     });
 
-    it('Cas 8 : score partiel reflète proportionnellement les composants présents', () => {
+    it('Cas 8 : PR6.6.6.1 — score partiel reflète complétude (NO renormalize)', () => {
       // baseEquity : persistence=0.83, momentum=0.02 (changePct1m), atr=0.03
       // Strict score : 0.5*0.83 + 0.3*0.2 + 0.2*0.8 = 0.415 + 0.06 + 0.16 = 0.635
       const strict = computeCompositeScore(baseEquity(), DEFAULT_COMPOSITE_SCORER_CONFIG);
 
-      // Shadow partiel sans persistence : (0.3*0.2 + 0.2*0.8) / (0.3+0.2) = 0.22/0.5 = 0.44
+      // Shadow partiel sans persistence (missing-penalty PR6.6.6.1) :
+      // weightedSum = 0.3*0.2 + 0.2*0.8 = 0.06 + 0.16 = 0.22 (max = 0.3+0.2 = 0.5)
       const partial = computeCompositeScore(
         baseEquity({ persistenceScore: null }),
         SHADOW_COMPOSITE_SCORER_CONFIG,
       );
       expect(strict).toBeCloseTo(0.635);
-      expect(partial).toBeCloseTo(0.44);
+      expect(partial).toBeCloseTo(0.22);
+      // Ranking préservé : strict (0.635) > partial (0.22) ✅
+      expect(strict!).toBeGreaterThan(partial!);
+    });
+
+    it('Cas 9 : PR6.6.6.1 — ranking ordering full vs partial vs minimal', () => {
+      // 3 candidats avec changePct1m identique 0.05 mais features différentes
+      const full = computeCompositeScore(
+        baseEquity({ changePct1m: 0.05, persistenceScore: 0.8, atrDailyRelative: 0.05 }),
+        SHADOW_COMPOSITE_SCORER_CONFIG,
+      );
+      const partial = computeCompositeScore(
+        baseEquity({ changePct1m: 0.05, persistenceScore: 0.8, atrDailyRelative: null }),
+        SHADOW_COMPOSITE_SCORER_CONFIG,
+      );
+      const minimal = computeCompositeScore(
+        baseEquity({ changePct1m: 0.05, persistenceScore: null, atrDailyRelative: null }),
+        SHADOW_COMPOSITE_SCORER_CONFIG,
+      );
+      // Ranking attendu : full > partial > minimal
+      expect(full!).toBeGreaterThan(partial!);
+      expect(partial!).toBeGreaterThan(minimal!);
     });
   });
 });

--- a/apps/api/src/modules/gainers-scanner/bloc1/composite-scorer.ts
+++ b/apps/api/src/modules/gainers-scanner/bloc1/composite-scorer.ts
@@ -69,12 +69,22 @@ const clamp01 = (x: number): number => Math.max(0, Math.min(1, x));
  *
  * Mode shadow PR6.6.6 (cfg.shadowAllowPartialScore=true) :
  *   - Calcule le score sur les composants disponibles uniquement
- *   - Re-normalise les poids (somme = 1.0) sur les composants présents
- *   - Si AUCUN composant n'est calculable (momentum est toujours dispo via
- *     changePct1m donc ce cas est rare) → fallback 0
+ *   - PR6.6.6.1 : missing-penalty (PAS renormalize) → score reflète
+ *     la complétude des données. Max possible :
+ *       - momentum only :          0.3 (= weightMomentum)
+ *       - momentum + atr :         0.5 (= weightMomentum + weightVolatilityInv)
+ *       - momentum + persistence : 0.8 (= weightMomentum + weightPersistence)
+ *       - tous présents :          1.0
+ *
+ *   - Avantage vs renormalize : ranking préservé (full > partial),
+ *     AutoTuner V2 trie par confidence, évite l'artifact "tous ACCEPT
+ *     shadow à 1.000" observé sur smoke test Q2 (changePct1m ≥ 10% +
+ *     persistence/atr null → renormalize donnait 1.0 systématique).
+ *
+ *   - Garde-fou implicite : un ACCEPT shadow avec score < 0.3 = bug
+ *     (momentum manquant impossible). Score 0.3 = momentum max only.
  *
  * Note : changePct1m (momentum) est TOUJOURS disponible (vient du screener).
- * Donc en mode shadow, on a au minimum momentum component → score non-null.
  */
 export function computeCompositeScore(
   raw: GainersCandidateRaw,
@@ -90,7 +100,7 @@ export function computeCompositeScore(
 
   const momentumComponent = clamp01(raw.changePct1m / cfg.momentumNormalizationCeiling);
 
-  // Mode strict : tous composants présents
+  // Mode strict ou shadow avec tous composants présents
   if (persistenceAvail && atrAvail) {
     const persistenceComponent = clamp01(raw.persistenceScore!);
     const volatilityInvComponent = 1 - clamp01(raw.atrDailyRelative! / cfg.volatilityClampMaxAtrRel);
@@ -101,29 +111,21 @@ export function computeCompositeScore(
     return clamp01(weighted);
   }
 
-  // Mode shadow partial : renormalize weights sur composants présents
+  // Mode shadow partial — PR6.6.6.1 missing-penalty (PAS renormalize)
   let weightedSum = 0;
-  let totalWeight = 0;
 
   // Momentum (toujours dispo via changePct1m)
   weightedSum += cfg.weightMomentum * momentumComponent;
-  totalWeight += cfg.weightMomentum;
 
   if (persistenceAvail) {
     const persistenceComponent = clamp01(raw.persistenceScore!);
     weightedSum += cfg.weightPersistence * persistenceComponent;
-    totalWeight += cfg.weightPersistence;
   }
 
   if (atrAvail) {
     const volatilityInvComponent = 1 - clamp01(raw.atrDailyRelative! / cfg.volatilityClampMaxAtrRel);
     weightedSum += cfg.weightVolatilityInv * volatilityInvComponent;
-    totalWeight += cfg.weightVolatilityInv;
   }
 
-  // Garde-fou : si totalWeight = 0 (impossible vu momentum), fallback 0
-  if (totalWeight === 0) return 0;
-
-  // Renormalize : score = weightedSum / totalWeight (équivalent ramener somme poids à 1.0)
-  return clamp01(weightedSum / totalWeight);
+  return clamp01(weightedSum);
 }


### PR DESCRIPTION
## Diagnostic post-PR6.6.6 deploy

Q2 smoke test : TOUS les top ACCEPT shadow à `composite_score = 1.000` (002371, BHEL, 000863, NESCO, etc.) — artifact renormalize.

```
weightedSum = momentum × 0.3 = 1.0 × 0.3 = 0.3
totalWeight = 0.3
score = 0.3 / 0.3 = 1.0  ← ARTIFACT
```

## Fix — missing-penalty (PR6.6.6.1)

```typescript
// AVANT (renormalize)
return clamp01(weightedSum / totalWeight);  // → max 1.0 même avec 1 composant

// APRÈS PR6.6.6.1 (missing-penalty)
return clamp01(weightedSum);  // → max = sum(weights present)
```

Max possible reflète données dispo :

| Composants présents | Max score |
|---|---|
| momentum only | 0.3 |
| momentum + atr | 0.5 |
| momentum + persistence | 0.8 |
| tous présents | 1.0 |

## Avantages

- Ranking préservé : full features > partial
- AutoTuner V2 trie par confidence (score reflète complétude)
- Évite l'artifact "tous ACCEPT à 1.000"
- Garde-fou implicite : ACCEPT shadow score < 0.3 = bug

## Tests

52/52 specs gainers-bloc1, 2 nouveaux + 2 ajustés :
- Cas 5 : 0.15 (au lieu de 0.5 renormalize)
- Cas 5bis : 0.3 plafonné (au lieu de 1.0)
- Cas 8 : strict 0.635 vs partial 0.22 (au lieu de 0.44)
- Cas 9 : ranking ordering full > partial > minimal vérifié

## Risk faible
Mode strict prod (DEFAULT) totalement inchangé. ADR-005 §1bis intact.

## Files
- `bloc1/composite-scorer.ts` (+25/-15)
- `__tests__/gainers-bloc1.spec.ts` (+30/-10)

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_