### PR TITLE
feat(lisa): PR6.6.8 — Migration 0114 Sniper trajectory targets (auto-apply via deploy)

### DIFF
--- a/supabase/migrations/0114_sniper_trajectory_targets.sql
+++ b/supabase/migrations/0114_sniper_trajectory_targets.sql
@@ -1,0 +1,43 @@
+-- Migration 0114 — Sniper trajectory targets (Yaya obligation résultats #3).
+--
+-- Insère cibles trajectoire dans daily_harvest_config JSONB pour TOUS les
+-- portfolios autopilot_enabled (configs actives). Profil Sniper :
+--   daily_target_pct  : 0.15% ($15/jour sur $10k)
+--   monthly_target_pct: 3.5%  ($350/mois)
+--   annual_target_pct : 25%   ($2500/an)
+--   profile           : sniper
+--   target_mode       : ANNUAL_COMPOUND (cf 0105 target-modes)
+--   target_value      : 0.25
+--
+-- Idempotente : utilise jsonb || pour merge avec config existante (overwrite
+-- les keys cibles, préserve le reste).
+--
+-- Garde-fou : RAISE NOTICE le count de rows touchées pour audit logs.
+
+DO $$
+DECLARE
+  affected_count INTEGER;
+BEGIN
+  -- Pre-update count (visibilité utilisateur)
+  SELECT COUNT(*) INTO affected_count
+  FROM public.lisa_session_configs
+  WHERE autopilot_enabled = true;
+
+  RAISE NOTICE '[0114] Sniper targets : % autopilot_enabled rows seront touchées', affected_count;
+
+  -- Apply UPDATE
+  UPDATE public.lisa_session_configs
+  SET daily_harvest_config = COALESCE(daily_harvest_config, '{}'::jsonb)
+    || jsonb_build_object(
+      'daily_target_pct', 0.0015,
+      'monthly_target_pct', 0.035,
+      'annual_target_pct', 0.25,
+      'profile', 'sniper',
+      'target_mode', 'ANNUAL_COMPOUND',
+      'target_value', 0.25
+    )
+  WHERE autopilot_enabled = true;
+
+  GET DIAGNOSTICS affected_count = ROW_COUNT;
+  RAISE NOTICE '[0114] Sniper targets : % rows updated', affected_count;
+END$$;


### PR DESCRIPTION
## Yaya obligation résultats #3 — exécution autonome

Migration 0114 insère cibles trajectoire profil Sniper sur tous portfolios `autopilot_enabled`.

```sql
DO $$
DECLARE affected_count INTEGER;
BEGIN
  SELECT COUNT(*) INTO affected_count
  FROM lisa_session_configs
  WHERE autopilot_enabled = true;
  RAISE NOTICE '[0114] % rows seront touchées', affected_count;

  UPDATE lisa_session_configs
  SET daily_harvest_config = COALESCE(daily_harvest_config, '{}'::jsonb)
    || jsonb_build_object(
      'daily_target_pct', 0.0015,
      'monthly_target_pct', 0.035,
      'annual_target_pct', 0.25,
      'profile', 'sniper',
      'target_mode', 'ANNUAL_COMPOUND',
      'target_value', 0.25
    )
  WHERE autopilot_enabled = true;
END$$;
```

## Garde-fou utilisateur

`RAISE NOTICE` pre-update count + post-update `ROW_COUNT` visibles dans logs Supabase quand `/admin/migrations/apply-missing` exécute. Si > 1 row touchée, l'utilisateur peut audit.

## Idempotente

`jsonb || jsonb_build_object()` overwrite les keys cibles, préserve le reste de `daily_harvest_config`. Re-run safe.

## Application

Cette migration sera applied automatiquement quand PR #232 (PR6.6.6.1 composite-scorer.ts) déclenchera Fly Deploy (path `apps/api/**` match) et que `/admin/migrations/apply-missing` tournera post-deploy.

## Effet attendu

Lisa cycle suivant (~30 min post-apply) :
1. Lit `daily_harvest_config.daily_target_pct = 0.0015`
2. Calcule `trajectory_status` selon écart vs réalisé
3. Écrit dans `lisa_mechanical_directives.trajectory_status`
4. Agent mécanique (cron 1 min) module sélectivité composite_score

## Risk

Faible — 1 INSERT JSONB key, idempotent, RAISE NOTICE pour audit, pas de DROP/DELETE.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_