### PR TITLE
feat(gainers): full autonomy + zero hardcode (PR #1+#2 fondations)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.config-driven.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.config-driven.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * PR Hardcodes-fix — tests que le scanner Gainers respecte la config
+ * lisa_session_configs (gainers_max_open_positions, gainers_max_per_cycle,
+ * gainers_position_pct, gainers_cash_reserve_pct, capital_simulation,
+ * gainers_cooldown_minutes).
+ *
+ * Tests logiques purs : on simule la résolution des params dérivés de
+ * cfgRow + les bornes (clamp, fallback).
+ */
+
+interface CfgRow {
+  capital_simulation?: number | string | null;
+  gainers_max_open_positions?: number | null;
+  gainers_max_per_cycle?: number | null;
+  gainers_position_pct?: number | string | null;
+  gainers_cash_reserve_pct?: number | string | null;
+  gainers_cooldown_minutes?: number | null;
+}
+
+const FALLBACK = {
+  capital: 10000,
+  maxOpen: 5,
+  maxPerCycle: 3,
+  positionPct: 20,
+  cashReservePct: 10,
+  cooldownMin: 30,
+};
+
+function resolveConfig(cfgRow: CfgRow | null | undefined) {
+  const capitalUsd = cfgRow?.capital_simulation != null
+    ? Math.max(100, Number(cfgRow.capital_simulation))
+    : FALLBACK.capital;
+  const maxOpen = cfgRow?.gainers_max_open_positions != null
+    ? Math.max(1, Math.min(20, Number(cfgRow.gainers_max_open_positions)))
+    : FALLBACK.maxOpen;
+  const maxPerCycle = cfgRow?.gainers_max_per_cycle != null
+    ? Math.max(1, Math.min(10, Number(cfgRow.gainers_max_per_cycle)))
+    : FALLBACK.maxPerCycle;
+  const positionPct = cfgRow?.gainers_position_pct != null
+    ? Math.max(1, Math.min(100, Number(cfgRow.gainers_position_pct)))
+    : FALLBACK.positionPct;
+  const cashReservePct = cfgRow?.gainers_cash_reserve_pct != null
+    ? Math.max(0, Math.min(50, Number(cfgRow.gainers_cash_reserve_pct)))
+    : FALLBACK.cashReservePct;
+  const cooldownMinutes = cfgRow?.gainers_cooldown_minutes != null
+    ? Math.max(0, Math.min(240, Number(cfgRow.gainers_cooldown_minutes)))
+    : FALLBACK.cooldownMin;
+  const positionNotionalUsd = capitalUsd * (positionPct / 100);
+
+  return {
+    capitalUsd,
+    maxOpen,
+    maxPerCycle,
+    positionPct,
+    cashReservePct,
+    cooldownMinutes,
+    positionNotionalUsd,
+  };
+}
+
+describe('TopGainersScannerService — scanPortfolio config-driven', () => {
+  describe('Capital + sizing', () => {
+    it('applique config UI : $50k capital × 25% = $12.5k notional', () => {
+      const c = resolveConfig({ capital_simulation: 50000, gainers_position_pct: 25 });
+      expect(c.capitalUsd).toBe(50000);
+      expect(c.positionPct).toBe(25);
+      expect(c.positionNotionalUsd).toBe(12500);
+    });
+
+    it('fallback $10k quand capital_simulation null', () => {
+      const c = resolveConfig({ capital_simulation: null });
+      expect(c.capitalUsd).toBe(10000);
+      expect(c.positionNotionalUsd).toBe(2000); // 20% × $10k
+    });
+
+    it('clamp capital min $100 (anti zero division)', () => {
+      const c = resolveConfig({ capital_simulation: 50 });
+      expect(c.capitalUsd).toBe(100);
+    });
+
+    it('positionPct clampé [1, 100]', () => {
+      expect(resolveConfig({ gainers_position_pct: 0 }).positionPct).toBe(1);
+      expect(resolveConfig({ gainers_position_pct: 150 }).positionPct).toBe(100);
+      expect(resolveConfig({ gainers_position_pct: 50 }).positionPct).toBe(50);
+    });
+  });
+
+  describe('Capacity (maxOpen × maxPerCycle)', () => {
+    it('respecte cfg.gainers_max_open_positions=8 (UI)', () => {
+      const c = resolveConfig({ gainers_max_open_positions: 8 });
+      expect(c.maxOpen).toBe(8);
+    });
+
+    it('clamp maxOpen [1, 20]', () => {
+      expect(resolveConfig({ gainers_max_open_positions: 0 }).maxOpen).toBe(1);
+      expect(resolveConfig({ gainers_max_open_positions: 50 }).maxOpen).toBe(20);
+    });
+
+    it('cfg.gainers_max_per_cycle = 3 → 3 ouvertures/cycle (vs 1 hardcoded avant)', () => {
+      const c = resolveConfig({ gainers_max_per_cycle: 3 });
+      expect(c.maxPerCycle).toBe(3);
+    });
+
+    it('clamp maxPerCycle [1, 10]', () => {
+      expect(resolveConfig({ gainers_max_per_cycle: 0 }).maxPerCycle).toBe(1);
+      expect(resolveConfig({ gainers_max_per_cycle: 100 }).maxPerCycle).toBe(10);
+    });
+  });
+
+  describe('Cash reserve & cooldown', () => {
+    it('cash_reserve_pct configurable [0, 50]', () => {
+      expect(resolveConfig({ gainers_cash_reserve_pct: 0 }).cashReservePct).toBe(0);
+      expect(resolveConfig({ gainers_cash_reserve_pct: 25 }).cashReservePct).toBe(25);
+      expect(resolveConfig({ gainers_cash_reserve_pct: 100 }).cashReservePct).toBe(50);
+    });
+
+    it('cooldown configurable [0, 240] min', () => {
+      expect(resolveConfig({ gainers_cooldown_minutes: 0 }).cooldownMinutes).toBe(0);
+      expect(resolveConfig({ gainers_cooldown_minutes: 60 }).cooldownMinutes).toBe(60);
+      expect(resolveConfig({ gainers_cooldown_minutes: 999 }).cooldownMinutes).toBe(240);
+    });
+
+    it('fallback cooldown = 30 min (legacy)', () => {
+      expect(resolveConfig(null).cooldownMinutes).toBe(30);
+    });
+  });
+
+  describe('Scenarios complets', () => {
+    it('config Sniper UI (capital $10k, max 5 pos, 20% notional, cooldown 30) = sane defaults', () => {
+      const c = resolveConfig({
+        capital_simulation: 10000,
+        gainers_max_open_positions: 5,
+        gainers_max_per_cycle: 3,
+        gainers_position_pct: 20,
+        gainers_cash_reserve_pct: 10,
+        gainers_cooldown_minutes: 30,
+      });
+      expect(c.capitalUsd).toBe(10000);
+      expect(c.maxOpen).toBe(5);
+      expect(c.maxPerCycle).toBe(3);
+      expect(c.positionNotionalUsd).toBe(2000); // 5 × $2k = $10k worst case (au-dessus capital, fees-aware guard arbitre)
+      expect(c.cashReservePct).toBe(10);
+      expect(c.cooldownMinutes).toBe(30);
+    });
+
+    it('config Aggressive UI (capital $50k, max 8 pos, 25% notional) = scaling correct', () => {
+      const c = resolveConfig({
+        capital_simulation: 50000,
+        gainers_max_open_positions: 8,
+        gainers_position_pct: 25,
+      });
+      expect(c.maxOpen).toBe(8);
+      expect(c.positionNotionalUsd).toBe(12500); // 25% × $50k
+    });
+
+    it('row sans config gainers_* (legacy pre-0115) = tous fallbacks', () => {
+      const c = resolveConfig({});
+      expect(c.capitalUsd).toBe(10000);
+      expect(c.maxOpen).toBe(5);
+      expect(c.maxPerCycle).toBe(3);
+      expect(c.positionPct).toBe(20);
+      expect(c.cashReservePct).toBe(10);
+      expect(c.cooldownMinutes).toBe(30);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/__tests__/autopilot-gainers-disconnect.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/autopilot-gainers-disconnect.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * PR Gainers-autonomy — tests du gate strategy_mode='gainers' dans
+ * LisaAutopilotService.runAutopilotCycleInner.
+ *
+ * En mode 'gainers' :
+ *   - Lisa LLM cycle SKIPPÉ (le scanner Gainers gère seul les opens)
+ *   - Aucun appel à runPortfolioCycle
+ *   - Aucun appel à maybeResumeOrSkip / generateProposal
+ *
+ * En mode 'investment' / 'harvest' :
+ *   - runPortfolioCycle appelé normalement
+ */
+
+import { LisaAutopilotService } from '../lisa-autopilot.service';
+
+interface MockState {
+  configsReturned: Array<Record<string, unknown>>;
+  runPortfolioCycleCalls: string[];
+  maybeResumeOrSkipCalls: string[];
+}
+
+function makeService(state: MockState) {
+  const supabase = {
+    getClient: () => ({
+      from: () => {
+        const chain: Record<string, unknown> = {};
+        chain.select = () => chain;
+        chain.eq = () => chain;
+        chain.then = (resolve: (v: unknown) => unknown) =>
+          resolve({ data: state.configsReturned, error: null });
+        return chain;
+      },
+    }),
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const service = new (LisaAutopilotService as any)(
+    supabase, null, { append: jest.fn() }, null, null, null, null, null, null, null,
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (service as any).runPortfolioCycle = jest.fn(async (_userId: string, portfolioId: string) => {
+    state.runPortfolioCycleCalls.push(portfolioId);
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (service as any).maybeResumeOrSkip = jest.fn(async (cfg: Record<string, unknown>) => {
+    state.maybeResumeOrSkipCalls.push(String(cfg.portfolio_id));
+    return true;
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return service as any;
+}
+
+const GAINERS_ID = 'aaaaaaaa-1111-1111-1111-111111111111';
+const INVESTMENT_ID = 'bbbbbbbb-2222-2222-2222-222222222222';
+const HARVEST_ID = 'cccccccc-3333-3333-3333-333333333333';
+
+describe('LisaAutopilotService.runAutopilotCycleInner — gainers gate', () => {
+  it('SKIPS portfolio with strategy_mode=gainers (no runPortfolioCycle, no maybeResumeOrSkip)', async () => {
+    const state: MockState = {
+      configsReturned: [
+        {
+          portfolio_id: GAINERS_ID,
+          user_id: 'user-1',
+          strategy_mode: 'gainers',
+          autopilot_enabled: true,
+          kill_switch_active: false,
+          autopilot_market_hours_only: false,
+          autopilot_cycle_minutes: 15,
+        },
+      ],
+      runPortfolioCycleCalls: [],
+      maybeResumeOrSkipCalls: [],
+    };
+    const service = makeService(state);
+    await service.runAutopilotCycleInner();
+
+    expect(state.runPortfolioCycleCalls).toEqual([]);
+    expect(state.maybeResumeOrSkipCalls).toEqual([]);
+  });
+
+  it('RUNS portfolio with strategy_mode=investment normally', async () => {
+    const state: MockState = {
+      configsReturned: [
+        {
+          portfolio_id: INVESTMENT_ID,
+          user_id: 'user-2',
+          strategy_mode: 'investment',
+          autopilot_enabled: true,
+          kill_switch_active: false,
+          autopilot_market_hours_only: false,
+          autopilot_cycle_minutes: 60,
+        },
+      ],
+      runPortfolioCycleCalls: [],
+      maybeResumeOrSkipCalls: [],
+    };
+    const service = makeService(state);
+    await service.runAutopilotCycleInner();
+
+    expect(state.maybeResumeOrSkipCalls).toEqual([INVESTMENT_ID]);
+    expect(state.runPortfolioCycleCalls).toEqual([INVESTMENT_ID]);
+  });
+
+  it('RUNS portfolio with strategy_mode=harvest normally', async () => {
+    const state: MockState = {
+      configsReturned: [
+        {
+          portfolio_id: HARVEST_ID,
+          user_id: 'user-3',
+          strategy_mode: 'harvest',
+          autopilot_enabled: true,
+          kill_switch_active: false,
+          autopilot_market_hours_only: false,
+          autopilot_cycle_minutes: 7,
+        },
+      ],
+      runPortfolioCycleCalls: [],
+      maybeResumeOrSkipCalls: [],
+    };
+    const service = makeService(state);
+    await service.runAutopilotCycleInner();
+
+    expect(state.runPortfolioCycleCalls).toEqual([HARVEST_ID]);
+  });
+
+  it('RUNS portfolio with NULL strategy_mode (legacy) normally — backward compat', async () => {
+    const state: MockState = {
+      configsReturned: [
+        {
+          portfolio_id: 'dddddddd-4444-4444-4444-444444444444',
+          user_id: 'user-4',
+          strategy_mode: null,
+          autopilot_enabled: true,
+          kill_switch_active: false,
+          autopilot_market_hours_only: false,
+          autopilot_cycle_minutes: 30,
+        },
+      ],
+      runPortfolioCycleCalls: [],
+      maybeResumeOrSkipCalls: [],
+    };
+    const service = makeService(state);
+    await service.runAutopilotCycleInner();
+
+    expect(state.runPortfolioCycleCalls).toHaveLength(1);
+  });
+
+  it('MIXED batch : skips only gainers, runs others', async () => {
+    const state: MockState = {
+      configsReturned: [
+        {
+          portfolio_id: GAINERS_ID,
+          user_id: 'user-1',
+          strategy_mode: 'gainers',
+          autopilot_enabled: true,
+          kill_switch_active: false,
+          autopilot_market_hours_only: false,
+        },
+        {
+          portfolio_id: INVESTMENT_ID,
+          user_id: 'user-2',
+          strategy_mode: 'investment',
+          autopilot_enabled: true,
+          kill_switch_active: false,
+          autopilot_market_hours_only: false,
+        },
+        {
+          portfolio_id: HARVEST_ID,
+          user_id: 'user-3',
+          strategy_mode: 'harvest',
+          autopilot_enabled: true,
+          kill_switch_active: false,
+          autopilot_market_hours_only: false,
+        },
+      ],
+      runPortfolioCycleCalls: [],
+      maybeResumeOrSkipCalls: [],
+    };
+    const service = makeService(state);
+    await service.runAutopilotCycleInner();
+
+    expect(state.runPortfolioCycleCalls).not.toContain(GAINERS_ID);
+    expect(state.runPortfolioCycleCalls).toContain(INVESTMENT_ID);
+    expect(state.runPortfolioCycleCalls).toContain(HARVEST_ID);
+    expect(state.runPortfolioCycleCalls).toHaveLength(2);
+  });
+});

--- a/apps/api/src/modules/lisa/services/__tests__/mechanical-trading-gainers-disconnect.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/mechanical-trading-gainers-disconnect.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * PR Gainers-autonomy — tests du gate strategy_mode='gainers' dans
+ * MechanicalTradingService.processPortfolio.
+ *
+ * En mode 'gainers' :
+ *   - Step 0.5 (agent ↔ Lisa wake-up) SKIPPÉ
+ *   - Step 1   (closes Lisa via directive.closeConditions) SKIPPÉ
+ *   - Step 3   (opens Lisa via directive.targetSymbols) SKIPPÉ (early return)
+ *
+ * Restent actifs en gainers (protections capital universelles) :
+ *   - Step 0   drawdown guard
+ *   - Step 0bis autonomy rules
+ *   - Step 0.6 news shock close
+ *   - Step 2   stops/TP/trailing
+ *
+ * Test logique pure, sans instancier le service complet (≈30 deps Supabase
+ * + Lisa + Binance + EODHD ne sont pas mockables en unit). On valide la
+ * cascade de skips telle qu'implémentée dans le source.
+ */
+
+interface MockSessionConfig {
+  portfolio_id: string;
+  strategy_mode: string | null;
+}
+
+interface ProcessedSteps {
+  step0_drawdown: boolean;
+  step0bis_autonomy: boolean;
+  step0_5_lisa_wake: boolean;
+  step0_6_news_shock: boolean;
+  step1_closes_lisa: boolean;
+  step2_stops_tp: boolean;
+  step3_opens_lisa: boolean;
+}
+
+/**
+ * Réplique la logique de processPortfolio post-PR Gainers-autonomy :
+ *   const isGainersMode = cfg.strategy_mode === 'gainers';
+ *   Step 0   → toujours
+ *   Step 0bis→ toujours
+ *   Step 0.5 → if (!isGainersMode) ...
+ *   Step 0.6 → toujours
+ *   Step 1   → if (directive && !isGainersMode) ...
+ *   Step 2   → toujours (stops/TP universels)
+ *   Step 3   → if (isGainersMode) early return; ...
+ */
+function simulateProcessPortfolio(
+  cfg: MockSessionConfig,
+  hasDirective: boolean,
+): ProcessedSteps {
+  const isGainersMode = cfg.strategy_mode === 'gainers';
+  const out: ProcessedSteps = {
+    step0_drawdown: true,
+    step0bis_autonomy: true,
+    step0_5_lisa_wake: !isGainersMode,
+    step0_6_news_shock: true,
+    step1_closes_lisa: hasDirective && !isGainersMode,
+    step2_stops_tp: true,
+    step3_opens_lisa: !isGainersMode && hasDirective,
+  };
+  return out;
+}
+
+describe('MechanicalTradingService — strategy_mode=gainers gates', () => {
+  it('GAINERS : Step 0.5 / 1 / 3 SKIPPÉS, protections capital actives', () => {
+    const result = simulateProcessPortfolio(
+      { portfolio_id: 'p1', strategy_mode: 'gainers' },
+      true,
+    );
+
+    // Skips Lisa LLM
+    expect(result.step0_5_lisa_wake).toBe(false);
+    expect(result.step1_closes_lisa).toBe(false);
+    expect(result.step3_opens_lisa).toBe(false);
+
+    // Protections capital toujours actives
+    expect(result.step0_drawdown).toBe(true);
+    expect(result.step0bis_autonomy).toBe(true);
+    expect(result.step0_6_news_shock).toBe(true);
+    expect(result.step2_stops_tp).toBe(true);
+  });
+
+  it('INVESTMENT : tous les steps actifs', () => {
+    const result = simulateProcessPortfolio(
+      { portfolio_id: 'p2', strategy_mode: 'investment' },
+      true,
+    );
+
+    expect(result.step0_5_lisa_wake).toBe(true);
+    expect(result.step1_closes_lisa).toBe(true);
+    expect(result.step3_opens_lisa).toBe(true);
+    expect(result.step2_stops_tp).toBe(true);
+  });
+
+  it('HARVEST : tous les steps actifs', () => {
+    const result = simulateProcessPortfolio(
+      { portfolio_id: 'p3', strategy_mode: 'harvest' },
+      true,
+    );
+
+    expect(result.step0_5_lisa_wake).toBe(true);
+    expect(result.step1_closes_lisa).toBe(true);
+    expect(result.step3_opens_lisa).toBe(true);
+  });
+
+  it('NULL strategy_mode (legacy) : tous les steps actifs (backward compat)', () => {
+    const result = simulateProcessPortfolio(
+      { portfolio_id: 'p4', strategy_mode: null },
+      true,
+    );
+
+    expect(result.step0_5_lisa_wake).toBe(true);
+    expect(result.step1_closes_lisa).toBe(true);
+    expect(result.step3_opens_lisa).toBe(true);
+  });
+
+  it('GAINERS sans directive : Step 1/3 sont déjà no-op, Step 0.5 reste skippé', () => {
+    const result = simulateProcessPortfolio(
+      { portfolio_id: 'p5', strategy_mode: 'gainers' },
+      false,
+    );
+
+    expect(result.step0_5_lisa_wake).toBe(false);
+    expect(result.step1_closes_lisa).toBe(false);
+    expect(result.step3_opens_lisa).toBe(false);
+    expect(result.step2_stops_tp).toBe(true); // critique : stops gainers fermés ici
+  });
+
+  it('INVESTMENT sans directive : Step 0.5 reste actif, Step 1/3 no-op faute de directive', () => {
+    const result = simulateProcessPortfolio(
+      { portfolio_id: 'p6', strategy_mode: 'investment' },
+      false,
+    );
+
+    expect(result.step0_5_lisa_wake).toBe(true);
+    expect(result.step1_closes_lisa).toBe(false);
+    expect(result.step3_opens_lisa).toBe(false);
+  });
+});

--- a/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
@@ -314,6 +314,16 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
 
     for (const cfg of configs) {
       try {
+        // PR Gainers-autonomy — strategy_mode='gainers' désactive complètement
+        // la pipeline Lisa LLM pour ce portfolio. Le scanner Gainers tourne sur
+        // son propre cron et gère les ouvertures via TopGainersScannerService.
+        // Les fermetures (stops/TP/drawdown/news shock) restent gérées par le
+        // moteur mécanique sans Lisa LLM (cf. mechanical-trading.service.ts).
+        if ((cfg.strategy_mode as string | null) === 'gainers') {
+          this.logger.debug(`Portfolio ${String(cfg.portfolio_id)}: strategy_mode=gainers → Lisa LLM cycle skipped`);
+          continue;
+        }
+
         // P8-BR — auto-resume si en pause budget et coût retombé < 90%,
         // sinon skip ce cycle pour ce portfolio.
         const canRun = await this.maybeResumeOrSkip(cfg);

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -149,6 +149,12 @@ interface SessionConfig {
    *  la sensibilité des wake-up triggers (VIX/drawdown/position pnl)
    *  pour aligner sur l'horizon scalping. */
   capital_discipline_mode?: string;
+  /** PR Gainers-autonomy — 'investment' | 'harvest' | 'gainers'. En 'gainers' :
+   *  Step 0.5 wake-up Lisa, Step 1 closes Lisa et Step 3 opens Lisa sont skippés.
+   *  Le scanner Gainers gère seul les ouvertures (cron dédié). Les protections
+   *  capital (Step 0 drawdown, Step 0.6 news shock, Step 2 stops/TP/trailing)
+   *  restent actives universellement. */
+  strategy_mode?: string;
 }
 
 @Injectable()
@@ -385,8 +391,15 @@ export class MechanicalTradingService {
     // souffrance, VIX spike) et réveille Lisa pour ré-analyse contextuelle.
     // Non-bloquant : échec Lisa n'interrompt pas le cycle mécanique.
     // Budget 8 wake-ups/jour + cooldown 5min par trigger pour éviter le spam.
-    await this.triggerAgentLisaSyncIfNeeded(cfg, openPositions)
-      .catch((e) => this.logger.warn(`[P5.1] Agent sync eval failed: ${String(e).slice(0, 120)}`));
+    //
+    // PR Gainers-autonomy — skip en mode 'gainers' : Lisa LLM est totalement
+    // déconnectée. Les protections capital (Step 0 drawdown, Step 0.6 news shock,
+    // Step 2 stops/TP/trailing) suffisent pour ce mode déterministe.
+    const isGainersMode = (cfg.strategy_mode as string | null | undefined) === 'gainers';
+    if (!isGainersMode) {
+      await this.triggerAgentLisaSyncIfNeeded(cfg, openPositions)
+        .catch((e) => this.logger.warn(`[P5.1] Agent sync eval failed: ${String(e).slice(0, 120)}`));
+    }
 
     // Step 0.6 — Close réactif sur news contraires fraîches.
     // Ne réveille pas Lisa : ferme directement avant qu'un wake-up Lisa
@@ -396,7 +409,11 @@ export class MechanicalTradingService {
       .catch((e) => this.logger.warn(`[news-shock-close] eval failed: ${String(e).slice(0, 120)}`));
 
     // Step 1 — Explicit close requests from Lisa
-    if (directive) {
+    // PR Gainers-autonomy — en mode 'gainers' Lisa LLM ne tourne pas, donc
+    // aucune directive n'est générée. On skip explicitement par sécurité au
+    // cas où une directive obsolète traînerait en DB (ex: bascule investment
+    // → gainers). Les closes Gainers passent par Step 2 (stops/TP) uniquement.
+    if (directive && !isGainersMode) {
       for (const cond of directive.closeConditions) {
         if (cond.urgency !== 'immediate') continue;
         const pos = openPositions.find((p) => p.id === cond.positionId);
@@ -443,6 +460,15 @@ export class MechanicalTradingService {
     }
 
     // Step 3 — Open new positions (seulement si directive valide + trajectoire permet)
+    // PR Gainers-autonomy — en mode 'gainers' les ouvertures sont gérées
+    // exclusivement par TopGainersScannerService (cron dédié). Le mécanique
+    // ne doit JAMAIS ouvrir de positions Lisa-driven en parallèle.
+    if (isGainersMode) {
+      await this.writeDefensiveCycleSummary(portfolioId, currentPositions)
+        .catch((e) => this.logger.debug(`defensive summary failed: ${String(e).slice(0, 80)}`));
+      return;
+    }
+
     if (!directive || directive.validUntil <= new Date()) {
       if (directive) {
         this.logger.debug(`${portfolioId}: directive expirée — mode défensif uniquement`);

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -185,10 +185,19 @@ const EU_FALLBACK_OPEN_UTC = '07:00';
 const EU_FALLBACK_CLOSE_UTC = '17:00';
 
 /**
- * P5-PIVOT-TOP-GAINERS v1 — Cap conservatif : 1 position/cycle.
- * Permet de valider end-to-end avant scaling à 3 (PR2).
+ * Fallback defaults quand `lisa_session_configs` n'a pas les colonnes
+ * gainers_* (migration 0115 pas encore appliquée OU portfolio sans config).
+ *
+ * Avant PR Hardcodes-fix : MAX_POSITIONS_PER_CYCLE_V1 et maxOpen étaient
+ * hardcodés ici. Désormais lus depuis cfg.gainers_max_per_cycle et
+ * cfg.gainers_max_open_positions, avec ces valeurs comme dernier recours.
  */
-const MAX_POSITIONS_PER_CYCLE_V1 = 1;
+const FALLBACK_MAX_PER_CYCLE = 3;
+const FALLBACK_MAX_OPEN = 5;
+const FALLBACK_POSITION_PCT = 20.0;
+const FALLBACK_CASH_RESERVE_PCT = 10.0;
+const FALLBACK_CAPITAL_USD = 10000;
+const FALLBACK_COOLDOWN_MIN = 30;
 
 const TOP_GAINERS_CRON_NAME = 'top-gainers-scanner';
 
@@ -1230,27 +1239,14 @@ export class TopGainersScannerService implements OnModuleInit {
       return; // skip cycle pour ce portfolio
     }
 
-    // Garde-fou : count current open positions
-    const { data: openPositions } = await this.supabase
-      .getClient()
-      .from('lisa_positions')
-      .select('symbol')
-      .eq('portfolio_id', portfolioId)
-      .eq('status', 'open');
-    const openSymbols = new Set((openPositions ?? []).map((p) => String(p.symbol).toUpperCase()));
-    const maxOpen = 3;
-    const slotsAvailable = Math.max(0, maxOpen - (openPositions?.length ?? 0));
-    if (slotsAvailable === 0) {
-      this.logger.log(`[top-gainers] ${portfolioId.slice(0, 8)}: no slots (${openPositions?.length}/3 open)`);
-      return;
-    }
-
-    // P8 + P19x.2 — Charge config gainers pour ce portfolio :
-    // min persistance + path efficiency + TP/SL defaults.
+    // PR Hardcodes-fix — Charge config complète gainers pour ce portfolio :
+    // min persistence + path efficiency + TP/SL + capital + sizing + cooldown.
+    // Migration 0115 expose toutes les colonnes gainers_*. Fallbacks définis
+    // au top du fichier (FALLBACK_*) si row absent ou colonne non encore migrée.
     const { data: cfgRow } = await this.supabase
       .getClient()
       .from('lisa_session_configs')
-      .select('gainers_min_persistence_score, gainers_min_path_efficiency, gainers_default_tp_pct, gainers_default_sl_pct')
+      .select('capital_simulation, gainers_min_persistence_score, gainers_min_path_efficiency, gainers_default_tp_pct, gainers_default_sl_pct, gainers_max_open_positions, gainers_max_per_cycle, gainers_position_pct, gainers_cash_reserve_pct, gainers_cooldown_minutes')
       .eq('portfolio_id', portfolioId)
       .maybeSingle();
     const minScore = this.resolveMinPersistenceScore(
@@ -1272,6 +1268,41 @@ export class TopGainersScannerService implements OnModuleInit {
       ? Math.max(0.1, Math.min(20, Number(cfgRow.gainers_default_sl_pct)))
       : 1.0;
 
+    // PR Hardcodes-fix — sizing & capacity dérivés de la config user
+    const capitalUsd = cfgRow?.capital_simulation != null
+      ? Math.max(100, Number(cfgRow.capital_simulation))
+      : FALLBACK_CAPITAL_USD;
+    const maxOpen = cfgRow?.gainers_max_open_positions != null
+      ? Math.max(1, Math.min(20, Number(cfgRow.gainers_max_open_positions)))
+      : FALLBACK_MAX_OPEN;
+    const maxPerCycle = cfgRow?.gainers_max_per_cycle != null
+      ? Math.max(1, Math.min(10, Number(cfgRow.gainers_max_per_cycle)))
+      : FALLBACK_MAX_PER_CYCLE;
+    const positionPct = cfgRow?.gainers_position_pct != null
+      ? Math.max(1, Math.min(100, Number(cfgRow.gainers_position_pct)))
+      : FALLBACK_POSITION_PCT;
+    const cashReservePct = cfgRow?.gainers_cash_reserve_pct != null
+      ? Math.max(0, Math.min(50, Number(cfgRow.gainers_cash_reserve_pct)))
+      : FALLBACK_CASH_RESERVE_PCT;
+    const cooldownMinutes = cfgRow?.gainers_cooldown_minutes != null
+      ? Math.max(0, Math.min(240, Number(cfgRow.gainers_cooldown_minutes)))
+      : FALLBACK_COOLDOWN_MIN;
+    const positionNotionalUsd = capitalUsd * (positionPct / 100);
+
+    // Garde-fou : count current open positions (utilise maxOpen depuis config)
+    const { data: openPositions } = await this.supabase
+      .getClient()
+      .from('lisa_positions')
+      .select('symbol')
+      .eq('portfolio_id', portfolioId)
+      .eq('status', 'open');
+    const openSymbols = new Set((openPositions ?? []).map((p) => String(p.symbol).toUpperCase()));
+    const slotsAvailable = Math.max(0, maxOpen - (openPositions?.length ?? 0));
+    if (slotsAvailable === 0) {
+      this.logger.log(`[top-gainers] ${portfolioId.slice(0, 8)}: no slots (${openPositions?.length}/${maxOpen} open)`);
+      return;
+    }
+
     // P8 — Calcule la persistance multi-TF pour les top candidats (parallèle)
     const persistenceMap = await this.mtfPersistence.analyzeBatch(
       top.map((c) => ({
@@ -1281,9 +1312,10 @@ export class TopGainersScannerService implements OnModuleInit {
       })),
     );
 
-    // Guard 3 v1 — cap conservatif : 1 position/cycle (test prudent avant
-    // bump à 3 dans v2). Permet de valider le pipeline end-to-end.
-    const maxThisCycle = Math.min(slotsAvailable, MAX_POSITIONS_PER_CYCLE_V1);
+    // PR Hardcodes-fix — cap par cycle dérivé de cfg.gainers_max_per_cycle.
+    // Permet à l'utilisateur d'ouvrir plusieurs candidats par cycle quand
+    // plusieurs setups A+ sont détectés simultanément.
+    const maxThisCycle = Math.min(slotsAvailable, maxPerCycle);
     let opened = 0;
     // P18e — accumule les skips pour log agrégé en fin de cycle (au lieu de
     // N lignes "no persistence data → skip" qui polluent les logs Fly).
@@ -1296,10 +1328,11 @@ export class TopGainersScannerService implements OnModuleInit {
     // top gainer et passe les gates → fees s'accumulent sans valeur ajoutée.
     //
     // Garde-fou : refuse toute open sur un (symbol, direction) si une
-    // position était fermée pour ce couple dans les 30 dernières minutes.
+    // position était fermée pour ce couple dans les N dernières minutes
+    // (cfg.gainers_cooldown_minutes, default 30, range [0, 240]).
     // Lookup unique par cycle : on charge tous les recent closes avant la
     // boucle puis on check en mémoire (évite N queries DB).
-    const cooldownMs = 30 * 60_000;
+    const cooldownMs = cooldownMinutes * 60_000;
     const cooldownSinceIso = new Date(Date.now() - cooldownMs).toISOString();
     // Failure-tolerant : si la query échoue (mock partiel en test, schema
     // out-of-sync, etc.), on passe le cooldown sans bloquer le pipeline.
@@ -1339,7 +1372,7 @@ export class TopGainersScannerService implements OnModuleInit {
       if (lastExitMs && Date.now() - lastExitMs < cooldownMs) {
         const elapsedMin = Math.floor((Date.now() - lastExitMs) / 60_000);
         this.logger.log(
-          `[top-gainers] ${cand.symbol} cooldown actif (fermé il y a ${elapsedMin} min < 30 min) → skip re-entry`,
+          `[top-gainers] ${cand.symbol} cooldown actif (fermé il y a ${elapsedMin} min < ${cooldownMinutes} min) → skip re-entry`,
         );
         continue;
       }
@@ -1500,7 +1533,14 @@ export class TopGainersScannerService implements OnModuleInit {
         portfolioId,
         cand,
         persistence,
-        { tpPct, slPct },
+        {
+          tpPct,
+          slPct,
+          capitalUsd,
+          positionPct,
+          positionNotionalUsd,
+          cashReservePct,
+        },
       ).catch((e) => {
         this.logger.warn(
           `[top-gainers] open ${cand.symbol} failed: ${String(e).slice(0, 120)}`,
@@ -1534,14 +1574,29 @@ export class TopGainersScannerService implements OnModuleInit {
     portfolioId: string,
     cand: TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass },
     persistence?: PersistenceResult,
-    // P19x.2 — TP/SL config par portfolio (DB lisa_session_configs.gainers_default_*).
-    // Fallback aux nouveaux defaults P19x.2 spec : TP=1.5% / SL=1.0%.
-    overrides?: { tpPct: number; slPct: number },
+    // PR Hardcodes-fix — toute la sizing config arrive par overrides depuis
+    // scanPortfolio (qui a lu lisa_session_configs). Plus aucune valeur
+    // hardcodée — capital, notional, position pct, cash reserve, TP, SL.
+    overrides?: {
+      tpPct: number;
+      slPct: number;
+      capitalUsd: number;
+      positionPct: number;
+      positionNotionalUsd: number;
+      cashReservePct: number;
+    },
   ): Promise<string | null> {
     const proposalId = randomUUID();
     const thesisId = randomUUID();
     const effectiveTp = overrides?.tpPct ?? 1.5;
     const effectiveSl = overrides?.slPct ?? 1.0;
+    // Fallbacks identiques aux defaults DB migration 0115 si overrides absents
+    // (caller hors scanPortfolio = legacy / test).
+    const effectiveCapital = overrides?.capitalUsd ?? FALLBACK_CAPITAL_USD;
+    const effectivePositionPct = overrides?.positionPct ?? FALLBACK_POSITION_PCT;
+    const effectiveNotional = overrides?.positionNotionalUsd
+      ?? (effectiveCapital * (effectivePositionPct / 100));
+    const effectiveCashReserve = overrides?.cashReservePct ?? FALLBACK_CASH_RESERVE_PCT;
 
     // P18 — LLM thesis generation (inert when SCANNER_LLM_ROUTER_ENABLED=false)
     const llmThesis = await this.generateThesis(cand);
@@ -1569,15 +1624,19 @@ export class TopGainersScannerService implements OnModuleInit {
       ],
     };
     const allocations = [
-      { thesisId, pctCapital: 30, amountUsd: '3000.00' },
+      {
+        thesisId,
+        pctCapital: effectivePositionPct,
+        amountUsd: effectiveNotional.toFixed(2),
+      },
     ];
 
-    // INSERT pseudo-proposal
+    // INSERT pseudo-proposal — capital + cash reserve viennent de la config.
     const { error: insErr } = await this.supabase.getClient().from('lisa_proposals').insert({
       id: proposalId,
       portfolio_id: portfolioId,
       user_id: userId,
-      capital_usd: '10000.00',
+      capital_usd: effectiveCapital.toFixed(2),
       base_currency: 'USD',
       detected_regime: 'momentum_top_gainers',
       market_momentum: 'bullish_strong',
@@ -1586,7 +1645,7 @@ export class TopGainersScannerService implements OnModuleInit {
       avoided_pockets: [],
       theses: [thesis],
       allocations,
-      cash_reserve_pct: 70,
+      cash_reserve_pct: effectiveCashReserve,
       warnings: [],
       status: 'proposed',
       claude_cost_usd: 0,


### PR DESCRIPTION
## Contexte

Réalignement complet du mode Gainers vers une **autonomie totale + configuration utilisateur intégrale**. Cette PR couvre les 2 fondations critiques (PR #1 + PR #2 de la roadmap 6 PRs). Les PRs #3 (UI panel), #4 (pWin gate ML), #5 (AutoTuner Phase C), #6 (UI dashboard insights) suivront une fois cette base mergée.

## Pourquoi

Audit code (cf. discussion `claude/review-repo-docs-f7qBN`) a révélé 2 dérives majeures par rapport à la spec :

1. **Lisa LLM tournait en parallèle du scanner Gainers** — le commit P7 (#64, 28/04) qui a introduit le toggle 3-modes a oublié de gater l'autopilot. Conséquence : positions "stagflation" Lisa-driven (LMT, IAU, RTX, USO, GDX, SLV) saturaient le compteur `maxOpen=3` du scanner Gainers (`6/3 open` → 0 trade Gainers exécuté pendant des heures malgré candidats valides).

2. **6 hardcodes critiques dans le scanner** ignoraient la config UI :
   - `capital_usd: '10000.00'`
   - `pctCapital: 30, amountUsd: '3000.00'`
   - `maxOpen = 3`
   - `MAX_POSITIONS_PER_CYCLE_V1 = 1`
   - `cash_reserve_pct: 70`
   - `cooldownMs = 30 × 60000`
   
   La carte UI affichait "5 positions × $200, SL -3% TP +8%" alors que le code réel utilisait 3 × $3000, SL 1.0% TP 1.5%.

Migration **0115** appliquée manuellement (full-config columns sur `lisa_session_configs`).

## Changements

### PR #1 — Lisa-disconnect (commit `cf4eecb`)

- `lisa-autopilot.service.ts:315` — `continue` si `cfg.strategy_mode === 'gainers'`
- `mechanical-trading.service.ts` :
  - Step 0.5 (agent ↔ Lisa wake-up) **skip si gainers**
  - Step 1 (closes Lisa via directive) **skip si gainers**
  - Step 3 (opens Lisa via directive) **early return si gainers**
- Restent universels en gainers : Step 0 drawdown / Step 0bis autonomy / Step 0.6 news shock / Step 2 stops/TP/trailing

### PR #2 — Hardcodes-fix (commit `e86b34a`)

- `scanPortfolio` lit la config complète depuis `lisa_session_configs` :
  - `capital_simulation` (clamp ≥ $100)
  - `gainers_max_open_positions` (clamp [1, 20])
  - `gainers_max_per_cycle` (clamp [1, 10])
  - `gainers_position_pct` (clamp [1, 100])
  - `gainers_cash_reserve_pct` (clamp [0, 50])
  - `gainers_cooldown_minutes` (clamp [0, 240])
- `positionNotionalUsd = capitalUsd × positionPct/100` calculé dynamiquement
- `openTopGainerPosition` utilise les overrides config au lieu de hardcodes
- Constantes `FALLBACK_*` au top du fichier comme dernier recours

### Effet utilisateur post-merge

| Avant | Après |
|---|---|
| Mode Gainers + Lisa LLM en parallèle (mélange des genres) | Mode Gainers = scanner seul, Lisa LLM totalement déconnectée |
| Capital scanner = $10k peu importe UI | Capital scanner = `cfg.capital_simulation` |
| Notional fixe $3000/position | Notional = `capital × position_pct/100` |
| Max 3 positions hardcoded | Max = `cfg.gainers_max_open_positions` (UI) |
| 1 ouverture/cycle hardcoded | Jusqu'à `cfg.gainers_max_per_cycle` |
| Cooldown 30 min hardcoded | Cooldown = `cfg.gainers_cooldown_minutes` |

## Tests

- `autopilot-gainers-disconnect.spec.ts` (5 cases)
- `mechanical-trading-gainers-disconnect.spec.ts` (6 cases)
- `top-gainers-scanner.config-driven.spec.ts` (14 cases)
- **1226/1228 tests passent** (100 suites, 2 todo expected)
- Typecheck clean

## Risques + rollback

- **Risque faible** : changements gated par `strategy_mode='gainers'`. Les portfolios `investment` / `harvest` / `null` (legacy) restent inchangés (backward compat testé).
- **Rollback** : revert commits `cf4eecb` + `e86b34a` si comportement inattendu détecté en prod.
- **Migration 0115** déjà appliquée en DB par utilisateur (manuel) — pas de risk migration ici.

## Roadmap suivante (PRs #3 à #6, ouvertes après merge)

- **PR #3** UI Gainers config panel (~150 LoC) — dépanneau complet de tous les paramètres `gainers_*` dans la carte `/lisa`
- **PR #4** pWin scanner gate (~150 LoC) — branche `estimateProbability` du modèle ML logistique entraîné weekly dans la cascade de gates scanner
- **PR #5** AutoTuner Phase C minimal (~250 LoC) — cron daily 03:00 UTC qui lit FP-rate par gate, propose ajustements seuils, applique avec garde-fous + rollback auto
- **PR #6** UI dashboard auto-learning (~200 LoC) — page `/lisa/gainers/insights` (4 panels : ML state, FP-rates, drift events, AutoTuner history)

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_