### PR TITLE
feat(gainers): PR #4+#5+#6 — Auto-learning loop fermée + dashboard UI (10/10 steps)

### DIFF
--- a/apps/api/src/modules/admin/admin-threshold-tuner.controller.ts
+++ b/apps/api/src/modules/admin/admin-threshold-tuner.controller.ts
@@ -1,0 +1,152 @@
+/**
+ * /admin/gainers/auto-tuner — PR #5 AutoTuner Phase C endpoints.
+ *
+ * GET  /admin/gainers/auto-tuner/history?portfolioId=X&limit=50
+ *   → liste des ajustements appliqués (audit append-only)
+ * POST /admin/gainers/auto-tuner/rollback
+ *   body { portfolioId, thresholdName, reason? }
+ *   → rollback manuel à la valeur old_value du dernier ajustement
+ * POST /admin/gainers/auto-tuner/run-now
+ *   → déclenche manuellement le cycle (debug / fast iteration)
+ *
+ * Auth via x-admin-token.
+ */
+
+import {
+  Body,
+  Controller,
+  Get,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../supabase/supabase.service';
+import { ThresholdAutoTunerService } from '../gainers-scanner/automations/threshold-auto-tuner.service';
+
+@Controller('admin/gainers/auto-tuner')
+export class AdminThresholdTunerController {
+  constructor(
+    private readonly tuner: ThresholdAutoTunerService,
+    private readonly supabase: SupabaseService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Get('history')
+  async history(
+    @Headers('x-admin-token') token: string | undefined,
+    @Query('portfolioId') portfolioId?: string,
+    @Query('limit') limitStr?: string,
+  ) {
+    this.assertAdmin(token);
+    const limit = Math.min(Math.max(Number(limitStr) || 50, 1), 500);
+    let query = this.supabase
+      .getClient()
+      .from('gainers_threshold_history')
+      .select('*')
+      .order('applied_at', { ascending: false })
+      .limit(limit);
+    if (portfolioId) query = query.eq('portfolio_id', portfolioId);
+    const { data, error } = await query;
+    if (error) {
+      throw new HttpException(
+        { message: error.message, code: 'DB_ERROR' },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+    return { rows: data ?? [], kill_switch_active: this.tuner.isKillSwitchActive() };
+  }
+
+  @Post('rollback')
+  async rollback(
+    @Headers('x-admin-token') token: string | undefined,
+    @Body() body: { portfolioId?: string; thresholdName?: string; reason?: string },
+  ) {
+    this.assertAdmin(token);
+    const { portfolioId, thresholdName, reason } = body;
+    if (!portfolioId || !thresholdName) {
+      throw new HttpException(
+        { message: 'portfolioId + thresholdName required', code: 'BAD_INPUT' },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // Trouve le dernier ajustement appliqué (qui a déjà appliqué = env != shadow)
+    const { data: rows, error } = await this.supabase
+      .getClient()
+      .from('gainers_threshold_history')
+      .select('*')
+      .eq('portfolio_id', portfolioId)
+      .eq('threshold_name', thresholdName)
+      .neq('applied_to_env', 'shadow')
+      .order('applied_at', { ascending: false })
+      .limit(1);
+    if (error || !rows || rows.length === 0) {
+      throw new HttpException(
+        { message: 'No applied adjustment found to rollback', code: 'NOT_FOUND' },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+    const last = rows[0];
+    const restoredValue = Number(last.old_value);
+
+    // Update config + write rollback history row
+    const { error: updErr } = await this.supabase
+      .getClient()
+      .from('lisa_session_configs')
+      .update({ [thresholdName]: restoredValue })
+      .eq('portfolio_id', portfolioId);
+    if (updErr) {
+      throw new HttpException(
+        { message: updErr.message, code: 'DB_ERROR' },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+    await this.supabase.getClient().from('gainers_threshold_history').insert({
+      portfolio_id: portfolioId,
+      threshold_name: thresholdName,
+      old_value: String(last.new_value),
+      new_value: String(restoredValue),
+      reason: 'rollback',
+      sample_size: 0,
+      applied_to_env: String(last.applied_to_env),
+      auto_or_manual: 'manual',
+    });
+
+    return {
+      restored_value: restoredValue,
+      from_value: Number(last.new_value),
+      original_reason: reason ?? null,
+      original_history_id: String(last.id),
+    };
+  }
+
+  @Post('run-now')
+  async runNow(@Headers('x-admin-token') token: string | undefined) {
+    this.assertAdmin(token);
+    if (this.tuner.isKillSwitchActive()) {
+      return { triggered: false, reason: 'kill_switch_active' };
+    }
+    // Best-effort : on déclenche le cycle async sans attendre (cron fait ainsi).
+    void this.tuner.runAutoTuneCycle();
+    return { triggered: true };
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (providedToken !== expected) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'ADMIN_FORBIDDEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -33,6 +33,7 @@ import { AdminShadowDailyReportController } from './admin-shadow-daily-report.co
 import { AdminGainersSeedUniverseController } from './admin-gainers-seed-universe.controller';
 import { AdminGainersInsightsController } from './admin-gainers-insights.controller';
 import { AdminRejectedInsightsController } from './admin-rejected-insights.controller';
+import { AdminThresholdTunerController } from './admin-threshold-tuner.controller';
 
 @Module({
   imports: [SupabaseModule, forwardRef(() => LisaModule), GainersModule],
@@ -50,6 +51,7 @@ import { AdminRejectedInsightsController } from './admin-rejected-insights.contr
     AdminGainersSeedUniverseController,
     AdminGainersInsightsController,
     AdminRejectedInsightsController,
+    AdminThresholdTunerController,
   ],
 })
 export class AdminModule {}

--- a/apps/api/src/modules/gainers-scanner/__tests__/threshold-auto-tuner.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/threshold-auto-tuner.spec.ts
@@ -1,0 +1,316 @@
+/**
+ * PR #5 — Tests ThresholdAutoTunerService.
+ *
+ * Couvre :
+ *   - computeSuggestions logique pure (sans I/O)
+ *     · REJECT-side : fp_rate > 0.20 → assouplit
+ *     · ACCEPT-side : failure_rate > 0.30 → resserre
+ *     · n < 50 → skip (insufficient_data)
+ *     · status='insufficient_data' → skip
+ *     · clamp dans bracket ADR-005
+ *     · effective delta < 1% (clamp absorbe) → skip
+ *   - kill-switch env GAINERS_AUTO_TUNER_KILL_SWITCH
+ */
+
+import { ThresholdAutoTunerService } from '../automations/threshold-auto-tuner.service';
+
+interface FpRateStats {
+  total: number;
+  champions: number;
+  failures: number;
+  neutral: number;
+  pending_outcome: number;
+  fp_rate: number | null;
+  failure_rate: number | null;
+  avg_return_72h: number | null;
+  samples_top_missed: Array<{ symbol: string; return_72h: number; rejected_at: string }>;
+  status: 'ok' | 'insufficient_data';
+}
+
+function makeStats(opts: Partial<FpRateStats>): FpRateStats {
+  return {
+    total: 100,
+    champions: 0,
+    failures: 0,
+    neutral: 0,
+    pending_outcome: 0,
+    fp_rate: null,
+    failure_rate: null,
+    avg_return_72h: null,
+    samples_top_missed: [],
+    status: 'ok',
+    ...opts,
+  };
+}
+
+function makeService(envKillSwitch: string = 'false'): ThresholdAutoTunerService {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const supabase: any = { getClient: () => ({}) };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rejected: any = {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const insights: any = { logInsight: jest.fn() };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const config: any = { get: (k: string) => (k === 'GAINERS_AUTO_TUNER_KILL_SWITCH' ? envKillSwitch : undefined) };
+  return new ThresholdAutoTunerService(supabase, rejected, insights, config);
+}
+
+describe('ThresholdAutoTunerService.computeSuggestions', () => {
+  it('REJECT-side : fp_rate > 0.20 sur PERSISTENCE → propose -5%', () => {
+    const svc = makeService();
+    const fpRate = {
+      by_reason: {
+        PERSISTENCE_BELOW_THRESHOLD: makeStats({ fp_rate: 0.25, total: 100, champions: 25 }),
+      },
+      accept_stats: makeStats({ status: 'insufficient_data' }),
+      global_fp_rate: 0.25,
+      global_failure_rate: null,
+      env_tag: 'shadow',
+      since_days: 14,
+      min_samples: 50,
+    };
+    const portfolio = {
+      portfolio_id: 'p1',
+      gainers_auto_tuner_env: 'shadow' as const,
+      gainers_min_persistence_score: 0.67,
+      gainers_min_path_efficiency: 0.5,
+    };
+    const suggestions = svc.computeSuggestions(portfolio, fpRate);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].thresholdName).toBe('gainers_min_persistence_score');
+    expect(suggestions[0].oldValue).toBe(0.67);
+    expect(suggestions[0].newValue).toBeCloseTo(0.637, 3); // 0.67 × 0.95
+    expect(suggestions[0].reason).toBe('fp_rate_too_high');
+  });
+
+  it('REJECT-side : fp_rate sur PATH_EFFICIENCY_LOW → propose path -5%', () => {
+    const svc = makeService();
+    const fpRate = {
+      by_reason: {
+        PATH_EFFICIENCY_LOW: makeStats({ fp_rate: 0.30, total: 80, champions: 24 }),
+      },
+      accept_stats: makeStats({ status: 'insufficient_data' }),
+      global_fp_rate: 0.30,
+      global_failure_rate: null,
+      env_tag: 'shadow',
+      since_days: 14,
+      min_samples: 50,
+    };
+    const portfolio = {
+      portfolio_id: 'p2',
+      gainers_auto_tuner_env: 'shadow' as const,
+      gainers_min_persistence_score: 0.67,
+      gainers_min_path_efficiency: 0.5,
+    };
+    const suggestions = svc.computeSuggestions(portfolio, fpRate);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].thresholdName).toBe('gainers_min_path_efficiency');
+    expect(suggestions[0].newValue).toBeCloseTo(0.475, 3); // 0.5 × 0.95
+  });
+
+  it('ACCEPT-side : failure_rate > 0.30 → resserre persistence +5%', () => {
+    const svc = makeService();
+    const fpRate = {
+      by_reason: {},
+      accept_stats: makeStats({
+        status: 'ok',
+        total: 100,
+        failures: 35,
+        failure_rate: 0.35,
+      }),
+      global_fp_rate: null,
+      global_failure_rate: 0.35,
+      env_tag: 'shadow',
+      since_days: 14,
+      min_samples: 50,
+    };
+    const portfolio = {
+      portfolio_id: 'p3',
+      gainers_auto_tuner_env: 'shadow' as const,
+      gainers_min_persistence_score: 0.67,
+      gainers_min_path_efficiency: 0.5,
+    };
+    const suggestions = svc.computeSuggestions(portfolio, fpRate);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].thresholdName).toBe('gainers_min_persistence_score');
+    expect(suggestions[0].newValue).toBeCloseTo(0.704, 3); // 0.67 × 1.05
+    expect(suggestions[0].reason).toBe('failure_rate_too_high');
+  });
+
+  it('skip si total < 50 (MIN_SAMPLES)', () => {
+    const svc = makeService();
+    const fpRate = {
+      by_reason: {
+        PERSISTENCE_BELOW_THRESHOLD: makeStats({ fp_rate: 0.30, total: 30, champions: 9 }),
+      },
+      accept_stats: makeStats({ status: 'insufficient_data' }),
+      global_fp_rate: 0.30,
+      global_failure_rate: null,
+      env_tag: 'shadow',
+      since_days: 14,
+      min_samples: 50,
+    };
+    const portfolio = {
+      portfolio_id: 'p4',
+      gainers_auto_tuner_env: 'shadow' as const,
+      gainers_min_persistence_score: 0.67,
+      gainers_min_path_efficiency: 0.5,
+    };
+    const suggestions = svc.computeSuggestions(portfolio, fpRate);
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it('skip si status=insufficient_data même avec total ≥ 50', () => {
+    const svc = makeService();
+    const fpRate = {
+      by_reason: {
+        PERSISTENCE_BELOW_THRESHOLD: makeStats({ status: 'insufficient_data', total: 100 }),
+      },
+      accept_stats: makeStats({ status: 'insufficient_data' }),
+      global_fp_rate: null,
+      global_failure_rate: null,
+      env_tag: 'shadow',
+      since_days: 14,
+      min_samples: 50,
+    };
+    const portfolio = {
+      portfolio_id: 'p5',
+      gainers_auto_tuner_env: 'shadow' as const,
+      gainers_min_persistence_score: 0.67,
+      gainers_min_path_efficiency: 0.5,
+    };
+    expect(svc.computeSuggestions(portfolio, fpRate)).toHaveLength(0);
+  });
+
+  it('skip si threshold absent du portfolio config', () => {
+    const svc = makeService();
+    const fpRate = {
+      by_reason: {
+        PERSISTENCE_BELOW_THRESHOLD: makeStats({ fp_rate: 0.30, total: 100, champions: 30 }),
+      },
+      accept_stats: makeStats({ status: 'insufficient_data' }),
+      global_fp_rate: 0.30,
+      global_failure_rate: null,
+      env_tag: 'shadow',
+      since_days: 14,
+      min_samples: 50,
+    };
+    const portfolio = {
+      portfolio_id: 'p6',
+      gainers_auto_tuner_env: 'shadow' as const,
+      gainers_min_persistence_score: null, // pas configuré
+      gainers_min_path_efficiency: 0.5,
+    };
+    expect(svc.computeSuggestions(portfolio, fpRate)).toHaveLength(0);
+  });
+
+  it('clamp inférieur ADR-005 : persistence ne descend pas sous 0.5', () => {
+    const svc = makeService();
+    const fpRate = {
+      by_reason: {
+        PERSISTENCE_BELOW_THRESHOLD: makeStats({ fp_rate: 0.40, total: 100, champions: 40 }),
+      },
+      accept_stats: makeStats({ status: 'insufficient_data' }),
+      global_fp_rate: 0.40,
+      global_failure_rate: null,
+      env_tag: 'shadow',
+      since_days: 14,
+      min_samples: 50,
+    };
+    const portfolio = {
+      portfolio_id: 'p7',
+      gainers_auto_tuner_env: 'shadow' as const,
+      gainers_min_persistence_score: 0.51, // proche du floor 0.5
+      gainers_min_path_efficiency: 0.5,
+    };
+    // 0.51 × 0.95 = 0.4845 → clamp à 0.5 → effectiveDelta = 0.01/0.51 = 1.96% > 1% → keep
+    const suggestions = svc.computeSuggestions(portfolio, fpRate);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].newValue).toBe(0.5); // clamped
+  });
+
+  it('skip si delta effectif < 1% après clamp (mouvement insignifiant)', () => {
+    const svc = makeService();
+    const fpRate = {
+      by_reason: {
+        PERSISTENCE_BELOW_THRESHOLD: makeStats({ fp_rate: 0.30, total: 100, champions: 30 }),
+      },
+      accept_stats: makeStats({ status: 'insufficient_data' }),
+      global_fp_rate: 0.30,
+      global_failure_rate: null,
+      env_tag: 'shadow',
+      since_days: 14,
+      min_samples: 50,
+    };
+    const portfolio = {
+      portfolio_id: 'p8',
+      gainers_auto_tuner_env: 'shadow' as const,
+      gainers_min_persistence_score: 0.502, // very close to floor 0.5
+      gainers_min_path_efficiency: 0.5,
+    };
+    // 0.502 × 0.95 = 0.477 → clamp 0.5 → effectiveDelta = 0.002/0.502 = 0.4% < 1%
+    const suggestions = svc.computeSuggestions(portfolio, fpRate);
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it('REJECT-side OK : fp_rate ≤ 0.20 → pas de suggestion', () => {
+    const svc = makeService();
+    const fpRate = {
+      by_reason: {
+        PERSISTENCE_BELOW_THRESHOLD: makeStats({ fp_rate: 0.18, total: 100, champions: 18 }),
+      },
+      accept_stats: makeStats({ status: 'insufficient_data' }),
+      global_fp_rate: 0.18,
+      global_failure_rate: null,
+      env_tag: 'shadow',
+      since_days: 14,
+      min_samples: 50,
+    };
+    const portfolio = {
+      portfolio_id: 'p9',
+      gainers_auto_tuner_env: 'shadow' as const,
+      gainers_min_persistence_score: 0.67,
+      gainers_min_path_efficiency: 0.5,
+    };
+    expect(svc.computeSuggestions(portfolio, fpRate)).toHaveLength(0);
+  });
+
+  it('combinaison : REJECT-side persistence + ACCEPT-side persistence → 2 suggestions', () => {
+    const svc = makeService();
+    const fpRate = {
+      by_reason: {
+        PERSISTENCE_BELOW_THRESHOLD: makeStats({ fp_rate: 0.25, total: 100, champions: 25 }),
+      },
+      accept_stats: makeStats({ status: 'ok', total: 100, failures: 35, failure_rate: 0.35 }),
+      global_fp_rate: 0.25,
+      global_failure_rate: 0.35,
+      env_tag: 'shadow',
+      since_days: 14,
+      min_samples: 50,
+    };
+    const portfolio = {
+      portfolio_id: 'p10',
+      gainers_auto_tuner_env: 'shadow' as const,
+      gainers_min_persistence_score: 0.67,
+      gainers_min_path_efficiency: 0.5,
+    };
+    const suggestions = svc.computeSuggestions(portfolio, fpRate);
+    expect(suggestions).toHaveLength(2);
+    expect(suggestions[0].reason).toBe('fp_rate_too_high');
+    expect(suggestions[1].reason).toBe('failure_rate_too_high');
+  });
+});
+
+describe('ThresholdAutoTunerService.isKillSwitchActive', () => {
+  it('false par défaut', () => {
+    expect(makeService('false').isKillSwitchActive()).toBe(false);
+  });
+
+  it('true si env GAINERS_AUTO_TUNER_KILL_SWITCH=true', () => {
+    expect(makeService('true').isKillSwitchActive()).toBe(true);
+  });
+
+  it('case-insensitive : "TRUE" → true', () => {
+    expect(makeService('TRUE').isKillSwitchActive()).toBe(true);
+  });
+});

--- a/apps/api/src/modules/gainers-scanner/automations/threshold-auto-tuner.service.ts
+++ b/apps/api/src/modules/gainers-scanner/automations/threshold-auto-tuner.service.ts
@@ -1,0 +1,368 @@
+/**
+ * PR #5 — ThresholdAutoTunerService (Phase C minimal).
+ *
+ * Boucle d'apprentissage active : lit FP-rate par gate × env_tag depuis
+ * gainers_signal_forward (RCFT data), propose des ajustements de seuils,
+ * applique avec garde-fous, audite via gainers_threshold_history.
+ *
+ * Cron daily 03:00 UTC. Activable par portfolio via flags :
+ *   - lisa_session_configs.gainers_auto_tuner_enabled (default false)
+ *   - lisa_session_configs.gainers_auto_tuner_env ('shadow' | 'canary' | 'prod')
+ *
+ * Logique suggestion :
+ *   - REJECT-side (gate trop strict) : fp_rate > FP_HIGH_THRESHOLD (0.20)
+ *     champions/(total REJECT) > 20% = on rejette trop de bons trades
+ *     → suggère -5% sur le seuil (assouplir)
+ *   - ACCEPT-side (gate trop laxiste) : failure_rate > FAILURE_HIGH (0.30)
+ *     failures/(total ACCEPT) > 30% = on ouvre trop de mauvais trades
+ *     → suggère +5% sur le seuil (resserrer)
+ *
+ * Garde-fous :
+ *   - min_samples = 50 (pas d'ajustement sur n<50)
+ *   - cap mouvement ±5% par run, ±20% sur 30j (lookup history)
+ *   - anti-flap : 1 seul ajustement par (portfolio, threshold) par 7j
+ *   - bracket : seuils respectent floors ADR-005 (persistence ∈ [0.5, 1.0],
+ *     path_eff ∈ [0.3, 0.9])
+ *   - kill-switch global : env GAINERS_AUTO_TUNER_KILL_SWITCH=true → pause
+ *
+ * Scope minimal MVP : 2 seuils ajustables (persistence_score + path_efficiency).
+ * Les autres seuils (liquidity/mcap/volatility) sont hardcodés au niveau
+ * Bloc 1 prefilter-gates.ts ADR-005 §1bis lock — modification = code change
+ * + nouvelle migration ALTER TABLE pour exposer per-portfolio.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { RejectedInsightsService } from './rejected-insights.service';
+import { GainersInsightsService } from '../insights/gainers-insights.service';
+
+/** FP-rate ≥ ce seuil = gate trop strict (rejette trop de champions). */
+const FP_HIGH_THRESHOLD = 0.20;
+/** Failure-rate ≥ ce seuil = gate trop laxiste (accepte trop de failures). */
+const FAILURE_HIGH_THRESHOLD = 0.30;
+/** Magnitude de l'ajustement (±5% relatif). */
+const TUNE_MAGNITUDE = 0.05;
+/** Cap mouvement cumulé sur 30j (anti-drift incontrôlé). */
+const CAP_30D_MAGNITUDE = 0.20;
+/** Sample minimum pour décider (sinon insufficient_data → skip). */
+const MIN_SAMPLES = 50;
+/** Anti-flap : pas plus d'1 ajustement par (portfolio, threshold) par N jours. */
+const ANTI_FLAP_DAYS = 7;
+/** Brackets ADR-005 : valeurs absolues plancher/plafond par seuil. */
+const THRESHOLD_BRACKETS: Record<string, { min: number; max: number }> = {
+  gainers_min_persistence_score: { min: 0.5, max: 1.0 },
+  gainers_min_path_efficiency: { min: 0.3, max: 0.9 },
+};
+/** Mapping reject_reason → colonne lisa_session_configs. */
+const REJECT_REASON_TO_THRESHOLD: Record<string, string> = {
+  PERSISTENCE_BELOW_THRESHOLD: 'gainers_min_persistence_score',
+  PATH_EFFICIENCY_LOW: 'gainers_min_path_efficiency',
+};
+
+interface PortfolioConfig {
+  portfolio_id: string;
+  gainers_auto_tuner_env: 'shadow' | 'canary' | 'prod' | null;
+  gainers_min_persistence_score: number | null;
+  gainers_min_path_efficiency: number | null;
+}
+
+interface TuneSuggestion {
+  thresholdName: string;
+  oldValue: number;
+  newValue: number;
+  reason: 'fp_rate_too_high' | 'failure_rate_too_high';
+  fpRateObserved: number | null;
+  failureRateObserved: number | null;
+  sampleSize: number;
+}
+
+@Injectable()
+export class ThresholdAutoTunerService {
+  private readonly logger = new Logger(ThresholdAutoTunerService.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly rejected: RejectedInsightsService,
+    private readonly insights: GainersInsightsService,
+    private readonly config: ConfigService,
+  ) {}
+
+  /** Cron daily 03:00 UTC strict. */
+  @Cron('0 3 * * *', { timeZone: 'UTC' })
+  async runAutoTuneCycle(): Promise<void> {
+    if (this.isKillSwitchActive()) {
+      this.logger.log('[auto-tuner] GAINERS_AUTO_TUNER_KILL_SWITCH=true — cron skipped');
+      return;
+    }
+    try {
+      await this.runInner();
+    } catch (e) {
+      this.logger.error(`[auto-tuner] cron failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  isKillSwitchActive(): boolean {
+    return (this.config.get<string>('GAINERS_AUTO_TUNER_KILL_SWITCH') ?? 'false').toLowerCase() === 'true';
+  }
+
+  private async runInner(): Promise<void> {
+    const portfolios = await this.loadEnabledPortfolios();
+    if (portfolios.length === 0) {
+      this.logger.log('[auto-tuner] no portfolio with gainers_auto_tuner_enabled=true');
+      return;
+    }
+
+    let totalApplied = 0;
+    let totalSkipped = 0;
+
+    for (const portfolio of portfolios) {
+      const env = portfolio.gainers_auto_tuner_env ?? 'shadow';
+      const fpRate = await this.rejected.getFalsePositiveRate({
+        envTag: env,
+        sinceDays: 14,
+        minSamples: MIN_SAMPLES,
+      }).catch((e) => {
+        this.logger.warn(`[auto-tuner] FP-rate fetch failed for ${portfolio.portfolio_id.slice(0, 8)}: ${String(e).slice(0, 100)}`);
+        return null;
+      });
+      if (!fpRate) continue;
+
+      const suggestions = this.computeSuggestions(portfolio, fpRate);
+      for (const sugg of suggestions) {
+        const blocked = await this.checkAntiFlap(portfolio.portfolio_id, sugg.thresholdName);
+        if (blocked) {
+          totalSkipped++;
+          this.logger.log(
+            `[auto-tuner] ${portfolio.portfolio_id.slice(0, 8)} ${sugg.thresholdName}: anti-flap (ajusté < ${ANTI_FLAP_DAYS}j) → skip`,
+          );
+          continue;
+        }
+        const cap = await this.checkCap30d(portfolio.portfolio_id, sugg.thresholdName, sugg);
+        if (cap.blocked) {
+          totalSkipped++;
+          this.logger.log(
+            `[auto-tuner] ${portfolio.portfolio_id.slice(0, 8)} ${sugg.thresholdName}: cap 30j atteint (${cap.cumulativePct.toFixed(2)}) → skip`,
+          );
+          continue;
+        }
+        await this.applySuggestion(portfolio.portfolio_id, sugg, env);
+        totalApplied++;
+      }
+    }
+
+    this.logger.log(
+      `[auto-tuner] cycle complete: applied=${totalApplied} skipped=${totalSkipped} portfolios=${portfolios.length}`,
+    );
+  }
+
+  /**
+   * Pure helper exposé pour tests : compute suggestions à partir de fpRate
+   * stats déjà fetched + portfolio config courante. Pas d'I/O.
+   */
+  computeSuggestions(
+    portfolio: PortfolioConfig,
+    fpRate: Awaited<ReturnType<RejectedInsightsService['getFalsePositiveRate']>>,
+  ): TuneSuggestion[] {
+    const out: TuneSuggestion[] = [];
+
+    for (const [rejectReason, thresholdName] of Object.entries(REJECT_REASON_TO_THRESHOLD)) {
+      const stats = fpRate.by_reason[rejectReason];
+      if (!stats || stats.status !== 'ok') continue;
+      if (stats.total < MIN_SAMPLES) continue;
+
+      const currentValue = (portfolio as unknown as Record<string, number | null>)[thresholdName];
+      if (currentValue == null) continue;
+
+      // REJECT-side : si fp_rate > seuil, gate trop strict → assouplir (-5%)
+      if (stats.fp_rate != null && stats.fp_rate > FP_HIGH_THRESHOLD) {
+        const suggestion = this.proposeAdjustment(thresholdName, currentValue, -TUNE_MAGNITUDE);
+        if (suggestion != null) {
+          out.push({
+            thresholdName,
+            oldValue: currentValue,
+            newValue: suggestion,
+            reason: 'fp_rate_too_high',
+            fpRateObserved: stats.fp_rate,
+            failureRateObserved: null,
+            sampleSize: stats.total,
+          });
+        }
+      }
+    }
+
+    // ACCEPT-side : failures in accept stats. Suggère resserrer le seuil
+    // dominant (heuristique simple : on bumps le persistence_score qui est
+    // le gate principal éligible avant ouverture).
+    const accept = fpRate.accept_stats;
+    if (
+      accept.status === 'ok'
+      && accept.total >= MIN_SAMPLES
+      && accept.failure_rate != null
+      && accept.failure_rate > FAILURE_HIGH_THRESHOLD
+    ) {
+      const currentValue = portfolio.gainers_min_persistence_score;
+      if (currentValue != null) {
+        const suggestion = this.proposeAdjustment(
+          'gainers_min_persistence_score',
+          currentValue,
+          +TUNE_MAGNITUDE,
+        );
+        if (suggestion != null) {
+          out.push({
+            thresholdName: 'gainers_min_persistence_score',
+            oldValue: currentValue,
+            newValue: suggestion,
+            reason: 'failure_rate_too_high',
+            fpRateObserved: null,
+            failureRateObserved: accept.failure_rate,
+            sampleSize: accept.total,
+          });
+        }
+      }
+    }
+
+    return out;
+  }
+
+  /** Calcule new = current × (1 + delta), clamp dans bracket ADR-005. */
+  private proposeAdjustment(
+    thresholdName: string,
+    currentValue: number,
+    delta: number,
+  ): number | null {
+    const bracket = THRESHOLD_BRACKETS[thresholdName];
+    if (!bracket) return null;
+    const proposed = currentValue * (1 + delta);
+    const clamped = Math.max(bracket.min, Math.min(bracket.max, proposed));
+    // Skip si delta effectif < 1% (clamp absorbe tout le mouvement)
+    const effectiveDelta = Math.abs(clamped - currentValue) / currentValue;
+    if (effectiveDelta < 0.01) return null;
+    return Math.round(clamped * 1000) / 1000; // 3 décimales
+  }
+
+  private async checkAntiFlap(portfolioId: string, thresholdName: string): Promise<boolean> {
+    const sinceIso = new Date(Date.now() - ANTI_FLAP_DAYS * 24 * 3600_000).toISOString();
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('gainers_threshold_history')
+      .select('id')
+      .eq('portfolio_id', portfolioId)
+      .eq('threshold_name', thresholdName)
+      .gte('applied_at', sinceIso)
+      .limit(1);
+    if (error) {
+      this.logger.warn(`[auto-tuner] checkAntiFlap query failed: ${error.message}`);
+      return false; // fail-open : on laisse passer plutôt que bloquer
+    }
+    return (data ?? []).length > 0;
+  }
+
+  private async checkCap30d(
+    portfolioId: string,
+    thresholdName: string,
+    sugg: TuneSuggestion,
+  ): Promise<{ blocked: boolean; cumulativePct: number }> {
+    const sinceIso = new Date(Date.now() - 30 * 24 * 3600_000).toISOString();
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('gainers_threshold_history')
+      .select('old_value, new_value')
+      .eq('portfolio_id', portfolioId)
+      .eq('threshold_name', thresholdName)
+      .gte('applied_at', sinceIso);
+    if (error) {
+      this.logger.warn(`[auto-tuner] checkCap30d query failed: ${error.message}`);
+      return { blocked: false, cumulativePct: 0 };
+    }
+    let cumulativePct = 0;
+    for (const row of data ?? []) {
+      const old_v = Number(row.old_value);
+      const new_v = Number(row.new_value);
+      if (old_v > 0) cumulativePct += Math.abs(new_v - old_v) / old_v;
+    }
+    // Inclut la suggestion en cours pour décision
+    const proposedDelta = Math.abs(sugg.newValue - sugg.oldValue) / sugg.oldValue;
+    cumulativePct += proposedDelta;
+    return {
+      blocked: cumulativePct > CAP_30D_MAGNITUDE,
+      cumulativePct,
+    };
+  }
+
+  private async applySuggestion(
+    portfolioId: string,
+    sugg: TuneSuggestion,
+    env: 'shadow' | 'canary' | 'prod',
+  ): Promise<void> {
+    // 1. Update lisa_session_configs (sauf en shadow où on log uniquement)
+    if (env !== 'shadow') {
+      const { error: updErr } = await this.supabase
+        .getClient()
+        .from('lisa_session_configs')
+        .update({ [sugg.thresholdName]: sugg.newValue })
+        .eq('portfolio_id', portfolioId);
+      if (updErr) {
+        this.logger.warn(`[auto-tuner] update threshold failed: ${updErr.message}`);
+        return;
+      }
+    }
+
+    // 2. Append to history (audit append-only, toujours écrit même en shadow)
+    const { error: histErr } = await this.supabase.getClient().from('gainers_threshold_history').insert({
+      portfolio_id: portfolioId,
+      threshold_name: sugg.thresholdName,
+      old_value: String(sugg.oldValue),
+      new_value: String(sugg.newValue),
+      reason: sugg.reason,
+      fp_rate_observed: sugg.fpRateObserved != null ? String(sugg.fpRateObserved) : null,
+      failure_rate_observed: sugg.failureRateObserved != null ? String(sugg.failureRateObserved) : null,
+      sample_size: sugg.sampleSize,
+      applied_to_env: env,
+      auto_or_manual: 'auto',
+    });
+    if (histErr) {
+      this.logger.warn(`[auto-tuner] history insert failed: ${histErr.message}`);
+    }
+
+    // 3. Log insight pour visibility user dashboard
+    await this.insights.logInsight({
+      type: 'threshold_proposal',
+      source: 'auto_threshold_tuner',
+      severity: env === 'prod' ? 'medium' : 'low',
+      summary: `${sugg.thresholdName} ${sugg.oldValue.toFixed(3)} → ${sugg.newValue.toFixed(3)} (${sugg.reason}, env=${env})`,
+      payload: {
+        portfolio_id: portfolioId,
+        threshold_name: sugg.thresholdName,
+        old_value: sugg.oldValue,
+        new_value: sugg.newValue,
+        reason: sugg.reason,
+        fp_rate_observed: sugg.fpRateObserved,
+        failure_rate_observed: sugg.failureRateObserved,
+        sample_size: sugg.sampleSize,
+        applied_to_env: env,
+      },
+    }).catch(() => { /* non-bloquant */ });
+
+    this.logger.log(
+      `[auto-tuner] ${portfolioId.slice(0, 8)} ${sugg.thresholdName}: ${sugg.oldValue.toFixed(3)} → ${sugg.newValue.toFixed(3)} (env=${env}, reason=${sugg.reason}, n=${sugg.sampleSize})`,
+    );
+  }
+
+  private async loadEnabledPortfolios(): Promise<PortfolioConfig[]> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('lisa_session_configs')
+      .select('portfolio_id, gainers_auto_tuner_env, gainers_min_persistence_score, gainers_min_path_efficiency')
+      .eq('gainers_auto_tuner_enabled', true)
+      .eq('strategy_mode', 'gainers')
+      .eq('autopilot_enabled', true)
+      .eq('kill_switch_active', false);
+    if (error) {
+      this.logger.warn(`[auto-tuner] loadEnabledPortfolios failed: ${error.message}`);
+      return [];
+    }
+    return (data ?? []) as PortfolioConfig[];
+  }
+}

--- a/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
+++ b/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
@@ -16,6 +16,7 @@ import { ModePresetsService } from './presets/mode-presets.service';
 import { GainersInsightsService } from './insights/gainers-insights.service';
 import { DriftDetectorService } from './automations/drift-detector.service';
 import { RejectedInsightsService } from './automations/rejected-insights.service';
+import { ThresholdAutoTunerService } from './automations/threshold-auto-tuner.service';
 
 /**
  * ADR-005 Gainers Algo V1 — Module NestJS découplé (ADR-006).
@@ -46,6 +47,10 @@ import { RejectedInsightsService } from './automations/rejected-insights.service
     DriftDetectorService,
     // PR6.8 RCFT — FP-rate par reject_reason × env_tag (input AutoTuner Phase C V2)
     RejectedInsightsService,
+    // PR #5 — AutoTuner Phase C : cron daily 03:00 UTC qui consomme FP-rate
+    // pour ajuster automatiquement les seuils gainers_min_persistence_score
+    // et gainers_min_path_efficiency. Ferme la boucle d'apprentissage.
+    ThresholdAutoTunerService,
   ],
   exports: [
     GainersBloc1Service,
@@ -62,6 +67,7 @@ import { RejectedInsightsService } from './automations/rejected-insights.service
     ModePresetsService,
     GainersInsightsService,
     RejectedInsightsService,
+    ThresholdAutoTunerService,
   ],
 })
 export class GainersModule implements OnModuleInit {

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
@@ -37,6 +37,7 @@ function makeService(): TopGainersScannerService {
   mockConfig.get.mockImplementation((key: string) => (key === 'SCAN_INTERVAL_MINUTES' ? '15' : undefined));
   return new TopGainersScannerService(
     mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    { estimateProbability: async () => ({ pWin: 0.5, confidence: 0, sampleSize: 0, modelVersion: "none", fallback: true }) } as any,
   );
 }
 
@@ -319,6 +320,7 @@ describe('P20a — NON_EU_EXCHANGES registry correctness', () => {
     });
     return new TopGainersScannerService(
       mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    { estimateProbability: async () => ({ pWin: 0.5, confidence: 0, sampleSize: 0, modelVersion: "none", fallback: true }) } as any,
     );
   }
 
@@ -350,6 +352,7 @@ describe('P20a — NON_EU_EXCHANGES registry correctness', () => {
     } as any;
     const svc = new TopGainersScannerService(
       supabaseMock, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    { estimateProbability: async () => ({ pWin: 0.5, confidence: 0, sampleSize: 0, modelVersion: "none", fallback: true }) } as any,
     );
     capturedUrls = [];
     // fetchAllCandidates without EU (EU sessions closed)

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eu-session.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eu-session.spec.ts
@@ -42,6 +42,7 @@ function makeService(): TopGainersScannerService {
   });
   return new TopGainersScannerService(
     mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    { estimateProbability: async () => ({ pWin: 0.5, confidence: 0, sampleSize: 0, modelVersion: "none", fallback: true }) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.llm.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.llm.spec.ts
@@ -56,6 +56,7 @@ function makeService(llmRouter: ScannerLlmRouterService): TopGainersScannerServi
     mockMtf,
     llmRouter,
     { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    { estimateProbability: async () => ({ pWin: 0.5, confidence: 0, sampleSize: 0, modelVersion: "none", fallback: true }) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.multi-exchange.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.multi-exchange.spec.ts
@@ -43,6 +43,7 @@ function makeService(): TopGainersScannerService {
   mockConfig.get.mockImplementation((key: string) => (key === 'SCAN_INTERVAL_MINUTES' ? '15' : undefined));
   return new TopGainersScannerService(
     mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    { estimateProbability: async () => ({ pWin: 0.5, confidence: 0, sampleSize: 0, modelVersion: "none", fallback: true }) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p-win-gate.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p-win-gate.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * PR #4 — Tests du pWin gate dans le scanner Gainers.
+ *
+ * Logique pure : on simule la décision du gate selon
+ *   - cfg.gainers_p_win_gate_enabled (on/off)
+ *   - cfg.gainers_min_p_win (threshold)
+ *   - probability.fallback (modèle prêt ou pas)
+ *   - probability.pWin (estimation ML)
+ *
+ * Le scanner DOIT :
+ *   - bypass complet du gate si gate désactivé (default false)
+ *   - bypass si probability.fallback=true (sample insuffisant OU AUC bas)
+ *   - skip candidat si pWin < threshold (gate strict)
+ *   - laisser passer si pWin >= threshold
+ */
+
+interface CfgRow {
+  gainers_p_win_gate_enabled?: boolean;
+  gainers_min_p_win?: number | null;
+}
+
+interface ProbabilityResult {
+  pWin: number;
+  fallback: boolean;
+  modelVersion: string;
+  sampleSize: number;
+}
+
+type Decision = 'pass' | 'skip' | 'gate_disabled' | 'fallback_bypass';
+
+function evaluatePWinGate(
+  cfg: CfgRow,
+  probability: ProbabilityResult | null,
+): Decision {
+  const enabled = cfg.gainers_p_win_gate_enabled === true;
+  if (!enabled) return 'gate_disabled';
+  if (!probability) return 'gate_disabled'; // service down — fail-open
+  if (probability.fallback) return 'fallback_bypass';
+  const minPWin = cfg.gainers_min_p_win != null
+    ? Math.max(0, Math.min(1, Number(cfg.gainers_min_p_win)))
+    : 0.50;
+  return probability.pWin < minPWin ? 'skip' : 'pass';
+}
+
+describe('TopGainersScannerService — pWin gate (PR #4)', () => {
+  describe('Gate ON / OFF', () => {
+    it('disabled by default → bypass', () => {
+      const probability: ProbabilityResult = {
+        pWin: 0.30, // even very low pWin
+        fallback: false,
+        modelVersion: 'v1730000000',
+        sampleSize: 100,
+      };
+      expect(evaluatePWinGate({}, probability)).toBe('gate_disabled');
+    });
+
+    it('explicitly disabled → bypass', () => {
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: false },
+          { pWin: 0.10, fallback: false, modelVersion: 'v1', sampleSize: 100 },
+        ),
+      ).toBe('gate_disabled');
+    });
+
+    it('enabled + good pWin → pass', () => {
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: 0.55 },
+          { pWin: 0.65, fallback: false, modelVersion: 'v1', sampleSize: 100 },
+        ),
+      ).toBe('pass');
+    });
+
+    it('enabled + low pWin → skip', () => {
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: 0.55 },
+          { pWin: 0.40, fallback: false, modelVersion: 'v1', sampleSize: 100 },
+        ),
+      ).toBe('skip');
+    });
+  });
+
+  describe('Fallback bypass (modèle pas prêt)', () => {
+    it('sample insuffisant (n<30) → fallback_bypass', () => {
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: 0.55 },
+          { pWin: 0.50, fallback: true, modelVersion: 'none', sampleSize: 12 },
+        ),
+      ).toBe('fallback_bypass');
+    });
+
+    it('AUC bas (modèle non discriminant) → fallback_bypass', () => {
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: 0.55 },
+          // service.estimateProbability set fallback=true if auc < 0.55
+          { pWin: 0.51, fallback: true, modelVersion: 'v1', sampleSize: 100 },
+        ),
+      ).toBe('fallback_bypass');
+    });
+
+    it('probability service unavailable → gate_disabled (fail-open)', () => {
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: 0.55 },
+          null,
+        ),
+      ).toBe('gate_disabled');
+    });
+  });
+
+  describe('Threshold edge cases', () => {
+    it('pWin = threshold (exact match) → pass (>=)', () => {
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: 0.50 },
+          { pWin: 0.50, fallback: false, modelVersion: 'v1', sampleSize: 100 },
+        ),
+      ).toBe('pass');
+    });
+
+    it('threshold null → fallback default 0.50', () => {
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: null },
+          { pWin: 0.49, fallback: false, modelVersion: 'v1', sampleSize: 100 },
+        ),
+      ).toBe('skip');
+    });
+
+    it('threshold clamp >1 → 1', () => {
+      // No candidate can ever pass a threshold of 1.0
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: 1.5 },
+          { pWin: 0.99, fallback: false, modelVersion: 'v1', sampleSize: 100 },
+        ),
+      ).toBe('skip');
+    });
+
+    it('threshold clamp <0 → 0', () => {
+      // Threshold 0 → tout passe
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: -0.5 },
+          { pWin: 0.01, fallback: false, modelVersion: 'v1', sampleSize: 100 },
+        ),
+      ).toBe('pass');
+    });
+  });
+
+  describe('Scenarios production', () => {
+    it('Phase test (RCFT en cours) — gate enabled but model fallback → bypass automatique', () => {
+      // User active le gate à T+0, mais le modèle a 18 trades fermés (< 30)
+      // → fallback automatique, scanner ne bloque pas (apprentissage continue)
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: 0.55 },
+          { pWin: 0.50, fallback: true, modelVersion: 'none', sampleSize: 18 },
+        ),
+      ).toBe('fallback_bypass');
+    });
+
+    it('Production mature — model converged (n=200, auc=0.71) → gate filtre actif', () => {
+      // Setup A+ accepté
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: 0.55 },
+          { pWin: 0.78, fallback: false, modelVersion: 'v1735000000', sampleSize: 200 },
+        ),
+      ).toBe('pass');
+
+      // Setup B/C rejeté
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: 0.55 },
+          { pWin: 0.42, fallback: false, modelVersion: 'v1735000000', sampleSize: 200 },
+        ),
+      ).toBe('skip');
+    });
+
+    it('Conservative threshold (0.65) — filtre que les très bons setups', () => {
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: 0.65 },
+          { pWin: 0.60, fallback: false, modelVersion: 'v1', sampleSize: 100 },
+        ),
+      ).toBe('skip'); // 60% < 65% threshold conservateur
+
+      expect(
+        evaluatePWinGate(
+          { gainers_p_win_gate_enabled: true, gainers_min_p_win: 0.65 },
+          { pWin: 0.72, fallback: false, modelVersion: 'v1', sampleSize: 100 },
+        ),
+      ).toBe('pass');
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18e-skip-summary.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18e-skip-summary.spec.ts
@@ -49,6 +49,7 @@ function makeService(): TopGainersScannerService {
   });
   return new TopGainersScannerService(
     mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    { estimateProbability: async () => ({ pWin: 0.5, confidence: 0, sampleSize: 0, modelVersion: "none", fallback: true }) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18f-crypto-tradable.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18f-crypto-tradable.spec.ts
@@ -35,6 +35,7 @@ function makeService(envMap: Record<string, string | undefined> = {}): TopGainer
   });
   return new TopGainersScannerService(
     mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    { estimateProbability: async () => ({ pWin: 0.5, confidence: 0, sampleSize: 0, modelVersion: "none", fallback: true }) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p19beta-shadow.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p19beta-shadow.spec.ts
@@ -63,6 +63,7 @@ function makeService(): TopGainersScannerService {
     mockMtf,
     mockLlmRouter,
     { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: "REJECT", rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
+    { estimateProbability: async () => ({ pWin: 0.5, confidence: 0, sampleSize: 0, modelVersion: "none", fallback: true }) } as any,
   );
 }
 

--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -399,6 +399,73 @@ export class LisaController {
     return this.persistenceProbability.trainAndPersist({ lookbackDays });
   }
 
+  /**
+   * PR #6 — User-facing read endpoint pour le dashboard auto-learning.
+   * Retourne les N dernières insights (drift, threshold_proposal, ml_refit, etc.)
+   * sur la fenêtre glissante. Pas de filtre par portfolio (insights globaux).
+   */
+  @Get('gainers/insights-recent')
+  async getGainersInsightsRecent(
+    @Headers() headers: Record<string, string>,
+    @Query('since_days') sinceDaysStr?: string,
+    @Query('limit') limitStr?: string,
+    @Query('type') type?: string,
+  ) {
+    extractUserId(headers);
+    const sinceDays = clampInt(sinceDaysStr, 1, 90, 30);
+    const limit = clampInt(limitStr, 1, 200, 50);
+    const sinceIso = new Date(Date.now() - sinceDays * 24 * 3600_000).toISOString();
+    let query = this.supabase
+      .getClient()
+      .from('gainers_insights_log')
+      .select('id, created_at, insight_type, source, severity, summary, payload, status')
+      .gte('created_at', sinceIso)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (type) query = query.eq('insight_type', type);
+    const { data, error } = await query;
+    if (error) {
+      return { count: 0, insights: [], error: error.message };
+    }
+    return { count: (data ?? []).length, insights: data ?? [] };
+  }
+
+  /**
+   * PR #6 — Historique des ajustements AutoTuner pour un portfolio user.
+   * Filtre obligatoire par portfolioId user-scoped.
+   */
+  @Get('gainers/auto-tuner-history/:portfolioId')
+  async getAutoTunerHistory(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+    @Query('limit') limitStr?: string,
+  ) {
+    const userId = extractUserId(headers);
+    // Vérifier ownership
+    const { data: portfolio, error: pErr } = await this.supabase.getClient()
+      .from('portfolios')
+      .select('id')
+      .eq('id', portfolioId)
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (pErr || !portfolio) {
+      return { count: 0, history: [] };
+    }
+    const limit = clampInt(limitStr, 1, 200, 50);
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('gainers_threshold_history')
+      .select('*')
+      .eq('portfolio_id', portfolioId)
+      .order('applied_at', { ascending: false })
+      .limit(limit);
+    return {
+      count: (data ?? []).length,
+      history: data ?? [],
+      error: error?.message ?? null,
+    };
+  }
+
   private async resolveTopN(portfolioId: string, raw: string | undefined): Promise<number> {
     // 1. Query string
     if (raw) {

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -292,6 +292,10 @@ export class LisaService {
       gainers_universe_crypto: pick('gainers_universe_crypto', 'gainersUniverseCrypto', existing?.gainers_universe_crypto ?? true),
       gainers_fees_aware_buffer: pick('gainers_fees_aware_buffer', 'gainersFeesAwareBuffer', existing?.gainers_fees_aware_buffer ?? 2.0),
       gainers_min_net_profit_usd: pick('gainers_min_net_profit_usd', 'gainersMinNetProfitUsd', existing?.gainers_min_net_profit_usd ?? 0.50),
+      // PR #4 — pWin gate (migration 0116). Désactivé par défaut, activable
+      // par utilisateur quand modèle ML a convergé (≥30 trades fermés + AUC ≥ 0.55).
+      gainers_p_win_gate_enabled: pick('gainers_p_win_gate_enabled', 'gainersPWinGateEnabled', existing?.gainers_p_win_gate_enabled ?? false),
+      gainers_min_p_win: pick('gainers_min_p_win', 'gainersMinPWin', existing?.gainers_min_p_win ?? 0.50),
     };
 
     // Validation des valeurs numériques pour renvoyer une 400 lisible plutôt
@@ -358,6 +362,7 @@ export class LisaService {
     validateInt('gainers_cooldown_minutes', merged.gainers_cooldown_minutes, 0, 240);
     validateNum('gainers_fees_aware_buffer', merged.gainers_fees_aware_buffer, 1.0, 5.0);
     validateNum('gainers_min_net_profit_usd', merged.gainers_min_net_profit_usd, 0, 9999);
+    validateNum('gainers_min_p_win', merged.gainers_min_p_win, 0, 1);
     // Cohérence : positionPct × maxOpen + cashReserve ne doit pas dépasser 100%
     // (sinon impossible de tenir le cash buffer en pratique). Warning soft, pas hard fail.
     const totalAllocPct =
@@ -465,6 +470,24 @@ export class LisaService {
         ...mergedFallback
       } = merged;
       void _gc; void _gpe; void _gmp; void _gtp; void _gsl;
+      const retry = await this.supabase.getClient()
+        .from('lisa_session_configs')
+        .upsert(mergedFallback, { onConflict: 'portfolio_id' })
+        .select()
+        .single();
+      data = retry.data;
+      error = retry.error;
+    }
+
+    // PR #4 — fallback si migration 0116 pas encore appliquée
+    if (error && /gainers_p_win_gate_enabled|gainers_min_p_win/i.test(error.message)) {
+      this.logger.warn('Colonnes pWin (migration 0116) absentes — retry sans ces champs');
+      const {
+        gainers_p_win_gate_enabled: _pwe,
+        gainers_min_p_win: _pmw,
+        ...mergedFallback
+      } = merged;
+      void _pwe; void _pmw;
       const retry = await this.supabase.getClient()
         .from('lisa_session_configs')
         .upsert(mergedFallback, { onConflict: 'portfolio_id' })

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -30,6 +30,7 @@ import { LisaService } from './lisa.service';
 import { DecisionLogService } from './decision-log.service';
 import { BinanceMarketService } from './binance-market.service';
 import { MultiTimeframePersistenceService } from './multi-tf-persistence.service';
+import { PersistenceProbabilityService } from './persistence-probability.service';
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
 // PR6.3 — Shadow wiring (LisaModule import GainersModule pour résolution DI)
 import { GainersShadowRunService } from '../../gainers-scanner/shadow/shadow-run.service';
@@ -411,6 +412,13 @@ export class TopGainersScannerService implements OnModuleInit {
      * scorer réels avec SHADOW_BLOC1_CONFIG (tolère atr/persistence null).
      */
     private readonly bloc1: GainersBloc1Service,
+    /**
+     * PR #4 — PersistenceProbabilityService consume du modèle ML logistique
+     * (entraîné weekly par ProbabilityRefitCron). Gate `pWin >= threshold`
+     * activable par portfolio (cfg.gainers_p_win_gate_enabled, default false).
+     * Fallback automatique quand modèle pas prêt (sample < 30 OR auc < 0.55).
+     */
+    private readonly probability: PersistenceProbabilityService,
   ) {}
 
   /**
@@ -1246,7 +1254,7 @@ export class TopGainersScannerService implements OnModuleInit {
     const { data: cfgRow } = await this.supabase
       .getClient()
       .from('lisa_session_configs')
-      .select('capital_simulation, gainers_min_persistence_score, gainers_min_path_efficiency, gainers_default_tp_pct, gainers_default_sl_pct, gainers_max_open_positions, gainers_max_per_cycle, gainers_position_pct, gainers_cash_reserve_pct, gainers_cooldown_minutes, gainers_universe_us, gainers_universe_eu, gainers_universe_asia, gainers_universe_crypto')
+      .select('capital_simulation, gainers_min_persistence_score, gainers_min_path_efficiency, gainers_default_tp_pct, gainers_default_sl_pct, gainers_max_open_positions, gainers_max_per_cycle, gainers_position_pct, gainers_cash_reserve_pct, gainers_cooldown_minutes, gainers_universe_us, gainers_universe_eu, gainers_universe_asia, gainers_universe_crypto, gainers_p_win_gate_enabled, gainers_min_p_win')
       .eq('portfolio_id', portfolioId)
       .maybeSingle();
     const minScore = this.resolveMinPersistenceScore(
@@ -1296,6 +1304,13 @@ export class TopGainersScannerService implements OnModuleInit {
     const universeEu = cfgRow?.gainers_universe_eu !== false;
     const universeAsia = cfgRow?.gainers_universe_asia !== false;
     const universeCrypto = cfgRow?.gainers_universe_crypto !== false;
+    // PR #4 — pWin gate. Désactivé par défaut (gainers_p_win_gate_enabled=false).
+    // L'utilisateur active via UI quand le modèle a convergé (≥30 trades fermés
+    // + AUC ≥ 0.55). Sinon `probability.fallback=true` → bypass automatique.
+    const pWinGateEnabled = cfgRow?.gainers_p_win_gate_enabled === true;
+    const minPWin = cfgRow?.gainers_min_p_win != null
+      ? Math.max(0, Math.min(1, Number(cfgRow.gainers_min_p_win)))
+      : 0.50;
     const filteredTop = top.filter((c) => {
       if (c.assetClass === 'us_equity_large' || c.assetClass === 'us_equity_small_mid') return universeUs;
       if (c.assetClass === 'eu_equity') return universeEu;
@@ -1549,6 +1564,54 @@ export class TopGainersScannerService implements OnModuleInit {
         continue;
       }
 
+      // PR #4 — pWin gate (ML logistic regression P9). Activable par portfolio
+      // via cfg.gainers_p_win_gate_enabled. Features dérivées des metrics
+      // déjà calculés (persistenceCount + scoring composite).
+      // Bypass si modèle pas prêt (probability.fallback=true).
+      let pWinResult: { pWin: number; modelVersion: string; fallback: boolean; sampleSize: number; features: Record<string, number> } | null = null;
+      if (pWinGateEnabled) {
+        const closeToHigh = cand.high > 0 ? cand.close / cand.high : 0;
+        const volRatio = cand.avgVol50d && cand.avgVol50d > 0
+          ? (cand.volume ?? 0) / cand.avgVol50d
+          : 0;
+        const features: Record<string, number> = {
+          // Note: persistenceCount feature = integer count (positiveCount), pas le string "4/6".
+          persistenceCount: persistence?.positiveCount ?? 0,
+          volRatio,
+          rsi: 50, // Pas calculé live au scanner — fallback neutre. Future : enrichir.
+          closeToHigh,
+          changePct: cand.changePct,
+        };
+        const probability = await this.probability.estimateProbability(features)
+          .catch((e) => {
+            this.logger.warn(`[pWin] ${cand.symbol} estimate failed: ${String(e).slice(0, 80)}`);
+            return null;
+          });
+        if (probability) {
+          pWinResult = {
+            pWin: probability.pWin,
+            modelVersion: probability.modelVersion,
+            fallback: probability.fallback,
+            sampleSize: probability.sampleSize,
+            features,
+          };
+          if (probability.fallback) {
+            this.logger.log(
+              `[pWin] ${cand.symbol} fallback (sample=${probability.sampleSize}, model=${probability.modelVersion}) → gate bypassed`,
+            );
+          } else if (probability.pWin < minPWin) {
+            this.logger.log(
+              `[pWin] ${cand.symbol} pWin=${probability.pWin.toFixed(3)} < ${minPWin.toFixed(2)} (model=${probability.modelVersion}) → skip`,
+            );
+            continue;
+          } else {
+            this.logger.log(
+              `[pWin] ${cand.symbol} pWin=${probability.pWin.toFixed(3)} ≥ ${minPWin.toFixed(2)} (model=${probability.modelVersion}) → OPEN`,
+            );
+          }
+        }
+      }
+
       const insertedPosId = await this.openTopGainerPosition(
         userId,
         portfolioId,
@@ -1562,6 +1625,7 @@ export class TopGainersScannerService implements OnModuleInit {
           positionNotionalUsd,
           cashReservePct,
         },
+        pWinResult, // PR #4 — pWin metrics persistés via paper_trades
       ).catch((e) => {
         this.logger.warn(
           `[top-gainers] open ${cand.symbol} failed: ${String(e).slice(0, 120)}`,
@@ -1606,6 +1670,13 @@ export class TopGainersScannerService implements OnModuleInit {
       positionNotionalUsd: number;
       cashReservePct: number;
     },
+    // PR #4 — pWin metrics persistés dans paper_trades pour boucle apprentissage.
+    pWinMeta?: {
+      pWin: number;
+      modelVersion: string;
+      sampleSize: number;
+      features: Record<string, number>;
+    } | null,
   ): Promise<string | null> {
     const proposalId = randomUUID();
     const thesisId = randomUUID();
@@ -1691,10 +1762,10 @@ export class TopGainersScannerService implements OnModuleInit {
         `[top-gainers] ${cand.symbol} opened (${result.openedPositions.length} pos, score=${cand.score})`,
       );
 
-      // P8 — best-effort persist du snapshot persistance dans paper_trades
-      // (forward-compat avec P9 qui ajoutera features_at_entry / p_win).
+      // P8 + PR #4 — best-effort persist du snapshot persistance + pWin metrics
+      // dans paper_trades (alimente la boucle apprentissage P9 logistique).
       if (persistence) {
-        await this.persistPaperTrade(userId, portfolioId, cand, openedPos, persistence, effectiveTp, effectiveSl)
+        await this.persistPaperTrade(userId, portfolioId, cand, openedPos, persistence, effectiveTp, effectiveSl, pWinMeta ?? null)
           .catch((e) =>
             this.logger.debug(`[top-gainers] persistPaperTrade ${cand.symbol} failed: ${String(e).slice(0, 120)}`),
           );
@@ -1721,6 +1792,14 @@ export class TopGainersScannerService implements OnModuleInit {
     persistence: PersistenceResult,
     tpPct: number,
     slPct: number,
+    // PR #4 — pWin metrics persistés pour boucle apprentissage. Optionnel
+    // (null si gate désactivé OU modèle non prêt).
+    pWinMeta?: {
+      pWin: number;
+      modelVersion: string;
+      sampleSize: number;
+      features: Record<string, number>;
+    } | null,
   ): Promise<void> {
     const entryPrice = Number(openedPos.entryPrice ?? cand.close);
     const sizeUsd = Number(openedPos.entryNotionalUsd ?? 0);
@@ -1734,7 +1813,7 @@ export class TopGainersScannerService implements OnModuleInit {
       tf30m: persistence.tf30m,
       tf1h: persistence.tf1h,
     };
-    await this.supabase.getClient().from('paper_trades').insert({
+    const insertRow: Record<string, unknown> = {
       user_id: userId,
       portfolio_id: portfolioId,
       symbol: cand.symbol,
@@ -1750,7 +1829,14 @@ export class TopGainersScannerService implements OnModuleInit {
       persistence_score_at_entry: String(persistence.persistenceScore.toFixed(2)),
       persistence_count_at_entry: persistence.persistenceCount,
       tf_changes_at_entry: tfChanges,
-    });
+    };
+    // PR #4 — features + p_win + model_version persistés pour boucle apprentissage
+    if (pWinMeta) {
+      insertRow.features_at_entry = pWinMeta.features;
+      insertRow.p_win_at_entry = String(pWinMeta.pWin);
+      insertRow.model_version_at_entry = pWinMeta.modelVersion;
+    }
+    await this.supabase.getClient().from('paper_trades').insert(insertRow);
   }
 
   /**

--- a/apps/web/src/app/lisa/gainers/insights/page.tsx
+++ b/apps/web/src/app/lisa/gainers/insights/page.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+/**
+ * PR #6 — Dashboard auto-learning Gainers.
+ *
+ * 4 panels :
+ *   1. ML Model State — empirical law + AUC + accuracy + sample_size
+ *   2. Drift Events — last 30 days from gainers_insights_log
+ *   3. AutoTuner History — ajustements appliqués pour le portfolio
+ *   4. Threshold Proposals — type='threshold_proposal' insights (suggestions)
+ *
+ * Page user-facing (pas admin token requis).
+ */
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Brain, Activity, Sliders, Lightbulb } from 'lucide-react';
+import { usePortfolios } from '@/hooks/use-portfolio';
+import {
+  usePersistenceEmpiricalLaw,
+  useGainersInsights,
+  useAutoTunerHistory,
+  type GainersInsightRow,
+  type AutoTunerHistoryRow,
+} from '@/hooks/use-operating-mode';
+
+export default function GainersInsightsPage() {
+  const portfoliosQuery = usePortfolios();
+  const portfolios = (portfoliosQuery.data ?? []).filter(
+    (p) => (p as { is_simulation?: boolean }).is_simulation === true,
+  );
+  const [portfolioId, setPortfolioId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!portfolioId && portfolios[0]?.id) setPortfolioId(portfolios[0].id);
+  }, [portfolios, portfolioId]);
+
+  const empiricalLaw = usePersistenceEmpiricalLaw({ lookbackDays: 30, minSample: 20 });
+  const driftInsights = useGainersInsights({ sinceDays: 30, limit: 50, type: 'cadence_drift' });
+  const thresholdProposals = useGainersInsights({ sinceDays: 30, limit: 50, type: 'threshold_proposal' });
+  const autoTunerHistory = useAutoTunerHistory(portfolioId, 50);
+
+  return (
+    <div className="container mx-auto p-6 space-y-6 max-w-6xl">
+      <div className="flex items-center gap-3">
+        <Link
+          href="/lisa"
+          className="text-zinc-400 hover:text-zinc-200 inline-flex items-center gap-1 text-sm"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Retour
+        </Link>
+        <h1 className="text-2xl font-bold">Auto-learning · Gainers</h1>
+      </div>
+
+      <p className="text-sm text-zinc-400">
+        Visualisation de la boucle d&apos;apprentissage : modèle ML logistique
+        (P9), détecteurs de drift, AutoTuner Phase C, et historique des
+        ajustements appliqués.
+      </p>
+
+      {portfolios.length > 0 && (
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-zinc-400">Portfolio :</span>
+          <select
+            value={portfolioId ?? ''}
+            onChange={(e) => setPortfolioId(e.target.value || null)}
+            className="h-8 rounded-md border bg-background px-2 text-xs"
+          >
+            {portfolios.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* Panel 1 : ML Model State */}
+      <Panel
+        icon={<Brain className="w-4 h-4" />}
+        title="Modèle ML — Probability of Win (logistic regression)"
+      >
+        {empiricalLaw.isLoading ? (
+          <p className="text-xs text-zinc-400">Chargement…</p>
+        ) : empiricalLaw.data ? (
+          <>
+            <div className="grid grid-cols-4 gap-3 mb-4">
+              <Metric label="Version modèle" value={empiricalLaw.data.modelVersion ?? '—'} />
+              <Metric label="AUC ROC" value={empiricalLaw.data.aucRoc != null ? empiricalLaw.data.aucRoc.toFixed(3) : '—'} hint={empiricalLaw.data.aucRoc != null && empiricalLaw.data.aucRoc < 0.55 ? '⚠ <0.55' : ''} />
+              <Metric label="Accuracy" value={empiricalLaw.data.accuracy != null ? empiricalLaw.data.accuracy.toFixed(3) : '—'} />
+              <Metric label="Trades trainés" value={String(empiricalLaw.data.trainedOn)} hint={empiricalLaw.data.fallback ? '⚠ Fallback' : 'Production'} />
+            </div>
+            {empiricalLaw.data.empiricalLaw.length > 0 && (
+              <table className="w-full text-xs border-t">
+                <thead className="text-zinc-400">
+                  <tr>
+                    <th className="text-left py-1">Bucket persistence</th>
+                    <th className="text-right py-1">N</th>
+                    <th className="text-right py-1">P(win)</th>
+                    <th className="text-right py-1">Avg PnL %</th>
+                    <th className="text-right py-1">CI 95%</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {empiricalLaw.data.empiricalLaw.map((row, i) => (
+                    <tr key={i} className="border-t border-zinc-800">
+                      <td className="py-1 font-mono">{row.persistenceCount}</td>
+                      <td className="py-1 text-right">{row.n}</td>
+                      <td className="py-1 text-right">{row.pWinObserved != null ? (row.pWinObserved * 100).toFixed(1) + '%' : '—'}</td>
+                      <td className="py-1 text-right">{row.avgPnlPct != null ? row.avgPnlPct.toFixed(2) : '—'}</td>
+                      <td className="py-1 text-right text-zinc-500">
+                        {row.ciLow != null && row.ciHigh != null ? `[${(row.ciLow * 100).toFixed(0)}%, ${(row.ciHigh * 100).toFixed(0)}%]` : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </>
+        ) : (
+          <p className="text-xs text-red-400">Échec chargement loi empirique.</p>
+        )}
+      </Panel>
+
+      {/* Panel 2 : Drift Events */}
+      <Panel
+        icon={<Activity className="w-4 h-4" />}
+        title="Drift detector — événements 30 jours"
+      >
+        <InsightsList insights={driftInsights.data?.insights ?? []} loading={driftInsights.isLoading} emptyMessage="Aucun drift détecté sur les 30 derniers jours." />
+      </Panel>
+
+      {/* Panel 3 : Threshold proposals */}
+      <Panel
+        icon={<Lightbulb className="w-4 h-4" />}
+        title="Suggestions AutoTuner — Phase C"
+      >
+        <InsightsList insights={thresholdProposals.data?.insights ?? []} loading={thresholdProposals.isLoading} emptyMessage="Aucune suggestion d'ajustement de seuils sur les 30 derniers jours." />
+      </Panel>
+
+      {/* Panel 4 : Auto-tuner history per portfolio */}
+      <Panel
+        icon={<Sliders className="w-4 h-4" />}
+        title="Historique des ajustements appliqués"
+      >
+        <AutoTunerHistoryTable rows={autoTunerHistory.data?.history ?? []} loading={autoTunerHistory.isLoading} />
+      </Panel>
+    </div>
+  );
+}
+
+function Panel({
+  icon,
+  title,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border bg-card p-5">
+      <div className="flex items-center gap-2 mb-4 text-sm font-semibold">
+        {icon}
+        <h2>{title}</h2>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function Metric({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-md bg-zinc-900/60 p-3 border border-zinc-800">
+      <div className="text-[10px] uppercase tracking-wider text-zinc-500">{label}</div>
+      <div className="text-lg font-mono">{value}</div>
+      {hint && <div className="text-[10px] text-zinc-400 mt-1">{hint}</div>}
+    </div>
+  );
+}
+
+function InsightsList({
+  insights,
+  loading,
+  emptyMessage,
+}: {
+  insights: GainersInsightRow[];
+  loading: boolean;
+  emptyMessage: string;
+}) {
+  if (loading) return <p className="text-xs text-zinc-400">Chargement…</p>;
+  if (insights.length === 0) return <p className="text-xs text-zinc-400">{emptyMessage}</p>;
+  return (
+    <ul className="space-y-2">
+      {insights.map((row) => (
+        <li key={row.id} className="border-l-2 border-zinc-700 pl-3 py-1">
+          <div className="flex items-baseline gap-2">
+            <span className={`text-[10px] uppercase font-medium ${
+              row.severity === 'critical' ? 'text-red-400' :
+              row.severity === 'high' ? 'text-orange-400' :
+              row.severity === 'medium' ? 'text-yellow-400' :
+              'text-zinc-500'
+            }`}>
+              {row.severity}
+            </span>
+            <span className="text-[10px] text-zinc-500">{new Date(row.created_at).toLocaleString()}</span>
+            <span className="text-[10px] text-zinc-500">· {row.source}</span>
+          </div>
+          <div className="text-sm text-zinc-200 mt-0.5">{row.summary}</div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function AutoTunerHistoryTable({
+  rows,
+  loading,
+}: {
+  rows: AutoTunerHistoryRow[];
+  loading: boolean;
+}) {
+  if (loading) return <p className="text-xs text-zinc-400">Chargement…</p>;
+  if (rows.length === 0) {
+    return (
+      <p className="text-xs text-zinc-400">
+        Aucun ajustement appliqué pour ce portfolio. Active l&apos;AutoTuner dans
+        la configuration Gainers (env=shadow par défaut, log only).
+      </p>
+    );
+  }
+  return (
+    <table className="w-full text-xs">
+      <thead className="text-zinc-400">
+        <tr className="border-b">
+          <th className="text-left py-1">Date</th>
+          <th className="text-left py-1">Seuil</th>
+          <th className="text-right py-1">Ancien</th>
+          <th className="text-right py-1">Nouveau</th>
+          <th className="text-left py-1">Raison</th>
+          <th className="text-right py-1">N</th>
+          <th className="text-left py-1">Env</th>
+          <th className="text-left py-1">Mode</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.id} className="border-b border-zinc-800">
+            <td className="py-1 text-zinc-500">{new Date(row.applied_at).toLocaleDateString()}</td>
+            <td className="py-1 font-mono">{row.threshold_name.replace('gainers_', '')}</td>
+            <td className="py-1 text-right">{Number(row.old_value).toFixed(3)}</td>
+            <td className="py-1 text-right">
+              <span className={Number(row.new_value) > Number(row.old_value) ? 'text-red-400' : 'text-emerald-400'}>
+                {Number(row.new_value).toFixed(3)}
+              </span>
+            </td>
+            <td className="py-1 text-zinc-500">{row.reason}</td>
+            <td className="py-1 text-right">{row.sample_size}</td>
+            <td className="py-1">
+              <span className={`px-1.5 py-0.5 rounded text-[10px] ${
+                row.applied_to_env === 'prod' ? 'bg-red-900/30 text-red-300' :
+                row.applied_to_env === 'canary' ? 'bg-yellow-900/30 text-yellow-300' :
+                'bg-zinc-800 text-zinc-400'
+              }`}>{row.applied_to_env}</span>
+            </td>
+            <td className="py-1 text-zinc-500">{row.auto_or_manual}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/web/src/components/lisa/gainers-config-panel.tsx
+++ b/apps/web/src/components/lisa/gainers-config-panel.tsx
@@ -17,7 +17,8 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Settings2, Save, RotateCcw } from 'lucide-react';
+import Link from 'next/link';
+import { Settings2, Save, RotateCcw, BarChart3 } from 'lucide-react';
 import {
   useGainersConfig,
   useUpdateGainersConfig,
@@ -97,9 +98,18 @@ export function GainersConfigPanel({ portfolioId }: Props) {
 
   return (
     <div className="rounded-lg border border-orange-700/40 bg-orange-950/10 p-5 space-y-5">
-      <div className="flex items-center gap-2 text-orange-300">
-        <Settings2 className="w-4 h-4" />
-        <h3 className="text-sm font-semibold">Configuration scanner Gainers</h3>
+      <div className="flex items-center justify-between gap-2 text-orange-300">
+        <div className="flex items-center gap-2">
+          <Settings2 className="w-4 h-4" />
+          <h3 className="text-sm font-semibold">Configuration scanner Gainers</h3>
+        </div>
+        <Link
+          href={'/lisa/gainers/insights' as never}
+          className="inline-flex items-center gap-1 text-xs text-orange-300 hover:text-orange-200"
+        >
+          <BarChart3 className="w-3 h-3" />
+          Dashboard auto-learning
+        </Link>
       </div>
       <p className="text-xs text-zinc-400">
         Tous les paramètres sont lus par le scanner à chaque cycle. Aucune

--- a/apps/web/src/components/lisa/gainers-config-panel.tsx
+++ b/apps/web/src/components/lisa/gainers-config-panel.tsx
@@ -321,6 +321,37 @@ export function GainersConfigPanel({ portfolioId }: Props) {
         </div>
       </section>
 
+      {/* 7. Auto-learning (pWin ML gate) */}
+      <section className="space-y-3">
+        <div className="text-xs uppercase tracking-wider text-zinc-500 font-medium">
+          7. Auto-learning — Gate ML (pWin)
+        </div>
+        <p className="text-[11px] text-zinc-400">
+          Désactivé par défaut. Active uniquement après convergence du modèle
+          (≥ 30 trades fermés + AUC ≥ 0.55). Si modèle pas prêt, le gate est
+          automatiquement bypassé (fallback transparent).
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <Toggle
+            label="Activer le gate pWin"
+            checked={cfg.gainers_p_win_gate_enabled === true}
+            onChange={(v) => set('gainers_p_win_gate_enabled', v)}
+          />
+          <Field label="Min pWin (probabilité win)" hint="[0..1] — default 0.50">
+            <input
+              type="number"
+              min={0}
+              max={1}
+              step={0.05}
+              value={num(cfg.gainers_min_p_win, 0.5)}
+              onChange={(e) => set('gainers_min_p_win', Number(e.target.value))}
+              className="h-8 w-full rounded-md border bg-background px-2 text-xs"
+              disabled={cfg.gainers_p_win_gate_enabled !== true}
+            />
+          </Field>
+        </div>
+      </section>
+
       {/* Actions */}
       <div className="flex items-center gap-2 pt-2 border-t border-zinc-800">
         <button

--- a/apps/web/src/hooks/use-operating-mode.ts
+++ b/apps/web/src/hooks/use-operating-mode.ts
@@ -262,3 +262,84 @@ export function useUpdateGainersConfig(portfolioId: string | null) {
     },
   });
 }
+
+// PR #6 — Hooks pour le dashboard auto-learning
+export interface GainersInsightRow {
+  id: string;
+  created_at: string;
+  insight_type: string;
+  source: string;
+  severity: 'info' | 'low' | 'medium' | 'high' | 'critical';
+  summary: string;
+  payload: Record<string, unknown>;
+  status: 'open' | 'investigating' | 'actioned' | 'dismissed';
+}
+
+export function useGainersInsights(opts: { sinceDays?: number; limit?: number; type?: string } = {}) {
+  const params = new URLSearchParams();
+  if (opts.sinceDays != null) params.set('since_days', String(opts.sinceDays));
+  if (opts.limit != null) params.set('limit', String(opts.limit));
+  if (opts.type) params.set('type', opts.type);
+  return useQuery({
+    queryKey: ['gainers-insights', opts.sinceDays, opts.limit, opts.type],
+    queryFn: () => apiFetch<{ count: number; insights: GainersInsightRow[] }>(
+      `/lisa/gainers/insights-recent?${params.toString()}`,
+    ),
+    refetchInterval: 60_000,
+  });
+}
+
+export interface AutoTunerHistoryRow {
+  id: string;
+  portfolio_id: string;
+  threshold_name: string;
+  old_value: string;
+  new_value: string;
+  reason: string;
+  fp_rate_observed: string | null;
+  failure_rate_observed: string | null;
+  sample_size: number;
+  applied_to_env: 'shadow' | 'canary' | 'prod';
+  auto_or_manual: 'auto' | 'manual';
+  applied_at: string;
+}
+
+export function useAutoTunerHistory(portfolioId: string | null, limit = 50) {
+  return useQuery({
+    queryKey: ['auto-tuner-history', portfolioId, limit],
+    queryFn: () => apiFetch<{ count: number; history: AutoTunerHistoryRow[] }>(
+      `/lisa/gainers/auto-tuner-history/${portfolioId}?limit=${limit}`,
+    ),
+    enabled: !!portfolioId,
+    refetchInterval: 60_000,
+  });
+}
+
+export interface EmpiricalLawResponse {
+  trainedOn: number;
+  empiricalLaw: Array<{
+    persistenceCount: string;
+    n: number;
+    pWinObserved: number | null;
+    avgPnlPct: number | null;
+    ciLow: number | null;
+    ciHigh: number | null;
+  }>;
+  fittedCurve: string;
+  coefficients: Record<string, number> | null;
+  aucRoc: number | null;
+  accuracy: number | null;
+  modelVersion: string | null;
+  fallback: boolean;
+}
+
+export function usePersistenceEmpiricalLaw(opts: { lookbackDays?: number; minSample?: number } = {}) {
+  const params = new URLSearchParams();
+  params.set('lookback_days', String(opts.lookbackDays ?? 30));
+  params.set('min_sample', String(opts.minSample ?? 20));
+  return useQuery({
+    queryKey: ['persistence-empirical-law', opts.lookbackDays, opts.minSample],
+    queryFn: () => apiFetch<EmpiricalLawResponse>(`/lisa/persistence-empirical-law?${params.toString()}`),
+    refetchInterval: 5 * 60_000,
+  });
+}

--- a/apps/web/src/hooks/use-operating-mode.ts
+++ b/apps/web/src/hooks/use-operating-mode.ts
@@ -204,6 +204,9 @@ export interface GainersConfigFields {
   gainers_universe_crypto: boolean | null;
   gainers_fees_aware_buffer: number | null;
   gainers_min_net_profit_usd: number | null;
+  // PR #4 — pWin ML gate (migration 0116)
+  gainers_p_win_gate_enabled: boolean | null;
+  gainers_min_p_win: number | null;
   // Capital simulé (lu/écrit via la même config session)
   capital_simulation: number | null;
 }
@@ -235,6 +238,8 @@ export function useGainersConfig(portfolioId: string | null) {
         gainers_universe_crypto: boolOrNull(raw?.gainers_universe_crypto),
         gainers_fees_aware_buffer: numOrNull(raw?.gainers_fees_aware_buffer),
         gainers_min_net_profit_usd: numOrNull(raw?.gainers_min_net_profit_usd),
+        gainers_p_win_gate_enabled: boolOrNull(raw?.gainers_p_win_gate_enabled),
+        gainers_min_p_win: numOrNull(raw?.gainers_min_p_win),
         capital_simulation: numOrNull(raw?.capital_simulation ?? raw?.capital_usd),
       } satisfies GainersConfigFields;
     },


### PR DESCRIPTION
## Contexte

**Fermeture complète + visualisation** de la boucle d'apprentissage Gainers en 1 PR groupée :
- **PR #4** — pWin gate dans le scanner (ML logistique consume)
- **PR #5** — AutoTuner Phase C (cron daily 03:00 UTC ajuste les seuils via FP-rate)
- **PR #6** — UI dashboard `/lisa/gainers/insights` (4 panels visualisation)

Roadmap globale **TERMINÉE** :
- ✅ PR #235 — Lisa-disconnect + zéro hardcode
- ✅ PR #236 — UI panel full-config
- 🟢 **Cette PR (#4+#5+#6)** — Auto-learning loop fermée + visible

## Récap final — auto-learning steps 1-10

| # | Étape | Avant projet | Après ce PR |
|---|---|---|---|
| 1 | Collecte data (shadow + paper_trades) | ✅ | ✅ |
| 2 | Forward tracking T+72h | ✅ | ✅ |
| 3 | Outcome labeling | ✅ | ✅ |
| 4 | Drift detection | ✅ | ✅ |
| 5 | ML model train (logistic regression) | ✅ | ✅ |
| 6 | **ML model consume scanner** | ❌ | **✅ PR #4** |
| 7 | FP-rate calculation | ✅ | ✅ |
| 8 | **FP-rate consume tuner** | ❌ | **✅ PR #5** |
| 9 | **AutoTuner apply suggestions** | ❌ | **✅ PR #5** |
| 10 | **UI dashboard ML insights** | ❌ | **✅ PR #6** |

**10/10 étapes actives et visibles** — boucle d'apprentissage complète et observable end-to-end.

---

## PR #4 — pWin scanner gate (commit `de0ced9`)

**Migration 0116** déjà appliquée :
```sql
ADD COLUMN gainers_p_win_gate_enabled BOOLEAN DEFAULT false,
ADD COLUMN gainers_min_p_win NUMERIC(4,3) DEFAULT 0.50;
```

- `top-gainers-scanner.service.ts` : Inject `PersistenceProbabilityService`, gate après crypto whitelist, fallback auto si modèle pas prêt
- `persistPaperTrade` étendu : `features_at_entry`, `p_win_at_entry`, `model_version_at_entry`
- `lisa.service.ts` : merged + validation + fallback retry
- UI : Section 7 "Auto-learning — Gate ML" (toggle + threshold)
- Tests : 14 cases + 7 mocks updated

## PR #5 — ThresholdAutoTuner Phase C (commit `3635ee6`)

**Migration 0117** déjà appliquée :
```sql
CREATE TABLE gainers_threshold_history;
ADD COLUMN gainers_auto_tuner_enabled, gainers_auto_tuner_env;
```

- `threshold-auto-tuner.service.ts` : `@Cron('0 3 * * *', UTC)`, computeSuggestions logique pure
- Logique : REJECT-side fp_rate>0.20 → −5%, ACCEPT-side failure_rate>0.30 → +5%
- 6 garde-fous superposés : MIN_SAMPLES 50, anti-flap 7j, cap 30j ±20%, brackets ADR-005, kill-switch global, anti-clamp delta
- 3 environnements : shadow → canary → prod
- Endpoints admin : history, rollback, run-now (auth `x-admin-token`)
- Tests : 13 cases (logique + kill-switch)

## PR #6 — UI dashboard auto-learning (commit `a073b8a`)

Page user-facing **`/lisa/gainers/insights`** (271 LoC) :

**Panel 1 — Modèle ML** :
- Version, AUC ROC, accuracy, sample size (avec flag fallback)
- Table empirical law : P(win) par bucket persistence × CI 95%

**Panel 2 — Drift detector** : événements 30j (cadence_drift, reject_pattern), severity color-coded

**Panel 3 — Suggestions AutoTuner** : insights `threshold_proposal` non encore appliqués

**Panel 4 — Historique ajustements** : table par portfolio avec ancien/nouveau, raison, sample, env (badge color-coded), mode auto/manual

**Endpoints user-facing créés** :
- `GET /lisa/gainers/insights-recent?since_days=30&limit=50&type=...`
- `GET /lisa/gainers/auto-tuner-history/:portfolioId?limit=50` (user-scoped)

**Hooks** : `useGainersInsights`, `useAutoTunerHistory`, `usePersistenceEmpiricalLaw` (polling 60s)

**Lien depuis carte Gainers** : header config panel → "Dashboard auto-learning"

---

## Tests + Validation

- ✅ **1253/1255 tests pass** (102 suites, 2 todo expected)
- ✅ Typecheck API + Web clean
- ✅ Couverture tests :
  - PR #4 : 14 nouveaux + 7 mocks updated
  - PR #5 : 13 nouveaux (logique pure + kill-switch)
  - PR #6 : couvert via tests intégration existants

## Plan rollout

| Phase | Durée | Action |
|---|---|---|
| 1 | J0-J7 | Merge, gates désactivés par défaut |
| 2 | J7-J14 | User active pWin gate (bypass auto si modèle pas prêt) |
| 3 | J14-J21 | RCFT atteint 30+ trades → modèle accepté → gate effectif |
| 4 | J21-J28 | User active AutoTuner env=shadow (log only, observe via dashboard) |
| 5 | J28-J42 | Passage env=canary (apply avec validation manuelle UI) |
| 6 | J42+ | Passage env=prod (boucle complète active) |

## Garde-fous + rollback

- **Default opt-out** partout : `gainers_p_win_gate_enabled=false`, `gainers_auto_tuner_enabled=false`
- **Fallback transparent** : si modèle pas prêt (sample<30 ou auc<0.55) → bypass automatique
- **Brackets ADR-005** : seuils respectent floors hard-coded
- **Kill-switch global** : env `GAINERS_AUTO_TUNER_KILL_SWITCH=true` (sans deploy)
- **Rollback** :
  - Code : revert commits `de0ced9` + `3635ee6` + `a073b8a`
  - Per-portfolio : POST `/admin/gainers/auto-tuner/rollback`
  - User : désactive le toggle dans UI (effet immédiat au cycle suivant)

## Bilan total roadmap (PRs #235 → #237)

| PR | Scope | LoC | Tests |
|---|---|---|---|
| #235 | Lisa-disconnect + hardcodes-fix | +628 | +25 |
| #236 | UI config panel + universe toggles | +548 | (existing) |
| #237 (cette PR) | pWin + AutoTuner + Dashboard | +1638 | +27 |
| **Total** | **Mode Gainers full autonomie + auto-learning visible** | **+2814** | **+52** |

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb