### PR TITLE
fix(gainers): Save ne force plus autopilot=true (bug F5 réactivation)

### DIFF
--- a/apps/web/src/components/lisa/gainers-config-panel.tsx
+++ b/apps/web/src/components/lisa/gainers-config-panel.tsx
@@ -67,16 +67,17 @@ export function GainersConfigPanel({ portfolioId }: Props) {
   };
 
   const handleSave = async () => {
-    // PR Autopilot toggle — Save force toujours autopilot=true. La désactivation
-    // se fait UNIQUEMENT via le bouton "Désactiver" du toggle (handleToggleAutopilot).
-    // Spec utilisateur : "il devra s'activer au moment de la sauvegarde des
-    // paramètres et reste désactivable manuellement."
-    const payload: EditableConfig = {
-      ...draft,
-      autopilot_enabled: true,
-    };
+    // PR Autopilot fix — Save ne force PLUS autopilot=true. Spec révisée :
+    // l'autopilot est contrôlé UNIQUEMENT par le toggle dédié au-dessus.
+    // Save sauvegarde les params modifiés sans toucher l'état autopilot
+    // (sauf si l'utilisateur a explicitement flippé le toggle dans la
+    // session draft).
+    //
+    // Comportement précédent (forçage true) provoquait le bug "F5 réactive
+    // autopilot" : un Save subséquent à un toggle-OFF écrasait l'état.
+    if (Object.keys(draft).length === 0) return;
     try {
-      await update.mutateAsync(payload);
+      await update.mutateAsync(draft);
       setDraft({});
       setSaved(true);
       setError(null);
@@ -429,10 +430,10 @@ export function GainersConfigPanel({ portfolioId }: Props) {
           onClick={handleSave}
           disabled={Object.keys(draft).length === 0 || update.isPending}
           className="flex items-center gap-2 px-4 py-2 rounded-md bg-orange-600 hover:bg-orange-500 disabled:bg-muted disabled:opacity-50 text-white text-sm font-medium"
-          title="Sauvegarde les paramètres et active l'autopilot"
+          title="Sauvegarde les paramètres modifiés (autopilot piloté séparément par le toggle ci-dessus)"
         >
           <Save className="w-4 h-4" />
-          {update.isPending ? 'Sauvegarde…' : 'Sauvegarder + activer'}
+          {update.isPending ? 'Sauvegarde…' : 'Sauvegarder'}
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Bug rapporté utilisateur

> "Hard refresh sur /lisa réactive systématiquement l'autopilot."

## Cause racine

Ma logique dans `handleSave` (PR #239) forçait toujours `autopilot_enabled=true` dans le payload, écrasant silencieusement le toggle "Désactiver".

```typescript
// AVANT (bug)
const handleSave = async () => {
  const payload = {
    ...draft,
    autopilot_enabled: true,  // ← FORCE TOUJOURS, écrase toggle-off
  };
};
```

### Scénario reproductible

1. User clique toggle **"Désactiver"** → API save `autopilot=false` ✅
2. User modifie un autre param (capital, position_pct, ...)
3. User clique **"Sauvegarder + activer"**
4. `handleSave` envoie `{ capital, autopilot_enabled: true }` → **écrase à true**
5. F5 → fetch DB → affiche `autopilot=true` (consistant avec DB mais inattendu pour user)

L'utilisateur voyait "F5 réactive autopilot" mais c'était en fait le Save précédent qui avait écrasé l'état désactivé.

## Fix

```typescript
// APRÈS (correct)
const handleSave = async () => {
  if (Object.keys(draft).length === 0) return;
  await update.mutateAsync(draft);  // ← SEULEMENT les fields modifiés
};
```

- `handleSave` ne force plus `autopilot_enabled=true`
- Save persiste uniquement les champs **explicitement modifiés** dans le draft
- Bouton renommé `"Sauvegarder + activer"` → `"Sauvegarder"` (plus honnête)
- Tooltip clarifié : `"autopilot piloté séparément par le toggle ci-dessus"`

## Comportement final cohérent

| Action | Effet |
|---|---|
| Toggle button vert/rouge | **SEUL** contrôle on/off autopilot (mutation immédiate) |
| Bouton "Sauvegarder" | Sauvegarde les params modifiés, ne touche **pas** autopilot |
| F5 / hard refresh | Re-affichage fidèle DB, **aucun side-effect** |

## Tests

- ✅ Typecheck Web clean
- ✅ Aucune regression backend (pas de modif API)

## Pas de migration

Modification 100% frontend. Aucune migration SQL nécessaire.

## Risques + rollback

- **Risque très faible** : suppression d'une override agressive qui causait le bug
- **Rollback** : revert commit `7bad57c`

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_