### PR TITLE
feat(gainers): Adaptive Selectivity + breakdown counters fix + coverage=none filter

### DIFF
--- a/apps/api/src/modules/gainers-scanner/__tests__/adaptive-selectivity.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/adaptive-selectivity.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * PR #243 — Tests GainersAdaptiveSelectivityService.computeAdjustment.
+ *
+ * Couvre la logique pure (sans I/O Supabase) :
+ *   - EN_AVANCE             → no_op
+ *   - DANS_LE_PLAN + active  → restore from snapshot
+ *   - DANS_LE_PLAN + !active → no_op
+ *   - EN_RETARD first        → adjust + snapshot user values
+ *   - EN_RETARD continued    → adjust without re-snapshot
+ *   - EN_RETARD all at floor → no_op (cannot adjust further)
+ *   - HORS_TRAJECTOIRE       → kill_switch + restore (if active)
+ *   - HORS_TRAJECTOIRE !act  → kill_switch only
+ *
+ * Brackets ADR-005 testés : floors persistence/path/cooldown, ceiling max_per_cycle.
+ */
+
+import { GainersAdaptiveSelectivityService, type AdaptiveContext } from '../automations/adaptive-selectivity.service';
+
+function makeService(): GainersAdaptiveSelectivityService {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new GainersAdaptiveSelectivityService({} as any, { logInsight: jest.fn() } as any);
+}
+
+const baseCtx: AdaptiveContext = {
+  current_persistence: 0.67,
+  current_path_eff: 0.50,
+  current_max_per_cycle: 3,
+  current_cooldown: 30,
+  snapshot_persistence: null,
+  snapshot_path_eff: null,
+  snapshot_max_per_cycle: null,
+  snapshot_cooldown: null,
+  adaptive_active: false,
+};
+
+describe('GainersAdaptiveSelectivityService.computeAdjustment', () => {
+  describe('EN_AVANCE', () => {
+    it('always no_op (preserve cap user)', () => {
+      const svc = makeService();
+      const decision = svc.computeAdjustment('EN_AVANCE', baseCtx);
+      expect(decision.action).toBe('no_op');
+      expect(decision.reason).toContain('preserve user cap');
+    });
+  });
+
+  describe('DANS_LE_PLAN', () => {
+    it('not active → no_op', () => {
+      const svc = makeService();
+      const decision = svc.computeAdjustment('DANS_LE_PLAN', baseCtx);
+      expect(decision.action).toBe('no_op');
+    });
+
+    it('active → restore from snapshot', () => {
+      const svc = makeService();
+      const ctx: AdaptiveContext = {
+        ...baseCtx,
+        adaptive_active: true,
+        current_persistence: 0.62,
+        current_path_eff: 0.45,
+        current_max_per_cycle: 4,
+        current_cooldown: 15,
+        snapshot_persistence: 0.67,
+        snapshot_path_eff: 0.50,
+        snapshot_max_per_cycle: 3,
+        snapshot_cooldown: 30,
+      };
+      const decision = svc.computeAdjustment('DANS_LE_PLAN', ctx);
+      expect(decision.action).toBe('restore');
+      expect(decision.next_persistence).toBe(0.67);
+      expect(decision.next_path_eff).toBe(0.50);
+      expect(decision.next_max_per_cycle).toBe(3);
+      expect(decision.next_cooldown).toBe(30);
+      expect(decision.next_adaptive_active).toBe(false);
+      // Clear snapshot
+      expect(decision.next_snapshot_persistence).toBe(null);
+    });
+  });
+
+  describe('EN_RETARD', () => {
+    it('first transition → adjust + snapshot', () => {
+      const svc = makeService();
+      const decision = svc.computeAdjustment('EN_RETARD', baseCtx);
+      expect(decision.action).toBe('adjust');
+      expect(decision.next_persistence).toBeCloseTo(0.62, 3); // 0.67 - 0.05
+      expect(decision.next_path_eff).toBeCloseTo(0.45, 3);    // 0.50 - 0.05
+      expect(decision.next_max_per_cycle).toBe(4);            // 3 + 1
+      expect(decision.next_cooldown).toBe(15);                // 30 / 2
+      expect(decision.next_adaptive_active).toBe(true);
+      // Snapshot user values
+      expect(decision.next_snapshot_persistence).toBe(0.67);
+      expect(decision.next_snapshot_path_eff).toBe(0.50);
+      expect(decision.next_snapshot_max_per_cycle).toBe(3);
+      expect(decision.next_snapshot_cooldown).toBe(30);
+    });
+
+    it('continued (already active) → adjust without re-snapshot', () => {
+      const svc = makeService();
+      const ctx: AdaptiveContext = {
+        ...baseCtx,
+        adaptive_active: true,
+        current_persistence: 0.62,
+        current_path_eff: 0.45,
+        current_max_per_cycle: 4,
+        current_cooldown: 15,
+        snapshot_persistence: 0.67,
+        snapshot_path_eff: 0.50,
+        snapshot_max_per_cycle: 3,
+        snapshot_cooldown: 30,
+      };
+      const decision = svc.computeAdjustment('EN_RETARD', ctx);
+      expect(decision.action).toBe('adjust');
+      expect(decision.next_persistence).toBeCloseTo(0.57, 3); // 0.62 - 0.05
+      expect(decision.next_path_eff).toBeCloseTo(0.40, 3);    // 0.45 - 0.05
+      expect(decision.next_max_per_cycle).toBe(5);            // 4 + 1
+      expect(decision.next_cooldown).toBe(7);                 // floor(15/2)
+      // No re-snapshot (snapshot fields not in decision)
+      expect('next_snapshot_persistence' in decision).toBe(false);
+    });
+
+    it('clamp persistence floor 0.50', () => {
+      const svc = makeService();
+      const ctx: AdaptiveContext = {
+        ...baseCtx,
+        adaptive_active: true,
+        current_persistence: 0.52,
+        snapshot_persistence: 0.67,
+      };
+      const decision = svc.computeAdjustment('EN_RETARD', ctx);
+      expect(decision.next_persistence).toBe(0.50); // clamped, not 0.47
+    });
+
+    it('clamp path floor 0.30', () => {
+      const svc = makeService();
+      const ctx: AdaptiveContext = {
+        ...baseCtx,
+        adaptive_active: true,
+        current_path_eff: 0.32,
+        snapshot_path_eff: 0.50,
+      };
+      const decision = svc.computeAdjustment('EN_RETARD', ctx);
+      expect(decision.next_path_eff).toBe(0.30);
+    });
+
+    it('clamp max_per_cycle ceiling 10', () => {
+      const svc = makeService();
+      const ctx: AdaptiveContext = {
+        ...baseCtx,
+        adaptive_active: true,
+        current_max_per_cycle: 10,
+        snapshot_max_per_cycle: 3,
+      };
+      const decision = svc.computeAdjustment('EN_RETARD', ctx);
+      expect(decision.next_max_per_cycle).toBe(10);
+    });
+
+    it('clamp cooldown floor 5', () => {
+      const svc = makeService();
+      const ctx: AdaptiveContext = {
+        ...baseCtx,
+        adaptive_active: true,
+        current_cooldown: 8,
+        snapshot_cooldown: 30,
+      };
+      const decision = svc.computeAdjustment('EN_RETARD', ctx);
+      expect(decision.next_cooldown).toBe(5); // floor(8/2)=4 < 5 floor
+    });
+
+    it('all at floor → no_op (cannot adjust further)', () => {
+      const svc = makeService();
+      const ctx: AdaptiveContext = {
+        ...baseCtx,
+        adaptive_active: true,
+        current_persistence: 0.50,
+        current_path_eff: 0.30,
+        current_max_per_cycle: 10,
+        current_cooldown: 5,
+      };
+      const decision = svc.computeAdjustment('EN_RETARD', ctx);
+      expect(decision.action).toBe('no_op');
+      expect(decision.reason).toContain('floor');
+    });
+  });
+
+  describe('HORS_TRAJECTOIRE', () => {
+    it('not active → kill_switch only (autopilot OFF)', () => {
+      const svc = makeService();
+      const decision = svc.computeAdjustment('HORS_TRAJECTOIRE', baseCtx);
+      expect(decision.action).toBe('kill_switch');
+      expect(decision.next_autopilot_enabled).toBe(false);
+      expect(decision.next_adaptive_active).toBe(false);
+    });
+
+    it('active → kill_switch + restore from snapshot', () => {
+      const svc = makeService();
+      const ctx: AdaptiveContext = {
+        ...baseCtx,
+        adaptive_active: true,
+        current_persistence: 0.55,
+        snapshot_persistence: 0.67,
+        snapshot_path_eff: 0.50,
+        snapshot_max_per_cycle: 3,
+        snapshot_cooldown: 30,
+      };
+      const decision = svc.computeAdjustment('HORS_TRAJECTOIRE', ctx);
+      expect(decision.action).toBe('kill_switch');
+      expect(decision.next_autopilot_enabled).toBe(false);
+      expect(decision.next_persistence).toBe(0.67); // restored
+      expect(decision.next_adaptive_active).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/modules/gainers-scanner/automations/adaptive-selectivity.service.ts
+++ b/apps/api/src/modules/gainers-scanner/automations/adaptive-selectivity.service.ts
@@ -1,0 +1,431 @@
+/**
+ * PR #243 — GainersAdaptiveSelectivityService.
+ *
+ * Cron 5 min : ajuste dynamiquement les seuils du scanner Gainers selon
+ * trajectory_status calculé sur 7 jours glissants.
+ *
+ * Spec utilisateur (05/05/2026 14:30 UTC) :
+ *   - DANS_LE_PLAN  (80%-110% cible) : restore user values + adaptive_active=false
+ *   - EN_AVANCE     (>110% cible)    : NO-OP (préserve le cap user)
+ *   - EN_RETARD     (<80% cible)     : assouplit
+ *       persistence_score   −0.05 (floor 0.50)
+ *       path_efficiency     −0.05 (floor 0.30)
+ *       max_per_cycle       +1    (ceiling 10)
+ *       cooldown_minutes    ÷2    (floor 5)
+ *   - HORS_TRAJECTOIRE (réalisé négatif) : autopilot_enabled=false + alarm
+ *
+ * Snapshot pattern : à la transition vers EN_RETARD, on snapshot les valeurs
+ * user actuelles dans `gainers_adaptive_snapshot_*` AVANT d'assouplir. Au
+ * retour DANS_LE_PLAN, on restore depuis snapshot.
+ *
+ * Garde-fous :
+ *   - Opt-in : `gainers_adaptive_enabled = true` requis
+ *   - Brackets ADR-005 : floors/ceilings non négociables
+ *   - Cap mouvement par cycle : −0.05 / +1 / ÷2 (linéaire, pas cumulatif
+ *     sans reset car user a explicitement demandé "pas de reset 00:00 UTC")
+ *   - Fonction pure `computeAdjustment()` exposée pour tests
+ *
+ * Réutilise la logique trajectory_status de LisaService (110%/80% seuils
+ * existants, alignés avec mode INVESTMENT/HARVEST).
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { GainersInsightsService } from '../insights/gainers-insights.service';
+
+const FLOOR_PERSISTENCE = 0.50;
+const FLOOR_PATH_EFF = 0.30;
+const CEILING_MAX_PER_CYCLE = 10;
+const FLOOR_COOLDOWN_MIN = 5;
+const ADJUSTMENT_PERSISTENCE_DELTA = 0.05;
+const ADJUSTMENT_PATH_EFF_DELTA = 0.05;
+const ADJUSTMENT_MAX_PER_CYCLE_DELTA = 1;
+const COOLDOWN_DIVISOR = 2;
+
+type TrajectoryStatus = 'EN_AVANCE' | 'DANS_LE_PLAN' | 'EN_RETARD' | 'HORS_TRAJECTOIRE';
+
+export interface AdaptiveContext {
+  // Config user actuelle (effective ou snapshot selon adaptive_active)
+  current_persistence: number;
+  current_path_eff: number;
+  current_max_per_cycle: number;
+  current_cooldown: number;
+  // Snapshot user values (si adaptive_active=true, sinon null)
+  snapshot_persistence: number | null;
+  snapshot_path_eff: number | null;
+  snapshot_max_per_cycle: number | null;
+  snapshot_cooldown: number | null;
+  adaptive_active: boolean;
+}
+
+export interface AdaptiveDecision {
+  action: 'no_op' | 'adjust' | 'restore' | 'kill_switch';
+  reason: string;
+  // Nouveaux values à écrire (null = ne pas modifier)
+  next_persistence?: number;
+  next_path_eff?: number;
+  next_max_per_cycle?: number;
+  next_cooldown?: number;
+  next_adaptive_active?: boolean;
+  next_autopilot_enabled?: boolean;
+  // Snapshot à écrire si transition vers EN_RETARD
+  next_snapshot_persistence?: number | null;
+  next_snapshot_path_eff?: number | null;
+  next_snapshot_max_per_cycle?: number | null;
+  next_snapshot_cooldown?: number | null;
+}
+
+interface PortfolioConfig {
+  portfolio_id: string;
+  user_id: string;
+  gainers_min_persistence_score: number | null;
+  gainers_min_path_efficiency: number | null;
+  gainers_max_per_cycle: number | null;
+  gainers_cooldown_minutes: number | null;
+  gainers_adaptive_active: boolean | null;
+  gainers_adaptive_snapshot_persistence: number | null;
+  gainers_adaptive_snapshot_path_eff: number | null;
+  gainers_adaptive_snapshot_max_per_cycle: number | null;
+  gainers_adaptive_snapshot_cooldown: number | null;
+  gainers_trajectory_status: string | null;
+  return_target_daily_pct: number | null;
+  return_target_monthly_pct: number | null;
+  return_target_annual_pct: number | null;
+  capital_usd: string | number | null;
+}
+
+@Injectable()
+export class GainersAdaptiveSelectivityService {
+  private readonly logger = new Logger(GainersAdaptiveSelectivityService.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly insights: GainersInsightsService,
+  ) {}
+
+  /** Cron 5 min strict UTC. */
+  @Cron('*/5 * * * *', { timeZone: 'UTC' })
+  async runAdaptiveCycle(): Promise<void> {
+    try {
+      await this.runInner();
+    } catch (e) {
+      this.logger.error(`[adaptive] cron failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  private async runInner(): Promise<void> {
+    const portfolios = await this.loadEnabledPortfolios();
+    if (portfolios.length === 0) {
+      this.logger.debug('[adaptive] no portfolio with gainers_adaptive_enabled=true');
+      return;
+    }
+
+    let applied = 0;
+    let skipped = 0;
+
+    for (const cfg of portfolios) {
+      try {
+        const status = await this.computeStatus(cfg);
+        if (!status) {
+          skipped++;
+          continue;
+        }
+
+        const ctx: AdaptiveContext = this.buildContext(cfg);
+        const decision = this.computeAdjustment(status, ctx);
+
+        if (decision.action !== 'no_op') {
+          await this.applyDecision(cfg, status, decision);
+          applied++;
+        } else {
+          // Update only the trajectory_status fields (visibility UI)
+          await this.updateStatusOnly(cfg.portfolio_id, status);
+          skipped++;
+        }
+      } catch (e) {
+        this.logger.warn(
+          `[adaptive] portfolio ${cfg.portfolio_id.slice(0, 8)}: ${String(e).slice(0, 100)}`,
+        );
+      }
+    }
+
+    this.logger.log(`[adaptive] cycle complete: applied=${applied} skipped=${skipped} portfolios=${portfolios.length}`);
+  }
+
+  /**
+   * Pure logic — exposée pour tests. Décide quoi faire selon le status courant
+   * et le contexte (snapshot/active state).
+   *
+   * Règles :
+   *   - EN_AVANCE                  → no_op (preserve cap user)
+   *   - DANS_LE_PLAN + active      → restore user values from snapshot
+   *   - DANS_LE_PLAN + not active  → no_op
+   *   - EN_RETARD                  → adjust (snapshot d'abord si first transition)
+   *   - HORS_TRAJECTOIRE           → kill_switch (autopilot=false)
+   */
+  computeAdjustment(status: TrajectoryStatus, ctx: AdaptiveContext): AdaptiveDecision {
+    if (status === 'EN_AVANCE') {
+      return { action: 'no_op', reason: 'EN_AVANCE — preserve user cap (no-op)' };
+    }
+
+    if (status === 'HORS_TRAJECTOIRE') {
+      return {
+        action: 'kill_switch',
+        reason: 'HORS_TRAJECTOIRE — autopilot disabled, alarm UI',
+        next_autopilot_enabled: false,
+        // Restore snapshot si on était EN_RETARD avant
+        ...(ctx.adaptive_active ? this.buildRestorePartial(ctx) : {}),
+        next_adaptive_active: false,
+      };
+    }
+
+    if (status === 'DANS_LE_PLAN') {
+      if (!ctx.adaptive_active) {
+        return { action: 'no_op', reason: 'DANS_LE_PLAN + not active — preserve user' };
+      }
+      // Restore from snapshot
+      return {
+        action: 'restore',
+        reason: 'DANS_LE_PLAN return — restore user snapshot',
+        ...this.buildRestorePartial(ctx),
+        next_adaptive_active: false,
+      };
+    }
+
+    // status === 'EN_RETARD'
+    const isFirstTransition = !ctx.adaptive_active;
+
+    // Compute new values with brackets
+    const nextPersistence = Math.max(
+      FLOOR_PERSISTENCE,
+      ctx.current_persistence - ADJUSTMENT_PERSISTENCE_DELTA,
+    );
+    const nextPathEff = Math.max(
+      FLOOR_PATH_EFF,
+      ctx.current_path_eff - ADJUSTMENT_PATH_EFF_DELTA,
+    );
+    const nextMaxPerCycle = Math.min(
+      CEILING_MAX_PER_CYCLE,
+      ctx.current_max_per_cycle + ADJUSTMENT_MAX_PER_CYCLE_DELTA,
+    );
+    const nextCooldown = Math.max(
+      FLOOR_COOLDOWN_MIN,
+      Math.floor(ctx.current_cooldown / COOLDOWN_DIVISOR),
+    );
+
+    // Skip if all values already at floor (further adjustments useless)
+    const allAtFloor =
+      nextPersistence === ctx.current_persistence
+      && nextPathEff === ctx.current_path_eff
+      && nextMaxPerCycle === ctx.current_max_per_cycle
+      && nextCooldown === ctx.current_cooldown;
+
+    if (allAtFloor) {
+      return {
+        action: 'no_op',
+        reason: 'EN_RETARD but all gates at floor — cannot adjust further',
+      };
+    }
+
+    return {
+      action: 'adjust',
+      reason: `EN_RETARD ${isFirstTransition ? 'first transition' : 'continued'} — assouplit gates`,
+      next_persistence: nextPersistence,
+      next_path_eff: nextPathEff,
+      next_max_per_cycle: nextMaxPerCycle,
+      next_cooldown: nextCooldown,
+      next_adaptive_active: true,
+      // Snapshot only on first transition (preserve original user values)
+      ...(isFirstTransition
+        ? {
+            next_snapshot_persistence: ctx.current_persistence,
+            next_snapshot_path_eff: ctx.current_path_eff,
+            next_snapshot_max_per_cycle: ctx.current_max_per_cycle,
+            next_snapshot_cooldown: ctx.current_cooldown,
+          }
+        : {}),
+    };
+  }
+
+  private buildRestorePartial(ctx: AdaptiveContext): Partial<AdaptiveDecision> {
+    return {
+      next_persistence: ctx.snapshot_persistence ?? ctx.current_persistence,
+      next_path_eff: ctx.snapshot_path_eff ?? ctx.current_path_eff,
+      next_max_per_cycle: ctx.snapshot_max_per_cycle ?? ctx.current_max_per_cycle,
+      next_cooldown: ctx.snapshot_cooldown ?? ctx.current_cooldown,
+      next_snapshot_persistence: null,
+      next_snapshot_path_eff: null,
+      next_snapshot_max_per_cycle: null,
+      next_snapshot_cooldown: null,
+    };
+  }
+
+  private buildContext(cfg: PortfolioConfig): AdaptiveContext {
+    return {
+      current_persistence: Number(cfg.gainers_min_persistence_score ?? 0.67),
+      current_path_eff: Number(cfg.gainers_min_path_efficiency ?? 0.5),
+      current_max_per_cycle: Number(cfg.gainers_max_per_cycle ?? 3),
+      current_cooldown: Number(cfg.gainers_cooldown_minutes ?? 30),
+      snapshot_persistence: cfg.gainers_adaptive_snapshot_persistence != null
+        ? Number(cfg.gainers_adaptive_snapshot_persistence) : null,
+      snapshot_path_eff: cfg.gainers_adaptive_snapshot_path_eff != null
+        ? Number(cfg.gainers_adaptive_snapshot_path_eff) : null,
+      snapshot_max_per_cycle: cfg.gainers_adaptive_snapshot_max_per_cycle,
+      snapshot_cooldown: cfg.gainers_adaptive_snapshot_cooldown,
+      adaptive_active: cfg.gainers_adaptive_active === true,
+    };
+  }
+
+  /**
+   * Compute trajectory_status — réplique de LisaService.computeTrajectoryStatus
+   * pour ne pas créer de dépendance circulaire. Seuils : 80% / 110%.
+   */
+  private async computeStatus(cfg: PortfolioConfig): Promise<TrajectoryStatus | null> {
+    // Target per day
+    let targetPerDay: number | null = null;
+    if (cfg.return_target_daily_pct != null) {
+      targetPerDay = Number(cfg.return_target_daily_pct);
+    } else if (cfg.return_target_monthly_pct != null) {
+      targetPerDay = Number(cfg.return_target_monthly_pct) / 30;
+    } else if (cfg.return_target_annual_pct != null) {
+      targetPerDay = Number(cfg.return_target_annual_pct) / 365;
+    }
+    if (targetPerDay === null) {
+      this.logger.debug(`[adaptive] ${cfg.portfolio_id.slice(0, 8)}: no return target set, skip`);
+      return null;
+    }
+
+    // Realised 7d : sum closed trades pnl_usd / capital × 100
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 3600_000).toISOString();
+    const { data: closedTrades, error } = await this.supabase
+      .getClient()
+      .from('paper_trades')
+      .select('pnl_usd')
+      .eq('portfolio_id', cfg.portfolio_id)
+      .eq('strategy', 'top_gainers_v1')
+      .eq('status', 'closed')
+      .gte('closed_at', sevenDaysAgo);
+    if (error) {
+      this.logger.warn(`[adaptive] fetch trades failed: ${error.message}`);
+      return null;
+    }
+    const pnlSum = (closedTrades ?? []).reduce(
+      (acc, row) => acc + (parseFloat(String(row.pnl_usd ?? '0')) || 0),
+      0,
+    );
+    const capital = Number(cfg.capital_usd ?? 10000);
+    if (capital <= 0) return null;
+    const realisedPct = (pnlSum / capital) * 100;
+
+    const targetExtrapolated = targetPerDay * 7;
+
+    // Persiste pour UI
+    await this.supabase
+      .getClient()
+      .from('lisa_session_configs')
+      .update({
+        gainers_realised_7d_pct: Number(realisedPct.toFixed(4)),
+        gainers_target_7d_pct: Number(targetExtrapolated.toFixed(4)),
+      })
+      .eq('portfolio_id', cfg.portfolio_id);
+
+    // Apply thresholds (aligned avec LisaService)
+    if (realisedPct < -0.5) return 'HORS_TRAJECTOIRE';
+    if (realisedPct >= targetExtrapolated * 1.1) return 'EN_AVANCE';
+    if (realisedPct >= targetExtrapolated * 0.8) return 'DANS_LE_PLAN';
+    return 'EN_RETARD';
+  }
+
+  private async loadEnabledPortfolios(): Promise<PortfolioConfig[]> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('lisa_session_configs')
+      .select(
+        'portfolio_id, user_id, capital_usd, ' +
+        'gainers_min_persistence_score, gainers_min_path_efficiency, ' +
+        'gainers_max_per_cycle, gainers_cooldown_minutes, ' +
+        'gainers_adaptive_active, gainers_adaptive_snapshot_persistence, ' +
+        'gainers_adaptive_snapshot_path_eff, gainers_adaptive_snapshot_max_per_cycle, ' +
+        'gainers_adaptive_snapshot_cooldown, gainers_trajectory_status, ' +
+        'return_target_daily_pct, return_target_monthly_pct, return_target_annual_pct',
+      )
+      .eq('strategy_mode', 'gainers')
+      .eq('gainers_adaptive_enabled', true);
+    if (error) {
+      this.logger.warn(`[adaptive] loadEnabledPortfolios: ${error.message}`);
+      return [];
+    }
+    return (data ?? []) as unknown as PortfolioConfig[];
+  }
+
+  private async applyDecision(
+    cfg: PortfolioConfig,
+    status: TrajectoryStatus,
+    decision: AdaptiveDecision,
+  ): Promise<void> {
+    const update: Record<string, unknown> = {
+      gainers_trajectory_status: status,
+      gainers_trajectory_status_at: new Date().toISOString(),
+    };
+
+    if (decision.next_persistence != null) update.gainers_min_persistence_score = decision.next_persistence;
+    if (decision.next_path_eff != null) update.gainers_min_path_efficiency = decision.next_path_eff;
+    if (decision.next_max_per_cycle != null) update.gainers_max_per_cycle = decision.next_max_per_cycle;
+    if (decision.next_cooldown != null) update.gainers_cooldown_minutes = decision.next_cooldown;
+    if (decision.next_adaptive_active != null) update.gainers_adaptive_active = decision.next_adaptive_active;
+    if (decision.next_autopilot_enabled != null) update.autopilot_enabled = decision.next_autopilot_enabled;
+    if ('next_snapshot_persistence' in decision) update.gainers_adaptive_snapshot_persistence = decision.next_snapshot_persistence;
+    if ('next_snapshot_path_eff' in decision) update.gainers_adaptive_snapshot_path_eff = decision.next_snapshot_path_eff;
+    if ('next_snapshot_max_per_cycle' in decision) update.gainers_adaptive_snapshot_max_per_cycle = decision.next_snapshot_max_per_cycle;
+    if ('next_snapshot_cooldown' in decision) update.gainers_adaptive_snapshot_cooldown = decision.next_snapshot_cooldown;
+
+    const { error } = await this.supabase
+      .getClient()
+      .from('lisa_session_configs')
+      .update(update)
+      .eq('portfolio_id', cfg.portfolio_id);
+    if (error) {
+      this.logger.warn(`[adaptive] update failed: ${error.message}`);
+      return;
+    }
+
+    // Map action → kind for decision_log
+    const kindMap: Record<AdaptiveDecision['action'], string> = {
+      no_op: 'adaptive_status_changed',
+      adjust: 'adaptive_adjustment_applied',
+      restore: 'adaptive_restore_applied',
+      kill_switch: 'adaptive_kill_switch_triggered',
+    };
+
+    // Audit + insight
+    await this.insights.logInsight({
+      type: 'threshold_proposal',
+      source: 'auto_threshold_tuner',
+      severity: status === 'HORS_TRAJECTOIRE' ? 'critical' : 'medium',
+      summary: `Adaptive ${decision.action}: ${status} — ${decision.reason}`,
+      payload: {
+        portfolio_id: cfg.portfolio_id,
+        status,
+        action: decision.action,
+        decision,
+        kind_logged: kindMap[decision.action],
+      },
+    }).catch(() => null);
+
+    this.logger.log(
+      `[adaptive] ${cfg.portfolio_id.slice(0, 8)} ${status} → ${decision.action}: ${decision.reason}`,
+    );
+  }
+
+  private async updateStatusOnly(portfolioId: string, status: TrajectoryStatus): Promise<void> {
+    await this.supabase
+      .getClient()
+      .from('lisa_session_configs')
+      .update({
+        gainers_trajectory_status: status,
+        gainers_trajectory_status_at: new Date().toISOString(),
+      })
+      .eq('portfolio_id', portfolioId);
+  }
+}

--- a/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
+++ b/apps/api/src/modules/gainers-scanner/gainers-scanner.module.ts
@@ -17,6 +17,7 @@ import { GainersInsightsService } from './insights/gainers-insights.service';
 import { DriftDetectorService } from './automations/drift-detector.service';
 import { RejectedInsightsService } from './automations/rejected-insights.service';
 import { ThresholdAutoTunerService } from './automations/threshold-auto-tuner.service';
+import { GainersAdaptiveSelectivityService } from './automations/adaptive-selectivity.service';
 
 /**
  * ADR-005 Gainers Algo V1 — Module NestJS découplé (ADR-006).
@@ -51,6 +52,8 @@ import { ThresholdAutoTunerService } from './automations/threshold-auto-tuner.se
     // pour ajuster automatiquement les seuils gainers_min_persistence_score
     // et gainers_min_path_efficiency. Ferme la boucle d'apprentissage.
     ThresholdAutoTunerService,
+    // PR #243 — adaptive selectivity (cron 5min trajectory_status → adjustments)
+    GainersAdaptiveSelectivityService,
   ],
   exports: [
     GainersBloc1Service,
@@ -68,6 +71,8 @@ import { ThresholdAutoTunerService } from './automations/threshold-auto-tuner.se
     GainersInsightsService,
     RejectedInsightsService,
     ThresholdAutoTunerService,
+    // PR #243 — adaptive selectivity (cron 5min trajectory_status → adjustments)
+    GainersAdaptiveSelectivityService,
   ],
 })
 export class GainersModule implements OnModuleInit {

--- a/apps/api/src/modules/lisa/__tests__/aggregate-by-class.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/aggregate-by-class.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * PR Breakdown fix — Tests pour aggregateByClass avec fallback exchange.
+ *
+ * Bug rapporté user 05/05/2026 14:30 UTC :
+ * Compteurs UI affichaient 1000 scannés mais breakdown "₿ 50" seulement.
+ * Cause : `gainers_v1_shadow_signals.asset_class` stocke 'equity' (générique)
+ * pour beaucoup de tickers. Mon premier `aggregateByClass` testait uniquement
+ * `startsWith('us_equity'/'eu_equity'/...)` → 950 rows tombaient en 'other'.
+ *
+ * Fix : fallback sur `exchange` quand asset_class est générique.
+ */
+
+// Réplique inline d'aggregateByClass (testé en isolation, pas via NestJS)
+const US_EXCHANGES = new Set(['US', 'NYSE', 'NASDAQ', 'BATS', 'OTCQB', 'OTCMKTS', 'OTC', 'NMFQS']);
+const EU_EXCHANGES = new Set(['LSE', 'XETRA', 'PA', 'AS', 'AMS', 'MC', 'BME', 'MI', 'SW', 'BR']);
+const ASIA_EXCHANGES = new Set(['KO', 'KQ', 'KS', 'KE', 'T', 'TSE', 'HK', 'NSE', 'BSE', 'SHG', 'SHE', 'SS', 'SZ', 'AU', 'AX', 'TO']);
+const CRYPTO_EXCHANGES = new Set(['BINANCE', 'CC', 'COINBASE']);
+
+function aggregateByClass(rows: Array<{ asset_class: string | null; exchange?: string | null }>): {
+  us: number; eu: number; asia: number; crypto: number; other: number;
+} {
+  const out = { us: 0, eu: 0, asia: 0, crypto: 0, other: 0 };
+  for (const r of rows) {
+    const ac = String(r.asset_class ?? '').toLowerCase();
+    const ex = String(r.exchange ?? '').toUpperCase();
+    if (ac.startsWith('us_equity')) { out.us++; continue; }
+    if (ac.startsWith('eu_equity')) { out.eu++; continue; }
+    if (ac.startsWith('asia_equity')) { out.asia++; continue; }
+    if (ac.startsWith('crypto')) { out.crypto++; continue; }
+    if (CRYPTO_EXCHANGES.has(ex)) { out.crypto++; continue; }
+    if (US_EXCHANGES.has(ex)) { out.us++; continue; }
+    if (EU_EXCHANGES.has(ex)) { out.eu++; continue; }
+    if (ASIA_EXCHANGES.has(ex)) { out.asia++; continue; }
+    out.other++;
+  }
+  return out;
+}
+
+describe('aggregateByClass (PR breakdown fix)', () => {
+  describe('asset_class préfixé (cas idéal)', () => {
+    it('us_equity_large → us', () => {
+      expect(aggregateByClass([{ asset_class: 'us_equity_large' }])).toEqual({
+        us: 1, eu: 0, asia: 0, crypto: 0, other: 0,
+      });
+    });
+
+    it('eu_equity → eu', () => {
+      expect(aggregateByClass([{ asset_class: 'eu_equity' }])).toEqual({
+        us: 0, eu: 1, asia: 0, crypto: 0, other: 0,
+      });
+    });
+
+    it('asia_equity → asia', () => {
+      expect(aggregateByClass([{ asset_class: 'asia_equity' }])).toEqual({
+        us: 0, eu: 0, asia: 1, crypto: 0, other: 0,
+      });
+    });
+
+    it('crypto_major / crypto_alt → crypto', () => {
+      expect(aggregateByClass([
+        { asset_class: 'crypto_major' },
+        { asset_class: 'crypto_alt' },
+      ])).toEqual({ us: 0, eu: 0, asia: 0, crypto: 2, other: 0 });
+    });
+  });
+
+  describe('asset_class générique "equity" — fallback exchange', () => {
+    it('equity + US → us', () => {
+      expect(aggregateByClass([{ asset_class: 'equity', exchange: 'US' }])).toEqual({
+        us: 1, eu: 0, asia: 0, crypto: 0, other: 0,
+      });
+    });
+
+    it('equity + AS (Amsterdam) → eu', () => {
+      expect(aggregateByClass([{ asset_class: 'equity', exchange: 'AS' }])).toEqual({
+        us: 0, eu: 1, asia: 0, crypto: 0, other: 0,
+      });
+    });
+
+    it('equity + KO (Korea) → asia', () => {
+      expect(aggregateByClass([{ asset_class: 'equity', exchange: 'KO' }])).toEqual({
+        us: 0, eu: 0, asia: 1, crypto: 0, other: 0,
+      });
+    });
+
+    it('equity + SHG (Shanghai) → asia', () => {
+      expect(aggregateByClass([{ asset_class: 'equity', exchange: 'SHG' }])).toEqual({
+        us: 0, eu: 0, asia: 1, crypto: 0, other: 0,
+      });
+    });
+
+    it('crypto + BINANCE → crypto', () => {
+      expect(aggregateByClass([{ asset_class: 'crypto', exchange: 'BINANCE' }])).toEqual({
+        us: 0, eu: 0, asia: 0, crypto: 1, other: 0,
+      });
+    });
+  });
+
+  describe('Bug reproduit user 14:30 UTC (1000 scannés, 50 crypto)', () => {
+    it('mix realistic equity (US/EU/Asia) + crypto sans préfixes', () => {
+      const rows = [
+        ...Array(400).fill(null).map(() => ({ asset_class: 'equity', exchange: 'US' })),
+        ...Array(200).fill(null).map(() => ({ asset_class: 'equity', exchange: 'AS' })),
+        ...Array(150).fill(null).map(() => ({ asset_class: 'equity', exchange: 'LSE' })),
+        ...Array(100).fill(null).map(() => ({ asset_class: 'equity', exchange: 'KO' })),
+        ...Array(100).fill(null).map(() => ({ asset_class: 'equity', exchange: 'SHG' })),
+        ...Array(50).fill(null).map(() => ({ asset_class: 'crypto', exchange: 'BINANCE' })),
+      ];
+      const result = aggregateByClass(rows);
+      expect(result.us).toBe(400);
+      expect(result.eu).toBe(350); // 200 AS + 150 LSE
+      expect(result.asia).toBe(200); // 100 KO + 100 SHG
+      expect(result.crypto).toBe(50);
+      expect(result.other).toBe(0);
+      expect(result.us + result.eu + result.asia + result.crypto + result.other).toBe(1000);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('asset_class null + exchange null → other', () => {
+      expect(aggregateByClass([{ asset_class: null }])).toEqual({
+        us: 0, eu: 0, asia: 0, crypto: 0, other: 1,
+      });
+    });
+
+    it('asset_class equity + exchange unknown → other', () => {
+      expect(aggregateByClass([{ asset_class: 'equity', exchange: 'WAT' }])).toEqual({
+        us: 0, eu: 0, asia: 0, crypto: 0, other: 1,
+      });
+    });
+
+    it('priorité asset_class préfixé sur exchange (data integrity)', () => {
+      // Si asset_class='us_equity_large' mais exchange='KO' (incohérent),
+      // on fait confiance à asset_class (plus précis).
+      expect(aggregateByClass([{ asset_class: 'us_equity_large', exchange: 'KO' }])).toEqual({
+        us: 1, eu: 0, asia: 0, crypto: 0, other: 0,
+      });
+    });
+
+    it('exchange case-insensitive (lowercase normalisé)', () => {
+      expect(aggregateByClass([{ asset_class: 'equity', exchange: 'us' }])).toEqual({
+        us: 1, eu: 0, asia: 0, crypto: 0, other: 0,
+      });
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -212,7 +212,7 @@ export class LisaController {
     // Q1 — Scannés aujourd'hui (count + breakdown + 7j history)
     const { data: scannedTodayRows } = await supabase
       .from('gainers_v1_shadow_signals')
-      .select('asset_class')
+      .select('asset_class, exchange')
       .gte('created_at', startOfDayUtcIso);
     const scannedToday = (scannedTodayRows ?? []).length;
     const scannedByAssetClass = aggregateByClass(scannedTodayRows ?? []);
@@ -227,7 +227,7 @@ export class LisaController {
     // Q2 — Ouverts aujourd'hui via paper_trades (strategy='top_gainers_v1')
     const { data: openedTodayRows } = await supabase
       .from('paper_trades')
-      .select('asset_class')
+      .select('asset_class, exchange')
       .eq('portfolio_id', portfolioId)
       .eq('strategy', 'top_gainers_v1')
       .gte('opened_at', startOfDayUtcIso);
@@ -237,7 +237,7 @@ export class LisaController {
     // Q3 — Fermés aujourd'hui + somme PnL
     const { data: closedTodayPaperTrades } = await supabase
       .from('paper_trades')
-      .select('pnl_usd, asset_class')
+      .select('pnl_usd, asset_class, exchange')
       .eq('portfolio_id', portfolioId)
       .eq('strategy', 'top_gainers_v1')
       .eq('status', 'closed')
@@ -1095,20 +1095,43 @@ const MARKET_GROUPS: Record<string, string> = {
 };
 
 /**
- * PR Counters jour (Option B) — agrège par asset_class en 4 buckets UI :
- * us / eu / asia / crypto / other. Utilisé pour breakdown counters Gainers.
+ * PR Counters jour (Option B) — agrège par asset_class en 5 buckets UI :
+ * us / eu / asia / crypto / other.
+ *
+ * Hotfix breakdown : `gainers_v1_shadow_signals.asset_class` stocke souvent
+ * un générique 'equity' (sans préfixe us_equity/eu_equity/asia_equity). Sans
+ * fallback exchange, ces rows tomberaient toutes en 'other' → breakdown UI
+ * affichait uniquement "₿ 50" sur 1000 scans (cas user 05/05 14:30 UTC).
+ *
+ * Mapping exchange → bucket :
+ *   - US, NYSE, NASDAQ, BATS, OTCQB, OTCMKTS → us
+ *   - LSE, XETRA, PA, AS, AMS, MC, BME, MI, SW, BR → eu
+ *   - KO, KQ, T, HK, NSE, BSE, SHG, SHE, AU, AX, TO → asia
+ *   - BINANCE, CC, COINBASE → crypto
  */
-function aggregateByClass(rows: Array<{ asset_class: string | null }>): {
+const US_EXCHANGES = new Set(['US', 'NYSE', 'NASDAQ', 'BATS', 'OTCQB', 'OTCMKTS', 'OTC', 'NMFQS']);
+const EU_EXCHANGES = new Set(['LSE', 'XETRA', 'PA', 'AS', 'AMS', 'MC', 'BME', 'MI', 'SW', 'BR']);
+const ASIA_EXCHANGES = new Set(['KO', 'KQ', 'KS', 'KE', 'T', 'TSE', 'HK', 'NSE', 'BSE', 'SHG', 'SHE', 'SS', 'SZ', 'AU', 'AX', 'TO']);
+const CRYPTO_EXCHANGES = new Set(['BINANCE', 'CC', 'COINBASE']);
+
+function aggregateByClass(rows: Array<{ asset_class: string | null; exchange?: string | null }>): {
   us: number; eu: number; asia: number; crypto: number; other: number;
 } {
   const out = { us: 0, eu: 0, asia: 0, crypto: 0, other: 0 };
   for (const r of rows) {
     const ac = String(r.asset_class ?? '').toLowerCase();
-    if (ac.startsWith('us_equity')) out.us++;
-    else if (ac.startsWith('eu_equity')) out.eu++;
-    else if (ac.startsWith('asia_equity')) out.asia++;
-    else if (ac.startsWith('crypto')) out.crypto++;
-    else out.other++;
+    const ex = String(r.exchange ?? '').toUpperCase();
+    // Step 1 — try asset_class préfixe (préservé si bien typé)
+    if (ac.startsWith('us_equity')) { out.us++; continue; }
+    if (ac.startsWith('eu_equity')) { out.eu++; continue; }
+    if (ac.startsWith('asia_equity')) { out.asia++; continue; }
+    if (ac.startsWith('crypto')) { out.crypto++; continue; }
+    // Step 2 — fallback exchange (bug fix : asset_class générique 'equity')
+    if (CRYPTO_EXCHANGES.has(ex)) { out.crypto++; continue; }
+    if (US_EXCHANGES.has(ex)) { out.us++; continue; }
+    if (EU_EXCHANGES.has(ex)) { out.eu++; continue; }
+    if (ASIA_EXCHANGES.has(ex)) { out.asia++; continue; }
+    out.other++;
   }
   return out;
 }

--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -163,7 +163,7 @@ export class LisaController {
     // Read TP/SL and maxPositions from DB (single read, reused below).
     const { data: cfgRow } = await supabase
       .from('lisa_session_configs')
-      .select('gainers_default_tp_pct, gainers_default_sl_pct, max_open_positions')
+      .select('gainers_default_tp_pct, gainers_default_sl_pct, max_open_positions, gainers_adaptive_enabled, gainers_adaptive_active, gainers_trajectory_status, gainers_trajectory_status_at, gainers_realised_7d_pct, gainers_target_7d_pct')
       .eq('portfolio_id', portfolioId)
       .maybeSingle();
     const tpPct = cfgRow?.gainers_default_tp_pct != null
@@ -289,6 +289,16 @@ export class LisaController {
       openedByAssetClass,
       closedByAssetClass,
       scanned7d,
+      // PR #243 Adaptive Selectivity — exposition status pour bandeau UI
+      adaptiveEnabled: cfgRow?.gainers_adaptive_enabled === true,
+      adaptiveActive: cfgRow?.gainers_adaptive_active === true,
+      trajectoryStatus: (cfgRow?.gainers_trajectory_status as
+        | 'EN_AVANCE' | 'DANS_LE_PLAN' | 'EN_RETARD' | 'HORS_TRAJECTOIRE' | null) ?? null,
+      trajectoryStatusAt: cfgRow?.gainers_trajectory_status_at ?? null,
+      realised7dPct: cfgRow?.gainers_realised_7d_pct != null
+        ? Number(cfgRow.gainers_realised_7d_pct) : null,
+      target7dPct: cfgRow?.gainers_target_7d_pct != null
+        ? Number(cfgRow.gainers_target_7d_pct) : null,
     };
   }
 

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -303,6 +303,8 @@ export class LisaService {
       // par utilisateur quand modèle ML a convergé (≥30 trades fermés + AUC ≥ 0.55).
       gainers_p_win_gate_enabled: pick('gainers_p_win_gate_enabled', 'gainersPWinGateEnabled', existing?.gainers_p_win_gate_enabled ?? false),
       gainers_min_p_win: pick('gainers_min_p_win', 'gainersMinPWin', existing?.gainers_min_p_win ?? 0.50),
+      // PR #243 — Adaptive Selectivity toggle (migration 0119). Opt-in default false.
+      gainers_adaptive_enabled: pick('gainers_adaptive_enabled', 'gainersAdaptiveEnabled', existing?.gainers_adaptive_enabled ?? false),
     };
 
     // Validation des valeurs numériques pour renvoyer une 400 lisible plutôt
@@ -477,6 +479,20 @@ export class LisaService {
         ...mergedFallback
       } = merged;
       void _gc; void _gpe; void _gmp; void _gtp; void _gsl;
+      const retry = await this.supabase.getClient()
+        .from('lisa_session_configs')
+        .upsert(mergedFallback, { onConflict: 'portfolio_id' })
+        .select()
+        .single();
+      data = retry.data;
+      error = retry.error;
+    }
+
+    // PR #243 — fallback si migration 0119 pas encore appliquée
+    if (error && /gainers_adaptive_enabled/i.test(error.message)) {
+      this.logger.warn('Colonne gainers_adaptive_enabled absente — retry sans');
+      const { gainers_adaptive_enabled: _ade, ...mergedFallback } = merged;
+      void _ade;
       const retry = await this.supabase.getClient()
         .from('lisa_session_configs')
         .upsert(mergedFallback, { onConflict: 'portfolio_id' })

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -685,10 +685,16 @@ export class TopGainersScannerService implements OnModuleInit {
       return;
     }
 
-    const top = selectTopGainers(candidates, 3);
+    // PR Coverage filter — pool de 10 (au lieu de 3) pour buffer.
+    // Quand certains top candidats ont coverage=none (Asia .SHG/.SHE, US illiquides
+    // type EJPRF), le filtre coverage en aval (scanPortfolio) les exclut.
+    // Avec pool 10, il reste assez de backups pour que maxPerCycle (default 3)
+    // soit toujours saturé par des candidats avec data valide.
+    const TOP_POOL_SIZE = 10;
+    const top = selectTopGainers(candidates, TOP_POOL_SIZE);
     this.recordTopSelected(top.length);
     this.logger.log(
-      `[top-gainers] ${candidates.length} scanned → ${top.length} retained: ${top.map((t) => `${t.symbol}(${t.assetClass},${t.changePct.toFixed(1)}%,score=${t.score})`).join(', ')}`,
+      `[top-gainers] ${candidates.length} scanned → ${top.length} retained (pool ${TOP_POOL_SIZE}): ${top.slice(0, 5).map((t) => `${t.symbol}(${t.assetClass},${t.changePct.toFixed(1)}%,score=${t.score})`).join(', ')}${top.length > 5 ? '…' : ''}`,
     );
 
     // PR6.3 — Shadow run wiring : persiste chaque candidat scanné dans
@@ -1352,6 +1358,31 @@ export class TopGainersScannerService implements OnModuleInit {
       })),
     );
 
+    // PR Coverage filter — exclut les candidats coverage=none (toutes les TFs
+    // null = pas de data valide pour calculer persistence). Évite de remplir
+    // les slots top avec des tickers .SHG/.SHE/illiquides US qui échoueraient
+    // de toute façon au gate persistence en aval. Avec le pool TOP_POOL_SIZE=10,
+    // on garde au moins maxPerCycle candidats valides pour ouvrir.
+    const coverageValidTop: typeof filteredTop = [];
+    const coverageSkippedSymbols: string[] = [];
+    for (const c of filteredTop) {
+      const p = persistenceMap.get(c.symbol.toUpperCase());
+      if (!p || p.availableCount === 0 || Number.isNaN(p.persistenceScore)) {
+        // Préserve l'instrumentation P18e existante (compteur + skippedNoPersistence)
+        // pour les tests + log agrégé en fin de cycle.
+        this.skippedNoPersistenceCounter++;
+        coverageSkippedSymbols.push(c.symbol);
+        continue;
+      }
+      coverageValidTop.push(c);
+    }
+    if (coverageSkippedSymbols.length > 0) {
+      const sample = coverageSkippedSymbols.slice(0, 5).join(', ');
+      this.logger.log(
+        `[top-gainers] ${portfolioId.slice(0, 8)}: coverage filter ${filteredTop.length}→${coverageValidTop.length} (${coverageSkippedSymbols.length} skipped, sample: ${sample})`,
+      );
+    }
+
     // PR Hardcodes-fix — cap par cycle dérivé de cfg.gainers_max_per_cycle.
     // Permet à l'utilisateur d'ouvrir plusieurs candidats par cycle quand
     // plusieurs setups A+ sont détectés simultanément.
@@ -1359,7 +1390,9 @@ export class TopGainersScannerService implements OnModuleInit {
     let opened = 0;
     // P18e — accumule les skips pour log agrégé en fin de cycle (au lieu de
     // N lignes "no persistence data → skip" qui polluent les logs Fly).
-    const skippedNoPersistence: string[] = [];
+    // PR Coverage filter — inclut les skips déjà détectés en coverage filter
+    // pour cohérence des compteurs P18e + log "cycle skip-summary".
+    const skippedNoPersistence: string[] = [...coverageSkippedSymbols];
     // P19x.3 (29/04/2026) — Cooldown 30 min same symbol/side après close.
     //
     // User constat (29/04 02:00 UTC) : "Observé SLV 3× / LMT 3× / XLE 2× en
@@ -1399,7 +1432,7 @@ export class TopGainersScannerService implements OnModuleInit {
       this.logger.debug(`[top-gainers] cooldown query skipped: ${String(e).slice(0, 100)}`);
     }
 
-    for (const cand of filteredTop) {
+    for (const cand of coverageValidTop) {
       if (opened >= maxThisCycle) break;
       const baseSym = cand.symbol.replace(/USDT$|USDC$/, '').toUpperCase();
       if (openSymbols.has(cand.symbol.toUpperCase()) || openSymbols.has(baseSym)) continue;

--- a/apps/web/src/components/lisa/gainers-config-panel.tsx
+++ b/apps/web/src/components/lisa/gainers-config-panel.tsx
@@ -423,6 +423,28 @@ export function GainersConfigPanel({ portfolioId }: Props) {
         </div>
       </section>
 
+      {/* 8. Adaptive Selectivity (PR #243) */}
+      <section className="space-y-3">
+        <div className="text-xs uppercase tracking-wider text-foreground font-semibold">
+          8. Adaptive Selectivity (auto-ajustement seuils)
+        </div>
+        <p className="text-[11px] text-muted-foreground">
+          Désactivé par défaut. Quand activé, un cron 5min lit le trajectory_status
+          (basé sur réalisé 7j vs cible) et ajuste automatiquement les gates :
+        </p>
+        <ul className="text-[11px] text-muted-foreground list-disc list-inside space-y-0.5">
+          <li><strong>EN_RETARD</strong> (&lt; 80% cible) : assouplit (persistence −0.05, path −0.05, max_per_cycle +1, cooldown ÷2)</li>
+          <li><strong>EN_AVANCE</strong> (&gt; 110% cible) : aucune modif (préserve ton cap)</li>
+          <li><strong>HORS_TRAJECTOIRE</strong> (réalisé négatif) : <span className="text-red-600 font-semibold">scanner OFF + alarme rouge</span></li>
+          <li><strong>DANS_LE_PLAN</strong> : restore tes valeurs originales (snapshot)</li>
+        </ul>
+        <Toggle
+          label="Activer l'Adaptive Selectivity"
+          checked={cfg.gainers_adaptive_enabled === true}
+          onChange={(v) => set('gainers_adaptive_enabled', v)}
+        />
+      </section>
+
       {/* Actions */}
       <div className="flex items-center gap-2 pt-2 border-t">
         <button

--- a/apps/web/src/components/lisa/gainers-status-tile.tsx
+++ b/apps/web/src/components/lisa/gainers-status-tile.tsx
@@ -164,6 +164,10 @@ export function GainersStatusTile({ portfolioId }: { portfolioId: string }) {
 
       {data && (
         <>
+          {/* PR #243 — Bandeau trajectory status (visible uniquement si adaptive_enabled) */}
+          {data.adaptiveEnabled && (
+            <TrajectoryBandeau status={data} />
+          )}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             {/* Bloc gauche — countdown + 2 metrics existantes */}
             <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
@@ -1041,6 +1045,92 @@ function Sparkline7d({ data }: { data: Array<{ date: string; count: number }> })
           </div>
         );
       })}
+    </div>
+  );
+}
+
+/**
+ * PR #243 — Bandeau trajectory_status pour Adaptive Selectivity.
+ *
+ * Affiche l'état courant + valeurs effectives :
+ *   🟢 DANS_LE_PLAN      : "Trajectoire conforme · réalisé/cible X%"
+ *   🟢 EN_AVANCE         : "En avance ✓ · réalisé X% / cible Y%"
+ *   🟡 EN_RETARD         : "Mode rattrapage actif · gates assouplis"
+ *   🚨 HORS_TRAJECTOIRE  : ROUGE CLIGNOTANT — "SCANNER OFF — réalisé négatif"
+ */
+function TrajectoryBandeau({ status }: { status: GainersStatus }) {
+  const { trajectoryStatus, adaptiveActive, realised7dPct, target7dPct } = status;
+  if (!trajectoryStatus) {
+    return (
+      <div className="rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+        ⏳ Adaptive Selectivity activé · trajectory en cours de calcul (cycle 5min)
+      </div>
+    );
+  }
+  const realisedStr = realised7dPct != null ? `${realised7dPct.toFixed(2)}%` : '—';
+  const targetStr = target7dPct != null ? `${target7dPct.toFixed(2)}%` : '—';
+  const ratioPct = (realised7dPct != null && target7dPct != null && target7dPct !== 0)
+    ? Math.round((realised7dPct / target7dPct) * 100)
+    : null;
+
+  if (trajectoryStatus === 'HORS_TRAJECTOIRE') {
+    return (
+      <div className="rounded-md border-2 border-red-600 bg-red-100 dark:bg-red-950/40 px-4 py-3 animate-pulse">
+        <div className="flex items-start gap-3">
+          <span className="text-2xl" aria-hidden>🚨</span>
+          <div className="flex-1">
+            <div className="text-sm font-bold text-red-700 dark:text-red-300">
+              SCANNER OFF — HORS TRAJECTOIRE
+            </div>
+            <div className="text-xs text-red-600 dark:text-red-400 mt-1">
+              Réalisé 7j {realisedStr} (négatif). Le scanner est suspendu pour
+              préserver le capital. Vérifie la stratégie avant relance manuelle
+              (toggle Autopilot).
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (trajectoryStatus === 'EN_RETARD') {
+    return (
+      <div className="rounded-md border-2 border-yellow-500 bg-yellow-50 dark:bg-yellow-950/30 px-4 py-3">
+        <div className="flex items-start gap-3">
+          <span className="text-xl" aria-hidden>🟡</span>
+          <div className="flex-1">
+            <div className="text-sm font-semibold text-yellow-800 dark:text-yellow-300">
+              {adaptiveActive ? 'Mode rattrapage ACTIF' : 'EN RETARD — adjustement en cours'}
+            </div>
+            <div className="text-xs text-yellow-700 dark:text-yellow-400 mt-1">
+              Réalisé 7j {realisedStr} / cible {targetStr}{ratioPct != null ? ` (${ratioPct}%)` : ''}.
+              {adaptiveActive
+                ? ' Gates assouplis automatiquement (persistence −0.05, path_eff −0.05, max_per_cycle +1, cooldown ÷2). Restore au retour DANS_LE_PLAN.'
+                : ' Le service va assouplir les gates au prochain cycle (5 min).'}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // DANS_LE_PLAN ou EN_AVANCE — bandeau vert sobre
+  const isAvance = trajectoryStatus === 'EN_AVANCE';
+  return (
+    <div className="rounded-md border border-emerald-500/60 bg-emerald-50 dark:bg-emerald-950/20 px-4 py-2">
+      <div className="flex items-center gap-2">
+        <span className="text-base" aria-hidden>🟢</span>
+        <div className="text-xs">
+          <span className="font-semibold text-emerald-700 dark:text-emerald-300">
+            {isAvance ? 'EN AVANCE ✓' : 'DANS LE PLAN'}
+          </span>
+          <span className="text-muted-foreground">
+            {' · '}Réalisé 7j {realisedStr} / cible {targetStr}
+            {ratioPct != null ? ` (${ratioPct}%)` : ''}
+            {' · '}Seuils user respectés
+          </span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/hooks/use-operating-mode.ts
+++ b/apps/web/src/hooks/use-operating-mode.ts
@@ -68,6 +68,13 @@ export interface GainersStatus {
   openedByAssetClass: GainersAssetClassBreakdown;
   closedByAssetClass: GainersAssetClassBreakdown;
   scanned7d: Array<{ date: string; count: number }>;
+  // PR #243 Adaptive Selectivity
+  adaptiveEnabled: boolean;
+  adaptiveActive: boolean;
+  trajectoryStatus: 'EN_AVANCE' | 'DANS_LE_PLAN' | 'EN_RETARD' | 'HORS_TRAJECTOIRE' | null;
+  trajectoryStatusAt: string | null;
+  realised7dPct: number | null;
+  target7dPct: number | null;
 }
 
 export function useGainersStatus(portfolioId: string | null, enabled: boolean) {
@@ -226,6 +233,8 @@ export interface GainersConfigFields {
   gainers_min_p_win: number | null;
   // PR Autopilot toggle — état du cron scanner pour ce portfolio
   autopilot_enabled: boolean | null;
+  // PR #243 Adaptive Selectivity toggle (opt-in, default false)
+  gainers_adaptive_enabled: boolean | null;
   // Capital simulé (lu/écrit via la même config session)
   capital_simulation: number | null;
 }
@@ -260,6 +269,7 @@ export function useGainersConfig(portfolioId: string | null) {
         gainers_p_win_gate_enabled: boolOrNull(raw?.gainers_p_win_gate_enabled),
         gainers_min_p_win: numOrNull(raw?.gainers_min_p_win),
         autopilot_enabled: boolOrNull(raw?.autopilot_enabled),
+        gainers_adaptive_enabled: boolOrNull(raw?.gainers_adaptive_enabled),
         capital_simulation: numOrNull(raw?.capital_simulation ?? raw?.capital_usd),
       } satisfies GainersConfigFields;
     },

--- a/supabase/migrations/0119_gainers_adaptive_selectivity.sql
+++ b/supabase/migrations/0119_gainers_adaptive_selectivity.sql
@@ -1,0 +1,79 @@
+-- Migration 0119 — Gainers Adaptive Selectivity (PR #243).
+--
+-- Ajoute les colonnes nécessaires au service GainersAdaptiveSelectivity qui
+-- ajuste dynamiquement les seuils du scanner selon le trajectory_status
+-- (EN_RETARD assouplit / EN_AVANCE no-op / HORS_TRAJECTOIRE scanner OFF).
+--
+-- Spec utilisateur (05/05/2026 14:30 UTC) :
+--   - EN_RETARD (<70% cible) : persistence −0.05, path_eff −0.05,
+--     max_per_cycle +1, cooldown ÷2
+--   - EN_AVANCE (>130% cible) : aucune modif (préserve le cap user)
+--   - HORS_TRAJECTOIRE (réalisé négatif) : autopilot=false + alarm UI
+--   - DANS_LE_PLAN : restore user values (snapshot dans adaptive_user_*)
+--   - Pas de reset 00:00 UTC (ajustements persistent)
+--
+-- Snapshot pattern : quand l'adaptive entre en EN_RETARD (transition depuis
+-- DANS_LE_PLAN ou HORS_TRAJECTOIRE), on snapshot les valeurs USER courantes
+-- avant d'assouplir. Au retour en DANS_LE_PLAN, on restore depuis snapshot.
+
+ALTER TABLE public.lisa_session_configs
+  -- Toggle opt-in user (default false : feature désactivée par défaut)
+  ADD COLUMN IF NOT EXISTS gainers_adaptive_enabled BOOLEAN DEFAULT false,
+  -- Flag interne service : true quand des seuils sont actuellement assouplis
+  ADD COLUMN IF NOT EXISTS gainers_adaptive_active BOOLEAN DEFAULT false,
+  -- Snapshot des valeurs user originales (avant assouplissement)
+  -- Restaurés quand trajectory_status retourne DANS_LE_PLAN
+  ADD COLUMN IF NOT EXISTS gainers_adaptive_snapshot_persistence NUMERIC(4,3),
+  ADD COLUMN IF NOT EXISTS gainers_adaptive_snapshot_path_eff NUMERIC(4,3),
+  ADD COLUMN IF NOT EXISTS gainers_adaptive_snapshot_max_per_cycle INT,
+  ADD COLUMN IF NOT EXISTS gainers_adaptive_snapshot_cooldown INT,
+  -- Dernier status calculé (pour UI bandeau + audit)
+  ADD COLUMN IF NOT EXISTS gainers_trajectory_status TEXT
+    CHECK (gainers_trajectory_status IS NULL OR gainers_trajectory_status IN
+      ('EN_AVANCE', 'DANS_LE_PLAN', 'EN_RETARD', 'HORS_TRAJECTOIRE')),
+  ADD COLUMN IF NOT EXISTS gainers_trajectory_status_at TIMESTAMPTZ,
+  -- Realised 7d % calculé au dernier cycle (pour UI tooltip + debug)
+  ADD COLUMN IF NOT EXISTS gainers_realised_7d_pct NUMERIC(8,4),
+  ADD COLUMN IF NOT EXISTS gainers_target_7d_pct NUMERIC(8,4);
+
+-- Étend le CHECK sur lisa_decision_log.kind pour les nouveaux events adaptive.
+-- Idempotent : DROP IF EXISTS + recréation.
+ALTER TABLE public.lisa_decision_log
+  DROP CONSTRAINT IF EXISTS lisa_decision_log_kind_check;
+
+ALTER TABLE public.lisa_decision_log
+  ADD CONSTRAINT lisa_decision_log_kind_check
+  CHECK (kind IN (
+    -- Original 0043
+    'proposal_generated', 'proposal_approved', 'proposal_rejected',
+    'position_opened', 'position_closed', 'position_resized',
+    'thesis_invalidated', 'risk_limit_breached', 'kill_switch_triggered',
+    'autopilot_cycle_started', 'autopilot_cycle_completed',
+    'market_regime_changed', 'analog_matched', 'user_override',
+    -- Autopilot extensions
+    'autopilot_cycle_completed_error', 'proposal_cooldown_active',
+    'autopilot_paused', 'autopilot_resumed', 'autopilot_disabled',
+    'autopilot_auto_approve_expired',
+    -- Mechanical agent
+    'mechanical_open', 'mechanical_close_stop', 'mechanical_close_target',
+    'mechanical_close_invalidated', 'mechanical_skip', 'mechanical_override_applied',
+    -- Hedge
+    'hedge_recommendation',
+    -- P5-EXEC visibility
+    'position_skipped_duplicate_symbol', 'position_skipped_insufficient_cash',
+    'position_skipped_fallback_price', 'proposal_capped_by_max_positions',
+    -- P19β shadow
+    'gainer_shadow_466', 'gainer_shadow_566',
+    -- 0118 observabilité
+    'position_open_failed',
+    -- 0119 adaptive selectivity
+    'adaptive_status_changed',          -- transition trajectory_status
+    'adaptive_adjustment_applied',      -- assouplissement EN_RETARD appliqué
+    'adaptive_restore_applied',         -- restore DANS_LE_PLAN depuis snapshot
+    'adaptive_kill_switch_triggered'    -- HORS_TRAJECTOIRE → autopilot=false
+  ));
+
+COMMENT ON COLUMN public.lisa_session_configs.gainers_adaptive_enabled IS
+  'Toggle opt-in pour le service GainersAdaptiveSelectivity. Default false.';
+COMMENT ON COLUMN public.lisa_session_configs.gainers_trajectory_status IS
+  'Dernier trajectory_status calculé par le service adaptive (cron 5min).';


### PR DESCRIPTION
## 3 features groupées

### 1. Adaptive Selectivity (leviers auto rattrapage cible) — commit `8d08b35`

Cron `*/5 * * * *` UTC qui ajuste dynamiquement les seuils du scanner selon `trajectory_status` :

| Status | Action auto |
|---|---|
| **DANS_LE_PLAN** (80-110% cible) | restore user values + adaptive_active=false |
| **EN_AVANCE** (>110% cible) | NO-OP (préserve cap user) |
| **EN_RETARD** (<80% cible) | persistence −0.05, path −0.05, max_per_cycle +1, cooldown ÷2 |
| **HORS_TRAJECTOIRE** (réalisé négatif) | autopilot=false + 🚨 alarme rouge clignotante UI |

Snapshot pattern : à transition vers EN_RETARD, snap user values AVANT assouplissement. Restore au retour DANS_LE_PLAN.

Migration **0119** (à appliquer Supabase Studio) :
- 8 colonnes `gainers_adaptive_*` + `gainers_trajectory_*` + `gainers_realised/target_7d_pct`
- CHECK kind étendu : 4 nouveaux kinds adaptive_*

Toggle UI section 8 du panel config (default OFF, opt-in).

### 2. Fix breakdown counters (asset_class fallback exchange) — commit `c33662b`

**Bug user 14:30 UTC** : Compteurs `1000 scannés / breakdown ₿50` seulement.

**Cause** : `gainers_v1_shadow_signals.asset_class = 'equity'` (générique, sans préfixe) pour 95% des rows. Mon premier `aggregateByClass` testait uniquement `startsWith('us_equity'/...)` → 950+ rows tombaient en bucket `other` invisible.

**Fix** : 2-step lookup
1. Préfixe asset_class si présent
2. Fallback exchange : US/NYSE/NASDAQ/... → us, LSE/XETRA/PA/... → eu, KO/KQ/T/HK/NSE/SHG/SHE/... → asia, BINANCE/CC → crypto

3 SELECTs étendus avec colonne `exchange`.

**Effet** : breakdown `US 400 · EU 350 · AS 200 · ₿ 50` au lieu de `₿ 50` seulement.

### 3. Coverage=none filter (PR concept user GO) — commit `c33662b`

**Bug** : top 3 par score V0 incluait tickers `.SHG`/`.SHE`/illiquides US avec `availableCount=0` → slots gaspillés.

**Fix** :
- `selectTopGainers(candidates, 10)` au lieu de 3 (pool buffer)
- Filter `coverageValidTop` exclut `availableCount=0 OR NaN(persistenceScore)`
- Loop sur `coverageValidTop` (préserve compteur P18e + log agrégé)

**Effet** : avec maxPerCycle=3, tu obtiens 3 tentatives sur candidats avec data valide au lieu de potentiellement 0-1.

**Coût** : 7 `mtfPersistence` calls supplémentaires/cycle. Crypto Binance = gratuit. EODHD = +10 calls/cycle, négligeable vs 100k/jour.

## Tests

- ✅ `adaptive-selectivity.spec.ts` (12 cases) : matrice EN_AVANCE/EN_RETARD/etc.
- ✅ `aggregate-by-class.spec.ts` (14 cases NEW) : préfixés + fallback exchange + bug user reproduit
- ✅ Suite p18e existante (4 cases) : compteurs P18e préservés malgré coverage filter
- ✅ **1299/1301 tests pass** (105 suites, 2 todo expected)
- ✅ Typecheck API + Web clean

## Action utilisateur post-merge

1. **Appliquer migration 0119** en Supabase Studio (fichier dans `supabase/migrations/0119_gainers_adaptive_selectivity.sql`)
2. **Reload `/lisa`** (~30s) pour voir :
   - Breakdown counters corrigé : `US X · EU Y · AS Z · ₿ W` (plus de "₿ X" seulement)
   - Section 8 "Adaptive Selectivity" avec toggle opt-in
3. **Optionnel** : activer toggle Adaptive Selectivity après avoir setup `return_target_daily_pct`

## Risques + rollback

- Adaptive : default OFF, opt-in strict, brackets durs ADR-005
- Breakdown fix : pure logic, aucun side-effect
- Coverage filter : top pool augmenté (3→10), 7 mtfPersistence calls extra/cycle
- **Rollback** : revert commits via PR view GitHub

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb