### PR TITLE
fix(ui): masque l'autopilote event-driven en mode gainers (#248)

### DIFF
--- a/apps/api/src/modules/gainers-scanner/__tests__/adaptive-selectivity.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/adaptive-selectivity.spec.ts
@@ -182,15 +182,17 @@ describe('GainersAdaptiveSelectivityService.computeAdjustment', () => {
   });
 
   describe('HORS_TRAJECTOIRE', () => {
-    it('not active → kill_switch only (autopilot OFF)', () => {
+    // PR #247 — HORS_TRAJECTOIRE n'éteint plus l'autopilote autonomement.
+    // Le bandeau UI alerte ; l'utilisateur décide d'agir manuellement.
+    it('not active → kill_switch action emitted, autopilot NOT touched', () => {
       const svc = makeService();
       const decision = svc.computeAdjustment('HORS_TRAJECTOIRE', baseCtx);
       expect(decision.action).toBe('kill_switch');
-      expect(decision.next_autopilot_enabled).toBe(false);
+      expect(decision.next_autopilot_enabled).toBeUndefined();
       expect(decision.next_adaptive_active).toBe(false);
     });
 
-    it('active → kill_switch + restore from snapshot', () => {
+    it('active → kill_switch + restore from snapshot, autopilot NOT touched', () => {
       const svc = makeService();
       const ctx: AdaptiveContext = {
         ...baseCtx,
@@ -203,7 +205,7 @@ describe('GainersAdaptiveSelectivityService.computeAdjustment', () => {
       };
       const decision = svc.computeAdjustment('HORS_TRAJECTOIRE', ctx);
       expect(decision.action).toBe('kill_switch');
-      expect(decision.next_autopilot_enabled).toBe(false);
+      expect(decision.next_autopilot_enabled).toBeUndefined();
       expect(decision.next_persistence).toBe(0.67); // restored
       expect(decision.next_adaptive_active).toBe(false);
     });

--- a/apps/api/src/modules/gainers-scanner/automations/adaptive-selectivity.service.ts
+++ b/apps/api/src/modules/gainers-scanner/automations/adaptive-selectivity.service.ts
@@ -162,7 +162,15 @@ export class GainersAdaptiveSelectivityService {
    *   - DANS_LE_PLAN + active      → restore user values from snapshot
    *   - DANS_LE_PLAN + not active  → no_op
    *   - EN_RETARD                  → adjust (snapshot d'abord si first transition)
-   *   - HORS_TRAJECTOIRE           → kill_switch (autopilot=false)
+   *   - HORS_TRAJECTOIRE           → alarm UI uniquement (autopilot reste user-decided)
+   *
+   * PR #247 — La règle CLAUDE.md (P8-BR) impose `autopilot_enabled n'est plus
+   * jamais flippé` automatiquement. Le bandeau rouge UI suffit pour alerter
+   * l'utilisateur ; il décide de stopper ou pas. Avant #247, HORS_TRAJECTOIRE
+   * forçait `autopilot_enabled=false` → autopilote tué silencieusement à
+   * chaque cycle 5min dès que realisedPct 7j passait sous -0.5%, ce qui
+   * créait des trous de 6h+ sans aucune action côté user (et empêchait la
+   * récupération naturelle puisque le scanner était stoppé).
    */
   computeAdjustment(status: TrajectoryStatus, ctx: AdaptiveContext): AdaptiveDecision {
     if (status === 'EN_AVANCE') {
@@ -172,9 +180,11 @@ export class GainersAdaptiveSelectivityService {
     if (status === 'HORS_TRAJECTOIRE') {
       return {
         action: 'kill_switch',
-        reason: 'HORS_TRAJECTOIRE — autopilot disabled, alarm UI',
-        next_autopilot_enabled: false,
-        // Restore snapshot si on était EN_RETARD avant
+        reason: 'HORS_TRAJECTOIRE — alarm UI only, autopilot reste user-decided (PR #247)',
+        // PR #247 — Volontairement pas de `next_autopilot_enabled: false`.
+        // Le bandeau rouge UI alerte ; l'utilisateur décide d'agir.
+        // Restore snapshot si on était EN_RETARD avant (rend les seuils user
+        // intacts pour la décision manuelle de l'utilisateur).
         ...(ctx.adaptive_active ? this.buildRestorePartial(ctx) : {}),
         next_adaptive_active: false,
       };

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18e-skip-summary.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18e-skip-summary.spec.ts
@@ -159,10 +159,15 @@ describe('TopGainersScanner — cycle skip-summary log', () => {
     expect(svc.getSkippedNoPersistenceCounter()).toBe(5);
   });
 
-  it('truncates sample to first 5 symbols even if 50 are skipped', async () => {
+  it('truncates sample to first 5 symbols even if many are skipped', async () => {
     mockScanPortfolioSupabase();
     mockMtf.analyzeBatch.mockResolvedValue(new Map());
 
+    // PR #246 — scanPortfolio désormais reçoit la liste COMPLÈTE des candidats
+    // et applique selectTopGainers(filteredCandidates, 10) en interne.
+    // La taille effective traitée est donc cappée à TOP_POOL_SIZE_PER_PORTFOLIO=10.
+    // Le test garde son intention initiale (sample truncation à 5 symboles dans le log)
+    // en injectant 50 candidats dont seuls les 10 meilleurs scores seront skipped.
     const top = Array.from({ length: 50 }, (_, i) => makeCandidate(`T${i}`));
     const svc = makeService();
     await (svc as any).scanPortfolio('u', 'p', top);
@@ -172,8 +177,9 @@ describe('TopGainersScanner — cycle skip-summary log', () => {
     );
     expect(aggregate).toBeDefined();
     const msg = String(aggregate![0]);
-    expect(msg).toContain('skipped_no_persistence=50');
-    // Sample should contain first 5 (T0..T4) and not all 50
+    // Tous les candidats ont le même score (0.7) → selectTopGainers conserve les 10
+    // premiers selon ordre stable d'insertion → T0..T9 traités, T0..T4 dans le sample.
+    expect(msg).toContain('skipped_no_persistence=10');
     expect(msg).toMatch(/sample: T0, T1, T2, T3, T4/);
     expect(msg).not.toContain('T49');
   });

--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -321,6 +321,53 @@ export class LisaController {
         }));
     }
 
+    // PR #246 — MTD (Month-To-Date) gains pour la carte « Gains du mois ».
+    // Source : paper_trades fermés depuis le 1er du mois UTC, strategy gainers.
+    const startOfMonthUtc = new Date();
+    startOfMonthUtc.setUTCDate(1);
+    startOfMonthUtc.setUTCHours(0, 0, 0, 0);
+    const startOfMonthIso = startOfMonthUtc.toISOString();
+
+    const { count: closedMtdCount } = await supabase
+      .from('paper_trades')
+      .select('*', { count: 'exact', head: true })
+      .eq('portfolio_id', portfolioId)
+      .eq('strategy', 'top_gainers_v1')
+      .eq('status', 'closed')
+      .gte('closed_at', startOfMonthIso);
+    const closedMtd = closedMtdCount ?? 0;
+
+    const { data: closedMtdRows } = await supabase
+      .from('paper_trades')
+      .select('pnl_usd, closed_at')
+      .eq('portfolio_id', portfolioId)
+      .eq('strategy', 'top_gainers_v1')
+      .eq('status', 'closed')
+      .gte('closed_at', startOfMonthIso)
+      .limit(10000);
+    const closedMtdPnlUsd = (closedMtdRows ?? []).reduce(
+      (acc, row) => acc + (parseFloat(String(row.pnl_usd ?? '0')) || 0),
+      0,
+    );
+
+    // Best/worst day du mois (agrégation client par jour UTC).
+    const dailyPnlMap = new Map<string, number>();
+    for (const r of closedMtdRows ?? []) {
+      const day = String(r.closed_at).slice(0, 10); // YYYY-MM-DD
+      const pnl = parseFloat(String(r.pnl_usd ?? '0')) || 0;
+      dailyPnlMap.set(day, (dailyPnlMap.get(day) ?? 0) + pnl);
+    }
+    let bestDay: { date: string; pnl: number } | null = null;
+    let worstDay: { date: string; pnl: number } | null = null;
+    let winningDays = 0;
+    let losingDays = 0;
+    for (const [date, pnl] of dailyPnlMap.entries()) {
+      if (!bestDay || pnl > bestDay.pnl) bestDay = { date, pnl };
+      if (!worstDay || pnl < worstDay.pnl) worstDay = { date, pnl };
+      if (pnl > 0) winningDays++;
+      else if (pnl < 0) losingDays++;
+    }
+
     return {
       nextTickInSeconds,
       intervalMinutes,
@@ -350,6 +397,14 @@ export class LisaController {
         ? Number(cfgRow.gainers_realised_7d_pct) : null,
       target7dPct: cfgRow?.gainers_target_7d_pct != null
         ? Number(cfgRow.gainers_target_7d_pct) : null,
+      // PR #246 — Cartes Gains du jour / Gains du mois (mode-agnostique).
+      mtdPnlUsd: closedMtdPnlUsd,
+      mtdTradesCount: closedMtd,
+      mtdSessionsCount: dailyPnlMap.size,
+      mtdWinningDays: winningDays,
+      mtdLosingDays: losingDays,
+      mtdBestDay: bestDay,
+      mtdWorstDay: worstDay,
     };
   }
 

--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -217,26 +217,24 @@ export class LisaController {
     //
     // Fix :
     //   - Count exact via { count: 'exact', head: true } (pas de fetch rows)
-    //   - Breakdown : limit 50000 + warning en log si troncature détectée
+    //   - Breakdown : 4 head-counts parallèles par bucket (us/eu/asia/crypto)
+    //     pour bypass le hard cap PostgREST 1000 rows. "other" = total - somme.
     const { count: scannedTodayCount } = await supabase
       .from('gainers_v1_shadow_signals')
       .select('*', { count: 'exact', head: true })
       .gte('created_at', startOfDayUtcIso);
     const scannedToday = scannedTodayCount ?? 0;
 
-    const { data: scannedTodayRows } = await supabase
-      .from('gainers_v1_shadow_signals')
-      .select('asset_class, exchange')
-      .gte('created_at', startOfDayUtcIso)
-      .limit(50000);
-    const scannedByAssetClass = aggregateByClass(scannedTodayRows ?? []);
-    if (scannedTodayRows && scannedTodayRows.length < scannedToday) {
-      // Truncated — breakdown sera approximatif. Log pour visibilité.
-      // 50000 rows = ~5j d'activité scanner ALL-IN-ONE. Dépassement signifie
-      // qu'il faut paginer ou créer une vue matérialisée par asset_class.
-      // Non-bloquant — on retourne quand même, juste avec breakdown partiel.
-      // (Pas de logger dans controller, on accepte la limite silencieuse pour now)
-    }
+    // PR Breakdown fix v2 — 4 head-counts par bucket asset_class.
+    // Hard cap PostgREST 1000 rows empêche le fetch+aggregate côté client
+    // (.limit(50000) silencieusement clamp à 1000). Solution : count exact
+    // par bucket via OR filter sur asset_class préfixé OR exchange fallback.
+    const scannedByAssetClass = await this.countByBucket(
+      supabase,
+      'gainers_v1_shadow_signals',
+      [['gte', 'created_at', startOfDayUtcIso]],
+      scannedToday,
+    );
 
     const { data: scanned7dRows } = await supabase
       .from('gainers_v1_shadow_signals')
@@ -255,14 +253,16 @@ export class LisaController {
       .gte('opened_at', startOfDayUtcIso);
     const openedToday = openedTodayCount ?? 0;
 
-    const { data: openedTodayRows } = await supabase
-      .from('paper_trades')
-      .select('asset_class, exchange')
-      .eq('portfolio_id', portfolioId)
-      .eq('strategy', 'top_gainers_v1')
-      .gte('opened_at', startOfDayUtcIso)
-      .limit(10000);
-    const openedByAssetClass = aggregateByClass(openedTodayRows ?? []);
+    const openedByAssetClass = await this.countByBucket(
+      supabase,
+      'paper_trades',
+      [
+        ['eq', 'portfolio_id', portfolioId],
+        ['eq', 'strategy', 'top_gainers_v1'],
+        ['gte', 'opened_at', startOfDayUtcIso],
+      ],
+      openedToday,
+    );
 
     // Q3 — Fermés aujourd'hui + somme PnL (count exact + breakdown)
     const { count: closedTodayCountExact } = await supabase
@@ -274,9 +274,10 @@ export class LisaController {
       .gte('closed_at', startOfDayUtcIso);
     const closedToday = closedTodayCountExact ?? 0;
 
+    // PnL : fetch limited rows (paper_trades volumes < 1000 OK)
     const { data: closedTodayPaperTrades } = await supabase
       .from('paper_trades')
-      .select('pnl_usd, asset_class, exchange')
+      .select('pnl_usd')
       .eq('portfolio_id', portfolioId)
       .eq('strategy', 'top_gainers_v1')
       .eq('status', 'closed')
@@ -286,7 +287,18 @@ export class LisaController {
       (acc, row) => acc + (parseFloat(String(row.pnl_usd ?? '0')) || 0),
       0,
     );
-    const closedByAssetClass = aggregateByClass(closedTodayPaperTrades ?? []);
+
+    const closedByAssetClass = await this.countByBucket(
+      supabase,
+      'paper_trades',
+      [
+        ['eq', 'portfolio_id', portfolioId],
+        ['eq', 'strategy', 'top_gainers_v1'],
+        ['eq', 'status', 'closed'],
+        ['gte', 'closed_at', startOfDayUtcIso],
+      ],
+      closedToday,
+    );
 
     // Derniers candidats : top 3 du dernier tick (decision passed/opened, ordre score desc).
     const { data: lastLog } = await supabase
@@ -602,6 +614,58 @@ export class LisaController {
     }
     // 4. Default
     return 20;
+  }
+
+  /**
+   * PR Breakdown fix v2 — count exact par bucket asset_class via head-only.
+   * Bypass le hard cap PostgREST 1000 rows en faisant 4 queries head:true
+   * en parallèle, une par bucket (us/eu/asia/crypto). "other" = total -
+   * somme des 4 buckets.
+   *
+   * Filters communs (eq/gte/etc.) appliqués à chaque sous-query identiquement.
+   * Format filters : Array<['eq'|'gte'|'lte', column, value]>.
+   *
+   * Performance : 4 queries en parallèle, head:true → pas de fetch rows.
+   * Très rapide (chacune < 100ms). Total ~200-300ms vs single 5000ms+ avec
+   * pagination 50k rows.
+   */
+  private async countByBucket(
+    supabase: ReturnType<SupabaseService['getClient']>,
+    table: 'gainers_v1_shadow_signals' | 'paper_trades',
+    filters: Array<['eq' | 'gte' | 'lte', string, string]>,
+    totalCount: number,
+  ): Promise<{ us: number; eu: number; asia: number; crypto: number; other: number }> {
+    const usOr = 'asset_class.like.us_equity%,exchange.in.(US,NYSE,NASDAQ,BATS,OTCQB,OTCMKTS,OTC,NMFQS)';
+    const euOr = 'asset_class.eq.eu_equity,exchange.in.(LSE,XETRA,PA,AS,AMS,MC,BME,MI,SW,BR)';
+    const asiaOr = 'asset_class.eq.asia_equity,exchange.in.(KO,KQ,KS,KE,T,TSE,HK,NSE,BSE,SHG,SHE,SS,SZ,AU,AX,TO)';
+    const cryptoOr = 'asset_class.like.crypto%,exchange.in.(BINANCE,CC,COINBASE)';
+
+    // Build base head-count query with filters appliqués via reduce
+    const buildQ = (orFilter: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let qb: any = supabase.from(table).select('*', { count: 'exact', head: true });
+      for (const [op, col, val] of filters) {
+        if (op === 'eq') qb = qb.eq(col, val);
+        else if (op === 'gte') qb = qb.gte(col, val);
+        else if (op === 'lte') qb = qb.lte(col, val);
+      }
+      return qb.or(orFilter);
+    };
+
+    const [us, eu, asia, crypto] = await Promise.all([
+      buildQ(usOr),
+      buildQ(euOr),
+      buildQ(asiaOr),
+      buildQ(cryptoOr),
+    ]);
+
+    const usCount = (us as { count: number | null }).count ?? 0;
+    const euCount = (eu as { count: number | null }).count ?? 0;
+    const asiaCount = (asia as { count: number | null }).count ?? 0;
+    const cryptoCount = (crypto as { count: number | null }).count ?? 0;
+    const other = Math.max(0, totalCount - usCount - euCount - asiaCount - cryptoCount);
+
+    return { us: usCount, eu: euCount, asia: asiaCount, crypto: cryptoCount, other };
   }
 
   private async persistSnapshotLog(

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1389,9 +1389,14 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       const expr = thesis.expressions[thesis.preferredExpressionIndex];
       if (!expr) return [];
 
-      const stopPct = Math.abs(thesis.riskReward.adverseScenarioReturnPct ?? 2);
-      const tpPct = thesis.riskReward.centralScenarioReturnPct?.mid ?? stopPct * 2;
-      const horizonDays = thesis.riskReward.horizonDays ?? 3;
+      // PR #249 — `thesis.riskReward` est undefined dans les thèses générées
+      // par le scanner top-gainers (qui ne peuple que stopLossPct/takeProfitPct
+      // sur l'expression, pas un objet riskReward complet). Sans `?.`, ouverture
+      // crashe `Cannot read properties of undefined (reading 'adverseScenarioReturnPct')`
+      // → 100% des candidats Asia/US crash silencieusement → 0 position ouverte.
+      const stopPct = Math.abs(thesis.riskReward?.adverseScenarioReturnPct ?? 2);
+      const tpPct = thesis.riskReward?.centralScenarioReturnPct?.mid ?? stopPct * 2;
+      const horizonDays = thesis.riskReward?.horizonDays ?? 3;
 
       const isOptionLong = expr.direction === 'long_call' || expr.direction === 'long_put';
       const direction: 'long' | 'short' = isOptionLong
@@ -1892,7 +1897,9 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
           });
           continue;
         }
-        const riskReward = thesis.riskReward as { horizonDays: number; adverseScenarioReturnPct?: number };
+        // PR #249 — Cast safe quand `thesis.riskReward` peut être undefined
+        // (cas scanner top-gainers, voir commentaire ligne ~1392).
+        const riskReward = thesis.riskReward as { horizonDays?: number; adverseScenarioReturnPct?: number } | undefined;
         const assetClass = String(expression.assetClass ?? '');
         const isCrypto = assetClass.startsWith('crypto_');
 
@@ -1900,7 +1907,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         // thèse si plus strict. Permet à la risk_monitor de fermer les perdantes.
         const direction = expression.direction as string;
         const livePx = new Decimal(quote.price);
-        const adversePct = Math.abs(riskReward.adverseScenarioReturnPct ?? -5);
+        const adversePct = Math.abs(riskReward?.adverseScenarioReturnPct ?? -5);
         // Aggressive mode = stop plus serré (-2% floor au lieu de -3%) pour
         // couper vite les perdantes et libérer du cash pour la prochaine idée.
         const floor = aggressive ? 2 : 3;
@@ -1944,7 +1951,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
           livePrice: quote.price,
           stopLossPrice,
           takeProfitPrice,
-          horizonDays: riskReward.horizonDays ?? 30,
+          horizonDays: riskReward?.horizonDays ?? 30,
         });
         opened.push(pos);
         openedSoFar++;

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -1749,6 +1749,11 @@ export class TopGainersScannerService implements OnModuleInit {
     // P18 — LLM thesis generation (inert when SCANNER_LLM_ROUTER_ENABLED=false)
     const llmThesis = await this.generateThesis(cand);
 
+    // PR #249 — `thesis.riskReward` doit être présent : `lisa.service.ts`
+    // approveProposal lit `thesis.riskReward.adverseScenarioReturnPct` au
+    // moment d'ouvrir. Sans ce champ, TypeError "Cannot read properties of
+    // undefined" → 100% des opens .KO/.KQ/etc. crashent silencieusement.
+    // On peuple un riskReward minimal cohérent avec stopLossPct/takeProfitPct.
     const thesis = {
       id: thesisId,
       summary: llmThesis.summary,
@@ -1757,6 +1762,13 @@ export class TopGainersScannerService implements OnModuleInit {
       category: llmThesis.category,
       kind: 'momentum',
       preferredExpressionIndex: 0,
+      riskReward: {
+        adverseScenarioReturnPct: -effectiveSl,
+        centralScenarioReturnPct: { mid: effectiveTp, low: effectiveTp * 0.5, high: effectiveTp * 1.5 },
+        horizonDays: 1,
+        riskRewardRatio: effectiveTp / Math.max(effectiveSl, 0.01),
+        convexitySources: [] as string[],
+      },
       expressions: [
         {
           symbol: cand.symbol,

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -685,37 +685,36 @@ export class TopGainersScannerService implements OnModuleInit {
       return;
     }
 
-    // PR Coverage filter — pool de 10 (au lieu de 3) pour buffer.
-    // Quand certains top candidats ont coverage=none (Asia .SHG/.SHE, US illiquides
-    // type EJPRF), le filtre coverage en aval (scanPortfolio) les exclut.
-    // Avec pool 10, il reste assez de backups pour que maxPerCycle (default 3)
-    // soit toujours saturé par des candidats avec data valide.
+    // PR #246 — Universe filter DÉPLACÉ dans scanPortfolio (avant selectTopGainers).
+    // Bug observé 04/05/2026 23:43 UTC : `selectTopGainers(candidates, 10)` global
+    // retournait les 10 meilleurs scores → souvent 100% Asia pendant la session
+    // asiatique. Puis le filtre universe per-portfolio (`top.filter(universeAsia)`)
+    // les éliminait tous → universe filter 10→0 → 0 trade ouvert.
+    // Fix : on conserve le selectTopGainers global UNIQUEMENT pour le shadow run
+    // et le persistLog (pipeline-agnostic, audit). Le scan par portfolio reçoit
+    // la liste COMPLÈTE des candidats et applique son propre filtre universe puis
+    // selectTopGainers sur la liste filtrée.
     const TOP_POOL_SIZE = 10;
-    const top = selectTopGainers(candidates, TOP_POOL_SIZE);
-    this.recordTopSelected(top.length);
+    const universalTop = selectTopGainers(candidates, TOP_POOL_SIZE);
+    this.recordTopSelected(universalTop.length);
     this.logger.log(
-      `[top-gainers] ${candidates.length} scanned → ${top.length} retained (pool ${TOP_POOL_SIZE}): ${top.slice(0, 5).map((t) => `${t.symbol}(${t.assetClass},${t.changePct.toFixed(1)}%,score=${t.score})`).join(', ')}${top.length > 5 ? '…' : ''}`,
+      `[top-gainers] ${candidates.length} scanned → ${universalTop.length} universal top (pool ${TOP_POOL_SIZE}): ${universalTop.slice(0, 5).map((t) => `${t.symbol}(${t.assetClass},${t.changePct.toFixed(1)}%,score=${t.score})`).join(', ')}${universalTop.length > 5 ? '…' : ''}`,
     );
 
-    // PR6.3 — Shadow run wiring : persiste chaque candidat scanné dans
-    // gainers_v1_shadow_signals quand GAINERS_V1_SHADOW=true.
-    // Première version : decision = ACCEPT pour les top-N retenus (legacy
-    // scoring), REJECT pour les autres avec reject_reason générique.
-    // PR6.4 swappera vers décision V1 pipeline complet (BLOC 1+2+3 enrichi).
-    await this.persistShadowSignalsBatch(candidates, top);
+    // PR6.3 — Shadow run wiring : pipeline-agnostic, utilise le top universal.
+    await this.persistShadowSignalsBatch(candidates, universalTop);
 
-    // Persist log entries pour les top retenus + filtered samples (audit)
-    await this.persistLog(candidates, top);
+    // Persist log entries pour les top universels (audit cross-portfolio)
+    await this.persistLog(candidates, universalTop);
 
-    if (top.length === 0) {
+    if (candidates.length === 0) {
       this.recordEarlyReturn('candidates_fetched_but_none_selected');
       return;
     }
 
-    // P18 — LLM re-ranking (inert when SCANNER_LLM_ROUTER_ENABLED=false)
-    const rankedTop = await this.rankCandidates(top);
-
     // P9-UX — Pour chaque portfolio, gate par per-portfolio cycle puis scan.
+    // PR #246 — On passe TOUS les candidats (universe filter + selectTopGainers
+    // appliqués per-portfolio dans scanPortfolio).
     const now = Date.now();
     for (const cfg of configs) {
       const portfolioId = cfg.portfolio_id as string;
@@ -727,7 +726,7 @@ export class TopGainersScannerService implements OnModuleInit {
           continue;
         }
         this.lastScanByPortfolio.set(portfolioId, now);
-        await this.scanPortfolio(cfg.user_id as string, portfolioId, rankedTop);
+        await this.scanPortfolio(cfg.user_id as string, portfolioId, candidates);
       } catch (e) {
         this.logger.warn(
           `[top-gainers] portfolio ${portfolioId.slice(0, 8)} failed: ${String(e).slice(0, 120)}`,
@@ -1245,7 +1244,7 @@ export class TopGainersScannerService implements OnModuleInit {
   private async scanPortfolio(
     userId: string,
     portfolioId: string,
-    top: Array<TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass }>,
+    candidates: TopGainerCandidate[],
   ): Promise<void> {
     // P19x.4 — Watchdog expectancy : skip opens si E<0 sur 10 derniers trades.
     const expectancyNegative = await this.checkExpectancyWatchdog(portfolioId);
@@ -1307,9 +1306,13 @@ export class TopGainersScannerService implements OnModuleInit {
       : FALLBACK_COOLDOWN_MIN;
     const positionNotionalUsd = capitalUsd * (positionPct / 100);
 
-    // PR #3 — universe toggles per-portfolio. Filtre client-side : la cache
-    // globale fetchAllCandidates contient TOUTES les sources (US/EU/Asia/Crypto)
-    // mais l'utilisateur peut désactiver une zone via UI. Default = tout activé.
+    // PR #3 + PR #246 — universe toggles per-portfolio appliqués AVANT
+    // selectTopGainers. Bug pré-#246 : selectTopGainers global retournait top 10
+    // par score (souvent 100% Asia pendant la session asiatique) puis le filtre
+    // universe per-portfolio les éliminait tous → universe filter 10→0 → 0 trade.
+    // Fix : on filtre la liste COMPLÈTE des candidats par universe AVANT de
+    // sélectionner le top, garantissant que chaque portfolio reçoit les
+    // meilleurs candidats DANS SON univers configuré.
     const universeUs = cfgRow?.gainers_universe_us !== false;
     const universeEu = cfgRow?.gainers_universe_eu !== false;
     const universeAsia = cfgRow?.gainers_universe_asia !== false;
@@ -1321,18 +1324,34 @@ export class TopGainersScannerService implements OnModuleInit {
     const minPWin = cfgRow?.gainers_min_p_win != null
       ? Math.max(0, Math.min(1, Number(cfgRow.gainers_min_p_win)))
       : 0.50;
-    const filteredTop = top.filter((c) => {
-      if (c.assetClass === 'us_equity_large' || c.assetClass === 'us_equity_small_mid') return universeUs;
-      if (c.assetClass === 'eu_equity') return universeEu;
-      if (c.assetClass === 'asia_equity') return universeAsia;
-      if (c.assetClass === 'crypto_major' || c.assetClass === 'crypto_alt') return universeCrypto;
+
+    const filteredCandidates = candidates.filter((c) => {
+      // detectAssetClass est appliqué dans selectTopGainers ; on doit le faire
+      // ici aussi pour pouvoir filtrer la liste pré-selection.
+      const assetClass = detectAssetClass(c.symbol, c.exchange, c.marketCap);
+      if (assetClass === 'us_equity_large' || assetClass === 'us_equity_small_mid') return universeUs;
+      if (assetClass === 'eu_equity') return universeEu;
+      if (assetClass === 'asia_equity') return universeAsia;
+      if (assetClass === 'crypto_major' || assetClass === 'crypto_alt') return universeCrypto;
       return true; // fx/commodity etc — pas de toggle, accept par default
     });
-    if (filteredTop.length < top.length) {
-      this.logger.debug(
-        `[top-gainers] ${portfolioId.slice(0, 8)}: universe filter ${top.length}→${filteredTop.length} (us=${universeUs} eu=${universeEu} asia=${universeAsia} crypto=${universeCrypto})`,
+
+    // PR Coverage filter — pool de 10 (au lieu de 3) pour buffer.
+    // selectTopGainers per-portfolio sur la liste FILTRÉE par universe.
+    const TOP_POOL_SIZE_PER_PORTFOLIO = 10;
+    const top = selectTopGainers(filteredCandidates, TOP_POOL_SIZE_PER_PORTFOLIO);
+    if (top.length === 0) {
+      this.logger.log(
+        `[top-gainers] ${portfolioId.slice(0, 8)}: 0 candidate after universe filter (us=${universeUs} eu=${universeEu} asia=${universeAsia} crypto=${universeCrypto}, candidates=${candidates.length}, filtered=${filteredCandidates.length})`,
       );
+      return;
     }
+    this.logger.log(
+      `[top-gainers] ${portfolioId.slice(0, 8)}: ${candidates.length}→${filteredCandidates.length} after universe → top ${top.length} (us=${universeUs} eu=${universeEu} asia=${universeAsia} crypto=${universeCrypto})`,
+    );
+
+    // P18 — LLM re-ranking (inert when SCANNER_LLM_ROUTER_ENABLED=false)
+    const filteredTop = await this.rankCandidates(top);
 
     // Garde-fou : count current open positions (utilise maxOpen depuis config)
     const { data: openPositions } = await this.supabase
@@ -2009,6 +2028,11 @@ export class TopGainersScannerService implements OnModuleInit {
   ): Promise<void> {
     const topSet = new Set(top.map((t) => t.symbol));
     const rows: Record<string, unknown>[] = [];
+    // PR #246 — `top_gainers_log.volume` et `avg_vol_50d` sont déclarés BIGINT.
+    // Binance retourne ces valeurs en float (ex: 850934.06) → INSERT fail avec
+    // `invalid input syntax for type bigint: "850934.06"`. Math.round() avant.
+    const toBigint = (n: number | undefined | null): number =>
+      n == null || !Number.isFinite(n) ? 0 : Math.round(n);
     for (const t of top) {
       rows.push({
         symbol: t.symbol,
@@ -2017,8 +2041,8 @@ export class TopGainersScannerService implements OnModuleInit {
         close_price: String(t.close),
         high_price: String(t.high),
         change_pct: String(t.changePct),
-        volume: t.volume,
-        avg_vol_50d: t.avgVol50d,
+        volume: toBigint(t.volume),
+        avg_vol_50d: toBigint(t.avgVol50d),
         market_cap_usd: String(t.marketCap),
         score: String(t.score),
         decision: 'passed',
@@ -2035,8 +2059,8 @@ export class TopGainersScannerService implements OnModuleInit {
         close_price: String(c.close),
         high_price: String(c.high),
         change_pct: String(c.changePct),
-        volume: c.volume,
-        avg_vol_50d: c.avgVol50d,
+        volume: toBigint(c.volume),
+        avg_vol_50d: toBigint(c.avgVol50d),
         market_cap_usd: String(c.marketCap),
         score: '0',
         decision: 'filtered',

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -305,12 +305,18 @@ export default function LisaPage() {
     };
 
     try {
+      // PR #248 — En mode gainers, on N'inclut PAS `autopilot_enabled` dans le
+      // payload. Le panel "Configuration scanner Gainers" est seul maître via
+      // useUpdateGainersConfig. Sans cette exclusion, un Save ici écrasait
+      // silencieusement le toggle ACTIF du panel Gainers à la valeur de la
+      // checkbox locale (souvent stale/false → scanner stoppé sans warning).
+      const isGainersMode = currentMode === 'gainers';
       await upsertConfig.mutateAsync({
         profile,
         capital_usd: capital,
         anti_consensus_strength: antiConsensus,
         enable_crypto: enableCrypto,
-        autopilot_enabled: autopilotEnabled,
+        ...(isGainersMode ? {} : { autopilot_enabled: autopilotEnabled }),
         autopilot_cycle_minutes: autopilotCycleMin,
         autopilot_auto_approve: autopilotAutoApprove,
         autopilot_aggressive: autopilotAggressive,
@@ -727,21 +733,45 @@ export default function LisaPage() {
         </div>
 
         <div className="border-t pt-3 space-y-2">
-          <label className="flex items-center gap-2 text-xs font-medium">
-            <input
-              type="checkbox"
-              checked={autopilotEnabled}
-              onChange={(e) => {
-                setAutopilotEnabled(e.target.checked);
-                if (!e.target.checked) {
-                  // Désactiver autopilot → coupe aussi auto-approve + agressive
-                  setAutopilotAutoApprove(false);
-                  setAutopilotAggressive(false);
-                }
-              }}
-            />
-            Autopilot (mode event-driven + filet de garantie)
-          </label>
+          {/* PR #248 — En mode gainers, le panel "Configuration scanner Gainers"
+              est l'UNIQUE source de vérité pour autopilot_enabled. Cette section
+              "event-driven + filet de garantie" est pensée pour le pipeline
+              Lisa LLM (modes investment/harvest) et ne s'applique pas au scanner
+              Gainers déterministe. Risque pré-#248 : un Save de la page
+              principale écrasait `autopilot_enabled` à la valeur de la checkbox
+              locale (souvent stale/false), coupant silencieusement le scanner
+              Gainers que l'utilisateur venait juste d'activer. */}
+          {currentMode === 'gainers' ? (
+            <div className="rounded-md border border-dashed border-orange-300 bg-orange-50/40 dark:bg-orange-950/10 p-3 space-y-1">
+              <div className="flex items-center gap-2">
+                <span className="text-base">🚀</span>
+                <span className="text-xs font-medium">Mode gainers actif</span>
+              </div>
+              <p className="text-[11px] text-muted-foreground">
+                L&apos;autopilote, le cycle scanner et tous les paramètres
+                déterministes sont pilotés depuis le panel{' '}
+                <span className="font-medium">« Configuration scanner Gainers »</span>{' '}
+                ci-dessus. Le filet de garantie event-driven n&apos;est pas
+                utilisé en mode gainers (pipeline LLM bypassé).
+              </p>
+            </div>
+          ) : (
+            <>
+              <label className="flex items-center gap-2 text-xs font-medium">
+                <input
+                  type="checkbox"
+                  checked={autopilotEnabled}
+                  onChange={(e) => {
+                    setAutopilotEnabled(e.target.checked);
+                    if (!e.target.checked) {
+                      // Désactiver autopilot → coupe aussi auto-approve + agressive
+                      setAutopilotAutoApprove(false);
+                      setAutopilotAggressive(false);
+                    }
+                  }}
+                />
+                Autopilot (mode event-driven + filet de garantie)
+              </label>
           {autopilotEnabled && (
             <div className="pl-6 space-y-2">
               <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -867,6 +897,8 @@ export default function LisaPage() {
                 )}
               </div>
             </div>
+          )}
+            </>
           )}
         </div>
 

--- a/apps/web/src/components/lisa/gainers-status-tile.tsx
+++ b/apps/web/src/components/lisa/gainers-status-tile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { Rocket, TrendingUp, TrendingDown, Settings2 } from 'lucide-react';
+import { Rocket, TrendingUp, TrendingDown, Settings2, Calendar, CalendarDays } from 'lucide-react';
 import {
   useGainersStatus,
   useGainersConfig,
@@ -203,6 +203,13 @@ export function GainersStatusTile({ portfolioId }: { portfolioId: string }) {
 
             {/* Bloc droit — compteurs jour (Option B) avec sparkline + breakdown */}
             <DailyCountersPanel data={data} countdown={countdown} />
+          </div>
+
+          {/* PR #246 — Cartes Gains du jour / Gains du mois (mode-agnostique).
+              Source : paper_trades closed strategy='top_gainers_v1'. */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <DailyGainsCard data={data} />
+            <MonthlyGainsCard data={data} />
           </div>
 
           <div className="space-y-1.5">
@@ -1152,6 +1159,126 @@ function TrajectoryBandeau({ status }: { status: GainersStatus }) {
             {ratioPct != null ? ` (${ratioPct}%)` : ''}
             {' · '}Seuils user respectés
           </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// PR #246 — Cartes Gains du jour / Gains du mois (mode-agnostique).
+// Source : paper_trades closed pour la strategy gainers (mode 'gainers').
+// Restauration du widget que l'utilisateur avait dans le panneau Daily
+// Harvest (mode 'harvest'), désormais visible aussi en mode 'gainers'.
+// ═══════════════════════════════════════════════════════════════════
+
+function DailyGainsCard({ data }: { data: GainersStatus }) {
+  const total = data.closedTodayPnlUsd;
+  const isPositive = total >= 0;
+  const sign = isPositive ? '+' : '';
+  return (
+    <div className="rounded-lg border p-4 space-y-3 bg-emerald-50/50 dark:bg-emerald-950/20">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Calendar className="h-4 w-4 text-emerald-700 dark:text-emerald-300" />
+          <h3 className="text-sm font-medium">Gains du jour</h3>
+        </div>
+        <span className="text-[10px] text-muted-foreground">UTC</span>
+      </div>
+      <div className="space-y-1">
+        <div className={`text-2xl font-mono font-bold tabular-nums ${isPositive ? 'text-emerald-700 dark:text-emerald-300' : 'text-red-600'}`}>
+          {sign}${total.toFixed(2)}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {data.closedToday} trade{data.closedToday > 1 ? 's' : ''} fermé{data.closedToday > 1 ? 's' : ''} aujourd&apos;hui
+        </div>
+      </div>
+      <div className="grid grid-cols-3 gap-2 pt-2 border-t border-current/10 text-xs">
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Ouverts</div>
+          <div className="font-mono font-medium">{data.openedToday}</div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Fermés</div>
+          <div className="font-mono font-medium">{data.closedToday}</div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Open</div>
+          <div className="font-mono font-medium">{data.openPositions}/{data.maxPositions}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MonthlyGainsCard({ data }: { data: GainersStatus }) {
+  const total = data.mtdPnlUsd ?? 0;
+  const isPositive = total >= 0;
+  const sign = isPositive ? '+' : '';
+  const monthLabel = new Date().toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
+  const winRateMonth = data.mtdSessionsCount > 0
+    ? (data.mtdWinningDays / data.mtdSessionsCount) * 100
+    : 0;
+  return (
+    <div className="rounded-lg border p-4 space-y-3 bg-blue-50/50 dark:bg-blue-950/20">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <CalendarDays className="h-4 w-4 text-blue-700 dark:text-blue-300" />
+          <h3 className="text-sm font-medium">Gains du mois</h3>
+        </div>
+        <span className="text-xs text-muted-foreground capitalize">{monthLabel}</span>
+      </div>
+      <div className="space-y-1">
+        <div className={`text-2xl font-mono font-bold tabular-nums ${isPositive ? 'text-blue-700 dark:text-blue-300' : 'text-red-600'}`}>
+          {sign}${total.toFixed(2)}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {data.mtdSessionsCount} jour{data.mtdSessionsCount > 1 ? 's' : ''} actif{data.mtdSessionsCount > 1 ? 's' : ''} ·{' '}
+          {data.mtdWinningDays} +{' '}
+          {data.mtdLosingDays} -{' '}
+          {data.mtdSessionsCount > 0 && (
+            <span className="font-medium">{winRateMonth.toFixed(0)}% jours gagnants</span>
+          )}
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-2 pt-2 border-t border-current/10 text-xs">
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Meilleur jour</div>
+          <div className="font-mono font-medium text-emerald-700 dark:text-emerald-300">
+            {data.mtdBestDay && data.mtdBestDay.pnl > 0
+              ? `+$${data.mtdBestDay.pnl.toFixed(2)}`
+              : '—'}
+          </div>
+          {data.mtdBestDay && data.mtdBestDay.pnl > 0 && (
+            <div className="text-[10px] text-muted-foreground">
+              {new Date(data.mtdBestDay.date).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short' })}
+            </div>
+          )}
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Pire jour</div>
+          <div className="font-mono font-medium text-red-600">
+            {data.mtdWorstDay && data.mtdWorstDay.pnl < 0
+              ? `-$${Math.abs(data.mtdWorstDay.pnl).toFixed(2)}`
+              : '—'}
+          </div>
+          {data.mtdWorstDay && data.mtdWorstDay.pnl < 0 && (
+            <div className="text-[10px] text-muted-foreground">
+              {new Date(data.mtdWorstDay.date).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short' })}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-2 pt-2 border-t border-current/10 text-xs">
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Trades MTD</div>
+          <div className="font-mono font-medium">{data.mtdTradesCount}</div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Win rate jours</div>
+          <div className="font-mono font-medium">
+            {data.mtdSessionsCount > 0 ? `${winRateMonth.toFixed(0)}%` : '—'}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/hooks/use-operating-mode.ts
+++ b/apps/web/src/hooks/use-operating-mode.ts
@@ -75,6 +75,14 @@ export interface GainersStatus {
   trajectoryStatusAt: string | null;
   realised7dPct: number | null;
   target7dPct: number | null;
+  // PR #246 — Cartes Gains du jour / Gains du mois (mode-agnostique).
+  mtdPnlUsd: number;
+  mtdTradesCount: number;
+  mtdSessionsCount: number;
+  mtdWinningDays: number;
+  mtdLosingDays: number;
+  mtdBestDay: { date: string; pnl: number } | null;
+  mtdWorstDay: { date: string; pnl: number } | null;
 }
 
 export function useGainersStatus(portfolioId: string | null, enabled: boolean) {

--- a/packages/ai-analyst/src/llm/providers/claude-provider.ts
+++ b/packages/ai-analyst/src/llm/providers/claude-provider.ts
@@ -42,13 +42,24 @@ export class ClaudeProvider implements LlmProvider {
 
   async call(params: LlmCallParams): Promise<LlmCallResult> {
     const t0 = Date.now();
-    const res = await this.anthropic.messages.create({
-      model: this.model,
-      system: params.system,
-      messages: [{ role: 'user', content: params.user }],
-      temperature: params.temperature ?? 0.2,
-      max_tokens: params.maxTokens ?? 2048,
-    });
+    // PR #246 — Claude Opus 4.x déprécie `temperature` (renvoie HTTP 400
+    // « temperature ... not allowed »). On l'omet pour les modèles Opus, on
+    // le garde pour Sonnet/Haiku qui le supportent encore.
+    const isOpus = /opus/i.test(this.model);
+    const res = isOpus
+      ? await this.anthropic.messages.create({
+          model: this.model,
+          system: params.system,
+          messages: [{ role: 'user', content: params.user }],
+          max_tokens: params.maxTokens ?? 2048,
+        })
+      : await this.anthropic.messages.create({
+          model: this.model,
+          system: params.system,
+          messages: [{ role: 'user', content: params.user }],
+          temperature: params.temperature ?? 0.2,
+          max_tokens: params.maxTokens ?? 2048,
+        });
     const latencyMs = Date.now() - t0;
 
     const block = res.content?.[0];


### PR DESCRIPTION
## Bug observé

L'utilisateur active l'autopilote dans le panel "Configuration scanner Gainers" → DB `autopilot_enabled=true`. Plus tard il ajuste un preset de risque dans la page Lisa principale et clique "Sauvegarder la config" → le payload `upsertConfig` écrase `autopilot_enabled` à la valeur de la checkbox locale "Autopilot (event-driven + filet de garantie)" (souvent stale/false en cas d'invalidation cache imparfaite) → **scanner Gainers stoppé silencieusement**.

Symptôme : 2 UIs désynchronisés affichant des états contradictoires :
- Panel Gainers : "Autopilot ACTIF" (vert)
- Section principale : checkbox "Autopilot event-driven" décochée
- DB : `autopilot_enabled=false` (le vrai état)

## Fix

1. **Section masquée en mode gainers** : "Autopilot (event-driven + filet de garantie)" remplacée par un message explicatif pointant vers le panel Gainers comme unique source de vérité.
2. **Save exclut `autopilot_enabled`** quand mode=gainers via `...(isGainersMode ? {} : { autopilot_enabled: ... })`. Plus aucun risque d'écrasement.

Le filet de garantie event-driven était pensé pour le pipeline Lisa LLM (modes investment/harvest). En mode gainers, le scanner déterministe a son propre cycle (`gainers_cycle_minutes`) — paramètre déjà géré dans le panel Gainers.

## Test plan

- [x] Typecheck web (clean)
- [ ] En mode gainers : la section event-driven n'apparaît plus, message orange visible
- [ ] En mode investment/harvest : la section event-driven s'affiche normalement
- [ ] Toggle ACTIF dans panel Gainers + Save dans page Lisa → `autopilot_enabled` reste à true en DB

https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5f17WdhyTYUFirJBUrLb)_