### PR TITLE
fix(mechanical): honor gainers_min_net_profit_usd UI value

### DIFF
--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -1788,6 +1788,24 @@ export class MechanicalTradingService {
     return isHyperActive ? 2.5 : 4;
   }
 
+  private async getMinNetProfitGate(portfolioId: string, notional: Decimal): Promise<Decimal> {
+    const fallback = Decimal.max(new Decimal(2), notional.mul(0.005));
+    try {
+      const { data: cfg } = await this.supabase.getClient()
+        .from('lisa_session_configs')
+        .select('strategy_mode, gainers_min_net_profit_usd')
+        .eq('portfolio_id', portfolioId)
+        .maybeSingle();
+
+      if (cfg?.strategy_mode !== 'gainers') return fallback;
+      const ui = cfg.gainers_min_net_profit_usd;
+      if (typeof ui === 'number' && Number.isFinite(ui) && ui >= 0) {
+        return new Decimal(ui);
+      }
+    } catch { /* fall through to default */ }
+    return fallback;
+  }
+
   /**
    * Détecte si une quote a été retournée via le fallback hardcoded
    * (au lieu d'une vraie source live). Toute source commençant par "fallback"
@@ -2261,9 +2279,14 @@ export class MechanicalTradingService {
     // Pourquoi seulement closed_target : closed_stop matérialise une perte
     // par design (protection drawdown) ; closed_invalidated refund les fees.
     if (reason === 'closed_target') {
-      const minNetProfit = Decimal.max(
-        new Decimal(2),
-        notional.mul(0.005),  // 0.5% du notional
+      // PR #279 (07/05/2026) — Honorer `gainers_min_net_profit_usd` (UI section 6)
+      // en mode gainers. Avant : gate hardcoded `max($2, 0.5% × notional)` =
+      // $5 pour notional $1000, ce qui bloquait indéfiniment des TP réactifs
+      // RSI à +0.5% (net ~$4.10). La valeur UI était silencieusement ignorée.
+      // Fallback hardcoded préservé pour le flow LLM (strategy_mode != gainers).
+      const minNetProfit = await this.getMinNetProfitGate(
+        pos.portfolio_id as string,
+        notional,
       );
       if (realizedPnl.lt(minNetProfit)) {
         this.logger.warn(


### PR DESCRIPTION
## Symptôme

Live 07/05 14:06 — `SAA.LSE` bloquée 5+ cycles consécutifs en `Skip closed_target` :

```
12:06:00 WARN [MechanicalTradingService] Skip closed_target SAA.LSE: net=$4.10 < min=$5.00 (notional=$1000, gross=$5.10, fees=$1.00). Position kept open.
12:07:00 WARN ... Skip closed_target SAA.LSE: net=$4.10 < min=$5.00 ...
12:08:04 WARN ... Skip closed_target SAA.LSE: net=$4.10 < min=$5.00 ...
12:09:02 WARN ... Skip closed_target SAA.LSE: net=$4.10 < min=$5.00 ...
```

Le TP réactif RSI veut matérialiser net=$4.10 sur un gross +0.51%, mais le gate hardcodé `max($2, 0.5% × notional)` = $5 sur notional $1000 le rejette indéfiniment. La position reste ouverte jusqu'au TP plein 2 % ou au stop-loss.

## Cause racine

`mechanical-trading.service.ts:2264` ignorait silencieusement la valeur UI `gainers_min_net_profit_usd` (UI section 6 « Profit min net (USD) »). Le champ était persisté en DB (`lisa_session_configs`) et exposé côté front (`gainers-config-panel.tsx:659`) mais jamais relu côté back.

## Fix

Ajout d'un helper `getMinNetProfitGate(portfolioId, notional)` symétrique à `getTakeProfitAbsolutePct` :

- En mode `gainers` ET `gainers_min_net_profit_usd` ≥ 0 → utilise la valeur UI.
- Sinon → préserve le fallback hardcodé P19x.1 `max($2, 0.5% × notional)` (calibré pour le flow LLM avec fees IBKR $0.35 × 2 sides sur tiny moves).

Avec le réglage actuel utilisateur (`gainers_min_net_profit_usd = 0.50`) :
- `minNetProfit = $0.50`
- SAA.LSE net $4.10 > $0.50 → TP fire normalement ✅

## Test plan

- [ ] CI typecheck vert
- [ ] CI Jest unit tests vert
- [ ] Post-merge : vérifier dans Fly logs que la prochaine exit réactive sur SAA.LSE déclenche `[MÉCANIQUE_CLOSE]` (et plus `Skip closed_target`)
- [ ] Vérifier que les portfolios en `strategy_mode != 'gainers'` continuent de voir le gate $5 (preservation du flow LLM P19x.1)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_