### PR TITLE
fix(shadow): order ASC + ms timestamp detection + ticks fallback

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/walk-forward.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/walk-forward.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * PR #283 — Tests pure logic walkForward + normalizeAndSortCandles.
+ *
+ * Bug observé prod 07/05/2026 : 100% NO_DATA sur 1304 rows / 24h. Cause :
+ * EODHD retournait les candles DESC (most-recent-first), walkForward
+ * itérait avec un break sur cutoffTs → break immédiat → lastBeforeCutoff
+ * stays null → NO_DATA. PR #283 force le tri ASC + détecte ms vs s.
+ */
+import {
+  walkForward,
+  normalizeAndSortCandles,
+  type SimGrid,
+  type CandleLike,
+} from '../services/gainers-user-shadow.service';
+
+const baselineGrid60: SimGrid = { key: 'baseline_60m', tpPct: 0.02, slPct: 0.009, windowMin: 60 };
+const baselineGrid30: SimGrid = { key: 'baseline_30m', tpPct: 0.02, slPct: 0.009, windowMin: 30 };
+
+// Helper : crée une candle 5m (timestamp en seconds)
+function candle(tsSec: number, open: number, high: number, low: number, close: number): CandleLike {
+  return { timestamp: tsSec, high, low, close, open } as CandleLike;
+}
+
+describe('normalizeAndSortCandles', () => {
+  it('keeps seconds timestamps unchanged when sorted ASC', () => {
+    const input = [
+      candle(1700000000, 100, 101, 99, 100.5),
+      candle(1700000300, 100.5, 102, 100, 101),
+      candle(1700000600, 101, 103, 100.5, 102),
+    ];
+    const out = normalizeAndSortCandles(input);
+    expect(out.map((c) => c.timestamp)).toEqual([1700000000, 1700000300, 1700000600]);
+    expect(out[0].close).toBe(100.5);
+  });
+
+  it('sorts DESC input to ASC', () => {
+    const input = [
+      candle(1700000600, 101, 103, 100.5, 102),
+      candle(1700000300, 100.5, 102, 100, 101),
+      candle(1700000000, 100, 101, 99, 100.5),
+    ];
+    const out = normalizeAndSortCandles(input);
+    expect(out.map((c) => c.timestamp)).toEqual([1700000000, 1700000300, 1700000600]);
+  });
+
+  it('detects ms timestamps (>1e12) and converts to seconds', () => {
+    const input = [
+      candle(1700000600000, 101, 103, 100.5, 102),
+      candle(1700000300000, 100.5, 102, 100, 101),
+      candle(1700000000000, 100, 101, 99, 100.5),
+    ];
+    const out = normalizeAndSortCandles(input);
+    expect(out.map((c) => c.timestamp)).toEqual([1700000000, 1700000300, 1700000600]);
+  });
+
+  it('handles empty input', () => {
+    expect(normalizeAndSortCandles([])).toEqual([]);
+  });
+
+  it('does not mutate input array', () => {
+    const input = [
+      candle(1700000600, 0, 0, 0, 0),
+      candle(1700000000, 0, 0, 0, 0),
+    ];
+    const before = [...input];
+    normalizeAndSortCandles(input);
+    expect(input).toEqual(before);
+  });
+});
+
+describe('walkForward', () => {
+  // Entry $100, TP $102 (+2%), SL $99.10 (-0.9%), window 60min
+  const startTs = 1700000000;
+  const entry = 100;
+
+  it('returns NO_DATA on empty candles', () => {
+    const out = walkForward(entry, [], startTs, baselineGrid60);
+    expect(out.outcome).toBe('NO_DATA');
+    expect(out.exit_price).toBeNull();
+    expect(out.exit_at).toBeNull();
+    expect(out.pnl_pct).toBeNull();
+  });
+
+  it('detects TP_HIT on first qualifying candle (high >= tp)', () => {
+    const candles = [
+      candle(startTs + 300, 100, 100.5, 99.5, 100.2),     // T+5min, no hit
+      candle(startTs + 600, 100.2, 102.5, 100, 102.1),    // T+10min, TP hit (high 102.5 ≥ 102)
+      candle(startTs + 900, 102, 103, 101.5, 102.5),      // T+15min, ignored (already returned)
+    ];
+    const out = walkForward(entry, candles, startTs, baselineGrid60);
+    expect(out.outcome).toBe('TP_HIT');
+    expect(out.exit_price).toBeCloseTo(102, 4);
+    expect(out.hit_at_min).toBe(10);
+    // pnl_pct = tpPct - slippage_total = 0.02 - 0.0030 = 0.017
+    expect(out.pnl_pct).toBeCloseTo(0.017, 4);
+  });
+
+  it('detects SL_HIT on first qualifying candle (low <= sl)', () => {
+    const candles = [
+      candle(startTs + 300, 100, 100.2, 99.8, 100),       // T+5min, no hit
+      candle(startTs + 600, 100, 100.5, 99.0, 99.2),      // T+10min, SL hit (low 99.0 ≤ 99.10)
+    ];
+    const out = walkForward(entry, candles, startTs, baselineGrid60);
+    expect(out.outcome).toBe('SL_HIT');
+    expect(out.exit_price).toBeCloseTo(99.10, 4);
+    expect(out.hit_at_min).toBe(10);
+    // pnl_pct = -slPct - slippage_total = -0.009 - 0.0030 = -0.012
+    expect(out.pnl_pct).toBeCloseTo(-0.012, 4);
+  });
+
+  it('SL takes precedence over TP when both could trigger same candle (conservative tie-break)', () => {
+    const candles = [
+      // Wide range candle : low 98 (would hit SL 99.10) AND high 103 (would hit TP 102)
+      candle(startTs + 300, 100, 103, 98, 100),
+    ];
+    const out = walkForward(entry, candles, startTs, baselineGrid60);
+    expect(out.outcome).toBe('SL_HIT');
+  });
+
+  it('returns TIME_LIMIT with last candle close when neither TP nor SL hit before cutoff', () => {
+    const candles = [
+      candle(startTs + 300, 100, 100.5, 99.5, 100.2),
+      candle(startTs + 1800, 100.2, 101, 99.5, 100.8),    // T+30min, mid-range
+      candle(startTs + 3600, 100.8, 101.5, 99.5, 101.2),  // T+60min, exactly at cutoff
+    ];
+    const out = walkForward(entry, candles, startTs, baselineGrid60);
+    expect(out.outcome).toBe('TIME_LIMIT');
+    expect(out.exit_price).toBeCloseTo(101.2, 4);
+    expect(out.hit_at_min).toBe(60);
+    // pnl_pct = (101.2 - 100) / 100 - 0.0030 = 0.012 - 0.003 = 0.009
+    expect(out.pnl_pct).toBeCloseTo(0.009, 4);
+  });
+
+  it('respects windowMin cutoff (baseline_30m breaks at +30min, ignores +45min TP)', () => {
+    const candles = [
+      candle(startTs + 600, 100, 100.5, 99.5, 100.2),     // T+10min
+      candle(startTs + 1500, 100.2, 100.8, 99.8, 100.5),  // T+25min, no hit
+      candle(startTs + 2700, 100.5, 102.5, 100.2, 102.2), // T+45min, would be TP but past 30m cutoff
+    ];
+    const out = walkForward(entry, candles, startTs, baselineGrid30);
+    // baseline_30m cutoffTs = startTs + 1800. T+2700 > 1800 → break.
+    // Last before cutoff = T+1500, close 100.5 → TIME_LIMIT
+    expect(out.outcome).toBe('TIME_LIMIT');
+    expect(out.exit_price).toBeCloseTo(100.5, 4);
+    expect(out.hit_at_min).toBe(25);
+  });
+
+  it('regression : DESC-ordered input alone would give NO_DATA — proving why normalize is mandatory', () => {
+    const candlesDesc = [
+      candle(startTs + 3600, 100.8, 101.5, 99.5, 101.2),
+      candle(startTs + 1800, 100.2, 101, 99.5, 100.8),
+      candle(startTs + 300, 100, 100.5, 99.5, 100.2),
+    ];
+    // Sans tri (input direct DESC) : break à la première itération
+    // car candlesDesc[0].timestamp (3600) > cutoffTs (3600) ? Non, ts EQUAL → pas break
+    // Mais T+3600 > startTs+1800 (cutoff baseline_30m) → break. Dernière itération.
+    const outDirect = walkForward(entry, candlesDesc, startTs, baselineGrid30);
+    expect(outDirect.outcome).toBe('NO_DATA');  // confirme le bug
+
+    // Avec normalize : tri ASC → walkForward fonctionne normalement.
+    // Candles ASC : [+300s, +1800s, +3600s]. cutoffTs (baseline_30m) = startTs + 1800.
+    // T+1800 inclusif (≤ cutoff), T+3600 break. lastBeforeCutoff = T+1800 (= 30min).
+    const sorted = normalizeAndSortCandles(candlesDesc);
+    const outSorted = walkForward(entry, sorted, startTs, baselineGrid30);
+    expect(outSorted.outcome).toBe('TIME_LIMIT');
+    expect(outSorted.hit_at_min).toBe(30);
+  });
+});

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -55,7 +55,7 @@ export interface RecordDecisionInput {
   };
 }
 
-interface SimGrid {
+export interface SimGrid {
   key: string;
   tpPct: number;
   slPct: number;
@@ -74,12 +74,116 @@ const SLIPPAGE_TOTAL = SLIPPAGE_HAIRCUT_BILATERAL * 2;  // 30bps round-trip
 const SIMULATE_AFTER_MIN = 60;  // attendre que la fenêtre 60m soit close
 const SIMULATE_BATCH_SIZE = 50;
 
-interface SimOutcome {
+// PR #283 — Lookback fenêtre 5m pour fetch candles. Configurable via env
+// `USER_SHADOW_5M_LOOKBACK_MIN` (default 150 min). Couvre largement la sim
+// window 60min + un buffer pour les rows pickées tardivement par le worker
+// (cron lag, ré-essais retro). Floor 75min (= 15 candles, le minimum
+// historique avant PR #283 où on observait 100% NO_DATA à cause du bug
+// d'ordering DESC dans walkForward).
+const SHADOW_5M_LOOKBACK_MIN_DEFAULT = 150;
+function resolveShadowLookbackCandles(): number {
+  const raw = process.env.USER_SHADOW_5M_LOOKBACK_MIN;
+  const minutes = raw != null ? Number(raw) : SHADOW_5M_LOOKBACK_MIN_DEFAULT;
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    return Math.ceil(SHADOW_5M_LOOKBACK_MIN_DEFAULT / 5);
+  }
+  return Math.max(15, Math.ceil(minutes / 5));
+}
+
+export interface SimOutcome {
   outcome: 'TP_HIT' | 'SL_HIT' | 'TIME_LIMIT' | 'NO_DATA';
   exit_price: number | null;
   exit_at: string | null;
   pnl_pct: number | null;       // NET (slippage already subtracted)
   hit_at_min: number | null;
+}
+
+// PR #283 — Type minimal pour walkForward (ne nécessite pas EodhdIntradayService.Candle)
+export interface CandleLike {
+  timestamp: number;  // unix seconds (auto-normalisé si en ms)
+  high: number;
+  low: number;
+  close: number;
+}
+
+/**
+ * PR #283 — Normalise les candles avant walkForward :
+ *   1. Auto-detect ms vs seconds : si timestamp > 1e12 (= année 33658 en sec,
+ *      = ~2001 en ms), on divise par 1000 (ms → s).
+ *   2. Sort ASC (most-old-first). EODHD intraday retournait DESC, ce qui
+ *      cassait walkForward (premier candle hors cutoff → break immédiat
+ *      → lastBeforeCutoff null → NO_DATA). Bug observé prod 07/05/2026
+ *      sur 1304 rows / 24h, 100% NO_DATA.
+ *
+ * Fonction pure exportée pour testabilité.
+ */
+export function normalizeAndSortCandles<T extends CandleLike>(candles: readonly T[]): T[] {
+  return [...candles]
+    .map((c) => (
+      c.timestamp > 1e12 ? { ...c, timestamp: Math.floor(c.timestamp / 1000) } : c
+    ))
+    .sort((a, b) => a.timestamp - b.timestamp);
+}
+
+/**
+ * PR #283 — walkForward : itère les candles ASCENDING, applique TP/SL d'une
+ * grille (TP%, SL%, windowMin), retourne le premier hit ou TIME_LIMIT.
+ *
+ * Conventions :
+ *   - candles DOIVENT être triées ASC (utiliser normalizeAndSortCandles)
+ *   - candles[i].timestamp en unix seconds
+ *   - startTs en unix seconds (timestamp de la décision originale)
+ *   - tie-break SL-first si les deux pourraient déclencher dans la même
+ *     candle 5m (impossible de connaître l'ordre intra-bougie sans tick data)
+ *   - slippage haircut SLIPPAGE_TOTAL (30bps) appliqué au pnl_pct net
+ *
+ * Fonction pure exportée pour testabilité.
+ */
+export function walkForward(
+  entry: number,
+  candles: readonly CandleLike[],
+  startTs: number,
+  grid: SimGrid,
+): SimOutcome {
+  const tpPrice = entry * (1 + grid.tpPct);
+  const slPrice = entry * (1 - grid.slPct);
+  const cutoffTs = startTs + grid.windowMin * 60;
+  let lastBeforeCutoff: CandleLike | null = null;
+
+  for (const c of candles) {
+    if (c.timestamp > cutoffTs) break;
+    lastBeforeCutoff = c;
+    if (c.low <= slPrice) {
+      return {
+        outcome: 'SL_HIT',
+        exit_price: slPrice,
+        exit_at: new Date(c.timestamp * 1000).toISOString(),
+        pnl_pct: -grid.slPct - SLIPPAGE_TOTAL,
+        hit_at_min: Math.round((c.timestamp - startTs) / 60),
+      };
+    }
+    if (c.high >= tpPrice) {
+      return {
+        outcome: 'TP_HIT',
+        exit_price: tpPrice,
+        exit_at: new Date(c.timestamp * 1000).toISOString(),
+        pnl_pct: grid.tpPct - SLIPPAGE_TOTAL,
+        hit_at_min: Math.round((c.timestamp - startTs) / 60),
+      };
+    }
+  }
+
+  if (lastBeforeCutoff) {
+    const closePnl = (lastBeforeCutoff.close - entry) / entry;
+    return {
+      outcome: 'TIME_LIMIT',
+      exit_price: lastBeforeCutoff.close,
+      exit_at: new Date(lastBeforeCutoff.timestamp * 1000).toISOString(),
+      pnl_pct: closePnl - SLIPPAGE_TOTAL,
+      hit_at_min: Math.round((lastBeforeCutoff.timestamp - startTs) / 60),
+    };
+  }
+  return { outcome: 'NO_DATA', exit_price: null, exit_at: null, pnl_pct: null, hit_at_min: null };
 }
 
 @Injectable()
@@ -210,69 +314,39 @@ export class GainersUserShadowService {
     // le suffix manquait par erreur.
     const eodhdTicker = args.symbol;
 
-    // Fetch ~13 candles 5m = 65 min window (enough for 60m grid)
-    const series = await this.eodhd.getCandles(eodhdTicker, '5m', 15).catch(() => null);
+    // PR #283 — Lookback configurable (env USER_SHADOW_5M_LOOKBACK_MIN, default
+    // 150min = 30 candles). Fallback ticks-data si getCandles retourne null
+    // (couvre Asia/NSE low-coverage où l'intraday standard échoue).
+    const candleCount = resolveShadowLookbackCandles();
+    let series = await this.eodhd.getCandles(eodhdTicker, '5m', candleCount).catch(() => null);
+    if (!series || series.candles.length === 0) {
+      series = await this.eodhd.getCandlesViaTicks(eodhdTicker, '5m', candleCount).catch(() => null);
+    }
     if (!series || series.candles.length === 0) {
       for (const g of SIM_GRIDS) results[g.key] = noEntry();
       return results;
     }
 
     const startTs = new Date(args.createdAt).getTime() / 1000;
-    const forward = series.candles.filter((c) => c.timestamp >= startTs);
+    // PR #283 — Critique : normaliser unité (ms→s) ET trier ASC AVANT
+    // walkForward. EODHD retournait DESC, le bug a causé 100% NO_DATA prod.
+    const normalized = normalizeAndSortCandles(series.candles);
+    const forward = normalized.filter((c) => c.timestamp >= startTs);
+
+    if (forward.length === 0) {
+      const first = normalized[0];
+      const last = normalized[normalized.length - 1];
+      this.logger.warn(
+        `[user-shadow] ${eodhdTicker}: forward=0 fetched=${normalized.length} ` +
+        `firstTs=${first?.timestamp ?? 'n/a'} lastTs=${last?.timestamp ?? 'n/a'} ` +
+        `startTs=${startTs} cutoffMaxTs=${startTs + 60 * 60}`,
+      );
+    }
 
     for (const grid of SIM_GRIDS) {
-      results[grid.key] = this.walkForward(args.entryPrice, forward, startTs, grid);
+      results[grid.key] = walkForward(args.entryPrice, forward, startTs, grid);
     }
     return results;
-  }
-
-  private walkForward(
-    entry: number,
-    candles: Array<{ timestamp: number; high: number; low: number; close: number }>,
-    startTs: number,
-    grid: SimGrid,
-  ): SimOutcome {
-    const tpPrice = entry * (1 + grid.tpPct);
-    const slPrice = entry * (1 - grid.slPct);
-    const cutoffTs = startTs + grid.windowMin * 60;
-    let lastBeforeCutoff: typeof candles[number] | null = null;
-
-    for (const c of candles) {
-      if (c.timestamp > cutoffTs) break;
-      lastBeforeCutoff = c;
-      // Conservative tie-break : SL prioritaire si les deux pourraient déclencher
-      // dans la même candle 5m (impossible de savoir l'ordre sans tick data).
-      if (c.low <= slPrice) {
-        return {
-          outcome: 'SL_HIT',
-          exit_price: slPrice,
-          exit_at: new Date(c.timestamp * 1000).toISOString(),
-          pnl_pct: -grid.slPct - SLIPPAGE_TOTAL,
-          hit_at_min: Math.round((c.timestamp - startTs) / 60),
-        };
-      }
-      if (c.high >= tpPrice) {
-        return {
-          outcome: 'TP_HIT',
-          exit_price: tpPrice,
-          exit_at: new Date(c.timestamp * 1000).toISOString(),
-          pnl_pct: grid.tpPct - SLIPPAGE_TOTAL,
-          hit_at_min: Math.round((c.timestamp - startTs) / 60),
-        };
-      }
-    }
-
-    if (lastBeforeCutoff) {
-      const closePnl = (lastBeforeCutoff.close - entry) / entry;
-      return {
-        outcome: 'TIME_LIMIT',
-        exit_price: lastBeforeCutoff.close,
-        exit_at: new Date(lastBeforeCutoff.timestamp * 1000).toISOString(),
-        pnl_pct: closePnl - SLIPPAGE_TOTAL,
-        hit_at_min: Math.round((lastBeforeCutoff.timestamp - startTs) / 60),
-      };
-    }
-    return { outcome: 'NO_DATA', exit_price: null, exit_at: null, pnl_pct: null, hit_at_min: null };
   }
 
   /**


### PR DESCRIPTION
## 🐛 Bug observé prod 07/05/2026

**100% NO_DATA** sur 1304 rows simulées en 24h, tous asset_class confondus (US large, Asia, China). Diagnostic ciblé via dump JSONB sur 3 samples (CCP.AU, NYT.US, 300161.SHE, THC.US) — tous le même pattern :

```json
{
  "alt15_30m":    { "outcome": "NO_DATA", "pnl_pct": null, ... },
  "alt15_60m":    { "outcome": "NO_DATA", "pnl_pct": null, ... },
  "baseline_30m": { "outcome": "NO_DATA", "pnl_pct": null, ... },
  "baseline_60m": { "outcome": "NO_DATA", "pnl_pct": null, ... }
}
```

## Cause racine

EODHD intraday retourne les candles **DESC** (most-recent-first), mais `walkForward` itère avec `break` quand `c.timestamp > cutoffTs` → premier candle (post-cutoff de la sim window) → break immédiat → `lastBeforeCutoff` stays `null` → NO_DATA.

## Conséquence

- PR #282 adaptive auto-relax tourne mais **0 input usable** (bootstrap CI sur n=0)
- PR #281 training `include_shadow=true` ne reçoit rien d'exploitable
- Pipeline complet shadow → ML → adaptive **bloqué**

## Fix

| # | Action | Pourquoi |
|---|---|---|
| 1 | **Sort ASC** avant walkForward | root cause du bug |
| 2 | **Auto-detect ms→s** (`>1e12 ÷ 1000`) | défense en profondeur sur sources EODHD variantes |
| 3 | **Log warn** sur `forward.length===0` avec `fetched/firstTs/lastTs/startTs/cutoffMaxTs` | diagnostic obligatoire post-deploy |
| 4 | **`USER_SHADOW_5M_LOOKBACK_MIN`** env (default 150) | couvre sim window 60min + buffer cron lag + ré-essais retro |
| 5 | **Fallback `getCandlesViaTicks`** si getCandles null | couvre Asia/NSE low-coverage |

## Architecture

Extraction `walkForward` + `normalizeAndSortCandles` en **fonctions pures exportées** au module-level. Avant : `private` méthodes de la classe, intestables sans mock NestJS lourd.

## Tests (12 nouveaux, tous verts)

`normalizeAndSortCandles` :
- ASC seconds unchanged
- DESC sorted to ASC
- ms (>1e12) converted to seconds
- empty handled
- doesn't mutate input

`walkForward` :
- NO_DATA on empty
- TP_HIT detection (high ≥ tp)
- SL_HIT detection (low ≤ sl)
- SL precedence on tie-break (conservative)
- TIME_LIMIT with last close before cutoff
- respects windowMin (30m vs 60m)
- **REGRESSION** : DESC input → NO_DATA (prouve le bug), ASC après normalize → TIME_LIMIT correct (prouve le fix)

## Post-deploy SQL

Une fois Fly redeployé avec PR #283, run :

```sql
-- Re-simulate les 1304 rows existantes (NO_DATA → vrais outcomes)
UPDATE gainers_user_shadow_signals
SET sim_run_at = NULL, sim_results = NULL
WHERE sim_results->'baseline_60m'->>'outcome' = 'NO_DATA'
  AND created_at > NOW() - INTERVAL '24 hours';
```

Le worker `simulatePending()` réacheminera ~50 rows par cycle scanner (~1min) → ~30 min pour rattraper.

Vérification post-rerun :

```sql
SELECT sim_results->'baseline_60m'->>'outcome' AS outcome, count(*) AS n
FROM gainers_user_shadow_signals
WHERE created_at > NOW() - INTERVAL '24 hours'
  AND sim_results IS NOT NULL
GROUP BY 1 ORDER BY 2 DESC;
```

Distribution attendue : `TP_HIT / SL_HIT / TIME_LIMIT` majoritaires, `NO_DATA` résiduel uniquement sur tickers vraiment sans data EODHD (NSE 404 known — HEG, NOCIL, etc. — couverts par le log warn pour diagnostic).

## Test plan

- [x] Typecheck + Jest local : 109 suites, 1353 tests passent (12 nouveaux tests sur walkForward + normalizer)
- [ ] CI verte sur PR
- [ ] Post-merge : Fly redeploy auto via workflow `fly.yml`
- [ ] Run `UPDATE sim_run_at = NULL...` pour re-simulation rétro
- [ ] T+30 min : SELECT distribution outcome → vérifier TP/SL/TIME_LIMIT apparaissent
- [ ] T+1 jour : `GET /lisa/gainers-shadow-regret/:portfolioId?days=7` retourne au moins 1 verdict non-INSUFFICIENT_DATA

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_