### PR TITLE
feat(shadow): explicit from/to range fetch + 5d retention guard

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/eodhd-intraday-range.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/eodhd-intraday-range.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * PR #284 — Tests range fetch (fromTs/toTs) + retention guard.
+ *
+ * Le fetch range explicite est critique pour la retro-simulation des shadow
+ * signals : sans ça, getCandles('5m', N) retourne les latest N candles, qui
+ * ne couvrent pas la fenêtre [startTs, startTs+60min] quand la sim tourne
+ * 12h+ après recordDecision (cas observé prod 08/05/2026).
+ *
+ * Note : EodhdIntradayService est lourd à mocker (cache, fetch, logs). Ces
+ * tests valident la logique pure de retention et d'URL building en mockant
+ * uniquement `fetch` global.
+ */
+import { Logger } from '@nestjs/common';
+import { EodhdIntradayService } from '../services/eodhd-intraday.service';
+
+// Mock minimal pour ApiCostTrackerService (constructor dep)
+const mockApiCostTracker = {
+  recordCall: jest.fn(),
+  // Add other methods if needed
+} as unknown as { recordCall: jest.Mock };
+
+const mockConfig = {
+  get: jest.fn((key: string) => {
+    if (key === 'EODHD_API_KEY') return 'test-api-key';
+    return undefined;
+  }),
+} as unknown as { get: jest.Mock };
+
+describe('EodhdIntradayService — PR #284 range fetch + retention', () => {
+  let service: EodhdIntradayService;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Suppress console output during tests
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+    service = new EodhdIntradayService(mockConfig as never, mockApiCostTracker as never);
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    jest.restoreAllMocks();
+  });
+
+  it('passes explicit fromTs/toTs to URL params (range mode)', async () => {
+    // fromTs récent (< 5d) pour passer le retention guard
+    const nowSec = Math.floor(Date.now() / 1000);
+    const fromTs = nowSec - 12 * 3600;     // 12h ago, well within 5d retention
+    const toTs = fromTs + 3900;             // +65min
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => [
+        { timestamp: fromTs + 300, open: 100, high: 101, low: 99.5, close: 100.5, volume: 1000 },
+        { timestamp: fromTs + 1200, open: 100.5, high: 102, low: 100, close: 101.5, volume: 1500 },
+        { timestamp: fromTs + 3600, open: 101.5, high: 102.2, low: 101, close: 102, volume: 2000 },
+      ],
+    } as Response);
+
+    const result = await service.getCandles('NYT.US', '5m', 30, { fromTs, toTs });
+
+    expect(result).not.toBeNull();
+    expect(result!.candles).toHaveLength(3);
+    // URL doit contenir from/to explicites, pas le default 5j
+    const calledUrl = fetchSpy.mock.calls[0][0] as string;
+    expect(calledUrl).toContain(`from=${fromTs}`);
+    expect(calledUrl).toContain(`to=${toTs}`);
+    expect(calledUrl).toContain('NYT.US');
+    expect(calledUrl).toContain('interval=5m');
+  });
+
+  it('returns null + warn EODHD_RETENTION_EXCEEDED when fromTs > 5 days ago', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn');
+    const nowSec = Math.floor(Date.now() / 1000);
+    const fromTs = nowSec - 6 * 86400;  // 6 days ago, beyond 5d retention
+    const toTs = fromTs + 3900;
+
+    const result = await service.getCandles('AAPL.US', '5m', 30, { fromTs, toTs });
+
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();  // early return, pas de fetch
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('EODHD_RETENTION_EXCEEDED'),
+    );
+    expect(warnSpy.mock.calls[0][0]).toContain('AAPL.US');
+  });
+
+  it('accepts fromTs exactly at the 5d boundary (allow ≤5d)', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const fromTs = nowSec - 4.9 * 86400;  // 4.9 days = within retention
+    const toTs = fromTs + 3900;
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => [
+        { timestamp: fromTs + 300, open: 100, high: 101, low: 99.5, close: 100.5, volume: 1000 },
+      ],
+    } as Response);
+
+    const result = await service.getCandles('AAPL.US', '5m', 30, { fromTs, toTs });
+    expect(result).not.toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('back-compat : no options → uses default windowForInterval (latest mode)', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => [
+        { timestamp: 1700000000, open: 100, high: 101, low: 99, close: 100.5, volume: 1000 },
+      ],
+    } as Response);
+
+    await service.getCandles('AAPL.US', '5m', 20);
+    const calledUrl = fetchSpy.mock.calls[0][0] as string;
+    // Default mode : from = now - 5*24*3600, doit être un timestamp récent
+    const fromMatch = /from=(\d+)/.exec(calledUrl);
+    expect(fromMatch).not.toBeNull();
+    const fromTs = parseInt(fromMatch![1], 10);
+    const nowSec = Math.floor(Date.now() / 1000);
+    // fromTs doit être ~5 jours dans le passé, pas un fromTs explicite
+    expect(nowSec - fromTs).toBeGreaterThan(4 * 86400);
+    expect(nowSec - fromTs).toBeLessThan(6 * 86400);
+  });
+
+  it('range mode : returns ALL candles in range (no slice -count)', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const fromTs = nowSec - 12 * 3600;
+    const toTs = fromTs + 3900;
+    // 30 candles dans la réponse, count=10 demandé → range mode garde tout
+    const candles = Array.from({ length: 30 }, (_, i) => ({
+      timestamp: fromTs + i * 300,
+      open: 100, high: 101, low: 99.5, close: 100, volume: 100,
+    }));
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => candles,
+    } as Response);
+
+    const result = await service.getCandles('NYT.US', '5m', 10, { fromTs, toTs });
+    expect(result!.candles).toHaveLength(30);  // pas slicé à 10
+  });
+});

--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -177,10 +177,21 @@ export class EodhdIntradayService {
     return 30 * 24 * 3600;                             // 30 jours pour 1h
   }
 
+  /**
+   * PR #284 — Limite de rétention EODHD intraday standard. Au-delà l'API
+   * peut retourner empty silencieusement (selon plan), créant des sims
+   * fantômes NO_DATA. On log explicite et on early-return null.
+   *
+   * Aligné avec les TTLs cache mais utilisé ici comme guard caller-side
+   * pour les fetch range explicites (shadow simulator retro-sim).
+   */
+  static readonly RETENTION_LIMIT_SEC = 5 * 24 * 3600;  // 5 days
+
   async getCandles(
     eodhdTicker: string,
     interval: '1m' | '5m' | '1h' = '5m',
     count = 20,
+    options?: { fromTs?: number; toTs?: number },
   ): Promise<CandleSeries | null> {
     // Hotfix EODHD bypass — defense in depth : si un caller passe un symbol
     // sans suffix exchange (ex: legacy row "005940" au lieu de "005940.KO"),
@@ -195,7 +206,24 @@ export class EodhdIntradayService {
     }
     // P19k — Normaliser le suffix avant cache key + URL pour cohérence.
     const normalized = this.normalizeForEodhdIntraday(eodhdTicker);
-    const cacheKey = `${normalized}::${interval}`;
+
+    // PR #284 — Mode range explicite : skip cache (range-specific), guard
+    // retention 5 jours, désactive le slice(-count) (on prend tout le range).
+    const useRange = options?.fromTs != null || options?.toTs != null;
+    if (useRange && options?.fromTs != null) {
+      const nowSec = Math.floor(Date.now() / 1000);
+      const ageDays = (nowSec - options.fromTs) / 86400;
+      if (ageDays > 5) {
+        this.logger.warn(
+          `[eodhd] ${eodhdTicker} EODHD_RETENTION_EXCEEDED : fromTs=${options.fromTs} (${ageDays.toFixed(1)}d ago) > 5d retention. Skipping fetch.`,
+        );
+        return null;
+      }
+    }
+
+    const cacheKey = useRange
+      ? `${normalized}::${interval}::${options?.fromTs ?? '_'}::${options?.toTs ?? '_'}`
+      : `${normalized}::${interval}`;
     const cached = this.cache.get(cacheKey);
     if (cached && Date.now() - cached.asOf < this.cacheTtlMs(interval)) {
       return cached;
@@ -210,8 +238,10 @@ export class EodhdIntradayService {
       return null;
     }
 
-    const toUnix = Math.floor(Date.now() / 1000);
-    const fromUnix = toUnix - this.windowForInterval(interval);
+    // PR #284 — Range explicite via options.fromTs/toTs override le default
+    // (latest window). Permet retro-sim shadow signals avec window précise.
+    const toUnix = options?.toTs ?? Math.floor(Date.now() / 1000);
+    const fromUnix = options?.fromTs ?? (toUnix - this.windowForInterval(interval));
 
     const tStart = Date.now();
     try {
@@ -243,7 +273,7 @@ export class EodhdIntradayService {
         return null;
       }
 
-      const candles: Candle[] = data
+      const allCandles: Candle[] = data
         .map((d) => ({
           timestamp: typeof d.timestamp === 'number' ? d.timestamp : Number(d.timestamp ?? 0),
           open: Number(d.open ?? 0),
@@ -252,8 +282,13 @@ export class EodhdIntradayService {
           close: Number(d.close ?? 0),
           volume: Number(d.volume ?? 0),
         }))
-        .filter((c) => c.timestamp > 0 && c.close > 0)
-        .slice(-count);
+        .filter((c) => c.timestamp > 0 && c.close > 0);
+
+      // PR #284 — En mode range, on prend toutes les candles dans la fenêtre
+      // (pas de slice(-count) qui prendrait juste les dernières et perdrait
+      // les candles utiles au caller). Le serveur EODHD a déjà restreint via
+      // les query params from/to.
+      const candles = useRange ? allCandles : allCandles.slice(-count);
 
       const series: CandleSeries = { ticker: eodhdTicker, interval, candles, asOf: Date.now() };
       this.cache.set(cacheKey, series);
@@ -402,9 +437,23 @@ export class EodhdIntradayService {
     eodhdTicker: string,
     interval: '1m' | '5m' | '1h' = '5m',
     count = 20,
+    options?: { fromTs?: number; toTs?: number },
   ): Promise<CandleSeries | null> {
-    const toUnix = Math.floor(Date.now() / 1000);
-    const fromUnix = toUnix - this.windowForInterval(interval);
+    // PR #284 — Range explicite override (cf. getCandles). Retention guard
+    // identique : >5j → log warn + return null.
+    const useRange = options?.fromTs != null || options?.toTs != null;
+    if (useRange && options?.fromTs != null) {
+      const nowSec = Math.floor(Date.now() / 1000);
+      const ageDays = (nowSec - options.fromTs) / 86400;
+      if (ageDays > 5) {
+        this.logger.warn(
+          `[eodhd:ticks] ${eodhdTicker} EODHD_RETENTION_EXCEEDED : fromTs=${options.fromTs} (${ageDays.toFixed(1)}d ago) > 5d. Skipping fetch.`,
+        );
+        return null;
+      }
+    }
+    const toUnix = options?.toTs ?? Math.floor(Date.now() / 1000);
+    const fromUnix = options?.fromTs ?? (toUnix - this.windowForInterval(interval));
     // Limit 5000 = compromis : sur ticker liquide ~100-500 ticks/5m → 5000 ticks
     // couvre 50-250 minutes ; sur micro-cap sparse ~5-20 ticks/5m → couvre 1-2j.
     const ticks = await this.getTickData(eodhdTicker, fromUnix, toUnix, 5000);
@@ -438,7 +487,8 @@ export class EodhdIntradayService {
       }
     }
     const sorted = [...buckets.values()].sort((a, b) => a.timestamp - b.timestamp);
-    const candles = sorted.slice(-count);
+    // PR #284 — En mode range, on prend tout (pas de slice(-count)).
+    const candles = useRange ? sorted : sorted.slice(-count);
     if (candles.length === 0) return null;
     const series: CandleSeries = {
       ticker: eodhdTicker,

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -314,20 +314,48 @@ export class GainersUserShadowService {
     // le suffix manquait par erreur.
     const eodhdTicker = args.symbol;
 
-    // PR #283 — Lookback configurable (env USER_SHADOW_5M_LOOKBACK_MIN, default
-    // 150min = 30 candles). Fallback ticks-data si getCandles retourne null
-    // (couvre Asia/NSE low-coverage où l'intraday standard échoue).
-    const candleCount = resolveShadowLookbackCandles();
-    let series = await this.eodhd.getCandles(eodhdTicker, '5m', candleCount).catch(() => null);
+    // PR #284 — FETCH RANGE EXPLICITE (au lieu de "latest N candles").
+    //
+    // Bug pré-PR #284 : `getCandles('5m', 30)` retournait les 30 dernières
+    // candles existantes. Pour une row simulée 12h après recordDecision (cas
+    // retro UPDATE), les latest candles couvraient la session courante, pas
+    // la fenêtre [startTs, startTs+60min] d'origine → 100% NO_DATA.
+    //
+    // Fix : passer `fromTs/toTs` explicites au range exact dont on a besoin
+    // ([startTs - 5min, endTs + buffer]). Le 5min de buffer côté gauche permet
+    // d'avoir 1 candle pré-entry comme contexte si on en veut plus tard
+    // (path quality forward, etc.). Côté droit, +5min pour clipper la dernière
+    // candle 60min cleanly.
+    //
+    // Retention guard EODHD 5j : cf. EodhdIntradayService.RETENTION_LIMIT_SEC.
+    // Au-delà l'API retourne empty → on log EODHD_RETENTION_EXCEEDED + null.
+    const startTs = new Date(args.createdAt).getTime() / 1000;
+    const fromTs = Math.floor(startTs - 300);                 // -5min buffer pré-entry
+    const toTs = Math.floor(startTs + 60 * 60 + 300);         // +60min sim window + 5min
+    const candleCount = resolveShadowLookbackCandles();        // legacy back-compat (slice when no range)
+
+    let series = await this.eodhd
+      .getCandles(eodhdTicker, '5m', candleCount, { fromTs, toTs })
+      .catch(() => null);
+
+    // Fallback ticks-data si getCandles range-fetch retourne null (low-coverage
+    // EODHD : Asia/NSE/AU certaines fois, ou plan-dependent gaps).
     if (!series || series.candles.length === 0) {
-      series = await this.eodhd.getCandlesViaTicks(eodhdTicker, '5m', candleCount).catch(() => null);
+      series = await this.eodhd
+        .getCandlesViaTicks(eodhdTicker, '5m', candleCount, { fromTs, toTs })
+        .catch(() => null);
     }
+
+    // Log info systématique pour monitoring du fetch range (PR #284).
+    this.logger.log(
+      `[user-shadow-fetch] ${eodhdTicker}: from=${fromTs} to=${toTs} got=${series?.candles?.length ?? 0}`,
+    );
+
     if (!series || series.candles.length === 0) {
       for (const g of SIM_GRIDS) results[g.key] = noEntry();
       return results;
     }
 
-    const startTs = new Date(args.createdAt).getTime() / 1000;
     // PR #283 — Critique : normaliser unité (ms→s) ET trier ASC AVANT
     // walkForward. EODHD retournait DESC, le bug a causé 100% NO_DATA prod.
     const normalized = normalizeAndSortCandles(series.candles);


### PR DESCRIPTION
## 🐛 Bug observé prod 08/05/2026 03:20 UTC (post-PR #283)

PR #283 (sort ASC + ms detect) résolvait le bug ordering, mais **100% NO_DATA persistait sur retro-sim**. Diagnostic via NYT.US :

```
sim_lag    : 11h 16min  ← row hier 15:47 UTC, sim ce matin 03:20 UTC
entry_price: 83.68      ← row valide
cfg        : TP 2% / SL 0.9%
```

`getCandles('5m', 30)` retourne les **30 dernières candles** (couvre `NOW-150min → NOW` = 01:00-03:30 UTC ce matin). Sim window = `row.created_at + 60min` = **15:47-16:47 UTC HIER**. Aucune overlap → toutes candles filtrées par cutoffTs → NO_DATA.

Le bug n'était pas l'ordering, mais l'API design : **"latest N candles" ne marche QUE si la sim tourne dans les 150min suivant recordDecision**. Pour retro-sim 12h+ après, il faut un fetch **historique explicite**.

## Fix

### 1. Extension `EodhdIntradayService.getCandles`

```ts
// Back-compat : signature existante préservée
async getCandles(
  eodhdTicker: string,
  interval: '1m' | '5m' | '1h' = '5m',
  count = 20,
  options?: { fromTs?: number; toTs?: number },  // ← nouveau, optionnel
): Promise<CandleSeries | null>
```

Quand `options.fromTs/toTs` fournis :
- Override les from/to query params EODHD (au lieu du default `windowForInterval` = 5j)
- Skip cache (range-specific, key inclut from/to)
- Skip slice(-count) (on prend toutes candles dans le range)

### 2. Retention guard 5j

Si `fromTs > 5j ago` :
```
[eodhd] X EODHD_RETENTION_EXCEEDED : fromTs=Y (Nd ago) > 5d retention. Skipping fetch.
```
+ return `null`. Évite les sims fantômes NO_DATA difficiles à diagnostiquer (l'API EODHD plan standard retourne empty silencieusement au-delà de 5j).

### 3. `getCandlesViaTicks` même pattern (fallback Asia/NSE)

### 4. `simulateRow` use range fetch

```ts
const startTs = createdAt / 1000;
const fromTs = startTs - 300;            // -5min buffer pré-entry
const toTs = startTs + 60*60 + 300;      // +60min sim window + 5min

let series = await this.eodhd
  .getCandles(eodhdTicker, '5m', count, { fromTs, toTs })
  .catch(() => null);

if (!series) {
  series = await this.eodhd
    .getCandlesViaTicks(eodhdTicker, '5m', count, { fromTs, toTs })
    .catch(() => null);
}

// Log info systématique pour monitoring
this.logger.log(`[user-shadow-fetch] ${ticker}: from=${fromTs} to=${toTs} got=${series?.candles?.length ?? 0}`);
```

## Tests (5 nouveaux, tous verts — 110 suites / 1358 tests)

`eodhd-intraday-range.spec.ts` mock `fetch` global :

- ✅ Range mode : URL contient `from=X&to=Y` explicites (pas le default)
- ✅ Retention guard : `fromTs` 6j ago → `null` + warn EODHD_RETENTION_EXCEEDED + 0 fetch réseau
- ✅ Boundary : `fromTs` 4.9j ago → fetch autorisé (≤ 5d OK)
- ✅ Back-compat : sans options → URL utilise default `windowForInterval`
- ✅ Range mode : retourne TOUTES les candles dans range (pas `slice(-count)`)

## SQL post-deploy

```sql
UPDATE gainers_user_shadow_signals
SET sim_run_at = NULL, sim_results = NULL
WHERE sim_results->'baseline_60m'->>'outcome' = 'NO_DATA'
  AND created_at > NOW() - INTERVAL '5 days';
```

Le worker `simulatePending()` retraitera ~50 rows/cycle → 30-50 min pour rattraper. Les rows > 5j sont **perdues** (au-delà retention EODHD), pas grave car on a 1304+ rows < 5j.

Vérification post-rerun :
```sql
SELECT sim_results->'baseline_60m'->>'outcome' AS outcome, count(*) AS n
FROM gainers_user_shadow_signals
WHERE sim_run_at > NOW() - INTERVAL '60 minutes'
  AND sim_results IS NOT NULL
GROUP BY 1 ORDER BY 2 DESC;
```

**Distribution attendue** :
- `TP_HIT` : 25-40% (cible TP 2% touché)
- `SL_HIT` : 20-30% (SL 0.9% touché)
- `TIME_LIMIT` : 25-40% (ni TP ni SL en 60min)
- `NO_DATA` résiduel : 5-15% (NSE 404, Asia/AU low-coverage)

Les `[user-shadow-fetch]` logs Fly détailleront par ticker si on observe encore du NO_DATA dominant — `got=0` → ticker sans data EODHD, `got=N` mais NO_DATA → bug autre à investiguer.

## Test plan

- [x] Typecheck + Jest local : 110 suites / 1358 tests
- [ ] CI verte sur PR
- [ ] Post-merge : Fly redeploy auto
- [ ] Run UPDATE post-deploy → re-simulation rétro
- [ ] T+30-50 min : SELECT distribution → vérifier `TP_HIT` / `SL_HIT` / `TIME_LIMIT` apparaissent
- [ ] J+1 : `GET /lisa/gainers-shadow-regret/:portfolioId?days=7` retourne au moins 1 verdict ≠ INSUFFICIENT_DATA → débloque PR #281 training avec data réelle ET PR #282 cron auto-relax avec input usable

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_