### PR TITLE
feat(shadow): asia diagnostic logs — rawCount, requestedSymbol, 4-step trace

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/eodhd-intraday-range.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/eodhd-intraday-range.spec.ts
@@ -147,4 +147,32 @@ describe('EodhdIntradayService — PR #284 range fetch + retention', () => {
     const result = await service.getCandles('NYT.US', '5m', 10, { fromTs, toTs });
     expect(result!.candles).toHaveLength(30);  // pas slicé à 10
   });
+
+  it('PR #285 — populates rawCount + requestedSymbol for diagnostic', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const fromTs = nowSec - 12 * 3600;
+    const toTs = fromTs + 3900;
+    // Réponse mixte : 5 candles, dont 2 avec close=null (filter doit les
+    // rejeter). rawCount doit refléter les 5, candles.length les 3 valides.
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => [
+        { timestamp: fromTs + 60, open: 100, high: 100.5, low: 99.5, close: 100.2, volume: 1000 },
+        { timestamp: fromTs + 360, open: null, high: null, low: null, close: null, volume: 0 },  // pre-market gap
+        { timestamp: fromTs + 660, open: 100.2, high: 101, low: 100, close: 100.8, volume: 1500 },
+        { timestamp: fromTs + 960, open: 0, high: 0, low: 0, close: 0, volume: 0 },               // empty bucket
+        { timestamp: fromTs + 1260, open: 100.8, high: 101.5, low: 100.5, close: 101, volume: 2000 },
+      ],
+    } as Response);
+
+    const result = await service.getCandles('300161.SHE', '5m', 30, { fromTs, toTs });
+    expect(result).not.toBeNull();
+    expect(result!.candles).toHaveLength(3);              // post-filter close>0
+    expect(result!.rawCount).toBe(5);                     // pre-filter total
+    expect(result!.requestedSymbol).toBe('300161.SHE');   // ce qui a été envoyé en URL
+    // diff rawCount - candles.length = nb buckets null/zero (= "nulls" dans le diag log)
+    expect(result!.rawCount! - result!.candles.length).toBe(2);
+  });
 });

--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -28,6 +28,19 @@ export interface CandleSeries {
   interval: '1m' | '5m' | '1h';
   candles: Candle[];
   asOf: number;
+  /**
+   * PR #285 — Total candles retournées par l'API EODHD AVANT filter
+   * `close > 0`. Permet diagnostic Asia/exotic : EODHD peut retourner des
+   * buckets avec close=null en pré-marché, lunch break, post-close.
+   * `rawCount - candles.length` = nb candles avec close invalide.
+   */
+  rawCount?: number;
+  /**
+   * PR #285 — Le ticker effectivement envoyé dans l'URL (post-normalize).
+   * Permet de détecter un éventuel mismatch entre input scanner et requête
+   * EODHD (ex: legacy `.SZ` mappé vers `.SHE`).
+   */
+  requestedSymbol?: string;
 }
 
 /**
@@ -290,7 +303,18 @@ export class EodhdIntradayService {
       // les query params from/to.
       const candles = useRange ? allCandles : allCandles.slice(-count);
 
-      const series: CandleSeries = { ticker: eodhdTicker, interval, candles, asOf: Date.now() };
+      // PR #285 — rawCount = nb candles AVANT filter close>0 ; requestedSymbol
+      // = ticker effectivement envoyé dans l'URL EODHD (peut différer de
+      // l'input scanner après injection `.US` ou si normalize divergeait).
+      // Permet diagnostic mismatch suffix.
+      const series: CandleSeries = {
+        ticker: eodhdTicker,
+        interval,
+        candles,
+        asOf: Date.now(),
+        rawCount: data.length,
+        requestedSymbol: eodhdTicker,
+      };
       this.cache.set(cacheKey, series);
       return series;
     } catch (e) {
@@ -495,6 +519,8 @@ export class EodhdIntradayService {
       interval,
       candles,
       asOf: Date.now(),
+      rawCount: ticks.length,        // PR #285 — diagnostic
+      requestedSymbol: eodhdTicker,  // PR #285 — ce qui a été envoyé en URL
     };
     this.logger.log(
       `[eodhd:ticks] ${eodhdTicker} reconstructed ${candles.length} ${interval} bars from ${ticks.length} ticks`,

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -334,16 +334,40 @@ export class GainersUserShadowService {
     const toTs = Math.floor(startTs + 60 * 60 + 300);         // +60min sim window + 5min
     const candleCount = resolveShadowLookbackCandles();        // legacy back-compat (slice when no range)
 
-    let series = await this.eodhd
+    const isAsia = args.assetClass === 'asia_equity';
+
+    const seriesPrimary = await this.eodhd
       .getCandles(eodhdTicker, '5m', candleCount, { fromTs, toTs })
       .catch(() => null);
 
+    // PR #285 — Diag verbeux Asia step 1 : ce que le primary path retourne
+    // AVANT fallback. Permet de voir si getCandles seul fonctionne sur Asia
+    // ou si on tombe systématiquement sur le fallback ticks.
+    if (isAsia) {
+      this.logger.warn(
+        `[user-shadow-fetch-asia] step1=getCandles ` +
+        `inputSymbol=${args.symbol} requestedSymbol=${seriesPrimary?.requestedSymbol ?? 'n/a'} ` +
+        `fromTs=${fromTs} toTs=${toTs} ` +
+        `rawCount=${seriesPrimary?.rawCount ?? 0} validClose=${seriesPrimary?.candles?.length ?? 0} ` +
+        `nulls=${(seriesPrimary?.rawCount ?? 0) - (seriesPrimary?.candles?.length ?? 0)}`,
+      );
+    }
+
     // Fallback ticks-data si getCandles range-fetch retourne null (low-coverage
     // EODHD : Asia/NSE/AU certaines fois, ou plan-dependent gaps).
+    let series = seriesPrimary;
     if (!series || series.candles.length === 0) {
-      series = await this.eodhd
+      const seriesTicks = await this.eodhd
         .getCandlesViaTicks(eodhdTicker, '5m', candleCount, { fromTs, toTs })
         .catch(() => null);
+      if (isAsia) {
+        this.logger.warn(
+          `[user-shadow-fetch-asia] step2=getCandlesViaTicks ` +
+          `inputSymbol=${args.symbol} requestedSymbol=${seriesTicks?.requestedSymbol ?? 'n/a'} ` +
+          `rawCount=${seriesTicks?.rawCount ?? 0} validClose=${seriesTicks?.candles?.length ?? 0}`,
+        );
+      }
+      series = seriesTicks;
     }
 
     // Log info systématique pour monitoring du fetch range (PR #284).
@@ -352,21 +376,44 @@ export class GainersUserShadowService {
     );
 
     if (!series || series.candles.length === 0) {
+      if (isAsia) {
+        this.logger.warn(
+          `[user-shadow-fetch-asia] step3=EARLY_RETURN_NO_DATA ` +
+          `inputSymbol=${args.symbol} fromTs=${fromTs} toTs=${toTs} reason=both_endpoints_empty`,
+        );
+      }
       for (const g of SIM_GRIDS) results[g.key] = noEntry();
       return results;
     }
 
     // PR #283 — Critique : normaliser unité (ms→s) ET trier ASC AVANT
     // walkForward. EODHD retournait DESC, le bug a causé 100% NO_DATA prod.
-    const normalized = normalizeAndSortCandles(series.candles);
-    const forward = normalized.filter((c) => c.timestamp >= startTs);
+    const normalizedCandles = normalizeAndSortCandles(series.candles);
+    const forward = normalizedCandles.filter((c) => c.timestamp >= startTs);
 
     if (forward.length === 0) {
-      const first = normalized[0];
-      const last = normalized[normalized.length - 1];
+      const first = normalizedCandles[0];
+      const last = normalizedCandles[normalizedCandles.length - 1];
       this.logger.warn(
-        `[user-shadow] ${eodhdTicker}: forward=0 fetched=${normalized.length} ` +
+        `[user-shadow] ${eodhdTicker}: forward=0 fetched=${normalizedCandles.length} ` +
         `firstTs=${first?.timestamp ?? 'n/a'} lastTs=${last?.timestamp ?? 'n/a'} ` +
+        `startTs=${startTs} cutoffMaxTs=${startTs + 60 * 60}`,
+      );
+    }
+
+    // PR #285 — Diag Asia post-filter : confirme la fenêtre walkForward
+    // dispose de candles utiles. Si fetched > 0 mais forward = 0 → le filter
+    // `c.timestamp >= startTs` rejette tout (fenêtre EODHD hors session ou
+    // session déjà clôturée). Si forward > 0 mais walkForward retourne
+    // NO_DATA, regarder cutoff (toutes candles > startTs+60min).
+    if (isAsia) {
+      const firstValid = normalizedCandles[0]?.timestamp ?? null;
+      const lastValid = normalizedCandles[normalizedCandles.length - 1]?.timestamp ?? null;
+      this.logger.warn(
+        `[user-shadow-fetch-asia] step4=post_filter ` +
+        `inputSymbol=${args.symbol} ` +
+        `fetched=${normalizedCandles.length} forward=${forward.length} ` +
+        `firstValidTs=${firstValid} lastValidTs=${lastValid} ` +
         `startTs=${startTs} cutoffMaxTs=${startTs + 60 * 60}`,
       );
     }


### PR DESCRIPTION
## 🔬 Diagnostic ciblé — pas de fix, pure observabilité

**Contexte** : post PR #284, fix retro-sim opérationnel sur US (88% real outcomes), mais Asia toujours **0/28 (0%)**. Test manuel EODHD direct par utilisateur prouve que la data EXISTE :
- `300161.SHE` (Shenzhen 01:30-03:30 UTC) : 25 candles, 12 OHLCV valides (28.42, vol=59100)
- `013310.KQ` (Seoul KOSDAQ) : 73 candles, OHLCV majoritaire (2910, vol=1813)
- `CCP.AU` (Sydney) : 72 candles, OHLCV quasi tous (13.98, vol=15083)

→ **EODHD a la data Asia, notre pipeline ne la consomme pas.**

## 3 hypothèses à départager

| H | Description |
|---|---|
| **H1** | Suffix ticker mal mappé (scanner `.SHE` → fetch `.SZ` ?) |
| **H2** | Fenêtre `[startTs, +60min]` hors session locale Asia |
| **H3** | walkForward break sur 1ère candle `close=null` mélangée avec valides (pré/post/lunch break) |

## Implémentation diagnostic 4-stage

Ajoute logs verbeux **uniquement sur `asset_class === 'asia_equity'`** (zéro overhead US/EU). Chaque row Asia simulée produit 4 lignes log séquentielles :

```
[user-shadow-fetch-asia] step1=getCandles inputSymbol=300161.SHE requestedSymbol=300161.SHE
                         fromTs=... toTs=... rawCount=25 validClose=12 nulls=13

[user-shadow-fetch-asia] step2=getCandlesViaTicks (si fallback déclenché)
                         inputSymbol=... requestedSymbol=... rawCount=N validClose=K

[user-shadow-fetch-asia] step3=EARLY_RETURN_NO_DATA (si both endpoints vides)
                         reason=both_endpoints_empty

[user-shadow-fetch-asia] step4=post_filter inputSymbol=... fetched=12 forward=8
                         firstValidTs=... lastValidTs=... startTs=... cutoffMaxTs=...
```

## Décodage

| Pattern observé | Hypothèse | Fix PR #286 |
|---|---|---|
| `step1 rawCount=0` sur tickers que user a testés manuellement | **H1** suffix bug | Fix `normalizeForEodhdIntraday` ou le path URL building |
| `step1 rawCount>0` puis `step4 forward=0` | **H2** session mismatch | Skip Asia rows hors session locale OU élargir window |
| `step1 rawCount>0` mais `step4 fetched>0 forward>0` mais NO_DATA | **H3** walkForward sur null | Fix walkForward pour skip candles invalid plutôt que break |

## Code

### `CandleSeries` étendu

```ts
export interface CandleSeries {
  ticker: string;
  interval: '1m' | '5m' | '1h';
  candles: Candle[];
  asOf: number;
  rawCount?: number;          // PR #285 — pre-filter close>0 count
  requestedSymbol?: string;   // PR #285 — ticker sent in URL
}
```

`rawCount - candles.length` = nb candles avec close=null/0 (= "nulls" dans le diag log).

### Test ajouté

```
✓ PR #285 — populates rawCount + requestedSymbol for diagnostic
  (5 candles dont 2 close=null → rawCount=5, candles.length=3, requestedSymbol exposé)
```

110 suites / 1359 tests.

## Action utilisateur post-deploy

```bash
flyctl logs -a smartvest --no-tail | grep "user-shadow-fetch-asia" | tail -50
```

Paste 5-10 lignes au prochain message → je dis **exactement** quelle hypothèse (H1/H2/H3) est la cause + j'écris la PR #286 fix.

## Hors scope

Pas de fix dans cette PR. Pure observabilité. Le fix arrive en PR #286 une fois la cause confirmée par les logs prod (~30 LoC).

## Test plan

- [x] Typecheck + Jest local : 110 suites / 1359 tests
- [ ] CI verte
- [ ] Post-merge Fly redeploy
- [ ] Capture des logs `[user-shadow-fetch-asia]` pour identifier H1/H2/H3
- [ ] Écrire PR #286 fix selon hypothèse confirmée

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_