### PR TITLE
feat(shadow): 4-step fallback chain + fetch_diag JSONB persist

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/shadow-fetch-diag.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/shadow-fetch-diag.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * PR #286 — Tests fetch_diag schema + fallback chain ordering.
+ *
+ * On valide la SHAPE du fetchDiag retourné par simulateRow (via injection
+ * d'un EodhdIntradayService mocké) et l'ORDRE de la fallback chain (4 steps
+ * dans l'ordre attendu : 5m_range → ticks_range → 1m_range → 5m_default).
+ *
+ * Le service complet est lourd à instancier (NestJS DI), on contourne via
+ * mock direct du eodhd-service. SupabaseService est aussi mocké minimal.
+ */
+import { GainersUserShadowService, type FetchDiag } from '../services/gainers-user-shadow.service';
+
+type FetchCall = { endpoint: string; ticker: string };
+
+function buildService(opts: {
+  candlesByEndpoint: Record<string, { candles: Array<{ timestamp: number; high: number; low: number; close: number; open?: number; volume?: number }>; rawCount?: number; requestedSymbol?: string } | null>;
+  callLog: FetchCall[];
+}): GainersUserShadowService {
+  const eodhdMock = {
+    getCandles: jest.fn(async (ticker: string, interval: string, _count: number, options?: unknown) => {
+      const range = options ? '_range' : '_default';
+      const key = `getCandles_${interval}${range}`;
+      opts.callLog.push({ endpoint: key, ticker });
+      return opts.candlesByEndpoint[key] ?? null;
+    }),
+    getCandlesViaTicks: jest.fn(async (ticker: string, _interval: string, _count: number, _options?: unknown) => {
+      opts.callLog.push({ endpoint: 'ticks_range', ticker });
+      return opts.candlesByEndpoint['ticks_range'] ?? null;
+    }),
+  };
+  const supabaseMock = {
+    getClient: () => ({ from: () => ({ select: () => ({ is: () => ({ lte: () => ({ order: () => ({ limit: async () => ({ data: [], error: null }) }) }) }) }) }) }),
+  };
+  return new GainersUserShadowService(supabaseMock as never, eodhdMock as never);
+}
+
+// Helper : appelle simulateRow via reflection (private méthode, mais accessible
+// via TS bracket notation pour tests). Sinon il faudrait exposer un wrapper.
+async function runSim(svc: GainersUserShadowService, args: { symbol: string; assetClass: string; entryPrice: number; createdAt: string }) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return await (svc as any).simulateRow(args);
+}
+
+describe('PR #286 — fetch_diag shape', () => {
+  it('populates 4-step fallback chain when all return empty', async () => {
+    const callLog: FetchCall[] = [];
+    const svc = buildService({
+      candlesByEndpoint: {
+        getCandles_5m_range: { candles: [], rawCount: 0, requestedSymbol: '300161.SHE' },
+        ticks_range: null,
+        getCandles_1m_range: null,
+        getCandles_5m_default: { candles: [], rawCount: 0, requestedSymbol: '300161.SHE' },
+      },
+      callLog,
+    });
+    const startTs = Math.floor(Date.now() / 1000) - 12 * 3600;  // 12h ago, within retention
+    const { fetchDiag } = await runSim(svc, {
+      symbol: '300161.SHE',
+      assetClass: 'asia_equity',
+      entryPrice: 28.42,
+      createdAt: new Date(startTs * 1000).toISOString(),
+    }) as { fetchDiag: FetchDiag };
+
+    expect(fetchDiag.steps).toHaveLength(4);
+    expect(fetchDiag.steps[0].endpoint).toBe('eodhd_getCandles_5m_range');
+    expect(fetchDiag.steps[1].endpoint).toBe('eodhd_ticks_5m_range');
+    expect(fetchDiag.steps[2].endpoint).toBe('eodhd_getCandles_1m_range');
+    expect(fetchDiag.steps[3].endpoint).toBe('eodhd_getCandles_5m_default');
+    expect(fetchDiag.selectedStep).toBeNull();
+    expect(fetchDiag.outcome).toBe('no_data');
+    expect(fetchDiag.steps[0].rangeMode).toBe(true);
+    expect(fetchDiag.steps[3].rangeMode).toBe(false);  // default mode
+    expect(fetchDiag.steps[0].inputSymbol).toBe('300161.SHE');
+  });
+
+  it('stops at step 1 when primary 5m_range returns valid candles', async () => {
+    const callLog: FetchCall[] = [];
+    const startTs = Math.floor(Date.now() / 1000) - 6 * 3600;
+    const validCandle = {
+      timestamp: startTs + 600,
+      open: 28.42, high: 28.50, low: 28.40, close: 28.48, volume: 1000,
+    };
+    const svc = buildService({
+      candlesByEndpoint: {
+        getCandles_5m_range: { candles: [validCandle], rawCount: 1, requestedSymbol: '300161.SHE' },
+      },
+      callLog,
+    });
+    const { fetchDiag, results } = await runSim(svc, {
+      symbol: '300161.SHE',
+      assetClass: 'asia_equity',
+      entryPrice: 28.42,
+      createdAt: new Date(startTs * 1000).toISOString(),
+    }) as { fetchDiag: FetchDiag; results: Record<string, { outcome: string }> };
+
+    expect(fetchDiag.selectedStep).toBe(0);
+    expect(fetchDiag.outcome).toBe('ok');
+    expect(fetchDiag.steps).toHaveLength(1);  // chain stopped at step 1
+    expect(fetchDiag.forwardCount).toBe(1);
+    expect(results.baseline_60m.outcome).toBe('TIME_LIMIT');  // 1 candle, no TP/SL hit
+    // Vérif callLog : seul l'endpoint primary a été appelé
+    expect(callLog).toEqual([{ endpoint: 'getCandles_5m_range', ticker: '300161.SHE' }]);
+  });
+
+  it('falls through to step 3 (1m_range) when 5m_range and ticks return empty', async () => {
+    const callLog: FetchCall[] = [];
+    const startTs = Math.floor(Date.now() / 1000) - 6 * 3600;
+    const validCandle = {
+      timestamp: startTs + 300,
+      open: 100, high: 102.5, low: 99.5, close: 102.1, volume: 1000,
+    };
+    const svc = buildService({
+      candlesByEndpoint: {
+        getCandles_5m_range: { candles: [], rawCount: 0, requestedSymbol: '013310.KQ' },
+        ticks_range: { candles: [], rawCount: 0, requestedSymbol: '013310.KQ' },
+        getCandles_1m_range: { candles: [validCandle], rawCount: 1, requestedSymbol: '013310.KQ' },
+      },
+      callLog,
+    });
+    const { fetchDiag } = await runSim(svc, {
+      symbol: '013310.KQ',
+      assetClass: 'asia_equity',
+      entryPrice: 100,
+      createdAt: new Date(startTs * 1000).toISOString(),
+    }) as { fetchDiag: FetchDiag };
+
+    expect(fetchDiag.selectedStep).toBe(2);  // 0-indexed : step3 → index 2
+    expect(fetchDiag.steps).toHaveLength(3);  // stopped at step 3
+    expect(fetchDiag.outcome).toBe('ok');
+    expect(callLog.map(c => c.endpoint)).toEqual([
+      'getCandles_5m_range',
+      'ticks_range',
+      'getCandles_1m_range',
+    ]);
+  });
+
+  it('records nulls correctly when EODHD returns mixed null/valid candles', async () => {
+    const callLog: FetchCall[] = [];
+    const startTs = Math.floor(Date.now() / 1000) - 6 * 3600;
+    const svc = buildService({
+      candlesByEndpoint: {
+        // rawCount=10 mais candles.length=3 (7 candles avec close=null filtrées)
+        getCandles_5m_range: {
+          candles: [
+            { timestamp: startTs + 300, open: 100, high: 101, low: 99.5, close: 100.5, volume: 1000 },
+            { timestamp: startTs + 600, open: 100.5, high: 102, low: 100, close: 101, volume: 1500 },
+            { timestamp: startTs + 900, open: 101, high: 101.5, low: 100.8, close: 101.2, volume: 800 },
+          ],
+          rawCount: 10,
+          requestedSymbol: '300161.SHE',
+        },
+      },
+      callLog,
+    });
+    const { fetchDiag } = await runSim(svc, {
+      symbol: '300161.SHE',
+      assetClass: 'asia_equity',
+      entryPrice: 100,
+      createdAt: new Date(startTs * 1000).toISOString(),
+    }) as { fetchDiag: FetchDiag };
+
+    expect(fetchDiag.steps[0].rawCount).toBe(10);
+    expect(fetchDiag.steps[0].validClose).toBe(3);
+    expect(fetchDiag.steps[0].nulls).toBe(7);
+    expect(fetchDiag.steps[0].requestedSymbol).toBe('300161.SHE');
+  });
+
+  it('returns precondition error step when entry_price missing', async () => {
+    const callLog: FetchCall[] = [];
+    const svc = buildService({ candlesByEndpoint: {}, callLog });
+    const { fetchDiag } = await runSim(svc, {
+      symbol: '300161.SHE',
+      assetClass: 'asia_equity',
+      entryPrice: 0,
+      createdAt: new Date().toISOString(),
+    }) as { fetchDiag: FetchDiag };
+    expect(fetchDiag.outcome).toBe('error');
+    expect(fetchDiag.steps[0].error).toBe('no_entry_price');
+    expect(callLog).toHaveLength(0);  // pas de fetch tenté
+  });
+
+  it('skips crypto with explicit error step (Binance not yet wired)', async () => {
+    const callLog: FetchCall[] = [];
+    const svc = buildService({ candlesByEndpoint: {}, callLog });
+    const { fetchDiag } = await runSim(svc, {
+      symbol: 'BTCUSDT',
+      assetClass: 'crypto_major',
+      entryPrice: 60000,
+      createdAt: new Date().toISOString(),
+    }) as { fetchDiag: FetchDiag };
+    expect(fetchDiag.outcome).toBe('error');
+    expect(fetchDiag.steps[0].error).toBe('crypto_not_supported');
+    expect(callLog).toHaveLength(0);
+  });
+});

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -98,6 +98,29 @@ export interface SimOutcome {
   hit_at_min: number | null;
 }
 
+// PR #286 — fetch_diag schema persisté en JSONB après chaque sim.
+// Permet SQL post-mortem de la fallback chain sans grep Fly logs.
+export interface FetchDiagStep {
+  endpoint: string;             // 'eodhd_getCandles_5m_range' | 'eodhd_ticks_range' | ...
+  interval: '1m' | '5m' | '1h';
+  rangeMode: boolean;
+  fromTs: number | null;
+  toTs: number | null;
+  inputSymbol: string;
+  requestedSymbol: string | null;
+  rawCount: number;             // pre-filter close>0 (selon fallback path)
+  validClose: number;           // post-filter
+  nulls: number;                // rawCount - validClose
+  ms: number;                   // latency
+  error?: string;
+}
+export interface FetchDiag {
+  steps: FetchDiagStep[];
+  selectedStep: number | null;  // index 0-based dans steps[] qui a fourni les candles
+  forwardCount: number;         // post normalize+filter par startTs
+  outcome: 'ok' | 'no_data' | 'error';
+}
+
 // PR #283 — Type minimal pour walkForward (ne nécessite pas EodhdIntradayService.Candle)
 export interface CandleLike {
   timestamp: number;  // unix seconds (auto-normalisé si en ms)
@@ -251,7 +274,7 @@ export class GainersUserShadowService {
     let failures = 0;
     for (const row of rows) {
       try {
-        const simResults = await this.simulateRow({
+        const { results: simResults, fetchDiag } = await this.simulateRow({
           symbol: String(row.symbol),
           assetClass: String(row.asset_class),
           entryPrice: row.entry_price != null ? Number(row.entry_price) : null,
@@ -261,6 +284,7 @@ export class GainersUserShadowService {
           .from('gainers_user_shadow_signals')
           .update({
             sim_results: simResults,
+            fetch_diag: fetchDiag,        // PR #286 — diagnostic JSONB
             sim_run_at: new Date().toISOString(),
             sim_window_max_min: 60,
           })
@@ -291,105 +315,175 @@ export class GainersUserShadowService {
     assetClass: string;
     entryPrice: number | null;
     createdAt: string;
-  }): Promise<Record<string, SimOutcome>> {
+  }): Promise<{ results: Record<string, SimOutcome>; fetchDiag: FetchDiag }> {
     const results: Record<string, SimOutcome> = {};
     const noEntry = (): SimOutcome => ({
       outcome: 'NO_DATA', exit_price: null, exit_at: null, pnl_pct: null, hit_at_min: null,
     });
+    const fetchDiag: FetchDiag = {
+      steps: [],
+      selectedStep: null,
+      forwardCount: 0,
+      outcome: 'no_data',
+    };
 
     if (args.entryPrice == null || args.entryPrice <= 0) {
       for (const g of SIM_GRIDS) results[g.key] = noEntry();
-      return results;
+      fetchDiag.outcome = 'error';
+      fetchDiag.steps.push({
+        endpoint: 'precondition',
+        interval: '5m',
+        rangeMode: false,
+        fromTs: null,
+        toTs: null,
+        inputSymbol: args.symbol,
+        requestedSymbol: null,
+        rawCount: 0,
+        validClose: 0,
+        nulls: 0,
+        ms: 0,
+        error: 'no_entry_price',
+      });
+      return { results, fetchDiag };
     }
 
     // Crypto = no support yet (would need Binance klines), skip gracefully
     if (args.assetClass === 'crypto_major' || args.assetClass === 'crypto_alt') {
       for (const g of SIM_GRIDS) results[g.key] = noEntry();
-      return results;
+      fetchDiag.outcome = 'error';
+      fetchDiag.steps.push({
+        endpoint: 'precondition',
+        interval: '5m',
+        rangeMode: false,
+        fromTs: null,
+        toTs: null,
+        inputSymbol: args.symbol,
+        requestedSymbol: null,
+        rawCount: 0,
+        validClose: 0,
+        nulls: 0,
+        ms: 0,
+        error: 'crypto_not_supported',
+      });
+      return { results, fetchDiag };
     }
 
-    // Le scanner stocke le symbol avec suffix exchange déjà appliqué
-    // ("WFCF.US", "017550.KO", "AAZ.LSE"). On garde le symbol tel quel
-    // — getCandles applique normalizeForEodhdIntraday + fallback .US si
-    // le suffix manquait par erreur.
     const eodhdTicker = args.symbol;
-
-    // PR #284 — FETCH RANGE EXPLICITE (au lieu de "latest N candles").
-    //
-    // Bug pré-PR #284 : `getCandles('5m', 30)` retournait les 30 dernières
-    // candles existantes. Pour une row simulée 12h après recordDecision (cas
-    // retro UPDATE), les latest candles couvraient la session courante, pas
-    // la fenêtre [startTs, startTs+60min] d'origine → 100% NO_DATA.
-    //
-    // Fix : passer `fromTs/toTs` explicites au range exact dont on a besoin
-    // ([startTs - 5min, endTs + buffer]). Le 5min de buffer côté gauche permet
-    // d'avoir 1 candle pré-entry comme contexte si on en veut plus tard
-    // (path quality forward, etc.). Côté droit, +5min pour clipper la dernière
-    // candle 60min cleanly.
-    //
-    // Retention guard EODHD 5j : cf. EodhdIntradayService.RETENTION_LIMIT_SEC.
-    // Au-delà l'API retourne empty → on log EODHD_RETENTION_EXCEEDED + null.
     const startTs = new Date(args.createdAt).getTime() / 1000;
-    const fromTs = Math.floor(startTs - 300);                 // -5min buffer pré-entry
-    const toTs = Math.floor(startTs + 60 * 60 + 300);         // +60min sim window + 5min
-    const candleCount = resolveShadowLookbackCandles();        // legacy back-compat (slice when no range)
-
+    const fromTs = Math.floor(startTs - 300);
+    const toTs = Math.floor(startTs + 60 * 60 + 300);
+    const candleCount = resolveShadowLookbackCandles();
     const isAsia = args.assetClass === 'asia_equity';
 
-    const seriesPrimary = await this.eodhd
-      .getCandles(eodhdTicker, '5m', candleCount, { fromTs, toTs })
-      .catch(() => null);
+    // PR #286 — Fallback chain alignée sur MultiTimeframePersistenceService
+    // (cf. multi-tf-persistence.service.ts:321-431) mais adaptée pour le
+    // mode range-fetch (PR #284). L'ordre maximise la probabilité de
+    // récupérer des candles dans la fenêtre [startTs - 5min, +65min]
+    // d'un row potentiellement vieux de plusieurs heures :
+    //
+    //   step1 : EODHD getCandles 5m + range mode  (primary, déjà testé)
+    //   step2 : EODHD getCandlesViaTicks 5m + range  (sparse coverage)
+    //   step3 : EODHD getCandles 1m + range mode  (parfois plus complet sur Asia)
+    //   step4 : EODHD getCandles 5m + DEFAULT mode + filter client-side
+    //           (si range mode pète, default mode peut couvrir si row récent)
+    //
+    // Chaque step alimente fetchDiag.steps[] persisté en JSONB pour SQL
+    // post-mortem. selectedStep = index du premier step qui a fourni
+    // assez de candles pour walkForward.
 
-    // PR #285 — Diag verbeux Asia step 1 : ce que le primary path retourne
-    // AVANT fallback. Permet de voir si getCandles seul fonctionne sur Asia
-    // ou si on tombe systématiquement sur le fallback ticks.
-    if (isAsia) {
-      this.logger.warn(
-        `[user-shadow-fetch-asia] step1=getCandles ` +
-        `inputSymbol=${args.symbol} requestedSymbol=${seriesPrimary?.requestedSymbol ?? 'n/a'} ` +
-        `fromTs=${fromTs} toTs=${toTs} ` +
-        `rawCount=${seriesPrimary?.rawCount ?? 0} validClose=${seriesPrimary?.candles?.length ?? 0} ` +
-        `nulls=${(seriesPrimary?.rawCount ?? 0) - (seriesPrimary?.candles?.length ?? 0)}`,
-      );
-    }
+    type StepDef = {
+      endpoint: string;
+      interval: '1m' | '5m';
+      fn: () => Promise<{ candles: Array<{ timestamp: number; open: number; high: number; low: number; close: number; volume: number }>; rawCount?: number; requestedSymbol?: string } | null>;
+      rangeMode: boolean;
+    };
+    const stepDefs: StepDef[] = [
+      {
+        endpoint: 'eodhd_getCandles_5m_range',
+        interval: '5m',
+        rangeMode: true,
+        fn: () => this.eodhd.getCandles(eodhdTicker, '5m', candleCount, { fromTs, toTs }).catch(() => null),
+      },
+      {
+        endpoint: 'eodhd_ticks_5m_range',
+        interval: '5m',
+        rangeMode: true,
+        fn: () => this.eodhd.getCandlesViaTicks(eodhdTicker, '5m', candleCount, { fromTs, toTs }).catch(() => null),
+      },
+      {
+        endpoint: 'eodhd_getCandles_1m_range',
+        interval: '1m',
+        rangeMode: true,
+        fn: () => this.eodhd.getCandles(eodhdTicker, '1m', 65, { fromTs, toTs }).catch(() => null),
+      },
+      {
+        endpoint: 'eodhd_getCandles_5m_default',
+        interval: '5m',
+        rangeMode: false,
+        fn: () => this.eodhd.getCandles(eodhdTicker, '5m', candleCount).catch(() => null),
+      },
+    ];
 
-    // Fallback ticks-data si getCandles range-fetch retourne null (low-coverage
-    // EODHD : Asia/NSE/AU certaines fois, ou plan-dependent gaps).
-    let series = seriesPrimary;
-    if (!series || series.candles.length === 0) {
-      const seriesTicks = await this.eodhd
-        .getCandlesViaTicks(eodhdTicker, '5m', candleCount, { fromTs, toTs })
-        .catch(() => null);
+    let selectedSeries: { candles: Array<{ timestamp: number; open: number; high: number; low: number; close: number; volume: number }> } | null = null;
+    for (let i = 0; i < stepDefs.length; i++) {
+      const step = stepDefs[i];
+      const t0 = Date.now();
+      const series = await step.fn();
+      const ms = Date.now() - t0;
+      const validClose = series?.candles?.length ?? 0;
+      const rawCount = series?.rawCount ?? validClose;
+      const stepEntry: FetchDiagStep = {
+        endpoint: step.endpoint,
+        interval: step.interval,
+        rangeMode: step.rangeMode,
+        fromTs: step.rangeMode ? fromTs : null,
+        toTs: step.rangeMode ? toTs : null,
+        inputSymbol: args.symbol,
+        requestedSymbol: series?.requestedSymbol ?? null,
+        rawCount,
+        validClose,
+        nulls: rawCount - validClose,
+        ms,
+      };
+      fetchDiag.steps.push(stepEntry);
+
       if (isAsia) {
         this.logger.warn(
-          `[user-shadow-fetch-asia] step2=getCandlesViaTicks ` +
-          `inputSymbol=${args.symbol} requestedSymbol=${seriesTicks?.requestedSymbol ?? 'n/a'} ` +
-          `rawCount=${seriesTicks?.rawCount ?? 0} validClose=${seriesTicks?.candles?.length ?? 0}`,
+          `[user-shadow-fetch-asia] step${i + 1}=${step.endpoint} ` +
+          `inputSymbol=${args.symbol} requestedSymbol=${stepEntry.requestedSymbol ?? 'n/a'} ` +
+          `rangeMode=${step.rangeMode} rawCount=${rawCount} validClose=${validClose} nulls=${stepEntry.nulls} ms=${ms}`,
         );
       }
-      series = seriesTicks;
+
+      if (validClose > 0) {
+        selectedSeries = series;
+        fetchDiag.selectedStep = i;
+        break;
+      }
     }
 
-    // Log info systématique pour monitoring du fetch range (PR #284).
     this.logger.log(
-      `[user-shadow-fetch] ${eodhdTicker}: from=${fromTs} to=${toTs} got=${series?.candles?.length ?? 0}`,
+      `[user-shadow-fetch] ${eodhdTicker}: from=${fromTs} to=${toTs} ` +
+      `selectedStep=${fetchDiag.selectedStep ?? 'none'} got=${selectedSeries?.candles?.length ?? 0}`,
     );
 
-    if (!series || series.candles.length === 0) {
+    if (!selectedSeries || selectedSeries.candles.length === 0) {
       if (isAsia) {
         this.logger.warn(
-          `[user-shadow-fetch-asia] step3=EARLY_RETURN_NO_DATA ` +
-          `inputSymbol=${args.symbol} fromTs=${fromTs} toTs=${toTs} reason=both_endpoints_empty`,
+          `[user-shadow-fetch-asia] EARLY_RETURN_NO_DATA inputSymbol=${args.symbol} ` +
+          `fromTs=${fromTs} toTs=${toTs} reason=all_4_steps_empty`,
         );
       }
       for (const g of SIM_GRIDS) results[g.key] = noEntry();
-      return results;
+      fetchDiag.outcome = 'no_data';
+      return { results, fetchDiag };
     }
 
     // PR #283 — Critique : normaliser unité (ms→s) ET trier ASC AVANT
     // walkForward. EODHD retournait DESC, le bug a causé 100% NO_DATA prod.
-    const normalizedCandles = normalizeAndSortCandles(series.candles);
+    const normalizedCandles = normalizeAndSortCandles(selectedSeries.candles);
     const forward = normalizedCandles.filter((c) => c.timestamp >= startTs);
+    fetchDiag.forwardCount = forward.length;
 
     if (forward.length === 0) {
       const first = normalizedCandles[0];
@@ -401,17 +495,12 @@ export class GainersUserShadowService {
       );
     }
 
-    // PR #285 — Diag Asia post-filter : confirme la fenêtre walkForward
-    // dispose de candles utiles. Si fetched > 0 mais forward = 0 → le filter
-    // `c.timestamp >= startTs` rejette tout (fenêtre EODHD hors session ou
-    // session déjà clôturée). Si forward > 0 mais walkForward retourne
-    // NO_DATA, regarder cutoff (toutes candles > startTs+60min).
     if (isAsia) {
       const firstValid = normalizedCandles[0]?.timestamp ?? null;
       const lastValid = normalizedCandles[normalizedCandles.length - 1]?.timestamp ?? null;
       this.logger.warn(
-        `[user-shadow-fetch-asia] step4=post_filter ` +
-        `inputSymbol=${args.symbol} ` +
+        `[user-shadow-fetch-asia] post_filter inputSymbol=${args.symbol} ` +
+        `selectedStep=${fetchDiag.selectedStep} ` +
         `fetched=${normalizedCandles.length} forward=${forward.length} ` +
         `firstValidTs=${firstValid} lastValidTs=${lastValid} ` +
         `startTs=${startTs} cutoffMaxTs=${startTs + 60 * 60}`,
@@ -421,7 +510,8 @@ export class GainersUserShadowService {
     for (const grid of SIM_GRIDS) {
       results[grid.key] = walkForward(args.entryPrice, forward, startTs, grid);
     }
-    return results;
+    fetchDiag.outcome = forward.length > 0 ? 'ok' : 'no_data';
+    return { results, fetchDiag };
   }
 
   /**

--- a/supabase/migrations/0136_gainers_user_shadow_fetch_diag.sql
+++ b/supabase/migrations/0136_gainers_user_shadow_fetch_diag.sql
@@ -1,0 +1,44 @@
+-- 0136_gainers_user_shadow_fetch_diag
+--
+-- PR #286 — Diagnostic JSONB pour comprendre pourquoi le simulator
+-- shadow produit 0/385 real outcomes sur asia_equity malgré le fix
+-- range fetch (PR #284).
+--
+-- Schema fetch_diag :
+--   {
+--     "step1": {
+--       "endpoint": "eodhd_getCandles",
+--       "interval": "5m",
+--       "rangeMode": true,
+--       "fromTs": <number>,
+--       "toTs": <number>,
+--       "inputSymbol": "300161.SHE",
+--       "requestedSymbol": "300161.SHE",
+--       "rawCount": <number>,         -- pre-filter close>0
+--       "validClose": <number>,       -- post-filter
+--       "nulls": <number>,            -- rawCount - validClose
+--       "ms": <number>                 -- latency
+--     },
+--     "step2": { ... endpoint: "eodhd_ticks", ... },
+--     "step3": { ... endpoint: "eodhd_getCandles_1m", ... },
+--     "step4": { ... endpoint: "eodhd_getCandles_5m_default", ... },
+--     "selectedStep": 1 | 2 | 3 | 4 | null,
+--     "forwardCount": <number>,        -- post normalize+filter par startTs
+--     "outcome": "ok" | "no_data" | "error"
+--   }
+--
+-- Permet SQL post-mortem de chaque sim Asia : quel endpoint a réussi, quel
+-- a retourné empty, quel inputSymbol vs requestedSymbol, etc.
+
+ALTER TABLE public.gainers_user_shadow_signals
+  ADD COLUMN IF NOT EXISTS fetch_diag JSONB;
+
+COMMENT ON COLUMN public.gainers_user_shadow_signals.fetch_diag IS
+  'PR #286 — Diagnostic chain fetch (4 steps : 5m_range / ticks_range / 1m_range / 5m_default+filter). '
+  'Permet SQL post-mortem sans grep Fly logs. Schema documenté dans la migration.';
+
+-- Index partiel pour analyse rapide des Asia NO_DATA
+CREATE INDEX IF NOT EXISTS gainers_user_shadow_fetch_diag_no_data_idx
+  ON public.gainers_user_shadow_signals(asset_class, created_at DESC)
+  WHERE asset_class = 'asia_equity'
+    AND sim_results->'baseline_60m'->>'outcome' = 'NO_DATA';


### PR DESCRIPTION
## Contexte

Diagnostic Asia bloqué : `0/385 real outcomes asia_equity` malgré PR #284 (range fetch). User n'a pas accès `flyctl` pour grep `[user-shadow-fetch-asia]` logs (PR #285). Plan A retenu : code défensif universel + diagnostic JSONB pour SQL post-mortem.

## Composants (3, ~400 LoC)

### 1. Migration `0136_gainers_user_shadow_fetch_diag.sql`

Nouvelle colonne `fetch_diag JSONB` avec schema :

```json
{
  "steps": [
    { "endpoint": "...", "interval": "5m", "rangeMode": true,
      "fromTs": ..., "toTs": ..., "inputSymbol": "300161.SHE",
      "requestedSymbol": "300161.SHE", "rawCount": 25, "validClose": 12,
      "nulls": 13, "ms": 312 }
  ],
  "selectedStep": 0,
  "forwardCount": 8,
  "outcome": "ok"
}
```

Index partiel `gainers_user_shadow_fetch_diag_no_data_idx` pour analyse rapide Asia NO_DATA.

### 2. 4-step fallback chain dans `simulateRow`

Aligne avec l'esprit de `MultiTimeframePersistenceService.fetchPersistence()` (yahoo → eodhd 1m → eodhd 5m → ticks → IntradayCache) **adapté au mode range-fetch** PR #284 :

| # | Endpoint | Mode | Pourquoi |
|---|---|---|---|
| 1 | `eodhd_getCandles_5m_range` | range from/to | primary, déjà testé |
| 2 | `eodhd_ticks_5m_range` | range from/to | sparse coverage Asia/NSE |
| 3 | `eodhd_getCandles_1m_range` | range from/to | parfois plus complet sur Asia (per logs prod) |
| 4 | `eodhd_getCandles_5m_default` | latest + filter | si range fail, latest mode peut couvrir si row récent < 150min |

Skip yahoo + IntradayCache (incompatibles range mode pour rows historiques).

Premier step qui retourne `candles.length > 0` → break + `selectedStep = index`. Chaque step alimente `fetchDiag.steps[]`.

### 3. Persist `fetch_diag` JSONB après chaque sim

`simulateRow` signature : `Record<string, SimOutcome>` → `{ results, fetchDiag }`.
`simulatePending` UPDATE row avec `sim_results` + `fetch_diag` en 1 call.

## Tests (6 nouveaux, tous verts — 111 suites / 1365 tests)

- 4-step chain populated quand all empty (`selectedStep=null`, `outcome='no_data'`)
- stops at step 1 quand primary returns valid (`selectedStep=0`, `callLog=[primary]`)
- falls through to step 3 quand step1+2 empty (`selectedStep=2`)
- records nulls correctly quand raw > valid (`rawCount=10`, `validClose=3`, `nulls=7`)
- precondition error step on missing `entry_price`
- precondition error step on crypto

## SQL post-deploy pour identifier la cause Asia

```sql
-- Voir distribution selectedStep par asset_class
SELECT asset_class, fetch_diag->>'selectedStep' AS step, count(*)
FROM gainers_user_shadow_signals
WHERE sim_run_at > NOW() - INTERVAL '1 hour'
  AND fetch_diag IS NOT NULL
GROUP BY asset_class, step ORDER BY asset_class, count(*) DESC;

-- Asia NO_DATA : voir rawCount step1 + requestedSymbol
SELECT
  symbol,
  fetch_diag->'steps'->0->>'endpoint' AS step1_endpoint,
  fetch_diag->'steps'->0->>'rawCount' AS step1_raw,
  fetch_diag->'steps'->0->>'validClose' AS step1_valid,
  fetch_diag->'steps'->0->>'requestedSymbol' AS step1_requested,
  fetch_diag->>'selectedStep' AS selected
FROM gainers_user_shadow_signals
WHERE asset_class = 'asia_equity'
  AND fetch_diag->>'outcome' = 'no_data'
  AND sim_run_at > NOW() - INTERVAL '1 hour'
ORDER BY sim_run_at DESC LIMIT 20;
```

## Décodage SQL

| Pattern | Conclusion | Fix PR #287 |
|---|---|---|
| Tous `selectedStep=null` Asia | API EODHD vraiment vide tous endpoints (suffix bug ou plan limit) | Suffix mapping ou plan upgrade |
| `selectedStep=2` ou `3` Asia | step1 fail mais 1m_range/default mode marche | Investiguer quoi diffère sur step1 |
| `selectedStep=0` Asia mais NO_DATA | `forwardCount=0` malgré fetch OK = fenêtre client-side mismatch | Élargir window ou fix filter |

## SQL action user post-merge

```sql
-- 1. Appliquer migration 0136
ALTER TABLE public.gainers_user_shadow_signals
  ADD COLUMN IF NOT EXISTS fetch_diag JSONB;

-- (+ index dans la migration complète, copier le fichier)

-- 2. Re-sim Asia rows pour populated fetch_diag
UPDATE gainers_user_shadow_signals
SET sim_run_at = NULL, sim_results = NULL, fetch_diag = NULL
WHERE asset_class = 'asia_equity'
  AND created_at > NOW() - INTERVAL '5 days'
  AND sim_results->'baseline_60m'->>'outcome' = 'NO_DATA';
```

## Test plan

- [x] Typecheck + Jest local : 111 suites / 1365 tests
- [ ] CI verte
- [ ] Post-merge Fly redeploy
- [ ] Migration 0136 appliquée Supabase
- [ ] UPDATE retro-sim Asia 1304+ rows
- [ ] T+30min : SQL diagnostic distribution selectedStep
- [ ] Si `selectedStep=2/3` cluster Asia → on sait que les autres endpoints sauvent. Si `selectedStep=null` cluster → on connait la nature exacte du bug pour PR #287.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_