### PR TITLE
feat(shadow): timestamp diag fields per step + requestedSymbol fallback

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/shadow-fetch-diag.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/shadow-fetch-diag.spec.ts
@@ -179,6 +179,65 @@ describe('PR #286 — fetch_diag shape', () => {
     expect(callLog).toHaveLength(0);  // pas de fetch tenté
   });
 
+  it('PR #287 — populates firstCandleTs/lastCandleTs + forwardCountAfterFilter per step', async () => {
+    const callLog: FetchCall[] = [];
+    const startTs = Math.floor(Date.now() / 1000) - 6 * 3600;
+    // 3 candles : 1 avant startTs (rejected by filter) + 2 après
+    const candles = [
+      { timestamp: startTs - 600, open: 100, high: 100, low: 99.5, close: 99.8, volume: 100 },
+      { timestamp: startTs + 300, open: 100, high: 101, low: 99.5, close: 100.5, volume: 1000 },
+      { timestamp: startTs + 900, open: 100.5, high: 102, low: 100, close: 101.5, volume: 1500 },
+    ];
+    const svc = buildService({
+      candlesByEndpoint: {
+        getCandles_5m_range: { candles, rawCount: 3, requestedSymbol: '300161.SHE' },
+      },
+      callLog,
+    });
+    const { fetchDiag } = await runSim(svc, {
+      symbol: '300161.SHE',
+      assetClass: 'asia_equity',
+      entryPrice: 100,
+      createdAt: new Date(startTs * 1000).toISOString(),
+    }) as { fetchDiag: FetchDiag };
+
+    expect(fetchDiag.steps[0].firstCandleTs).toBe(startTs - 600);
+    expect(fetchDiag.steps[0].lastCandleTs).toBe(startTs + 900);
+    expect(fetchDiag.steps[0].forwardCountAfterFilter).toBe(2); // 2/3 candles >= startTs
+    // Top-level startTs/cutoffTs60 capturés
+    expect(fetchDiag.startTs).toBe(startTs);
+    expect(fetchDiag.cutoffTs60).toBe(startTs + 60 * 60);
+  });
+
+  it('PR #287 — requestedSymbol falls back to inputSymbol when call returns null', async () => {
+    const callLog: FetchCall[] = [];
+    const svc = buildService({
+      candlesByEndpoint: {
+        getCandles_5m_range: null,  // EODHD returns null → no series object
+        ticks_range: null,
+        getCandles_1m_range: null,
+        getCandles_5m_default: null,
+      },
+      callLog,
+    });
+    const { fetchDiag } = await runSim(svc, {
+      symbol: '300303.SHE',
+      assetClass: 'asia_equity',
+      entryPrice: 28.42,
+      createdAt: new Date(Date.now() - 6 * 3600 * 1000).toISOString(),
+    }) as { fetchDiag: FetchDiag };
+
+    // PR #287 — Avant : requestedSymbol=null sur tous les steps quand call=null.
+    // Maintenant : fallback à inputSymbol → permet de voir en SQL le ticker tenté.
+    expect(fetchDiag.steps).toHaveLength(4);
+    for (const step of fetchDiag.steps) {
+      expect(step.requestedSymbol).toBe('300303.SHE');
+      expect(step.inputSymbol).toBe('300303.SHE');
+      expect(step.firstCandleTs).toBeUndefined();  // pas de candles → pas de timestamps
+      expect(step.lastCandleTs).toBeUndefined();
+    }
+  });
+
   it('skips crypto with explicit error step (Binance not yet wired)', async () => {
     const callLog: FetchCall[] = [];
     const svc = buildService({ candlesByEndpoint: {}, callLog });

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -112,6 +112,16 @@ export interface FetchDiagStep {
   validClose: number;           // post-filter
   nulls: number;                // rawCount - validClose
   ms: number;                   // latency
+  // PR #287 — Diagnostic timestamps : extrema des candles retournées par
+  // ce step. Permet SQL post-deploy de comparer aux startTs/cutoffTs et
+  // détecter cause exacte du `forward_count=0` malgré `selectedStep>=0`.
+  // Populated UNIQUEMENT quand validClose > 0 (sinon undefined).
+  firstCandleTs?: number;
+  lastCandleTs?: number;
+  // PR #287 — forwardCount par step (= candles avec timestamp >= startTs).
+  // Pour le step `selectedStep`, c'est le même que fetchDiag.forwardCount
+  // (compatibility). Pour les autres, undefined (on ne calcule pas).
+  forwardCountAfterFilter?: number;
   error?: string;
 }
 export interface FetchDiag {
@@ -119,6 +129,10 @@ export interface FetchDiag {
   selectedStep: number | null;  // index 0-based dans steps[] qui a fourni les candles
   forwardCount: number;         // post normalize+filter par startTs
   outcome: 'ok' | 'no_data' | 'error';
+  // PR #287 — Pour analyse SQL : on persiste startTs et cutoffTs (sim window
+  // 60min). Sans ça il faut recalculer depuis created_at à chaque query.
+  startTs?: number;
+  cutoffTs60?: number;
 }
 
 // PR #283 — Type minimal pour walkForward (ne nécessite pas EodhdIntradayService.Candle)
@@ -374,6 +388,9 @@ export class GainersUserShadowService {
     const toTs = Math.floor(startTs + 60 * 60 + 300);
     const candleCount = resolveShadowLookbackCandles();
     const isAsia = args.assetClass === 'asia_equity';
+    // PR #287 — Capture top-level pour SQL post-mortem (vs recalcul depuis created_at)
+    fetchDiag.startTs = Math.floor(startTs);
+    fetchDiag.cutoffTs60 = Math.floor(startTs + 60 * 60);
 
     // PR #286 — Fallback chain alignée sur MultiTimeframePersistenceService
     // (cf. multi-tf-persistence.service.ts:321-431) mais adaptée pour le
@@ -439,12 +456,29 @@ export class GainersUserShadowService {
         fromTs: step.rangeMode ? fromTs : null,
         toTs: step.rangeMode ? toTs : null,
         inputSymbol: args.symbol,
-        requestedSymbol: series?.requestedSymbol ?? null,
+        // PR #287 — Force fallback à inputSymbol si requestedSymbol est null
+        // (cas où la call EODHD a retourné null sans construire de series).
+        // Permet diagnostic SQL : voir le ticker qu'on AURAIT envoyé.
+        requestedSymbol: series?.requestedSymbol ?? args.symbol,
         rawCount,
         validClose,
         nulls: rawCount - validClose,
         ms,
       };
+      // PR #287 — Capture extrema timestamps (utiles SQL pour comparer
+      // au startTs et identifier les patterns "candles d'une session OLDER").
+      if (series?.candles && series.candles.length > 0) {
+        const tsList = series.candles.map((c) => Number(c.timestamp)).filter((t) => Number.isFinite(t));
+        if (tsList.length > 0) {
+          stepEntry.firstCandleTs = Math.min(...tsList);
+          stepEntry.lastCandleTs = Math.max(...tsList);
+          stepEntry.forwardCountAfterFilter = tsList.filter((t) => {
+            // Auto-detect ms vs s (mirror normalizeAndSortCandles logic)
+            const tsec = t > 1e12 ? Math.floor(t / 1000) : t;
+            return tsec >= startTs;
+          }).length;
+        }
+      }
       fetchDiag.steps.push(stepEntry);
 
       if (isAsia) {


### PR DESCRIPTION
## Contexte

PR #286 fetch_diag JSONB a révélé : Asia rows ont `selectedStep=3` (step4 default mode succeeded, `validClose>0`) **MAIS `forward_count=0`**.

3 hypothèses encore possibles :
- **#4** EODHD default mode renvoie session OLDER (latest candles antérieures à startTs)
- **#2** Bug parse ms vs s sur branche default mode uniquement
- **#1** Tickers inactifs (peu probable, présents dans logs scanner récents)

Sans data sur les **timestamps réels** des candles retournées, on parie. Cette PR ajoute les champs pour trancher **en 1 SQL**.

## Changes (~30 LoC)

### `FetchDiagStep` étendu
- `firstCandleTs`, `lastCandleTs` — extrema candles par step (uniquement si `validClose > 0`)
- `forwardCountAfterFilter` — `candles >= startTs` post auto-detect ms/s

### `FetchDiag` (top-level)
- `startTs` — row.created_at en seconds (capturé pour SQL compare)
- `cutoffTs60` — `startTs + 60min` (sim window upper bound)

### Bonus défensif
- `requestedSymbol` fallback à `inputSymbol` quand call retourne null. Avant : null si series indisponible. Maintenant : on voit en SQL le ticker qu'on AURAIT envoyé.

## Décodage SQL post-deploy

```sql
SELECT
  symbol,
  fetch_diag->>'startTs' AS start_ts,
  fetch_diag->>'cutoffTs60' AS cutoff_ts,
  fetch_diag->'steps'->3->>'firstCandleTs' AS step4_first,
  fetch_diag->'steps'->3->>'lastCandleTs' AS step4_last,
  fetch_diag->'steps'->3->>'forwardCountAfterFilter' AS step4_forward,
  fetch_diag->>'forwardCount' AS top_forward
FROM gainers_user_shadow_signals
WHERE asset_class = 'asia_equity'
  AND fetch_diag->>'outcome' = 'no_data'
  AND fetch_diag->>'selectedStep' = '3'
  AND sim_run_at > NOW() - INTERVAL '30 minutes'
LIMIT 10;
```

| Pattern observé | Hypothèse confirmée | Fix PR #288 |
|---|---|---|
| `step4_last < start_ts` | **#4** : default mode renvoie OLDER session | Skip default mode pour Asia ou clamp window |
| `step4_last > start_ts` mais `step4_forward=0` | **#2** : parse ms vs s sur default branch | Audit `normalizeAndSortCandles` |
| `step4_first/last ≈ start_ts` ET `top_forward=0` mais `step4_forward>0` | bug ordre des opérations | Investiguer flow normalize/filter |

## Tests (2 nouveaux, 111 suites / 1367 tests verts)

- ✅ Populates `firstCandleTs`/`lastCandleTs`/`forwardCountAfterFilter` per step (3 candles, 1 < startTs + 2 ≥ startTs → forward=2)
- ✅ `requestedSymbol` falls back to `inputSymbol` when call returns null (4 steps null → tous ont requestedSymbol=inputSymbol)

## Hors scope

Pas de fix. Observabilité supplémentaire. **Fix PR #288 ciblé** dès qu'on a la conclusion SQL post-deploy.

## Test plan

- [x] Typecheck + Jest local : 111 suites / 1367 tests
- [ ] CI verte
- [ ] Post-merge Fly redeploy
- [ ] User SQL query → identifie #4/#2/autre en 30s
- [ ] PR #288 fix ciblé selon hypothèse

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_