### PR TITLE
fix(shadow): asia tz offset correction on candle timestamps

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/asia-tz-offset.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/asia-tz-offset.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * PR #288 — Tests offset detection + correction TZ Asia/Pacific.
+ *
+ * Bug confirmé prod 08/05/2026 : EODHD intraday encode les timestamps des
+ * candles en local exchange time treated as UTC. Pour 300161.SHE :
+ *   - Candle réelle close 15:00 CST = 07:00 UTC May 8
+ *   - EODHD timestamp = May 7 23:00 UTC (= 15:00 CST naïvement encodé UTC)
+ * → notre filter `c.timestamp >= startTs` (real UTC) rejetait tout.
+ *
+ * Fix : ajouter offset (8h SHE/SHG/HK, 9h KO/KQ/T, 10h AU) avant filter.
+ */
+import {
+  getExchangeUtcOffsetSec,
+} from '../services/gainers-user-shadow.service';
+
+describe('PR #288 — getExchangeUtcOffsetSec', () => {
+  it('returns 8h for China exchanges (SHE, SHG, HK)', () => {
+    expect(getExchangeUtcOffsetSec('300161.SHE')).toBe(8 * 3600);
+    expect(getExchangeUtcOffsetSec('600519.SHG')).toBe(8 * 3600);
+    expect(getExchangeUtcOffsetSec('0700.HK')).toBe(8 * 3600);
+  });
+
+  it('returns 9h for Korea/Japan (KO, KQ, T)', () => {
+    expect(getExchangeUtcOffsetSec('005930.KO')).toBe(9 * 3600);
+    expect(getExchangeUtcOffsetSec('013310.KQ')).toBe(9 * 3600);
+    expect(getExchangeUtcOffsetSec('7203.T')).toBe(9 * 3600);
+  });
+
+  it('returns 10h for Australia (AU)', () => {
+    expect(getExchangeUtcOffsetSec('CCP.AU')).toBe(10 * 3600);
+  });
+
+  it('returns 0 for US/EU (no offset needed)', () => {
+    expect(getExchangeUtcOffsetSec('AAPL.US')).toBe(0);
+    expect(getExchangeUtcOffsetSec('NYT.US')).toBe(0);
+    expect(getExchangeUtcOffsetSec('AAZ.LSE')).toBe(0);
+    expect(getExchangeUtcOffsetSec('BMW.XETRA')).toBe(0);
+    expect(getExchangeUtcOffsetSec('AC.PA')).toBe(0);
+  });
+
+  it('returns 0 for null/undefined/empty/no-suffix', () => {
+    expect(getExchangeUtcOffsetSec(null)).toBe(0);
+    expect(getExchangeUtcOffsetSec(undefined)).toBe(0);
+    expect(getExchangeUtcOffsetSec('')).toBe(0);
+    expect(getExchangeUtcOffsetSec('NOSUFFIX')).toBe(0);
+  });
+
+  it('handles lowercase suffix (defensive)', () => {
+    expect(getExchangeUtcOffsetSec('300161.she')).toBe(8 * 3600);
+    expect(getExchangeUtcOffsetSec('aapl.us')).toBe(0);
+  });
+});
+
+describe('PR #288 — Offset shift math validation', () => {
+  it('candle encoded in CST (-8h vs real UTC) shifts back to real UTC after offset+', () => {
+    // Real UTC : 06:30 today = exemple X
+    const realUtcSec = Math.floor(Date.now() / 1000) - 60;
+    // EODHD encoderait cette candle Shenzhen comme "real - 8h"
+    const encodedByEodhd = realUtcSec - 8 * 3600;
+    // Notre fix : timestamp + offset
+    const corrected = encodedByEodhd + getExchangeUtcOffsetSec('300161.SHE');
+    expect(corrected).toBe(realUtcSec);
+  });
+
+  it('candle for KOSDAQ shifts by +9h', () => {
+    const realUtcSec = 1778166000;
+    const encodedByEodhd = realUtcSec - 9 * 3600;
+    const corrected = encodedByEodhd + getExchangeUtcOffsetSec('013310.KQ');
+    expect(corrected).toBe(realUtcSec);
+  });
+
+  it('US ticker timestamps remain unchanged (offset=0)', () => {
+    const ts = 1778166000;
+    expect(ts + getExchangeUtcOffsetSec('AAPL.US')).toBe(ts);
+  });
+
+  it('regression : real-prod values from PR #287 SQL diag — Shenzhen close TODAY', () => {
+    // Source: SQL diag user 08/05/2026 — 300161.SHE step4_last = 1778137200
+    const step4LastEncoded = 1778137200;
+    const correctedToRealUtc = step4LastEncoded + getExchangeUtcOffsetSec('300161.SHE');
+    // = 1778137200 + 28800 = 1778166000 = May 8 06:20 UTC (just before Shenzhen close at 07:00)
+    expect(correctedToRealUtc).toBe(1778166000);
+  });
+
+  it('regression : real-prod KOSDAQ — 013310.KQ step4_last shifts to KOSDAQ close TODAY', () => {
+    const step4LastEncoded = 1778133600;
+    const correctedToRealUtc = step4LastEncoded + getExchangeUtcOffsetSec('013310.KQ');
+    // = 1778133600 + 32400 = 1778166000 = same May 8 06:20 UTC (just before KOSDAQ close at 06:30)
+    expect(correctedToRealUtc).toBe(1778166000);
+  });
+});

--- a/apps/api/src/modules/lisa/__tests__/shadow-fetch-diag.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/shadow-fetch-diag.spec.ts
@@ -82,13 +82,15 @@ describe('PR #286 — fetch_diag shape', () => {
     };
     const svc = buildService({
       candlesByEndpoint: {
-        getCandles_5m_range: { candles: [validCandle], rawCount: 1, requestedSymbol: '300161.SHE' },
+        getCandles_5m_range: { candles: [validCandle], rawCount: 1, requestedSymbol: 'WFCF.US' },
       },
       callLog,
     });
+    // PR #288 — Test utilise un ticker US (offset=0) pour éviter le shift TZ
+    // Asia/Pacific qui décalerait la candle hors cutoff sim window 60min.
     const { fetchDiag, results } = await runSim(svc, {
-      symbol: '300161.SHE',
-      assetClass: 'asia_equity',
+      symbol: 'WFCF.US',
+      assetClass: 'us_equity_small_mid',
       entryPrice: 28.42,
       createdAt: new Date(startTs * 1000).toISOString(),
     }) as { fetchDiag: FetchDiag; results: Record<string, { outcome: string }> };
@@ -99,7 +101,7 @@ describe('PR #286 — fetch_diag shape', () => {
     expect(fetchDiag.forwardCount).toBe(1);
     expect(results.baseline_60m.outcome).toBe('TIME_LIMIT');  // 1 candle, no TP/SL hit
     // Vérif callLog : seul l'endpoint primary a été appelé
-    expect(callLog).toEqual([{ endpoint: 'getCandles_5m_range', ticker: '300161.SHE' }]);
+    expect(callLog).toEqual([{ endpoint: 'getCandles_5m_range', ticker: 'WFCF.US' }]);
   });
 
   it('falls through to step 3 (1m_range) when 5m_range and ticks return empty', async () => {

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -69,6 +69,40 @@ const SIM_GRIDS: SimGrid[] = [
   { key: 'alt15_60m',    tpPct: 0.015, slPct: 0.006, windowMin: 60 },
 ];
 
+// PR #288 — TZ offset par exchange Asia/Pacific.
+//
+// Bug observé prod 08/05/2026 07:30 UTC : Asia rows 100% NO_DATA même
+// après PR #284-#287. Diagnostic via fetch_diag JSONB (PR #287) confirme :
+// EODHD intraday renvoie les timestamps des candles encodés en LOCAL exchange
+// time traités comme UTC. Pour 300161.SHE Shenzhen :
+//   - Candle réelle close à 15:00 CST (= 07:00 UTC May 8)
+//   - EODHD encode timestamp = "2026-05-07 23:00 UTC" (= 15:00 CST en lecture
+//     naïve treating as UTC, soit -8h vs real UTC)
+// → notre filtre `c.timestamp >= startTs` (en real UTC) rejette tout.
+//
+// Fix : ajouter l'offset timezone de l'exchange aux timestamps avant filter.
+// Vérifié manuellement par utilisateur via SQL : step4_last + 8h = ~Shenzhen
+// close TODAY ; step4_last + 9h = ~KOSDAQ close TODAY. Cohérent.
+//
+// Sources : ces offsets sont stables (pas de DST en Asia/China/Korea/Japan).
+// Australie a DST mais en May/June = AEST stable UTC+10. DST Australia
+// (Oct-Avr UTC+11) sera fix follow-up si besoin.
+const EXCHANGE_UTC_OFFSET_SEC: Record<string, number> = {
+  SHE: 8 * 3600,   // Shenzhen — China Standard Time (no DST)
+  SHG: 8 * 3600,   // Shanghai
+  HK:  8 * 3600,   // Hong Kong
+  KO:  9 * 3600,   // KOSPI — Korea Standard Time (no DST)
+  KQ:  9 * 3600,   // KOSDAQ
+  T:   9 * 3600,   // Tokyo — JST (no DST)
+  AU: 10 * 3600,   // ASX — AEST (May-Sep, no DST during this window)
+};
+
+export function getExchangeUtcOffsetSec(symbol: string | null | undefined): number {
+  if (!symbol) return 0;
+  const suffix = symbol.split('.').pop()?.toUpperCase() ?? '';
+  return EXCHANGE_UTC_OFFSET_SEC[suffix] ?? 0;
+}
+
 const SLIPPAGE_HAIRCUT_BILATERAL = 0.0015;  // 15bps each side
 const SLIPPAGE_TOTAL = SLIPPAGE_HAIRCUT_BILATERAL * 2;  // 30bps round-trip
 const SIMULATE_AFTER_MIN = 60;  // attendre que la fenêtre 60m soit close
@@ -133,6 +167,10 @@ export interface FetchDiag {
   // 60min). Sans ça il faut recalculer depuis created_at à chaque query.
   startTs?: number;
   cutoffTs60?: number;
+  // PR #288 — Offset TZ appliqué sur les candles (positif si Asia/Pacific,
+  // 0 sinon). Audit SQL : permet de vérifier qu'on a bien shifté pour Asia
+  // et de débugguer si certains tickers sont mal détectés.
+  applied_tz_offset_sec?: number;
 }
 
 // PR #283 — Type minimal pour walkForward (ne nécessite pas EodhdIntradayService.Candle)
@@ -515,7 +553,24 @@ export class GainersUserShadowService {
 
     // PR #283 — Critique : normaliser unité (ms→s) ET trier ASC AVANT
     // walkForward. EODHD retournait DESC, le bug a causé 100% NO_DATA prod.
-    const normalizedCandles = normalizeAndSortCandles(selectedSeries.candles);
+    let normalizedCandles = normalizeAndSortCandles(selectedSeries.candles);
+
+    // PR #288 — Asia/Pacific timezone correction. EODHD encode les timestamps
+    // intraday en LOCAL exchange time traités comme UTC pour Asia. Sans cette
+    // correction, candles paraissent ~8-10h dans le passé vs startTs (real
+    // UTC) → forward filter rejette tout → NO_DATA. Détection par suffix
+    // ticker (.SHE/.SHG/.HK +8h ; .KO/.KQ/.T +9h ; .AU +10h ; US/EU=0).
+    const tzOffsetSec = getExchangeUtcOffsetSec(args.symbol);
+    if (tzOffsetSec > 0) {
+      normalizedCandles = normalizedCandles.map((c) => ({
+        ...c,
+        timestamp: c.timestamp + tzOffsetSec,
+      }));
+      fetchDiag.applied_tz_offset_sec = tzOffsetSec;
+    } else {
+      fetchDiag.applied_tz_offset_sec = 0;
+    }
+
     const forward = normalizedCandles.filter((c) => c.timestamp >= startTs);
     fetchDiag.forwardCount = forward.length;
 


### PR DESCRIPTION
## Cause confirmée par PR #287 SQL diag

EODHD intraday encode les timestamps des candles **en local exchange time treated as UTC** pour Asia/Pacific. Vérification math via SQL prod 08/05/2026 :

| Ticker | step4_last (encoded) | + offset | = Real UTC | Match |
|---|---|---|---|---|
| 300161.SHE | 1778137200 | +28800 (CST) | 1778166000 = May 8 06:20 UTC | 40min avant Shenzhen close 07:00 ✅ |
| 013310.KQ | 1778133600 | +32400 (KST) | 1778166000 = May 8 06:20 UTC | 10min avant KOSDAQ close 06:30 ✅ |

Pattern = **exactement la TZ offset de l'exchange**.

## Pourquoi mtfPersistence (scanner) marche

mtfPersistence calcule des deltas de prix entre candles consécutives → **ne filtre pas par timestamp absolu**. Le shift relatif n'a pas d'impact. Notre shadow simulator filtre par timestamp absolu (`c.timestamp >= startTs`) → bug visible **uniquement dans shadow**.

## Fix (~50 LoC)

```ts
const EXCHANGE_UTC_OFFSET_SEC: Record<string, number> = {
  SHE: 8 * 3600,   // Shenzhen — CST (no DST)
  SHG: 8 * 3600,   // Shanghai
  HK:  8 * 3600,   // Hong Kong
  KO:  9 * 3600,   // KOSPI — KST (no DST)
  KQ:  9 * 3600,   // KOSDAQ
  T:   9 * 3600,   // Tokyo — JST (no DST)
  AU: 10 * 3600,   // ASX — AEST (May-Sep)
};

export function getExchangeUtcOffsetSec(symbol): number {
  const suffix = symbol.split('.').pop()?.toUpperCase() ?? '';
  return EXCHANGE_UTC_OFFSET_SEC[suffix] ?? 0;
}
```

Dans `simulateRow` après `normalizeAndSortCandles` :

```ts
const tzOffsetSec = getExchangeUtcOffsetSec(args.symbol);
if (tzOffsetSec > 0) {
  normalizedCandles = normalizedCandles.map((c) => ({
    ...c,
    timestamp: c.timestamp + tzOffsetSec,
  }));
  fetchDiag.applied_tz_offset_sec = tzOffsetSec;
}
```

`fetchDiag.applied_tz_offset_sec` persisté pour audit SQL.

## Tests (11 nouveaux, 112 suites / 1378 tests verts)

`asia-tz-offset.spec.ts` :
- 8h pour China (SHE, SHG, HK)
- 9h pour Korea/Japan (KO, KQ, T)
- 10h pour Australia (AU)
- 0 pour US/EU/null/undefined/empty
- Lowercase suffix défensif
- Math validation : encoded - 8h + 8h = real UTC
- Math validation : KOSDAQ +9h
- US ticker offset=0
- **REGRESSION** : valeurs réelles prod 1778137200/1778133600 → 1778166000 (Shenzhen/KOSDAQ close TODAY) ✅

`shadow-fetch-diag.spec.ts` : test "stops at step 1 valid" mis à jour avec ticker US (WFCF.US) pour éviter shift TZ dans le test.

## Hors scope (potentiel PR #289)

- Australie DST (Oct-Avr UTC+11, hors fenêtre actuelle May 2026)
- **Retry `pending_forward`** pour rows < 90min — EODHD intraday Asia a une latence d'ingestion ~30-40min, donc rows très récents pourraient encore avoir `forwardCount=0` même après fix offset

## Validation post-deploy

```sql
SELECT
  symbol,
  fetch_diag->>'applied_tz_offset_sec' AS offset,
  fetch_diag->>'forwardCount' AS forward,
  sim_results->'baseline_60m'->>'outcome' AS outcome,
  count(*) AS n
FROM gainers_user_shadow_signals
WHERE asset_class = 'asia_equity'
  AND sim_run_at > NOW() - INTERVAL '15 minutes'
GROUP BY 1,2,3,4 ORDER BY 1, n DESC;
```

**Expected** :
- `.SHE/.SHG/.HK` → `offset=28800`
- `.KO/.KQ/.T` → `offset=32400`
- `.AU` → `offset=36000`
- `forwardCount > 0` majoritairement
- `outcome = TP_HIT/SL_HIT/TIME_LIMIT` (vs NO_DATA pré-fix)

## Test plan

- [x] Typecheck + Jest local : 112 suites / 1378 tests
- [ ] CI verte
- [ ] Post-merge Fly redeploy v457
- [ ] Re-sim Asia rows : `UPDATE gainers_user_shadow_signals SET sim_run_at=NULL, sim_results=NULL, fetch_diag=NULL WHERE asset_class='asia_equity' AND created_at > NOW() - INTERVAL '5 days' AND sim_results->'baseline_60m'->>'outcome' = 'NO_DATA';`
- [ ] T+30min : SELECT validation ci-dessus → distribution Asia avec real outcomes apparaît

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_