### PR TITLE
fix(shadow): revert TZ shift (PR #288) + add OFF_SESSION outcome

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/off-session-detection.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/off-session-detection.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * PR #289 — Tests revert TZ shift + OFF_SESSION detection.
+ *
+ * PR #288 avait introduit un +offset shift sur les candles Asia, basé sur
+ * une mauvaise interprétation des timestamps EODHD. Postgres `to_timestamp`
+ * confirme : EODHD retourne déjà real UTC. Le shift introduisait des
+ * timestamps fictifs pour les rows captées DURANT session Asia.
+ *
+ * PR #289 :
+ *   - Revert le shift (timestamps EODHD utilisés tels quels)
+ *   - Garde le helper `getExchangeUtcOffsetSec` pour future session-aware logic
+ *   - Détecte OFF_SESSION quand toutes les candles fetched < startTs
+ *     (signe que la row a été captée hors session de trading active du
+ *     symbole — typique scanner Asia pendant US session)
+ *   - getRegretSummary exclut OFF_SESSION pour ne pas polluer les KPI
+ */
+import { GainersUserShadowService, type FetchDiag, type SimOutcome } from '../services/gainers-user-shadow.service';
+
+type FetchCall = { endpoint: string; ticker: string };
+
+function buildService(opts: {
+  candlesByEndpoint: Record<string, { candles: Array<{ timestamp: number; high: number; low: number; close: number; open?: number; volume?: number }>; rawCount?: number; requestedSymbol?: string } | null>;
+  callLog: FetchCall[];
+}): GainersUserShadowService {
+  const eodhdMock = {
+    getCandles: jest.fn(async (ticker: string, interval: string, _count: number, options?: unknown) => {
+      const range = options ? '_range' : '_default';
+      const key = `getCandles_${interval}${range}`;
+      opts.callLog.push({ endpoint: key, ticker });
+      return opts.candlesByEndpoint[key] ?? null;
+    }),
+    getCandlesViaTicks: jest.fn(async (ticker: string, _interval: string, _count: number, _options?: unknown) => {
+      opts.callLog.push({ endpoint: 'ticks_range', ticker });
+      return opts.candlesByEndpoint['ticks_range'] ?? null;
+    }),
+  };
+  const supabaseMock = {
+    getClient: () => ({ from: () => ({ select: () => ({ is: () => ({ lte: () => ({ order: () => ({ limit: async () => ({ data: [], error: null }) }) }) }) }) }) }),
+  };
+  return new GainersUserShadowService(supabaseMock as never, eodhdMock as never);
+}
+
+async function runSim(svc: GainersUserShadowService, args: { symbol: string; assetClass: string; entryPrice: number; createdAt: string }) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return await (svc as any).simulateRow(args);
+}
+
+describe('PR #289 — TZ shift reverted', () => {
+  it('Asia ticker candles are NOT shifted (timestamps used as-is)', async () => {
+    const callLog: FetchCall[] = [];
+    // Row captured at startTs. Candle at startTs + 600 (+10min within sim window).
+    // Avant PR #289 : ce candle aurait été shifté +8h → bien au-delà cutoff → NO_DATA.
+    // Après PR #289 : timestamp utilisé tel quel → walkForward normal.
+    const startTs = Math.floor(Date.now() / 1000) - 6 * 3600;
+    const candles = [
+      { timestamp: startTs + 300, open: 100, high: 100.5, low: 99.5, close: 100.2, volume: 1000 },
+      { timestamp: startTs + 900, open: 100.2, high: 102.5, low: 100, close: 102.1, volume: 1500 },
+    ];
+    const svc = buildService({
+      candlesByEndpoint: {
+        getCandles_5m_range: { candles, rawCount: 2, requestedSymbol: '300161.SHE' },
+      },
+      callLog,
+    });
+    const { fetchDiag, results } = await runSim(svc, {
+      symbol: '300161.SHE',
+      assetClass: 'asia_equity',
+      entryPrice: 100,
+      createdAt: new Date(startTs * 1000).toISOString(),
+    }) as { fetchDiag: FetchDiag; results: Record<string, SimOutcome> };
+
+    expect(fetchDiag.applied_tz_offset_sec).toBe(0);     // pas de shift appliqué
+    expect(fetchDiag.forwardCount).toBe(2);              // les 2 candles passent le filter
+    expect(fetchDiag.outcome).toBe('ok');
+    // T+15min, high=102.5 ≥ tp=102 → TP_HIT
+    expect(results.baseline_60m.outcome).toBe('TP_HIT');
+  });
+
+  it('US ticker still has zero offset (no regression)', async () => {
+    const callLog: FetchCall[] = [];
+    const startTs = Math.floor(Date.now() / 1000) - 6 * 3600;
+    const candles = [
+      { timestamp: startTs + 300, open: 100, high: 100.5, low: 99.5, close: 100.2, volume: 1000 },
+    ];
+    const svc = buildService({
+      candlesByEndpoint: {
+        getCandles_5m_range: { candles, rawCount: 1, requestedSymbol: 'AAPL.US' },
+      },
+      callLog,
+    });
+    const { fetchDiag } = await runSim(svc, {
+      symbol: 'AAPL.US',
+      assetClass: 'us_equity_large',
+      entryPrice: 100,
+      createdAt: new Date(startTs * 1000).toISOString(),
+    }) as { fetchDiag: FetchDiag };
+
+    expect(fetchDiag.applied_tz_offset_sec).toBe(0);
+    expect(fetchDiag.outcome).toBe('ok');
+  });
+});
+
+describe('PR #289 — OFF_SESSION detection', () => {
+  it('marks OFF_SESSION when all fetched candles are before startTs', async () => {
+    const callLog: FetchCall[] = [];
+    // startTs = TODAY 18:02 UTC (~ scanner US session)
+    const startTs = Math.floor(Date.now() / 1000);
+    // Latest candle Shenzhen close = TODAY 07:00 UTC = 11h avant startTs
+    const candles = [
+      { timestamp: startTs - 12 * 3600, open: 28, high: 28.5, low: 27.9, close: 28.2, volume: 1000 },
+      { timestamp: startTs - 11 * 3600, open: 28.2, high: 28.5, low: 28.0, close: 28.42, volume: 1500 },
+    ];
+    const svc = buildService({
+      candlesByEndpoint: {
+        getCandles_5m_range: { candles, rawCount: 2, requestedSymbol: '300161.SHE' },
+      },
+      callLog,
+    });
+    const { fetchDiag, results } = await runSim(svc, {
+      symbol: '300161.SHE',
+      assetClass: 'asia_equity',
+      entryPrice: 28.42,
+      createdAt: new Date(startTs * 1000).toISOString(),
+    }) as { fetchDiag: FetchDiag; results: Record<string, SimOutcome> };
+
+    expect(fetchDiag.outcome).toBe('off_session');
+    expect(fetchDiag.forwardCount).toBe(0);
+    // Tous les grids OFF_SESSION (pas de NO_DATA, pas de TIME_LIMIT)
+    expect(results.baseline_60m.outcome).toBe('OFF_SESSION');
+    expect(results.baseline_30m.outcome).toBe('OFF_SESSION');
+    expect(results.alt15_60m.outcome).toBe('OFF_SESSION');
+    expect(results.alt15_30m.outcome).toBe('OFF_SESSION');
+    expect(results.baseline_60m.pnl_pct).toBeNull();
+    expect(results.baseline_60m.exit_price).toBeNull();
+  });
+
+  it('does NOT mark OFF_SESSION when some candles >= startTs (normal flow)', async () => {
+    const callLog: FetchCall[] = [];
+    const startTs = Math.floor(Date.now() / 1000) - 6 * 3600;
+    // Mix : 1 candle avant startTs + 2 après (forward filter en garde 2)
+    const candles = [
+      { timestamp: startTs - 600, open: 100, high: 100.5, low: 99.5, close: 99.8, volume: 1000 },
+      { timestamp: startTs + 300, open: 100, high: 100.8, low: 99.5, close: 100.5, volume: 1500 },
+      { timestamp: startTs + 900, open: 100.5, high: 101.5, low: 100, close: 101.2, volume: 2000 },
+    ];
+    const svc = buildService({
+      candlesByEndpoint: {
+        getCandles_5m_range: { candles, rawCount: 3, requestedSymbol: '300161.SHE' },
+      },
+      callLog,
+    });
+    const { fetchDiag, results } = await runSim(svc, {
+      symbol: '300161.SHE',
+      assetClass: 'asia_equity',
+      entryPrice: 100,
+      createdAt: new Date(startTs * 1000).toISOString(),
+    }) as { fetchDiag: FetchDiag; results: Record<string, SimOutcome> };
+
+    expect(fetchDiag.outcome).toBe('ok');
+    expect(results.baseline_60m.outcome).toBe('TIME_LIMIT');  // 2 candles, no TP/SL hit
+    expect(results.baseline_60m.outcome).not.toBe('OFF_SESSION');
+  });
+
+  it('NO_DATA (not OFF_SESSION) when zero candles fetched at all', async () => {
+    const callLog: FetchCall[] = [];
+    const startTs = Math.floor(Date.now() / 1000) - 6 * 3600;
+    const svc = buildService({
+      candlesByEndpoint: {
+        getCandles_5m_range: { candles: [], rawCount: 0, requestedSymbol: 'HEG.NSE' },
+        ticks_range: null,
+        getCandles_1m_range: null,
+        getCandles_5m_default: null,
+      },
+      callLog,
+    });
+    const { fetchDiag, results } = await runSim(svc, {
+      symbol: 'HEG.NSE',
+      assetClass: 'asia_equity',
+      entryPrice: 100,
+      createdAt: new Date(startTs * 1000).toISOString(),
+    }) as { fetchDiag: FetchDiag; results: Record<string, SimOutcome> };
+
+    // Aucun endpoint n'a retourné de candle → NO_DATA, PAS OFF_SESSION
+    // (sémantique : "EODHD n'a vraiment rien", distinct de "row hors session")
+    expect(fetchDiag.outcome).toBe('no_data');
+    expect(results.baseline_60m.outcome).toBe('NO_DATA');
+    expect(results.baseline_60m.outcome).not.toBe('OFF_SESSION');
+  });
+});

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -125,7 +125,7 @@ function resolveShadowLookbackCandles(): number {
 }
 
 export interface SimOutcome {
-  outcome: 'TP_HIT' | 'SL_HIT' | 'TIME_LIMIT' | 'NO_DATA';
+  outcome: 'TP_HIT' | 'SL_HIT' | 'TIME_LIMIT' | 'NO_DATA' | 'OFF_SESSION';
   exit_price: number | null;
   exit_at: string | null;
   pnl_pct: number | null;       // NET (slippage already subtracted)
@@ -162,7 +162,7 @@ export interface FetchDiag {
   steps: FetchDiagStep[];
   selectedStep: number | null;  // index 0-based dans steps[] qui a fourni les candles
   forwardCount: number;         // post normalize+filter par startTs
-  outcome: 'ok' | 'no_data' | 'error';
+  outcome: 'ok' | 'no_data' | 'error' | 'off_session';
   // PR #287 — Pour analyse SQL : on persiste startTs et cutoffTs (sim window
   // 60min). Sans ça il faut recalculer depuis created_at à chaque query.
   startTs?: number;
@@ -553,26 +553,30 @@ export class GainersUserShadowService {
 
     // PR #283 — Critique : normaliser unité (ms→s) ET trier ASC AVANT
     // walkForward. EODHD retournait DESC, le bug a causé 100% NO_DATA prod.
-    let normalizedCandles = normalizeAndSortCandles(selectedSeries.candles);
+    const normalizedCandles = normalizeAndSortCandles(selectedSeries.candles);
 
-    // PR #288 — Asia/Pacific timezone correction. EODHD encode les timestamps
-    // intraday en LOCAL exchange time traités comme UTC pour Asia. Sans cette
-    // correction, candles paraissent ~8-10h dans le passé vs startTs (real
-    // UTC) → forward filter rejette tout → NO_DATA. Détection par suffix
-    // ticker (.SHE/.SHG/.HK +8h ; .KO/.KQ/.T +9h ; .AU +10h ; US/EU=0).
-    const tzOffsetSec = getExchangeUtcOffsetSec(args.symbol);
-    if (tzOffsetSec > 0) {
-      normalizedCandles = normalizedCandles.map((c) => ({
-        ...c,
-        timestamp: c.timestamp + tzOffsetSec,
-      }));
-      fetchDiag.applied_tz_offset_sec = tzOffsetSec;
-    } else {
-      fetchDiag.applied_tz_offset_sec = 0;
-    }
+    // PR #289 — REVERT du +offset shift (PR #288 introduit par mauvaise
+    // interprétation). Postgres `to_timestamp` confirme : EODHD retourne
+    // déjà real UTC pour les timestamps Asia. Le helper getExchangeUtcOffsetSec
+    // est conservé pour future logic session-aware (PR #290+) mais N'EST PLUS
+    // appliqué sur les candles. Persisted = 0 pour audit.
+    fetchDiag.applied_tz_offset_sec = 0;
 
     const forward = normalizedCandles.filter((c) => c.timestamp >= startTs);
     fetchDiag.forwardCount = forward.length;
+
+    // PR #289 — Détection OFF_SESSION : si on a fetché des candles MAIS
+    // toutes sont AVANT startTs, ça signifie que la row a été créée en
+    // dehors de la session de trading active du symbole (ex: scanner
+    // capture Asia ticker pendant US session 18:02 UTC → Shenzhen fermé
+    // depuis 11h, latest candle = 07:00 UTC bien avant startTs).
+    //
+    // Sémantique : "row hors session, sim impossible structurellement".
+    // Distinct de NO_DATA (= échec EODHD) et de TIME_LIMIT (= sim normal
+    // sans hit). Exclu de getRegretSummary pour ne pas polluer les stats.
+    const isOffSession = forward.length === 0
+      && normalizedCandles.length > 0
+      && normalizedCandles[normalizedCandles.length - 1].timestamp < startTs;
 
     if (forward.length === 0) {
       const first = normalizedCandles[0];
@@ -594,6 +598,21 @@ export class GainersUserShadowService {
         `firstValidTs=${firstValid} lastValidTs=${lastValid} ` +
         `startTs=${startTs} cutoffMaxTs=${startTs + 60 * 60}`,
       );
+    }
+
+    // PR #289 — Si OFF_SESSION détecté, court-circuiter walkForward avec
+    // outcome dédié sur toutes les grilles (au lieu de NO_DATA générique).
+    if (isOffSession) {
+      const offSessionOutcome: SimOutcome = {
+        outcome: 'OFF_SESSION',
+        exit_price: null,
+        exit_at: null,
+        pnl_pct: null,
+        hit_at_min: null,
+      };
+      for (const g of SIM_GRIDS) results[g.key] = offSessionOutcome;
+      fetchDiag.outcome = 'off_session';
+      return { results, fetchDiag };
     }
 
     for (const grid of SIM_GRIDS) {
@@ -634,6 +653,11 @@ export class GainersUserShadowService {
       for (const grid of SIM_GRIDS) {
         const o = sim[grid.key];
         if (!o || o.pnl_pct == null) continue;
+        // PR #289 — Exclure OFF_SESSION du calcul regret stats. Ces rows
+        // n'ont pas pu être simulées car capturées hors session de trading
+        // (ex: scanner détecte Asia ticker en US session). Pas un échec
+        // de gate, juste un constraint structurel — ne pollue pas les KPI.
+        if (o.outcome === 'OFF_SESSION') continue;
         const key = `${row.decision}|${grid.key}`;
         if (!buckets.has(key)) buckets.set(key, { pnls: [], notional });
         buckets.get(key)!.pnls.push(Number(o.pnl_pct));


### PR DESCRIPTION
## 🔄 Cause régression PR #288

PR #288 a introduit un `+offset` shift aux candles Asia basé sur une mauvaise interprétation. Validation `1778137200 + 28800 = 1778166000` était mathématiquement correcte mais la **conversion manuelle epoch→datetime était off de ~15h** (timezone navigateur). Postgres `to_timestamp()` confirme : `1778137200 → 2026-05-07 07:00 UTC = Shenzhen close`. **EODHD retourne déjà du real UTC**.

## ⚠️ Pourquoi urgent

Sur rows actuelles (post-Asia-close), pas d'impact visible. **Mais sur rows captées DURANT session Asia**, le +8h shift décale candles dans futur fictif → walkForward break immédiat → faux NO_DATA. Bombe à retardement.

## Fix (~30 LoC)

1. **Revert** : retirer le shift `.map((c) => ({ ...c, timestamp: c.timestamp + tzOffsetSec }))`
2. **Garder helper** `getExchangeUtcOffsetSec` exporté pour future logic session-aware
3. **`applied_tz_offset_sec = 0` toujours** (audit SQL traçable)

## ✨ Nouveau outcome `OFF_SESSION`

```ts
outcome: 'TP_HIT' | 'SL_HIT' | 'TIME_LIMIT' | 'NO_DATA' | 'OFF_SESSION'
```

**Détection** : `forward.length === 0` ET `candles.length > 0` ET `lastCandleTs < startTs`.

**Sémantique** : "row capturée hors session de trading active — sim impossible structurellement". Distinct de :
- `NO_DATA` (échec EODHD réel)
- `TIME_LIMIT` (sim normal sans hit)

**Cas typique** : scanner Asia → US session → Shenzhen fermé depuis 11h → latest candle 07:00 UTC < startTs 18:00 UTC. Auparavant `NO_DATA` polluait stats. Désormais `OFF_SESSION` exclu de `getRegretSummary`.

## Tests (5 nouveaux, 113 suites / 1383 tests verts)

- ✅ Asia ticker candles NOT shifted (verify revert) — TP_HIT correctement détecté
- ✅ US ticker zero offset (no regression)
- ✅ OFF_SESSION marqué quand toutes candles < startTs
- ✅ Pas OFF_SESSION quand mix avant/après startTs (flow normal)
- ✅ NO_DATA (pas OFF_SESSION) quand zero candles total

## Impact stats

Asia rows post-close (la majorité actuelle) : `NO_DATA` → `OFF_SESSION`. Stats `getRegretSummary` plus propres, pas de biais "Asia toutes échec data".

## Hors scope (PR #290 next)

Investiguer pourquoi `gainers_session_filter_enabled=true` ne filtre pas Asia rows post-close au scan-time (si fonctionnait, 0 rows OFF_SESSION).

## Test plan

- [x] Typecheck + Jest local : 113 suites / 1383 tests
- [ ] CI verte
- [ ] Post-merge Fly redeploy v458
- [ ] Re-sim Asia rows : `UPDATE gainers_user_shadow_signals SET sim_run_at=NULL, sim_results=NULL, fetch_diag=NULL WHERE asset_class='asia_equity' AND created_at > NOW() - INTERVAL '5 days' AND sim_results->'baseline_60m'->>'outcome' IN ('NO_DATA');`
- [ ] T+15min : SELECT distribution outcome → OFF_SESSION majoritaire sur Asia post-close, NO_DATA résiduel sur tickers sans coverage

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_