### PR TITLE
feat(analytics): post_sl_path JSONB + backfill + ATR analysis

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/post-sl-analysis.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/post-sl-analysis.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * PR #292 — Tests pure helper post_sl_analysis (rebound, ATR, drawdown).
+ */
+import {
+  computeAtr,
+  computePostSlAnalysis,
+  type OhlcCandle,
+} from '../services/post-sl-analysis.helper';
+
+function candle(ts: number, o: number, h: number, l: number, c: number): OhlcCandle {
+  return { timestamp: ts, open: o, high: h, low: l, close: c };
+}
+
+describe('computeAtr', () => {
+  it('returns null when not enough candles for period+1', () => {
+    const candles = Array.from({ length: 14 }, (_, i) => candle(1000 + i * 60, 100, 101, 99, 100));
+    expect(computeAtr(candles, 14)).toBeNull();
+  });
+
+  it('computes ATR(14) on sample with consistent volatility', () => {
+    // 15 candles, each with TR ≈ 1.0 (high-low = 1.0 systematically)
+    const candles = Array.from({ length: 15 }, (_, i) => candle(1000 + i * 60, 100, 101, 100, 100.5));
+    const atr = computeAtr(candles, 14);
+    expect(atr).not.toBeNull();
+    expect(atr).toBeCloseTo(1.0, 2);
+  });
+
+  it('handles gap-style TR via |high - close_prev|', () => {
+    // Candle gap up : high=105, close_prev=100 → TR_gap = 5
+    const candles: OhlcCandle[] = [
+      candle(1000, 100, 100.5, 99.5, 100),    // close_prev = 100
+      candle(1060, 105, 105.5, 104.5, 105),   // gap up : TR = max(1, |105.5 - 100|, |104.5 - 100|) = 5.5
+    ];
+    // Pour ATR(1) (period=1, need 2 candles)
+    const atr = computeAtr(candles, 1);
+    expect(atr).toBeCloseTo(5.5, 2);
+  });
+});
+
+describe('computePostSlAnalysis', () => {
+  const exitTs = 1700000000;
+  const exitPrice = 100;
+
+  it('detects rebound to 50% within 30min', () => {
+    // 30 candles 1min post-SL.
+    // Drawdown : low atteint 99 (drop 1%) après 5min
+    // Recovery : high atteint 99.5 (rebound 50% du drop -1% = +0.5% from low = 99.5) après 15min
+    const candlesPost: OhlcCandle[] = [
+      candle(exitTs + 60, 100, 100, 99.5, 99.5),     // 1min : drop 0.5%
+      candle(exitTs + 120, 99.5, 99.5, 99, 99),       // 2min : drop 1% (worst)
+      candle(exitTs + 300, 99, 99.5, 99, 99.5),       // 5min : already 50% recovery
+    ];
+    const result = computePostSlAnalysis({
+      exitPrice,
+      exitTimestamp: exitTs,
+      direction: 'long',
+      candlesPostSl: candlesPost,
+      candlesPriorAtr: [],
+    });
+    expect(result.max_drawdown_post_sl_pct).toBeCloseTo(-0.01, 4); // -1%
+    expect(result.max_recovery_post_sl_pct).toBeCloseTo(0, 4);
+    // recovery=0 vs |drawdown|/2=0.5%. 0 < 0.5% → rebound50 = false
+    expect(result.rebound_to_50pct_within_30min).toBe(false);
+  });
+
+  it('detects 100% rebound (high comes back to exitPrice)', () => {
+    const candlesPost: OhlcCandle[] = [
+      candle(exitTs + 60, 100, 100, 99, 99),
+      candle(exitTs + 120, 99, 100, 99, 100),  // rebond complet
+      candle(exitTs + 180, 100, 100.5, 100, 100.3),  // dépasse exitPrice
+    ];
+    const result = computePostSlAnalysis({
+      exitPrice,
+      exitTimestamp: exitTs,
+      direction: 'long',
+      candlesPostSl: candlesPost,
+      candlesPriorAtr: [],
+    });
+    // max recovery vs exitPrice = +0.5% (high 100.5)
+    expect(result.max_recovery_post_sl_pct).toBeCloseTo(0.005, 4);
+    // |max drawdown| = 1% (low 99). recovery 0.5% >= 1%/2 = 0.5% → rebound50 = true
+    expect(result.rebound_to_50pct_within_30min).toBe(true);
+    // recovery 0.5% < 1% (full drawdown) → rebound100 = false
+    expect(result.rebound_to_100pct_within_30min).toBe(false);
+  });
+
+  it('classifies as wick when drawdown < 1× ATR', () => {
+    // ATR : 14 candles 5m avec variation 0.01% chaque (bruit faible)
+    const candlesPriorAtr: OhlcCandle[] = Array.from({ length: 15 }, (_, i) =>
+      candle(exitTs - (15 - i) * 300, 100, 100.05, 99.95, 100)
+    );
+    // ATR ≈ 0.10 absolute / 100 = 0.001 = 0.1%
+    // Post-SL drawdown : 0.05% (= 0.05 absolute)
+    const candlesPost: OhlcCandle[] = [
+      candle(exitTs + 60, 100, 100, 99.95, 99.95),  // -0.05%
+    ];
+    const result = computePostSlAnalysis({
+      exitPrice,
+      exitTimestamp: exitTs,
+      direction: 'long',
+      candlesPostSl: candlesPost,
+      candlesPriorAtr,
+    });
+    expect(result.atr_14_at_exit_pct).toBeCloseTo(0.001, 4);
+    expect(result.max_drawdown_post_sl_pct).toBeCloseTo(-0.0005, 4);
+    // |drawdown| / atr = 0.0005 / 0.001 = 0.5 → wick
+    expect(result.drawdown_in_atr_units).toBeCloseTo(0.5, 2);
+    expect(result.drawdown_in_atr_units).toBeLessThan(1);
+  });
+
+  it('classifies as real move when drawdown > 2× ATR', () => {
+    // ATR low (0.1%), but drawdown big (0.5%)
+    const candlesPriorAtr: OhlcCandle[] = Array.from({ length: 15 }, (_, i) =>
+      candle(exitTs - (15 - i) * 300, 100, 100.05, 99.95, 100)
+    );
+    const candlesPost: OhlcCandle[] = [
+      candle(exitTs + 60, 100, 100, 99.5, 99.5),  // -0.5%
+    ];
+    const result = computePostSlAnalysis({
+      exitPrice,
+      exitTimestamp: exitTs,
+      direction: 'long',
+      candlesPostSl: candlesPost,
+      candlesPriorAtr,
+    });
+    expect(result.drawdown_in_atr_units).toBeCloseTo(5, 2);  // 0.005/0.001 = 5
+    expect(result.drawdown_in_atr_units).toBeGreaterThan(2);
+  });
+
+  it('handles empty post-SL candles gracefully', () => {
+    const result = computePostSlAnalysis({
+      exitPrice,
+      exitTimestamp: exitTs,
+      direction: 'long',
+      candlesPostSl: [],
+      candlesPriorAtr: [],
+    });
+    expect(result.max_drawdown_post_sl_pct).toBe(0);
+    expect(result.max_recovery_post_sl_pct).toBe(0);
+    expect(result.candle_count).toBe(0);
+    expect(result.atr_14_at_exit_pct).toBeNull();
+  });
+
+  it('inverts drawdown/recovery direction for short positions', () => {
+    // Short : prix monte = perte. exitPrice 100, high 102 = drawdown -2% (perte)
+    const candlesPost: OhlcCandle[] = [
+      candle(exitTs + 60, 100, 102, 100, 101),  // high 102 = mauvais pour short
+    ];
+    const result = computePostSlAnalysis({
+      exitPrice,
+      exitTimestamp: exitTs,
+      direction: 'short',
+      candlesPostSl: candlesPost,
+      candlesPriorAtr: [],
+    });
+    expect(result.max_drawdown_post_sl_pct).toBeCloseTo(-0.02, 4);  // -2% loss for short
+    expect(result.max_recovery_post_sl_pct).toBeCloseTo(0, 4);  // low=100=exit, no recovery
+  });
+});

--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -20,6 +20,7 @@ import { TopGainersScannerService } from './services/top-gainers-scanner.service
 import { TradingStatsService } from './services/trading-stats.service';
 import { GainersUserShadowService } from './services/gainers-user-shadow.service';
 import { GainersAutoRelaxService } from './services/gainers-auto-relax.service';
+import { PostSlBackfillService } from './services/post-sl-backfill.service';
 import { MultiTimeframePersistenceService } from './services/multi-tf-persistence.service';
 import { PersistenceProbabilityService } from './services/persistence-probability.service';
 import { EodhdQuotaService } from './services/eodhd-quota.service';
@@ -48,6 +49,7 @@ export class LisaController {
     private readonly tradingStats: TradingStatsService,
     private readonly gainersUserShadow: GainersUserShadowService,
     private readonly gainersAutoRelax: GainersAutoRelaxService,
+    private readonly postSlBackfill: PostSlBackfillService,
   ) {}
 
   // ─────────────────────────────────────────────────────────────────
@@ -858,6 +860,41 @@ export class LisaController {
   ) {
     const userId = extractUserId(headers);
     return this.gainersAutoRelax.applyProposal(proposalId, userId);
+  }
+
+  /**
+   * PR #292 — Backfill post_sl_path JSONB sur une position closed_stop.
+   * Refetch EODHD 1m candles 30min post-SL + 5m candles 75min prior pour ATR(14).
+   * Calcule rebound metrics, drawdown_in_atr_units, recovery thresholds.
+   * Utile pour analyser si les SL sont des wicks vs vrais mouvements.
+   */
+  @Post('positions/:positionId/backfill-post-sl-path')
+  @HttpCode(200)
+  async backfillPostSlPath(
+    @Headers() headers: Record<string, string>,
+    @Param('positionId') positionId: string,
+    @Query('force') forceRaw?: string,
+  ) {
+    extractUserId(headers);
+    const force = forceRaw === 'true';
+    return this.postSlBackfill.backfillOne(positionId, force);
+  }
+
+  /**
+   * PR #292 — Backfill batch (par défaut 10 closed_stop pending).
+   * Body : { limit?: number, portfolioId?: string }
+   */
+  @Post('positions/backfill-post-sl-path-batch')
+  @HttpCode(200)
+  async backfillPostSlPathBatch(
+    @Headers() headers: Record<string, string>,
+    @Body() body: { limit?: number; portfolioId?: string },
+  ) {
+    extractUserId(headers);
+    const limit = Math.max(1, Math.min(50, Number(body?.limit) || 10));
+    const opts: { limit: number; portfolioId?: string } = { limit };
+    if (body?.portfolioId) opts.portfolioId = body.portfolioId;
+    return this.postSlBackfill.backfillBatch(opts);
   }
 
   /**

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -48,6 +48,7 @@ import { OhlcvCacheService } from './services/ohlcv-cache.service';
 import { TopGainersScannerService } from './services/top-gainers-scanner.service';
 import { GainersUserShadowService } from './services/gainers-user-shadow.service';
 import { GainersAutoRelaxService } from './services/gainers-auto-relax.service';
+import { PostSlBackfillService } from './services/post-sl-backfill.service';
 import { ShadowExitSimulatorService } from './services/shadow-exit-simulator.service';
 import { OperatingModeService } from './services/operating-mode.service';
 import { MultiTimeframePersistenceService } from './services/multi-tf-persistence.service';
@@ -117,6 +118,8 @@ import { SignalForwardTrackerService } from '../gainers-scanner/automations/sign
     GainersUserShadowService,
     // PR #282 — Auto-relax adaptive : lit cumulative_regret 7j et propose/auto-applique relax
     GainersAutoRelaxService,
+    // PR #292 — Backfill post_sl_path JSONB (analysis rebound/ATR post closed_stop)
+    PostSlBackfillService,
     // PR6.5 — Worker exit-simulator : replay BLOC 4 state machine sur shadow signals ACCEPT
     ShadowExitSimulatorService,
     // P7-MODE-GAINERS-BADGE — toggle 3-modes opératoires (UI badge → DB strategy_mode)

--- a/apps/api/src/modules/lisa/services/post-sl-analysis.helper.ts
+++ b/apps/api/src/modules/lisa/services/post-sl-analysis.helper.ts
@@ -1,0 +1,133 @@
+/**
+ * PR #292 — Pure helper pour analyser le price action 30min post-SL.
+ *
+ * Inputs :
+ *   - exitPrice : prix au moment du SL trigger
+ *   - exitTimestamp : timestamp du SL (unix seconds)
+ *   - direction : 'long' | 'short' (gainers ouvre toujours long mais
+ *     futur-proof la signature)
+ *   - candlesPostSl : candles 1m sur [exitTs, exitTs + 30min] (sorted ASC)
+ *   - candlesPriorAtr : candles 5m AVANT exitTs (au moins 14 pour ATR(14))
+ *
+ * Outputs JSONB-ready :
+ *   - max_drawdown_post_sl_pct : % de baisse max après le SL (vs exitPrice)
+ *   - max_recovery_post_sl_pct : % de hausse max post-SL (vs exitPrice)
+ *   - rebound_to_50pct_within_30min : bool (high atteint exitPrice + |drawdown|/2 ?)
+ *   - rebound_to_100pct_within_30min : bool (high atteint exitPrice ?)
+ *   - atr_14_at_exit_pct : ATR(14) en % calculé sur les 14 dernières 5m candles
+ *   - drawdown_in_atr_units : |drawdown_pct| / atr_pct (>1 = vrai mouvement, <1 = wick)
+ *
+ * Source ATR formula : average True Range = AVG(max(high-low, |high-close_prev|, |low-close_prev|))
+ * sur 14 périodes. Référence : Wilder 1978 "New Concepts in Technical Trading Systems".
+ */
+
+export interface OhlcCandle {
+  timestamp: number;       // unix seconds
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+export interface PostSlAnalysis {
+  max_drawdown_post_sl_pct: number;       // négatif (baisse continuée after SL)
+  max_recovery_post_sl_pct: number;       // positif (rebond)
+  rebound_to_50pct_within_30min: boolean;
+  rebound_to_100pct_within_30min: boolean;
+  atr_14_at_exit_pct: number | null;
+  drawdown_in_atr_units: number | null;   // |drawdown_pct| / atr_pct
+  candle_count: number;
+}
+
+/**
+ * Compute Average True Range (ATR) sur N périodes.
+ * Inputs : candles ASC, retourne la valeur en valeur absolue (pas en %).
+ * Si moins de N+1 candles, retourne null (pas assez de data).
+ */
+export function computeAtr(candles: readonly OhlcCandle[], period = 14): number | null {
+  if (candles.length < period + 1) return null;
+  const trList: number[] = [];
+  // True Range nécessite la close précédente. On itère depuis index 1.
+  for (let i = 1; i < candles.length; i++) {
+    const c = candles[i];
+    const prevClose = candles[i - 1].close;
+    const tr = Math.max(
+      c.high - c.low,
+      Math.abs(c.high - prevClose),
+      Math.abs(c.low - prevClose),
+    );
+    trList.push(tr);
+  }
+  // ATR = simple average sur les `period` derniers TR
+  const lastN = trList.slice(-period);
+  if (lastN.length < period) return null;
+  const sum = lastN.reduce((acc, x) => acc + x, 0);
+  return sum / period;
+}
+
+/**
+ * Analyse complète post-SL : drawdown, recovery, rebound thresholds, ATR comparison.
+ * Pure function, testable isolation.
+ */
+export function computePostSlAnalysis(input: {
+  exitPrice: number;
+  exitTimestamp: number;
+  direction: 'long' | 'short';
+  candlesPostSl: readonly OhlcCandle[];      // sorted ASC, [exitTs, exitTs+30min]
+  candlesPriorAtr: readonly OhlcCandle[];    // sorted ASC, candles AVANT exitTs (5m TF)
+}): PostSlAnalysis {
+  const { exitPrice, candlesPostSl, candlesPriorAtr, direction } = input;
+
+  // Pour direction='long' : drawdown = baisse vs exitPrice, recovery = hausse
+  // Pour direction='short' : inverse (mais on garde la convention positif=movement adverse)
+  const isLong = direction === 'long';
+
+  let maxDrawdownPct = 0;   // toujours <= 0 (négatif si baisse pour long)
+  let maxRecoveryPct = 0;   // toujours >= 0 (positif si hausse pour long)
+
+  for (const c of candlesPostSl) {
+    if (isLong) {
+      // Drawdown = low le plus bas
+      const dropPct = (c.low - exitPrice) / exitPrice;  // négatif si low < exit
+      if (dropPct < maxDrawdownPct) maxDrawdownPct = dropPct;
+      // Recovery = high le plus haut
+      const recoveryPct = (c.high - exitPrice) / exitPrice;  // positif si high > exit
+      if (recoveryPct > maxRecoveryPct) maxRecoveryPct = recoveryPct;
+    } else {
+      // Short : drawdown = high (perte si prix monte), recovery = low
+      const dropPct = (exitPrice - c.high) / exitPrice;  // négatif si high > exit
+      if (dropPct < maxDrawdownPct) maxDrawdownPct = dropPct;
+      const recoveryPct = (exitPrice - c.low) / exitPrice;  // positif si low < exit
+      if (recoveryPct > maxRecoveryPct) maxRecoveryPct = recoveryPct;
+    }
+  }
+
+  // Rebound to 50% : recovery atteint au moins |drawdown|/2 vs exitPrice ?
+  // Rebound to 100% : recovery atteint exitPrice (= price came back to entry) ?
+  // Note : si maxDrawdownPct = 0 (pas de baisse), rebound_50 trivialement true.
+  const halfDrawdown = Math.abs(maxDrawdownPct) / 2;
+  const rebound50 = maxRecoveryPct >= halfDrawdown;
+  const rebound100 = maxRecoveryPct >= Math.abs(maxDrawdownPct);
+
+  // ATR(14) en % de exitPrice (rapporté à exitPrice pour comparaison drawdown)
+  const atrAbs = computeAtr(candlesPriorAtr, 14);
+  const atrPct = atrAbs != null ? atrAbs / exitPrice : null;
+  const drawdownInAtrUnits = atrPct != null && atrPct > 0
+    ? Math.abs(maxDrawdownPct) / atrPct
+    : null;
+
+  return {
+    max_drawdown_post_sl_pct: roundTo(maxDrawdownPct, 5),
+    max_recovery_post_sl_pct: roundTo(maxRecoveryPct, 5),
+    rebound_to_50pct_within_30min: rebound50,
+    rebound_to_100pct_within_30min: rebound100,
+    atr_14_at_exit_pct: atrPct != null ? roundTo(atrPct, 5) : null,
+    drawdown_in_atr_units: drawdownInAtrUnits != null ? roundTo(drawdownInAtrUnits, 3) : null,
+    candle_count: candlesPostSl.length,
+  };
+}
+
+function roundTo(value: number, decimals: number): number {
+  const f = Math.pow(10, decimals);
+  return Math.round(value * f) / f;
+}

--- a/apps/api/src/modules/lisa/services/post-sl-backfill.service.ts
+++ b/apps/api/src/modules/lisa/services/post-sl-backfill.service.ts
@@ -1,0 +1,165 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { EodhdIntradayService } from './eodhd-intraday.service';
+import {
+  computePostSlAnalysis,
+  type OhlcCandle,
+  type PostSlAnalysis,
+} from './post-sl-analysis.helper';
+
+/**
+ * PR #292 — Backfill `lisa_positions.post_sl_path` JSONB pour les closed_stop.
+ *
+ * Refetch EODHD :
+ *   - 1m candles sur [exit_timestamp, exit_timestamp + 30min] → analyse rebound
+ *   - 5m candles sur [exit_timestamp - 75min, exit_timestamp] → ATR(14) prior
+ *
+ * Limites :
+ *   - EODHD intraday 1m retention ~2 jours sur plan standard. Au-delà → null.
+ *   - 5m retention 5 jours.
+ *   - Trades > 5j ne pourront pas avoir le post_sl_path complet.
+ *
+ * Endpoint POST /lisa/positions/:id/backfill-post-sl-path déclenche row-by-row.
+ * Pour batch backfill, le caller (script ou cron) itère sur closed_stop pending.
+ */
+@Injectable()
+export class PostSlBackfillService {
+  private readonly logger = new Logger(PostSlBackfillService.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly eodhd: EodhdIntradayService,
+  ) {}
+
+  /**
+   * Backfill une seule position. Retourne le résultat ou error.
+   * Idempotent : si post_sl_path déjà populé, skip et return existant.
+   */
+  async backfillOne(positionId: string, force = false): Promise<{
+    ok: boolean;
+    analysis?: PostSlAnalysis;
+    error?: string;
+  }> {
+    const { data: pos, error: fetchErr } = await this.supabase.getClient()
+      .from('lisa_positions')
+      .select('id, symbol, status, exit_price, exit_timestamp, post_sl_path, direction')
+      .eq('id', positionId)
+      .single();
+
+    if (fetchErr || !pos) {
+      return { ok: false, error: `position_not_found: ${fetchErr?.message ?? 'no_row'}` };
+    }
+    if (pos.status !== 'closed_stop') {
+      return { ok: false, error: 'not_closed_stop' };
+    }
+    if (pos.post_sl_path && !force) {
+      return { ok: true, error: 'already_backfilled' };
+    }
+    if (!pos.exit_timestamp || !pos.exit_price) {
+      return { ok: false, error: 'missing_exit_data' };
+    }
+
+    const exitPrice = Number(pos.exit_price);
+    const exitTs = Math.floor(new Date(pos.exit_timestamp as string).getTime() / 1000);
+    const direction = (pos.direction as 'long' | 'short' | null) ?? 'long';
+
+    // Fetch 1m post-SL : window = [exitTs, exitTs + 30min + 60s buffer]
+    const postFromTs = exitTs;
+    const postToTs = exitTs + 30 * 60 + 60;
+    const seriesPost = await this.eodhd
+      .getCandles(String(pos.symbol), '1m', 35, { fromTs: postFromTs, toTs: postToTs })
+      .catch(() => null);
+
+    if (!seriesPost || seriesPost.candles.length === 0) {
+      const errBlob = {
+        error: 'eodhd_post_sl_empty',
+        fetched_at: new Date().toISOString(),
+      };
+      await this.supabase.getClient()
+        .from('lisa_positions')
+        .update({ post_sl_path: errBlob })
+        .eq('id', positionId);
+      return { ok: false, error: 'eodhd_post_sl_empty' };
+    }
+
+    const candlesPostSl: OhlcCandle[] = seriesPost.candles
+      .filter((c) => c.timestamp >= exitTs && c.close > 0)
+      .sort((a, b) => a.timestamp - b.timestamp);
+
+    // Fetch 5m prior ATR : window = [exitTs - 75min, exitTs]
+    // 14 ATR periods × 5min = 70min, +5min buffer
+    const priorFromTs = exitTs - 75 * 60;
+    const priorToTs = exitTs;
+    const seriesPrior = await this.eodhd
+      .getCandles(String(pos.symbol), '5m', 20, { fromTs: priorFromTs, toTs: priorToTs })
+      .catch(() => null);
+
+    const candlesPriorAtr: OhlcCandle[] = seriesPrior?.candles
+      .filter((c) => c.close > 0)
+      .sort((a, b) => a.timestamp - b.timestamp) ?? [];
+
+    const analysis = computePostSlAnalysis({
+      exitPrice,
+      exitTimestamp: exitTs,
+      direction,
+      candlesPostSl,
+      candlesPriorAtr,
+    });
+
+    const persistBlob = {
+      ...analysis,
+      exit_price: exitPrice,
+      direction,
+      candles_1m: candlesPostSl.slice(0, 30),  // store max 30 candles raw
+      fetched_at: new Date().toISOString(),
+    };
+
+    await this.supabase.getClient()
+      .from('lisa_positions')
+      .update({ post_sl_path: persistBlob })
+      .eq('id', positionId);
+
+    this.logger.log(
+      `[post-sl-backfill] ${pos.symbol} pos=${positionId.slice(0, 8)}: ` +
+      `dd=${analysis.max_drawdown_post_sl_pct} recovery=${analysis.max_recovery_post_sl_pct} ` +
+      `rebound50=${analysis.rebound_to_50pct_within_30min} atr=${analysis.atr_14_at_exit_pct} ` +
+      `dd_in_atr=${analysis.drawdown_in_atr_units}`,
+    );
+
+    return { ok: true, analysis };
+  }
+
+  /**
+   * Batch : backfill toutes les closed_stop sans post_sl_path,
+   * limit configurable (default 10 pour ne pas saturer EODHD quota).
+   */
+  async backfillBatch(opts: { limit?: number; portfolioId?: string } = {}): Promise<{
+    processed: number;
+    succeeded: number;
+    failed: number;
+  }> {
+    const limit = opts.limit ?? 10;
+    let query = this.supabase.getClient()
+      .from('lisa_positions')
+      .select('id')
+      .eq('status', 'closed_stop')
+      .is('post_sl_path', null)
+      .order('exit_timestamp', { ascending: false })
+      .limit(limit);
+    if (opts.portfolioId) {
+      query = query.eq('portfolio_id', opts.portfolioId);
+    }
+    const { data: rows, error } = await query;
+    if (error || !rows) {
+      this.logger.warn(`[post-sl-backfill] batch query failed: ${error?.message ?? 'no_data'}`);
+      return { processed: 0, succeeded: 0, failed: 0 };
+    }
+    let succeeded = 0;
+    let failed = 0;
+    for (const row of rows) {
+      const result = await this.backfillOne(String(row.id));
+      if (result.ok) succeeded++; else failed++;
+    }
+    return { processed: rows.length, succeeded, failed };
+  }
+}

--- a/supabase/migrations/0137_lisa_positions_post_sl_path.sql
+++ b/supabase/migrations/0137_lisa_positions_post_sl_path.sql
@@ -1,0 +1,46 @@
+-- 0137_lisa_positions_post_sl_path
+--
+-- PR #292 — Post-SL path analysis pour identifier wick-stops vs vrais SL.
+--
+-- Contexte : analyse Kelly du 08/05/2026 montre R-ratio = 1.067 (proche
+-- de 1) au lieu du 2.22 théorique (TP 2% / SL 0.9%). Hypothèse : 24% des
+-- closed_stop sont des "early exits" RSI/MACD prématurés (PnL -0.1% à
+-- -0.7%, bien avant le SL) ET certains stops "réels" sont des wicks
+-- (drawdown < 1× ATR puis rebound).
+--
+-- Cette colonne capture le price action 30min POST-SL pour chaque trade
+-- closed_stop, afin de mesurer :
+--   - Quel % des SL ont rebondi ≥ 50% du drawdown dans les 30min ?
+--   - Quel % était un wick (drawdown < 1× ATR) vs vrai mouvement (>= 2× ATR) ?
+--   - SL fixe 0.9% est-il trop serré vs ATR(14) instantané ?
+--
+-- Schema JSONB :
+--   {
+--     "exit_price": <number>,
+--     "candles_1m": [{ ts, open, high, low, close, volume }, ...] (max 30),
+--     "max_drawdown_post_sl_pct": <number>,        -- worst additional loss
+--     "max_recovery_post_sl_pct": <number>,        -- best recovery vs exit_price
+--     "rebound_to_50pct_within_30min": <bool>,
+--     "rebound_to_100pct_within_30min": <bool>,    -- price came back above entry?
+--     "atr_14_at_exit_pct": <number>,              -- ATR(14) calc en %
+--     "drawdown_in_atr_units": <number>,           -- |drawdown| / atr → < 1 = wick
+--     "candle_count": <int>,
+--     "fetched_at": <iso timestamp>,
+--     "error": <string?>                            -- si refetch a échoué
+--   }
+--
+-- Populated par backfill manuel (endpoint POST /lisa/positions/:id/backfill-post-sl-path)
+-- ou par un script one-shot. Pas backfill auto au close (limite EODHD calls).
+
+ALTER TABLE public.lisa_positions
+  ADD COLUMN IF NOT EXISTS post_sl_path JSONB;
+
+CREATE INDEX IF NOT EXISTS lisa_positions_post_sl_path_pending_idx
+  ON public.lisa_positions(exit_timestamp DESC)
+  WHERE status = 'closed_stop' AND post_sl_path IS NULL;
+
+COMMENT ON COLUMN public.lisa_positions.post_sl_path IS
+  'PR #292 — JSONB avec price action 30min post-SL : candles_1m, max_drawdown_post_sl_pct, '
+  'max_recovery_post_sl_pct, rebound_to_50pct_within_30min, atr_14_at_exit_pct, '
+  'drawdown_in_atr_units. Permet de distinguer wick-stops (drawdown < 1× ATR) '
+  'vs vrais SL. Populated via backfill manuel (endpoint dédié).';


### PR DESCRIPTION
## 🎯 Objectif — Analyse forensique des 22 closed_stop

Le Kelly négatif (-4.32%, R=1.067) suggère que les SL coupent souvent **avant le vrai mouvement**. Cette PR fournit la data pour distinguer :
- **Wick stops** (drawdown < 1× ATR) → SL trop serré
- **Real moves** (drawdown > 2× ATR) → SL légitime
- **Rebounds** ≥ 50% du drawdown dans les 30min post-SL

## Architecture (~540 LoC, 9 tests)

### Migration `0137_lisa_positions_post_sl_path.sql`
Colonne `post_sl_path JSONB` + index partiel sur `(status='closed_stop' AND post_sl_path IS NULL)`.

### Pure helper `post-sl-analysis.helper.ts`
- `computeAtr(candles, period=14)` — Wilder 1978 ATR formula
- `computePostSlAnalysis({...})` — drawdown + recovery + rebound 50%/100% + ATR-units classification

### Service `PostSlBackfillService`
- `backfillOne(positionId, force?)` : refetch EODHD 1m post-SL [+30min] + 5m prior [-75min] pour ATR(14), persist JSONB
- `backfillBatch({ limit, portfolioId? })` : batch closed_stop pending

### Endpoints
```
POST /lisa/positions/:id/backfill-post-sl-path?force=true
POST /lisa/positions/backfill-post-sl-path-batch  body { limit: 30, portfolioId: "..." }
```

## SQL d'analyse post-deploy

```sql
-- 1. Trigger backfill batch via curl/Postman
-- POST /lisa/positions/backfill-post-sl-path-batch
--      { "limit": 30, "portfolioId": "58439d86-..." }

-- 2. Distribution wick vs real move
SELECT
  CASE
    WHEN (post_sl_path->>'drawdown_in_atr_units')::numeric < 1 THEN 'wick'
    WHEN (post_sl_path->>'drawdown_in_atr_units')::numeric < 2 THEN 'borderline'
    ELSE 'real_move'
  END AS sl_classification,
  COUNT(*) AS n,
  ROUND(AVG((post_sl_path->>'max_drawdown_post_sl_pct')::numeric)::numeric * 100, 3) AS avg_dd_pct,
  COUNT(*) FILTER (WHERE (post_sl_path->>'rebound_to_50pct_within_30min')::bool) AS rebound_50,
  COUNT(*) FILTER (WHERE (post_sl_path->>'rebound_to_100pct_within_30min')::bool) AS rebound_100
FROM public.lisa_positions
WHERE portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2'
  AND status = 'closed_stop'
  AND post_sl_path IS NOT NULL
  AND post_sl_path->>'error' IS NULL
GROUP BY sl_classification
ORDER BY n DESC;
```

## Décodage attendu

| Pattern | Diagnostic | Recommandation |
|---|---|---|
| `> 50%` wick | SL fixe 0.9% trop serré | SL dynamique 1.5-2× ATR(14) |
| `> 70%` rebound_50 | Mean-reversion intraday (Avellaneda-Lee 2010) | Trailing stop large + resserrer post-confirm |
| `> 50%` real_move | SL légitime, pas de bug | Fix R-ratio via exits réactifs (PR future) |

## Limites

- **EODHD 1m retention ~2j** sur plan standard. Trades > 2j → `error: 'eodhd_post_sl_empty'` persisté
- **Pas de SL dynamique en open** (lecture seule cette PR — measure first)
- **Pas de cron auto-backfill** : on-demand via endpoint pour quota EODHD

## Tests

- ✅ 9 nouveaux tests (computeAtr ×3, computePostSlAnalysis ×6)
- ✅ 115 suites / 1395 tests verts
- ✅ Long/short symétrique testé

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_