### PR TITLE
PR Phase 1 — Statistical pre-trade filters (earnings + opening buffer)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/scanner-stat-filters.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/scanner-stat-filters.spec.ts
@@ -8,7 +8,8 @@
 
 describe('PR Phase 1 — Earnings filter logic', () => {
   it('threshold 0 (default) → filter disabled, no skip', () => {
-    const earningsFilterDays = Number(undefined ?? '0');
+    const envValue: string | undefined = undefined;
+    const earningsFilterDays = Number(envValue ?? '0');
     expect(earningsFilterDays).toBe(0);
     expect(earningsFilterDays > 0).toBe(false);
   });
@@ -125,25 +126,25 @@ describe('PR Phase 1 — Crypto exempt from both filters', () => {
   // Both filters check `cand.assetClass !== 'crypto_major' && cand.assetClass !== 'crypto_alt'`.
 
   it('crypto_major bypasses earnings filter', () => {
-    const assetClass = 'crypto_major';
+    const assetClass: string = 'crypto_major';
     const isNonCrypto = assetClass !== 'crypto_major' && assetClass !== 'crypto_alt';
     expect(isNonCrypto).toBe(false);  // crypto = no filter
   });
 
   it('crypto_alt bypasses opening buffer filter', () => {
-    const assetClass = 'crypto_alt';
+    const assetClass: string = 'crypto_alt';
     const isNonCrypto = assetClass !== 'crypto_major' && assetClass !== 'crypto_alt';
     expect(isNonCrypto).toBe(false);
   });
 
   it('us_equity_large gets filters applied', () => {
-    const assetClass = 'us_equity_large';
+    const assetClass: string = 'us_equity_large';
     const isNonCrypto = assetClass !== 'crypto_major' && assetClass !== 'crypto_alt';
     expect(isNonCrypto).toBe(true);
   });
 
   it('asia_equity gets filters applied', () => {
-    const assetClass = 'asia_equity';
+    const assetClass: string = 'asia_equity';
     const isNonCrypto = assetClass !== 'crypto_major' && assetClass !== 'crypto_alt';
     expect(isNonCrypto).toBe(true);
   });

--- a/apps/api/src/modules/lisa/__tests__/scanner-stat-filters.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/scanner-stat-filters.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * PR Phase 1 — Tests des filtres statistiques pré-trade.
+ *
+ * Tests UNIT du comportement attendu (env GAINERS_EARNINGS_FILTER_DAYS et
+ * GAINERS_OPEN_BUFFER_MIN). Pas d'intégration scanner complète : on teste
+ * la logique de décision en isolation.
+ */
+
+describe('PR Phase 1 — Earnings filter logic', () => {
+  it('threshold 0 (default) → filter disabled, no skip', () => {
+    const earningsFilterDays = Number(undefined ?? '0');
+    expect(earningsFilterDays).toBe(0);
+    expect(earningsFilterDays > 0).toBe(false);
+  });
+
+  it('threshold 1 → skip si earnings dans 1 jour', () => {
+    const earningsFilterDays = 1;
+    const nextEarnings = new Date(Date.now() + 12 * 3600 * 1000).toISOString();
+    const daysUntil = Math.floor(
+      (new Date(nextEarnings).getTime() - Date.now()) / 86_400_000,
+    );
+    expect(daysUntil >= 0 && daysUntil <= earningsFilterDays).toBe(true);  // skip
+  });
+
+  it('threshold 1 → no skip si earnings dans 3 jours', () => {
+    const earningsFilterDays = 1;
+    const nextEarnings = new Date(Date.now() + 3 * 86_400_000).toISOString();
+    const daysUntil = Math.floor(
+      (new Date(nextEarnings).getTime() - Date.now()) / 86_400_000,
+    );
+    expect(daysUntil >= 0 && daysUntil <= earningsFilterDays).toBe(false);  // proceed
+  });
+
+  it('threshold 2 → skip si earnings dans 1 ou 2 jours', () => {
+    const earningsFilterDays = 2;
+    const t1 = new Date(Date.now() + 1 * 86_400_000).toISOString();
+    const t2 = new Date(Date.now() + 2 * 86_400_000).toISOString();
+    const t3 = new Date(Date.now() + 3 * 86_400_000).toISOString();
+    const daysUntil1 = Math.floor((new Date(t1).getTime() - Date.now()) / 86_400_000);
+    const daysUntil2 = Math.floor((new Date(t2).getTime() - Date.now()) / 86_400_000);
+    const daysUntil3 = Math.floor((new Date(t3).getTime() - Date.now()) / 86_400_000);
+
+    expect(daysUntil1 >= 0 && daysUntil1 <= earningsFilterDays).toBe(true);   // skip
+    expect(daysUntil2 >= 0 && daysUntil2 <= earningsFilterDays).toBe(true);   // skip
+    expect(daysUntil3 >= 0 && daysUntil3 <= earningsFilterDays).toBe(false);  // proceed
+  });
+
+  it('past earnings ignored (daysUntil < 0)', () => {
+    const earningsFilterDays = 1;
+    const pastEarnings = new Date(Date.now() - 86_400_000).toISOString();
+    const daysUntil = Math.floor(
+      (new Date(pastEarnings).getTime() - Date.now()) / 86_400_000,
+    );
+    expect(daysUntil < 0).toBe(true);  // past earnings = skip filter
+  });
+});
+
+describe('PR Phase 1 — Opening buffer filter logic', () => {
+  // NYSE open = 13:30 UTC (= 9:30 EDT)
+  // Asia open = 00:00 UTC
+  // EU open = 08:00 UTC
+
+  function computeMinsSinceOpen(nowUtc: Date, openUtcMin: number): number {
+    const nowMin = nowUtc.getUTCHours() * 60 + nowUtc.getUTCMinutes();
+    return nowMin - openUtcMin;
+  }
+
+  it('NYSE 13:32 UTC = 2min after open → skip if buffer=5', () => {
+    const buffer = 5;
+    const nyseOpen = 13 * 60 + 30;
+    const now = new Date('2026-05-13T13:32:00Z');  // Wed 13:32 UTC
+    const mins = computeMinsSinceOpen(now, nyseOpen);
+    expect(mins).toBe(2);
+    expect(mins >= 0 && mins < buffer).toBe(true);  // skip
+  });
+
+  it('NYSE 13:35 UTC = 5min after open → no skip if buffer=5', () => {
+    const buffer = 5;
+    const nyseOpen = 13 * 60 + 30;
+    const now = new Date('2026-05-13T13:35:00Z');
+    const mins = computeMinsSinceOpen(now, nyseOpen);
+    expect(mins).toBe(5);
+    expect(mins >= 0 && mins < buffer).toBe(false);  // proceed (>= 5)
+  });
+
+  it('NYSE 13:30 UTC = 0min exactly at open → skip if buffer=5', () => {
+    const buffer = 5;
+    const nyseOpen = 13 * 60 + 30;
+    const now = new Date('2026-05-13T13:30:00Z');
+    const mins = computeMinsSinceOpen(now, nyseOpen);
+    expect(mins).toBe(0);
+    expect(mins >= 0 && mins < buffer).toBe(true);
+  });
+
+  it('NYSE 13:29 UTC = -1min before open → no skip', () => {
+    const buffer = 5;
+    const nyseOpen = 13 * 60 + 30;
+    const now = new Date('2026-05-13T13:29:00Z');
+    const mins = computeMinsSinceOpen(now, nyseOpen);
+    expect(mins).toBe(-1);
+    expect(mins >= 0 && mins < buffer).toBe(false);  // pre-market, not in buffer
+  });
+
+  it('Asia 00:03 UTC = 3min after Asia open → skip if buffer=10', () => {
+    const buffer = 10;
+    const asiaOpen = 0;
+    const now = new Date('2026-05-13T00:03:00Z');
+    const mins = computeMinsSinceOpen(now, asiaOpen);
+    expect(mins).toBe(3);
+    expect(mins >= 0 && mins < buffer).toBe(true);
+  });
+
+  it('buffer 0 (default) → never skip', () => {
+    const buffer = 0;
+    const nyseOpen = 13 * 60 + 30;
+    const now = new Date('2026-05-13T13:30:00Z');
+    const mins = computeMinsSinceOpen(now, nyseOpen);
+    expect(mins).toBe(0);
+    expect(mins >= 0 && mins < buffer).toBe(false);  // 0 < 0 is false, proceed
+  });
+});
+
+describe('PR Phase 1 — Crypto exempt from both filters', () => {
+  // Crypto candidates have assetClass 'crypto_major' or 'crypto_alt'.
+  // Both filters check `cand.assetClass !== 'crypto_major' && cand.assetClass !== 'crypto_alt'`.
+
+  it('crypto_major bypasses earnings filter', () => {
+    const assetClass = 'crypto_major';
+    const isNonCrypto = assetClass !== 'crypto_major' && assetClass !== 'crypto_alt';
+    expect(isNonCrypto).toBe(false);  // crypto = no filter
+  });
+
+  it('crypto_alt bypasses opening buffer filter', () => {
+    const assetClass = 'crypto_alt';
+    const isNonCrypto = assetClass !== 'crypto_major' && assetClass !== 'crypto_alt';
+    expect(isNonCrypto).toBe(false);
+  });
+
+  it('us_equity_large gets filters applied', () => {
+    const assetClass = 'us_equity_large';
+    const isNonCrypto = assetClass !== 'crypto_major' && assetClass !== 'crypto_alt';
+    expect(isNonCrypto).toBe(true);
+  });
+
+  it('asia_equity gets filters applied', () => {
+    const assetClass = 'asia_equity';
+    const isNonCrypto = assetClass !== 'crypto_major' && assetClass !== 'crypto_alt';
+    expect(isNonCrypto).toBe(true);
+  });
+});

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -33,6 +33,8 @@ export type ShadowDecision =
   | 'reject_p_win'
   | 'reject_budget_cap'
   | 'reject_no_tf_data'
+  | 'reject_earnings_imminent'  // PR Phase 1 — earnings dans la fenêtre filter
+  | 'reject_opening_buffer'     // PR Phase 1 — premières N min après open
   | 'reject_other';
 
 export interface RecordDecisionInput {

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -31,6 +31,7 @@ import { BinanceMarketService } from './binance-market.service';
 import { MultiTimeframePersistenceService, type PersistenceWithPath } from './multi-tf-persistence.service';
 import { PersistenceProbabilityService } from './persistence-probability.service';
 import { EodhdQuotaService } from './eodhd-quota.service';
+import { EodhdCalendarService } from './eodhd-calendar.service';
 import { GainersUserShadowService, type ShadowDecision } from './gainers-user-shadow.service';
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
 // PR6.3 — Shadow wiring (LisaModule import GainersModule pour résolution DI)
@@ -500,6 +501,12 @@ export class TopGainersScannerService implements OnModuleInit {
      * silencieusement quand absent (cf. call sites).
      */
     private readonly userShadow?: GainersUserShadowService,
+    /**
+     * PR Phase 1 — EODHD calendar service pour earnings filter pré-trade.
+     * Optional pour back-compat tests (qui n'injectent pas le calendar).
+     * Quand undefined → earnings filter no-op silencieux.
+     */
+    private readonly eodhdCalendar?: EodhdCalendarService,
   ) {}
 
   /**
@@ -1866,6 +1873,54 @@ export class TopGainersScannerService implements OnModuleInit {
           );
           recordShadowDecision(cand, 'reject_post_sl_cooldown', undefined);
           continue;
+        }
+      }
+
+      // PR Phase 1 — Statistical pré-trade filters (env-gated, default off).
+      //
+      // Filtre #1 : earnings_tomorrow → skip si earnings dans N jours (default 1).
+      // Justification : earnings = event binaire, gap risk démeures momentum.
+      // Configurable via env GAINERS_EARNINGS_FILTER_DAYS (default 0 = disabled).
+      const earningsFilterDays = Number(this.config.get<string>('GAINERS_EARNINGS_FILTER_DAYS') ?? '0');
+      if (earningsFilterDays > 0 && this.eodhdCalendar && cand.assetClass !== 'crypto_major' && cand.assetClass !== 'crypto_alt') {
+        try {
+          const nextEarnings = await this.eodhdCalendar.getNextEarningsDate(cand.symbol, earningsFilterDays + 1);
+          if (nextEarnings) {
+            const daysUntil = Math.floor(
+              (new Date(nextEarnings).getTime() - Date.now()) / 86_400_000,
+            );
+            if (daysUntil >= 0 && daysUntil <= earningsFilterDays) {
+              this.logger.log(
+                `[top-gainers] ${cand.symbol} earnings ${nextEarnings} dans ${daysUntil}j (filter window=${earningsFilterDays}j) → skip`,
+              );
+              recordShadowDecision(cand, 'reject_earnings_imminent', undefined);
+              continue;
+            }
+          }
+        } catch {
+          // Earnings fetch fail = proceed (fail-safe, ne bloque pas le trade)
+        }
+      }
+
+      // Filtre #2 : opening_buffer → skip si dans les N premières minutes après
+      // open du marché concerné. Justification : volatilité/slippage gap-fill,
+      // faux signaux de momentum sur premier tick. Crypto exempt (24/7, no open).
+      // Configurable via env GAINERS_OPEN_BUFFER_MIN (default 0 = disabled).
+      const openBufferMin = Number(this.config.get<string>('GAINERS_OPEN_BUFFER_MIN') ?? '0');
+      if (openBufferMin > 0 && cand.assetClass !== 'crypto_major' && cand.assetClass !== 'crypto_alt') {
+        const sessionCls = sessionClassFor(cand.assetClass);
+        if (sessionCls) {
+          const { openUtcMin } = MARKET_SESSION_HOURS[sessionCls];
+          // `nowUtc` = new Date() défini plus haut L1525 (in scope ici)
+          const localNowMin = nowUtc.getUTCHours() * 60 + nowUtc.getUTCMinutes();
+          const localMinsSinceOpen = localNowMin - openUtcMin;
+          if (localMinsSinceOpen >= 0 && localMinsSinceOpen < openBufferMin) {
+            this.logger.log(
+              `[top-gainers] ${cand.symbol} (${sessionCls}) opening buffer ${localMinsSinceOpen}/${openBufferMin}min → skip`,
+            );
+            recordShadowDecision(cand, 'reject_opening_buffer', undefined);
+            continue;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

Pré-trade filters env-gated (default OFF, back-compat) pour réduire les entrées défavorables sans LLM, sans backtest préalable nécessaire (filtres déterministes, low-risk).

**Phase 0 résultat** : 0/36 trades SL avaient un rebond >1% post-SL → pas de regret pre-SL → **Phase 4 du plan original (LLM pre-SL gate) abandonnée empiriquement**. Phase 1 indépendante du pattern rebond, reste pertinente.

## 2 filtres ajoutés

### Filtre #1 — `earnings_imminent`

Skip candidat si earnings dans N jours. Réutilise `EodhdCalendarService.getNextEarningsDate` (cached).

```bash
flyctl secrets set GAINERS_EARNINGS_FILTER_DAYS=1 -a smartvest  # skip <= 1j
```

Crypto exempt (assetClass `crypto_major`/`crypto_alt` = no earnings).

### Filtre #2 — `opening_buffer`

Skip candidat si dans les N premières minutes après open du marché concerné. Mappage session class déjà existant :
- US RTH = 13:30 UTC
- EU = 08:00 UTC
- Asia = 00:00 UTC

```bash
flyctl secrets set GAINERS_OPEN_BUFFER_MIN=5 -a smartvest  # skip 5min après open
```

Crypto exempt (24/7).

## Test plan

- [x] **944/944 lisa tests** pass
- [x] `tsc --noEmit` clean
- [x] **15 specs** Phase 1 (earnings threshold 0/1/2, past earnings, NYSE/Asia open buffer borders, crypto bypass)
- [x] **Backward-compat** : default `0` = filters disabled, comportement actuel inchangé
- [ ] **A/B test 2 semaines post-activation** : KPI = expectancy/trade (pas juste win rate)

## LoC stats

```
Net : +207 / 0 = +207
- Tests       : ~73% (~150 LoC, 15 specs)
- Code        : ~27% (~57 LoC dont ~25 commentaires)
```

## Activation post-merge

1. Merge → Fly redeploy auto ~5min
2. Activation progressive recommandée (1 filtre à la fois) :
   ```bash
   flyctl secrets set GAINERS_EARNINGS_FILTER_DAYS=1 -a smartvest
   # Attendre 1 semaine + mesure KPI
   flyctl secrets set GAINERS_OPEN_BUFFER_MIN=5 -a smartvest
   # Attendre 1 semaine + mesure KPI
   ```
3. **KPI à mesurer** (par filtre, sur 7-14j) :
   ```sql
   SELECT
     CASE
       WHEN closed_reason ILIKE '%earnings%' THEN 'rejected_earnings'
       WHEN closed_reason ILIKE '%opening_buffer%' THEN 'rejected_open_buffer'
       ELSE 'accepted'
     END AS bucket,
     COUNT(*) AS n,
     ROUND(AVG(pnl_pct)::numeric, 3) AS avg_pnl,
     ROUND(SUM(pnl_pct)::numeric, 2) AS sum_pnl
   FROM lisa_positions
   WHERE created_at > NOW() - INTERVAL '14 days'
   GROUP BY bucket;
   ```
4. **Threshold de validation** : expectancy ≥ +0.4%/trade pour activé vs ~+0.26% baseline (cf. plan stratégique)

## Out of scope (follow-up)

- **Phase 1b** : volume_avg filter (~50 LoC) + 3SMA extension Z-score (~80 LoC) — à scope si Phase 1 valide
- **Phase 2** : ATR-based dynamic SL — à reconsidérer après analyse RSI-TP exits (cf. issue #298 réorientée)
- **Phase 3** : LLM macro veto hourly (#300) — conditionnel sur résultats Phase 1+2

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_