### PR TITLE
PR — EU weekend skip (residual #301 fix)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/scanner-session-aware.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/scanner-session-aware.spec.ts
@@ -109,3 +109,66 @@ describe('PR #298 BUG 1 — Session-aware skip logic', () => {
     expect(skipped).toHaveLength(0);  // 0 skip = back-compat preserved
   });
 });
+
+describe('PR follow-up — EU weekend skip (sessionAware mode)', () => {
+  // Bug résiduel observé prod 09/05/2026 10:00 UTC samedi :
+  //   [top-gainers] EU session active (cac40/dax40/ftse100), scanning 9 exchanges
+  // alors que EU markets sont fermés weekend.
+  //
+  // Cause : isWithinSession (helper) check uniquement open/close UTC, pas
+  // weekend. Saturday 10:00 UTC ∈ [08:00, 16:30] → returns true.
+  //
+  // Fix : wrap getActiveEuWatchlists avec isMarketOpen('eu', now) qui check
+  // weekend ET hours, quand sessionAware=true.
+
+  it('isMarketOpen("eu") returns FALSE on Saturday in EU window', () => {
+    // Saturday 2026-05-09T10:00:00Z = 12:00 CEST samedi
+    // Inside EU window 08:00-16:30 UTC mais Saturday → must be false
+    const saturdayInWindow = new Date('2026-05-09T10:00:00Z');
+    expect(isMarketOpen('eu', saturdayInWindow)).toBe(false);
+  });
+
+  it('isMarketOpen("eu") returns FALSE on Sunday in EU window', () => {
+    const sundayInWindow = new Date('2026-05-10T12:00:00Z');
+    expect(isMarketOpen('eu', sundayInWindow)).toBe(false);
+  });
+
+  it('isMarketOpen("eu") returns TRUE on Wednesday in EU window', () => {
+    // Wed 2026-05-13T10:00:00Z = 12:00 CEST mercredi
+    const wedInWindow = new Date('2026-05-13T10:00:00Z');
+    expect(isMarketOpen('eu', wedInWindow)).toBe(true);
+  });
+
+  it('isMarketOpen("eu") returns FALSE Wed before open', () => {
+    // Wed 07:30 UTC = before 08:00 UTC open
+    const wedBeforeOpen = new Date('2026-05-13T07:30:00Z');
+    expect(isMarketOpen('eu', wedBeforeOpen)).toBe(false);
+  });
+
+  it('isMarketOpen("eu") returns FALSE Wed after close', () => {
+    // Wed 17:00 UTC = after 16:30 UTC close
+    const wedAfterClose = new Date('2026-05-13T17:00:00Z');
+    expect(isMarketOpen('eu', wedAfterClose)).toBe(false);
+  });
+
+  it('sessionAware=true + Saturday → euMarketOpen=false → skip EU watchlists fetch', () => {
+    const sessionAware = true;
+    const saturday = new Date('2026-05-09T10:00:00Z');
+    const euMarketOpen = !sessionAware || isMarketOpen('eu', saturday);
+    expect(euMarketOpen).toBe(false);  // skip EU
+  });
+
+  it('sessionAware=true + Wed → euMarketOpen=true → fetch EU watchlists', () => {
+    const sessionAware = true;
+    const wed = new Date('2026-05-13T10:00:00Z');
+    const euMarketOpen = !sessionAware || isMarketOpen('eu', wed);
+    expect(euMarketOpen).toBe(true);  // fetch
+  });
+
+  it('sessionAware=false (back-compat) → euMarketOpen=true regardless', () => {
+    const sessionAware = false;
+    const saturday = new Date('2026-05-09T10:00:00Z');
+    const euMarketOpen = !sessionAware || isMarketOpen('eu', saturday);
+    expect(euMarketOpen).toBe(true);  // legacy behavior preserved
+  });
+});

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -1072,7 +1072,15 @@ export class TopGainersScannerService implements OnModuleInit {
       }
 
       // EU exchanges gated on session windows.
-      const activeEu = await this.getActiveEuWatchlists(now);
+      // PR follow-up #303 — Bug résiduel : `getActiveEuWatchlists` (via
+      // `isWithinSession` helper) check uniquement open/close UTC, pas le
+      // weekend. Saturday 10:00 UTC tombe dans la fenêtre 08:00-16:30 UTC
+      // → considéré "active" alors qu'EU markets sont fermés samedi/dimanche.
+      // Fix : wrap avec `isMarketOpen('eu', now)` (qui check weekend ET hours)
+      // quand SCANNER_SESSION_AWARE=true. Économie : ~9 calls EODHD screener
+      // /cycle weekend = ~5k calls supplémentaires sauvés.
+      const euMarketOpen = !sessionAware || isMarketOpen('eu', now);
+      const activeEu = euMarketOpen ? await this.getActiveEuWatchlists(now) : [];
       if (activeEu.length > 0) {
         this.logger.log(
           `[top-gainers] EU session active (${activeEu.join('/')}), scanning ${EU_EXCHANGES.length} exchanges: ${EU_EXCHANGES.join(',')}`,
@@ -1085,6 +1093,10 @@ export class TopGainersScannerService implements OnModuleInit {
             }),
           );
         }
+      } else if (sessionAware && !euMarketOpen) {
+        this.logger.log(
+          `[top-gainers] session-aware fetch: EU markets closed (weekend or off-hours UTC=${now.toISOString().slice(11, 16)}) — saved ${EU_EXCHANGES.length} EODHD screener calls`,
+        );
       } else {
         this.logger.log(
           `[top-gainers] EU sessions closed — skipping ${EU_EXCHANGES.length} exchanges (${EU_EXCHANGES.join(',')})`,


### PR DESCRIPTION
## Summary

**Bug résiduel** observé prod 09/05/2026 10:00 UTC samedi (post-merge PR #301) :

```
[top-gainers] EU session active (cac40/dax40/ftse100), scanning 9 exchanges: LSE,XETRA,PA,SW,MI,MC,BME,AS,AMS
[top-gainers] EODHD screener exchange=LSE filters=2
[top-gainers] EODHD screener exchange=XETRA filters=2
... (9 EU exchanges scannés)
```

Saturday 10:00 UTC = 12:00 CEST samedi. EU markets fermés. Mais le scanner fetch quand même.

## Cause

`isWithinSession` helper (`@smartvest/ai-analyst/strategies/session-windows.ts`) check uniquement `open ≤ now ≤ close` UTC. Pas de check weekend. Samedi 10:00 UTC tombe dans 08:00-16:30 UTC → `true`.

PR #301 BUG 1 fix a couvert `NON_EU_EXCHANGES` (US/Asia/TO) mais pas `EU_EXCHANGES`.

## Fix (5 LoC)

```ts
const euMarketOpen = !sessionAware || isMarketOpen('eu', now);
const activeEu = euMarketOpen ? await this.getActiveEuWatchlists(now) : [];
```

`isMarketOpen` (local function, déjà existante) check **ET hours ET weekend** (`day === 0 || day === 6 → false`).

## Économie

- 9 EODHD screener calls/cycle weekend
- 576 cycles weekend × 9 = **~5184 calls EODHD additionnels sauvés/weekend**
- Cumul avec PR #301 : **~10k calls/weekend total** = ~10% du quota journalier

## Test plan

- [x] **966/966 lisa tests** pass
- [x] `tsc --noEmit` clean (TS 5.5.4 pinned)
- [x] **8 nouveaux specs** : Saturday/Sunday in window, Wed in window/before/after, sessionAware=true|false × weekend
- [ ] **Vérification prod 10 min après merge** : log attendu :
  ```
  [top-gainers] session-aware fetch: EU markets closed (weekend or off-hours UTC=10:00) — saved 9 EODHD screener calls
  ```
- [ ] **Disparu** : `[top-gainers] EU session active (cac40/dax40/ftse100), scanning 9 exchanges` les samedis/dimanches

## Activation

**Aucune action utilisateur requise** — le fix s'active automatiquement quand `SCANNER_SESSION_AWARE=true` (déjà set en prod). Pour les portfolios sans ce secret, comportement actuel inchangé.

## LoC stats

```
Net : +76 / -1 = +75
- Tests : ~67% (~50 LoC, 8 specs)
- Code  : ~33% (~25 LoC dont ~10 commentaires)
```

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_