### PR TITLE
fix(lisa): bug #A — crypto simulator Binance 5m

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ supabase/.branches/
 # Docs copiés au build time pour bundling Vercel (cf. apps/web/scripts/copy-docs.mjs).
 # Source de vérité = docs/ à la racine.
 apps/web/content/docs/
+
+# SHORT-SHADOW Phase 2 local outputs (rétroactif rigoureux, local only)
+phase2-retro-results.json

--- a/apps/api/src/modules/lisa/__tests__/crypto-simulator.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/crypto-simulator.spec.ts
@@ -1,0 +1,501 @@
+/**
+ * Bug #A (13/05/2026) — Tests crypto simulator via Binance klines range.
+ *
+ * Couvre :
+ *   - Flag CRYPTO_SIMULATOR_ENABLED off → short-circuit legacy crypto_not_supported
+ *   - Flag on + binance manquant → error 'crypto_simulator_no_binance_service'
+ *   - Flag on + symbol unmappable → error 'crypto_unmappable_symbol'
+ *   - Flag on + binance retourne null → no_data 'binance_api_error'
+ *   - Flag on + binance retourne [] → no_data 'empty_response'
+ *   - Flag on + candles valides → walkForward run, TP/SL/TIME hits selon shape
+ *   - Conversion ms→sec via normalizeAndSortCandles (timestamp Binance openTime
+ *     en ms, converti automatiquement par auto-detect > 1e12)
+ *   - getKlinesRange appelé avec startTime/endTime en MILLISECONDES
+ *
+ * Stratégie : mock BinanceMarketService directement (pas de réel HTTP).
+ * Mock EodhdIntradayService minimal (jamais appelé sur crypto path).
+ */
+import {
+  GainersUserShadowService,
+  type FetchDiag,
+} from '../services/gainers-user-shadow.service';
+import type { BinanceCandle } from '../services/binance-market.service';
+
+type BinanceCall = {
+  method: 'getKlinesRange' | 'toBinanceSymbol';
+  args: unknown[];
+};
+
+function buildService(opts: {
+  klinesRangeResult: BinanceCandle[] | null;
+  toBinanceSymbolResult?: string | null;
+  withBinance?: boolean;
+  callLog: BinanceCall[];
+}): GainersUserShadowService {
+  const eodhdMock = {
+    getCandles: jest.fn(async () => null),
+    getCandlesViaTicks: jest.fn(async () => null),
+  };
+  const supabaseMock = {
+    getClient: () => ({
+      from: () => ({
+        select: () => ({
+          is: () => ({
+            lte: () => ({
+              order: () => ({
+                limit: async () => ({ data: [], error: null }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  };
+  const binanceMock = {
+    toBinanceSymbol: jest.fn((symbol: string) => {
+      opts.callLog.push({ method: 'toBinanceSymbol', args: [symbol] });
+      if (opts.toBinanceSymbolResult !== undefined) return opts.toBinanceSymbolResult;
+      // Default passthrough behavior matching real BinanceMarketService
+      const s = symbol.toUpperCase();
+      if (s.endsWith('USDT')) return s;
+      return null;
+    }),
+    getKlinesRange: jest.fn(
+      async (sym: string, interval: string, startMs: number, endMs: number) => {
+        opts.callLog.push({
+          method: 'getKlinesRange',
+          args: [sym, interval, startMs, endMs],
+        });
+        return opts.klinesRangeResult;
+      },
+    ),
+  };
+  return new GainersUserShadowService(
+    supabaseMock as never,
+    eodhdMock as never,
+    undefined,
+    opts.withBinance === false ? undefined : (binanceMock as never),
+  );
+}
+
+// In-session timestamp pour crypto = n'importe quand (crypto 24/7). On choisit
+// un Mercredi UTC pour cohérence avec autres tests.
+function cryptoStartTs(): number {
+  return Math.floor(new Date('2026-05-13T12:00:00Z').getTime() / 1000);
+}
+
+// Helper : construit N candles 5m alignées avec startTs, OHLC paramétrable.
+function buildBinanceCandles(
+  startTs: number,
+  count: number,
+  shape: (i: number) => { open: number; high: number; low: number; close: number },
+): BinanceCandle[] {
+  const candles: BinanceCandle[] = [];
+  for (let i = 0; i < count; i++) {
+    const openTimeMs = (startTs + i * 300) * 1000;  // 5min intervals in ms
+    const { open, high, low, close } = shape(i);
+    candles.push({
+      openTime: openTimeMs,
+      open,
+      high,
+      low,
+      close,
+      volume: 1000,
+      closeTime: openTimeMs + 299_000,
+      trades: 42,
+    });
+  }
+  return candles;
+}
+
+async function runSim(
+  svc: GainersUserShadowService,
+  args: {
+    symbol: string;
+    assetClass: string;
+    entryPrice: number;
+    createdAt: string;
+  },
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return await (svc as any).simulateRow(args);
+}
+
+describe('Bug #A — Crypto simulator via Binance', () => {
+  const ORIGINAL_FLAG = process.env.CRYPTO_SIMULATOR_ENABLED;
+
+  afterEach(() => {
+    if (ORIGINAL_FLAG === undefined) {
+      delete process.env.CRYPTO_SIMULATOR_ENABLED;
+    } else {
+      process.env.CRYPTO_SIMULATOR_ENABLED = ORIGINAL_FLAG;
+    }
+  });
+
+  describe('flag off (legacy short-circuit preserved)', () => {
+    it('returns crypto_not_supported when CRYPTO_SIMULATOR_ENABLED is undefined', async () => {
+      delete process.env.CRYPTO_SIMULATOR_ENABLED;
+      const callLog: BinanceCall[] = [];
+      const svc = buildService({ klinesRangeResult: null, callLog });
+
+      const { fetchDiag } = (await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date().toISOString(),
+      })) as { fetchDiag: FetchDiag };
+
+      expect(fetchDiag.outcome).toBe('error');
+      expect(fetchDiag.steps[0].error).toBe('crypto_not_supported');
+      // Aucun appel à Binance car flag off
+      expect(callLog).toHaveLength(0);
+    });
+
+    it('returns crypto_not_supported when flag is "false"', async () => {
+      process.env.CRYPTO_SIMULATOR_ENABLED = 'false';
+      const callLog: BinanceCall[] = [];
+      const svc = buildService({ klinesRangeResult: null, callLog });
+
+      const { fetchDiag } = (await runSim(svc, {
+        symbol: 'ETHUSDT',
+        assetClass: 'crypto_alt',
+        entryPrice: 3000,
+        createdAt: new Date().toISOString(),
+      })) as { fetchDiag: FetchDiag };
+
+      expect(fetchDiag.outcome).toBe('error');
+      expect(fetchDiag.steps[0].error).toBe('crypto_not_supported');
+      expect(callLog).toHaveLength(0);
+    });
+
+    it('returns crypto_simulator_no_binance_service when flag on but binance not injected', async () => {
+      process.env.CRYPTO_SIMULATOR_ENABLED = 'true';
+      const callLog: BinanceCall[] = [];
+      const svc = buildService({
+        klinesRangeResult: null,
+        withBinance: false,
+        callLog,
+      });
+
+      const { fetchDiag } = (await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date().toISOString(),
+      })) as { fetchDiag: FetchDiag };
+
+      expect(fetchDiag.outcome).toBe('error');
+      expect(fetchDiag.steps[0].error).toBe('crypto_simulator_no_binance_service');
+      expect(callLog).toHaveLength(0);
+    });
+  });
+
+  describe('flag on + binance injected', () => {
+    beforeEach(() => {
+      process.env.CRYPTO_SIMULATOR_ENABLED = 'true';
+    });
+
+    it('emits crypto_unmappable_symbol when toBinanceSymbol returns null', async () => {
+      const callLog: BinanceCall[] = [];
+      const svc = buildService({
+        klinesRangeResult: null,
+        toBinanceSymbolResult: null,
+        callLog,
+      });
+
+      const { fetchDiag } = (await runSim(svc, {
+        symbol: 'UNKNOWN-COIN',
+        assetClass: 'crypto_alt',
+        entryPrice: 100,
+        createdAt: new Date().toISOString(),
+      })) as { fetchDiag: FetchDiag };
+
+      expect(fetchDiag.outcome).toBe('error');
+      expect(fetchDiag.steps[0].error).toBe('crypto_unmappable_symbol');
+      // toBinanceSymbol appelé, mais getKlinesRange jamais
+      expect(callLog.filter((c) => c.method === 'getKlinesRange')).toHaveLength(0);
+      expect(callLog.filter((c) => c.method === 'toBinanceSymbol')).toHaveLength(1);
+    });
+
+    it('emits binance_api_error when getKlinesRange returns null', async () => {
+      const callLog: BinanceCall[] = [];
+      const svc = buildService({ klinesRangeResult: null, callLog });
+
+      const { fetchDiag } = (await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date().toISOString(),
+      })) as { fetchDiag: FetchDiag };
+
+      expect(fetchDiag.outcome).toBe('no_data');
+      expect(fetchDiag.steps).toHaveLength(1);
+      expect(fetchDiag.steps[0].endpoint).toBe('binance_klines_range_5m');
+      expect(fetchDiag.steps[0].error).toBe('binance_api_error');
+      expect(fetchDiag.steps[0].rawCount).toBe(0);
+    });
+
+    it('emits empty_response when getKlinesRange returns []', async () => {
+      const callLog: BinanceCall[] = [];
+      const svc = buildService({ klinesRangeResult: [], callLog });
+
+      const { fetchDiag } = (await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date().toISOString(),
+      })) as { fetchDiag: FetchDiag };
+
+      expect(fetchDiag.outcome).toBe('no_data');
+      expect(fetchDiag.steps[0].error).toBe('empty_response');
+      expect(fetchDiag.steps[0].validClose).toBe(0);
+    });
+
+    it('calls getKlinesRange with startTime/endTime in MILLISECONDS', async () => {
+      const callLog: BinanceCall[] = [];
+      const startTs = cryptoStartTs();
+      const svc = buildService({ klinesRangeResult: [], callLog });
+
+      await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date(startTs * 1000).toISOString(),
+      });
+
+      const rangeCall = callLog.find((c) => c.method === 'getKlinesRange');
+      expect(rangeCall).toBeDefined();
+      const [sym, interval, startMs, endMs] = rangeCall!.args as [
+        string,
+        string,
+        number,
+        number,
+      ];
+      expect(sym).toBe('BTCUSDT');
+      expect(interval).toBe('5m');
+      // Bug #A spec : fromTs = startTs - 300s, toTs = startTs + 3900s, multiplié par 1000 pour ms
+      expect(startMs).toBe((startTs - 300) * 1000);
+      expect(endMs).toBe((startTs + 60 * 60 + 300) * 1000);
+    });
+
+    it('runs walkForward and detects TP_HIT on a clean +5% candle', async () => {
+      const callLog: BinanceCall[] = [];
+      const startTs = cryptoStartTs();
+      // 13 candles, candle 5 = TP hit (high > entry × 1.020 = 61_200 for baseline grid)
+      const candles = buildBinanceCandles(startTs, 13, (i) => {
+        if (i === 5) {
+          return { open: 60_500, high: 62_000, low: 60_400, close: 61_500 };
+        }
+        return { open: 60_000, high: 60_200, low: 59_900, close: 60_100 };
+      });
+      const svc = buildService({ klinesRangeResult: candles, callLog });
+
+      const { results, fetchDiag } = (await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date(startTs * 1000).toISOString(),
+      })) as { results: Record<string, { outcome: string }>; fetchDiag: FetchDiag };
+
+      expect(fetchDiag.outcome).toBe('ok');
+      expect(fetchDiag.steps[0].endpoint).toBe('binance_klines_range_5m');
+      expect(fetchDiag.steps[0].rawCount).toBe(13);
+      expect(fetchDiag.steps[0].validClose).toBe(13);
+      expect(fetchDiag.forwardCount).toBeGreaterThan(0);
+      // baseline_30m : TP 2% → entry × 1.02 = 61_200 ; candle 5 high=62_000 → hit
+      expect(results.baseline_30m.outcome).toBe('TP_HIT');
+      expect(results.baseline_60m.outcome).toBe('TP_HIT');
+    });
+
+    it('runs walkForward and detects SL_HIT on a -2% drop', async () => {
+      const callLog: BinanceCall[] = [];
+      const startTs = cryptoStartTs();
+      // candle 3 = SL hit (low < entry × 0.991 = 59_460 for baseline 0.9% sl)
+      const candles = buildBinanceCandles(startTs, 13, (i) => {
+        if (i === 3) {
+          return { open: 60_000, high: 60_100, low: 58_500, close: 59_000 };
+        }
+        return { open: 60_000, high: 60_200, low: 59_800, close: 60_050 };
+      });
+      const svc = buildService({ klinesRangeResult: candles, callLog });
+
+      const { results } = (await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date(startTs * 1000).toISOString(),
+      })) as { results: Record<string, { outcome: string; pnl_pct: number | null }> };
+
+      expect(results.baseline_30m.outcome).toBe('SL_HIT');
+      // pnl_pct = -slPct - SLIPPAGE_TOTAL = -0.009 - 0.003 = -0.012
+      expect(results.baseline_30m.pnl_pct).toBeCloseTo(-0.012, 5);
+    });
+
+    it('runs walkForward and returns TIME_LIMIT on a sideways path', async () => {
+      const callLog: BinanceCall[] = [];
+      const startTs = cryptoStartTs();
+      // 13 candles toutes sideways +/-0.1% (ni TP 2% ni SL 0.9% hit)
+      const candles = buildBinanceCandles(startTs, 13, () => ({
+        open: 60_000,
+        high: 60_050,
+        low: 59_950,
+        close: 60_010,
+      }));
+      const svc = buildService({ klinesRangeResult: candles, callLog });
+
+      const { results } = (await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date(startTs * 1000).toISOString(),
+      })) as {
+        results: Record<string, { outcome: string; exit_price: number | null }>;
+      };
+
+      expect(results.baseline_30m.outcome).toBe('TIME_LIMIT');
+      expect(results.baseline_30m.exit_price).toBeCloseTo(60_010, 1);
+    });
+
+    it('converts Binance openTime (ms) to seconds via normalizeAndSortCandles', async () => {
+      const callLog: BinanceCall[] = [];
+      const startTs = cryptoStartTs();
+      const candles = buildBinanceCandles(startTs, 6, () => ({
+        open: 60_000,
+        high: 60_100,
+        low: 59_900,
+        close: 60_050,
+      }));
+      // Tous les openTime devraient être > 1e12 (ms)
+      for (const c of candles) {
+        expect(c.openTime).toBeGreaterThan(1e12);
+      }
+      const svc = buildService({ klinesRangeResult: candles, callLog });
+
+      const { fetchDiag } = (await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date(startTs * 1000).toISOString(),
+      })) as { fetchDiag: FetchDiag };
+
+      // forwardCount > 0 prouve que normalizeAndSortCandles a converti
+      // openTime ms → timestamp sec et que le filter timestamp >= startTs a pu matcher
+      expect(fetchDiag.forwardCount).toBeGreaterThan(0);
+      expect(fetchDiag.outcome).toBe('ok');
+    });
+
+    it('persists fetchDiag.startTs and cutoffTs60 for SQL post-mortem', async () => {
+      const callLog: BinanceCall[] = [];
+      const startTs = cryptoStartTs();
+      const candles = buildBinanceCandles(startTs, 13, () => ({
+        open: 60_000,
+        high: 60_050,
+        low: 59_950,
+        close: 60_010,
+      }));
+      const svc = buildService({ klinesRangeResult: candles, callLog });
+
+      const { fetchDiag } = (await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date(startTs * 1000).toISOString(),
+      })) as { fetchDiag: FetchDiag };
+
+      expect(fetchDiag.startTs).toBe(startTs);
+      expect(fetchDiag.cutoffTs60).toBe(startTs + 60 * 60);
+      expect(fetchDiag.selectedStep).toBe(0);
+      expect(fetchDiag.applied_tz_offset_sec).toBe(0);
+    });
+
+    it('flags partial_window=true when Binance returns fewer candles than expected', async () => {
+      // Bug #A P2 — Si Binance retourne 4 candles au lieu de 13 (gap réseau,
+      // maintenance, etc.), simulator NE marque PAS no_data — il run walkForward
+      // sur ce qu'il a + flag partial_window=true sur les outcomes hit/time.
+      // Comportement aligné sur le path EODHD (lignes 933-955).
+      //
+      // Threshold default 0.5 : partial_window=true si forward < 12 × 0.5 = 6 candles.
+      // 4 candles < 6 → partial_window=true sur TIME_LIMIT (pas de TP/SL hit ici).
+      const callLog: BinanceCall[] = [];
+      const startTs = cryptoStartTs();
+      const candles = buildBinanceCandles(startTs, 4, () => ({
+        open: 60_000,
+        high: 60_050,
+        low: 59_950,
+        close: 60_010,
+      }));
+      const svc = buildService({ klinesRangeResult: candles, callLog });
+
+      const { results, fetchDiag } = (await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date(startTs * 1000).toISOString(),
+      })) as {
+        results: Record<string, { outcome: string; partial_window?: boolean }>;
+        fetchDiag: FetchDiag;
+      };
+
+      expect(fetchDiag.outcome).toBe('ok');
+      expect(fetchDiag.forwardCount).toBe(4);
+      // walkForward toujours run sur ces 4 candles → TIME_LIMIT pour grilles 30/60min
+      expect(results.baseline_30m.outcome).toBe('TIME_LIMIT');
+      expect(results.baseline_30m.partial_window).toBe(true);
+      expect(results.baseline_60m.partial_window).toBe(true);
+    });
+
+    it('does NOT flag partial_window when forward >= threshold (12 × 0.5 = 6 candles)', async () => {
+      // Bug #A P2 — Edge case symétrique : exactement 6 candles forward.
+      // Threshold 0.5 default : `forward.length < 12 * 0.5` ⇒ `6 < 6` ⇒ false ⇒ pas partial.
+      const callLog: BinanceCall[] = [];
+      const startTs = cryptoStartTs();
+      const candles = buildBinanceCandles(startTs, 6, () => ({
+        open: 60_000,
+        high: 60_050,
+        low: 59_950,
+        close: 60_010,
+      }));
+      const svc = buildService({ klinesRangeResult: candles, callLog });
+
+      const { results } = (await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date(startTs * 1000).toISOString(),
+      })) as {
+        results: Record<string, { outcome: string; partial_window?: boolean }>;
+      };
+
+      expect(results.baseline_30m.outcome).toBe('TIME_LIMIT');
+      // partial_window absent (=== undefined) quand forward >= threshold
+      expect(results.baseline_30m.partial_window).toBeUndefined();
+    });
+
+    it('returns priceSnapshots at 5/15/30/60 minutes on successful walkForward', async () => {
+      const callLog: BinanceCall[] = [];
+      const startTs = cryptoStartTs();
+      const candles = buildBinanceCandles(startTs, 13, (i) => ({
+        open: 60_000 + i * 10,
+        high: 60_050 + i * 10,
+        low: 59_950 + i * 10,
+        close: 60_010 + i * 10,
+      }));
+      const svc = buildService({ klinesRangeResult: candles, callLog });
+
+      const { priceSnapshots } = (await runSim(svc, {
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        entryPrice: 60_000,
+        createdAt: new Date(startTs * 1000).toISOString(),
+      })) as {
+        priceSnapshots: { '5': number | null; '15': number | null; '30': number | null; '60': number | null };
+      };
+
+      expect(priceSnapshots).toBeDefined();
+      // 5 min = candle 1 (i=1), close = 60_020
+      expect(priceSnapshots['5']).toBeCloseTo(60_020, 0);
+      // 15 min = candle 3 (i=3), close = 60_040
+      expect(priceSnapshots['15']).toBeCloseTo(60_040, 0);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/__tests__/macro-veto.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/macro-veto.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * PR Action 3 — Tests MacroVetoService.
+ *
+ * Tests UNIT du parsing LLM, fail-open behavior, cache, et integration scanner gate.
+ */
+
+import { MacroVetoService, type MacroVetoDecision } from '../services/macro-veto.service';
+
+describe('MacroVetoService — JSON parsing', () => {
+  // Mirror la logique de parsing de callLlm (private, on teste indirectement via mock)
+
+  function parseLlmResponse(content: string): { allowed: boolean; regime: string; confidence: number } {
+    const cleaned = content.trim().replace(/^```json\s*/i, '').replace(/\s*```$/i, '');
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(cleaned);
+    } catch {
+      throw new Error('LLM response not valid JSON');
+    }
+    const p = parsed as Record<string, unknown>;
+    return {
+      allowed: typeof p.macro_allowed === 'boolean' ? p.macro_allowed : true,
+      regime: ['risk_on', 'risk_off', 'transitioning', 'uncertain'].includes(String(p.regime))
+        ? String(p.regime)
+        : 'uncertain',
+      confidence: typeof p.confidence === 'number' && p.confidence >= 0 && p.confidence <= 1
+        ? p.confidence
+        : 0.5,
+    };
+  }
+
+  it('parses valid JSON allow decision', () => {
+    const json = '{"macro_allowed":true,"regime":"risk_on","veto_reason":null,"confidence":0.85}';
+    const r = parseLlmResponse(json);
+    expect(r.allowed).toBe(true);
+    expect(r.regime).toBe('risk_on');
+    expect(r.confidence).toBe(0.85);
+  });
+
+  it('parses valid JSON veto decision', () => {
+    const json = '{"macro_allowed":false,"regime":"risk_off","veto_reason":"VIX +30%","confidence":0.92}';
+    const r = parseLlmResponse(json);
+    expect(r.allowed).toBe(false);
+    expect(r.regime).toBe('risk_off');
+    expect(r.confidence).toBe(0.92);
+  });
+
+  it('handles markdown code-fenced JSON', () => {
+    const fenced = '```json\n{"macro_allowed":true,"regime":"transitioning","veto_reason":null,"confidence":0.6}\n```';
+    const r = parseLlmResponse(fenced);
+    expect(r.allowed).toBe(true);
+    expect(r.regime).toBe('transitioning');
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseLlmResponse('not json')).toThrow();
+  });
+
+  it('defaults to allow when macro_allowed missing', () => {
+    const json = '{"regime":"uncertain","confidence":0.5}';
+    const r = parseLlmResponse(json);
+    expect(r.allowed).toBe(true);
+  });
+
+  it('defaults to uncertain on invalid regime', () => {
+    const json = '{"macro_allowed":false,"regime":"INVALID","confidence":0.7}';
+    const r = parseLlmResponse(json);
+    expect(r.regime).toBe('uncertain');
+  });
+
+  it('clamps confidence to 0.5 when out of range', () => {
+    const json = '{"macro_allowed":true,"regime":"risk_on","confidence":1.5}';
+    const r = parseLlmResponse(json);
+    expect(r.confidence).toBe(0.5);
+  });
+});
+
+describe('MacroVetoService — Stale decision detection', () => {
+  const STALE_THRESHOLD_MS = 2 * 60 * 60 * 1000;
+
+  function isStale(decisionTimestamp: number, now: number): boolean {
+    return now - decisionTimestamp > STALE_THRESHOLD_MS;
+  }
+
+  it('detects fresh decision (15min old) as not stale', () => {
+    const now = Date.now();
+    const decisionTime = now - 15 * 60 * 1000;
+    expect(isStale(decisionTime, now)).toBe(false);
+  });
+
+  it('detects 1h45min old decision as not stale (just under threshold)', () => {
+    const now = Date.now();
+    const decisionTime = now - 1.75 * 60 * 60 * 1000;
+    expect(isStale(decisionTime, now)).toBe(false);
+  });
+
+  it('detects 2h05min old decision as stale', () => {
+    const now = Date.now();
+    const decisionTime = now - 2.083 * 60 * 60 * 1000;
+    expect(isStale(decisionTime, now)).toBe(true);
+  });
+
+  it('detects 6h old decision as stale', () => {
+    const now = Date.now();
+    const decisionTime = now - 6 * 60 * 60 * 1000;
+    expect(isStale(decisionTime, now)).toBe(true);
+  });
+});
+
+describe('MacroVetoService — Fail-open semantics (safety)', () => {
+  // Si LLM fail OU pas de décision OU stale → default ALLOW (fail-open).
+  // Critère : ne JAMAIS bloquer le trading sur une panne LLM.
+
+  it('fail-open default decision allows trading', () => {
+    const failOpenDecision: MacroVetoDecision = {
+      macroAllowed: true,
+      regime: 'uncertain',
+      vetoReason: null,
+      confidence: 0,
+      fallbackUsed: true,
+    };
+    expect(failOpenDecision.macroAllowed).toBe(true);
+    expect(failOpenDecision.fallbackUsed).toBe(true);
+  });
+
+  it('scanner gate respects fallback flag — fallback decisions DO NOT veto', () => {
+    // Logic du scanner :
+    //   if (macroFlag && !macroFlag.macroAllowed && !macroFlag.fallbackUsed) → SKIP
+    // Donc fallback=true même avec macroAllowed=false ne déclenche pas le skip.
+    const fallbackDecision: MacroVetoDecision = {
+      macroAllowed: false,  // techniquement non-autorisé MAIS
+      regime: 'uncertain',
+      vetoReason: null,
+      confidence: 0,
+      fallbackUsed: true,    // c'est un fallback → ignore le veto
+    };
+    const shouldSkip = fallbackDecision && !fallbackDecision.macroAllowed && !fallbackDecision.fallbackUsed;
+    expect(shouldSkip).toBe(false);  // ne skip PAS car fallback
+  });
+
+  it('scanner gate respects real LLM veto — real decisions DO veto', () => {
+    const realVeto: MacroVetoDecision = {
+      macroAllowed: false,
+      regime: 'risk_off',
+      vetoReason: 'VIX +30%',
+      confidence: 0.92,
+      fallbackUsed: false,
+    };
+    const shouldSkip = realVeto && !realVeto.macroAllowed && !realVeto.fallbackUsed;
+    expect(shouldSkip).toBe(true);  // skip
+  });
+});
+
+describe('MacroVetoService — Cache TTL behavior', () => {
+  const CACHE_TTL_MS = 60 * 1000;
+
+  function isCacheValid(fetchedAt: number, now: number): boolean {
+    return now - fetchedAt < CACHE_TTL_MS;
+  }
+
+  it('30s old cache is valid (<60s)', () => {
+    const now = Date.now();
+    expect(isCacheValid(now - 30 * 1000, now)).toBe(true);
+  });
+
+  it('59s old cache is valid (just under TTL)', () => {
+    const now = Date.now();
+    expect(isCacheValid(now - 59 * 1000, now)).toBe(true);
+  });
+
+  it('60s old cache is invalid (TTL exceeded, exclusive)', () => {
+    const now = Date.now();
+    expect(isCacheValid(now - 60 * 1000, now)).toBe(false);
+  });
+
+  it('5min old cache is invalid', () => {
+    const now = Date.now();
+    expect(isCacheValid(now - 5 * 60 * 1000, now)).toBe(false);
+  });
+});

--- a/apps/api/src/modules/lisa/__tests__/walk-forward-snapshots.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/walk-forward-snapshots.spec.ts
@@ -1,0 +1,313 @@
+/**
+ * MESURE-PR (11/05/2026) — Tests pour le patch persistance directionnelle.
+ *
+ * 3 sections :
+ *   A. computePriceSnapshots — fonction pure, 3 scenarios (empty / sparse / partial)
+ *   B. walkForward rétro-compat — outcome/pnl_pct/hit_at_min inchangés vs pré-patch
+ *   C. Microbenchmark p95 — walkForward + computePriceSnapshots (mix 30/30/40)
+ *
+ * Pas de PR, pas de deploy. Phase MESURE strict.
+ */
+
+import {
+  walkForward,
+  computePriceSnapshots,
+  type SimGrid,
+  type CandleLike,
+} from '../services/gainers-user-shadow.service';
+
+const BASELINE_GRID: SimGrid = { key: 'baseline_60m', tpPct: 0.02, slPct: 0.009, windowMin: 60 };
+
+function mkCandle(tsOffsetSec: number, close: number, opts: { high?: number; low?: number } = {}): CandleLike {
+  return {
+    timestamp: 1700000000 + tsOffsetSec,
+    high: opts.high ?? close,
+    low: opts.low ?? close,
+    close,
+  };
+}
+
+// ============================================================
+// A. computePriceSnapshots — fonction pure
+// ============================================================
+describe('computePriceSnapshots — fonction pure', () => {
+  const startTs = 1700000000;
+
+  it('candles vides → tous snapshots null', () => {
+    expect(computePriceSnapshots([], startTs))
+      .toEqual({ '5': null, '15': null, '30': null, '60': null });
+  });
+
+  it('TIME_LIMIT-like : 13 candles 5min linéaires → 4 snapshots populés', () => {
+    const candles = Array.from({ length: 13 }, (_, i) =>
+      mkCandle(i * 300, 100 + i * 0.08),
+    );
+    const r = computePriceSnapshots(candles, startTs);
+    expect(r['5']).toBeCloseTo(100.08, 2);   // candle at +5min (i=1)
+    expect(r['15']).toBeCloseTo(100.24, 2);  // candle at +15min (i=3)
+    expect(r['30']).toBeCloseTo(100.48, 2);  // candle at +30min (i=6)
+    expect(r['60']).toBeCloseTo(100.96, 2);  // candle at +60min (i=12)
+  });
+
+  it('candles sparses 20min → snapshot 5 et 15 pointent vers candle +20min', () => {
+    const candles = [
+      mkCandle(1200, 100.5),   // +20min
+      mkCandle(2400, 101.0),   // +40min
+      mkCandle(3600, 101.5),   // +60min
+    ];
+    const r = computePriceSnapshots(candles, startTs);
+    expect(r['5']).toBeCloseTo(100.5, 2);
+    expect(r['15']).toBeCloseTo(100.5, 2);
+    expect(r['30']).toBeCloseTo(101.0, 2);
+    expect(r['60']).toBeCloseTo(101.5, 2);
+  });
+
+  it('candles partielles (jusqu\'à +30min) → snapshot 60 reste null', () => {
+    const candles = [
+      mkCandle(300, 100.2),
+      mkCandle(1800, 101.0),
+    ];
+    const r = computePriceSnapshots(candles, startTs);
+    expect(r['5']).toBeCloseTo(100.2, 2);
+    expect(r['30']).toBeCloseTo(101.0, 2);
+    expect(r['60']).toBeNull();
+  });
+
+  it('candles tronquées avant 5min → tous null', () => {
+    const candles = [mkCandle(60, 100.1)];  // +1min seulement
+    const r = computePriceSnapshots(candles, startTs);
+    expect(r).toEqual({ '5': null, '15': null, '30': null, '60': null });
+  });
+});
+
+// ============================================================
+// B. walkForward rétro-compat — pré-patch behavior preserved
+// ============================================================
+describe('walkForward — rétro-compat (MESURE-PR ne modifie pas walkForward)', () => {
+  const startTs = 1700000000;
+  const entry = 100;
+
+  it('TP_HIT @+7min : outcome/exit_price/pnl_pct/hit_at_min inchangés vs pré-patch', () => {
+    const candles = [
+      mkCandle(180, 100.3),
+      mkCandle(420, 102.5, { high: 102.5 }),
+    ];
+    const r = walkForward(entry, candles, startTs, BASELINE_GRID);
+    expect(r.outcome).toBe('TP_HIT');
+    expect(r.exit_price).toBe(102);
+    expect(r.pnl_pct).toBeCloseTo(0.017, 3);  // 0.02 - 0.003 slippage
+    expect(r.hit_at_min).toBe(7);
+  });
+
+  it('SL_HIT @+12min : outcome/pnl_pct préservés', () => {
+    const candles = [
+      mkCandle(300, 99.8),
+      mkCandle(720, 99.5, { low: 99.0 }),
+    ];
+    const r = walkForward(entry, candles, startTs, BASELINE_GRID);
+    expect(r.outcome).toBe('SL_HIT');
+    expect(r.hit_at_min).toBe(12);
+    expect(r.pnl_pct).toBeCloseTo(-0.012, 3);  // -0.009 - 0.003 slip
+  });
+
+  it('TIME_LIMIT : close at last candle', () => {
+    const candles = Array.from({ length: 13 }, (_, i) =>
+      mkCandle(i * 300, 100 + i * 0.05),
+    );
+    const r = walkForward(entry, candles, startTs, BASELINE_GRID);
+    expect(r.outcome).toBe('TIME_LIMIT');
+    expect(r.pnl_pct).toBeCloseTo(0.0030, 4);  // (100.6 - 100) / 100 - 0.003 = 0.003
+  });
+
+  it('NO_DATA on empty candles', () => {
+    const r = walkForward(entry, [], startTs, BASELINE_GRID);
+    expect(r.outcome).toBe('NO_DATA');
+    expect(r.pnl_pct).toBeNull();
+  });
+});
+
+// ============================================================
+// C. Microbenchmark p95 — Option A baseline
+// ============================================================
+describe('Microbenchmark p95 — Option A (MESURE-PR baseline)', () => {
+  const N = 10000;
+  const startTs = 1700000000;
+  const entry = 100;
+
+  function genCandles(scenario: 'TP' | 'SL' | 'TIME'): CandleLike[] {
+    if (scenario === 'TP') {
+      // TP_HIT à +5min : high=102.5 hits TP=102
+      return [
+        mkCandle(60, 100.3, { high: 100.5, low: 99.8 }),
+        mkCandle(300, 101.8, { high: 102.5, low: 100.2 }),
+      ];
+    }
+    if (scenario === 'SL') {
+      // SL_HIT à +8min : low=99.0 hits SL=99.1
+      return [
+        mkCandle(60, 99.8, { high: 100.2, low: 99.6 }),
+        mkCandle(480, 99.2, { high: 99.9, low: 99.0 }),
+      ];
+    }
+    // TIME_LIMIT : 13 candles spaced 5min, no TP/SL hit
+    return Array.from({ length: 13 }, (_, i) => {
+      const close = 100 + i * 0.05;
+      return mkCandle(i * 300, close, { high: close + 0.05, low: close - 0.05 });
+    });
+  }
+
+  function percentile(sorted: number[], p: number): number {
+    return sorted[Math.floor(sorted.length * p)];
+  }
+
+  it('walkForward p95 multi-metric 3 runs (Option A — mix 30/30/40 + projected 3/3/94)', () => {
+    // 3 runs consécutifs pour mesurer variance (stddev) sur les métriques clés.
+    type RunMetrics = {
+      p95_brut: number;       // p95 mix 30/30/40
+      p95_weighted: number;   // p95 projeté prod 3/3/94 via resampling
+      p95_tp: number;         // p95 path TP_HIT seul
+      p95_sl: number;         // p95 path SL_HIT seul
+      p95_time: number;       // p95 path TIME_LIMIT seul
+      p50_brut: number;
+    };
+    const runs: RunMetrics[] = [];
+
+    for (let run = 0; run < 3; run++) {
+      const fixtures: CandleLike[][] = [];
+      const scenarios: ('TP' | 'SL' | 'TIME')[] = [];
+      for (let i = 0; i < N; i++) {
+        const r = i % 10;
+        const scenario: 'TP' | 'SL' | 'TIME' = r < 3 ? 'TP' : r < 6 ? 'SL' : 'TIME';
+        fixtures.push(genCandles(scenario));
+        scenarios.push(scenario);
+      }
+
+      // Warm-up V8 (1000 calls discarded)
+      for (let i = 0; i < 1000; i++) walkForward(entry, fixtures[i % N], startTs, BASELINE_GRID);
+
+      // Bench timing
+      const latenciesAll: number[] = [];
+      const byPath: Record<'TP' | 'SL' | 'TIME', number[]> = { TP: [], SL: [], TIME: [] };
+      for (let i = 0; i < N; i++) {
+        const t0 = performance.now();
+        walkForward(entry, fixtures[i], startTs, BASELINE_GRID);
+        const lat = performance.now() - t0;
+        latenciesAll.push(lat);
+        byPath[scenarios[i]].push(lat);
+      }
+
+      // Per-path p95 (chaque path indépendamment, robust à n~3000)
+      const p95_tp = percentile([...byPath.TP].sort((a, b) => a - b), 0.95);
+      const p95_sl = percentile([...byPath.SL].sort((a, b) => a - b), 0.95);
+      const p95_time = percentile([...byPath.TIME].sort((a, b) => a - b), 0.95);
+
+      // Brut p95 sur mix 30/30/40
+      const sortedAll = [...latenciesAll].sort((a, b) => a - b);
+      const p50_brut = percentile(sortedAll, 0.50);
+      const p95_brut = percentile(sortedAll, 0.95);
+
+      // Projected p95 prod 3/3/94 : resampling pondéré sur les samples per-path
+      // Tire 10000 latences en respectant la distribution prod observée.
+      const projected: number[] = [];
+      for (let i = 0; i < N; i++) {
+        const r = Math.random() * 100;
+        const arr = r < 3 ? byPath.TP : r < 6 ? byPath.SL : byPath.TIME;
+        projected.push(arr[Math.floor(Math.random() * arr.length)]);
+      }
+      const p95_weighted = percentile(projected.sort((a, b) => a - b), 0.95);
+
+      runs.push({ p95_brut, p95_weighted, p95_tp, p95_sl, p95_time, p50_brut });
+    }
+
+    // Aggregate mean + stddev across 3 runs
+    const stats = (key: keyof RunMetrics) => {
+      const vals = runs.map((r) => r[key]);
+      const mean = vals.reduce((a, b) => a + b, 0) / vals.length;
+      const variance = vals.reduce((a, b) => a + (b - mean) ** 2, 0) / vals.length;
+      return { mean, stddev: Math.sqrt(variance), vals };
+    };
+
+    const fmt = (s: { mean: number; stddev: number; vals: number[] }) =>
+      `mean=${(s.mean * 1000).toFixed(2)}μs stddev=${(s.stddev * 1000).toFixed(2)}μs ` +
+      `runs=[${s.vals.map((v) => (v * 1000).toFixed(2)).join(',')}]μs`;
+
+    /* eslint-disable no-console */
+    console.log(`[BENCH walkForward] 3 runs × N=${N} chacun`);
+    console.log(`  p50_brut    (30/30/40)         : ${fmt(stats('p50_brut'))}`);
+    console.log(`  p95_brut    (30/30/40)         : ${fmt(stats('p95_brut'))}`);
+    console.log(`  p95_weighted (projeté 3/3/94) : ${fmt(stats('p95_weighted'))}`);
+    console.log(`  p95_tp      (path TP_HIT)      : ${fmt(stats('p95_tp'))}`);
+    console.log(`  p95_sl      (path SL_HIT)      : ${fmt(stats('p95_sl'))}`);
+    console.log(`  p95_time    (path TIME_LIMIT)  : ${fmt(stats('p95_time'))}`);
+    /* eslint-enable no-console */
+
+    // Smoke check ultra-conservatif sur p95 brut max sur les 3 runs
+    const maxP95 = Math.max(...runs.map((r) => r.p95_brut));
+    expect(maxP95).toBeLessThan(1);
+  });
+
+  it('computePriceSnapshots p95 sur 10000 calls (TIME scenario, slowest)', () => {
+    const candles = genCandles('TIME');  // 13 candles = full iteration
+
+    // Warm-up
+    for (let i = 0; i < 1000; i++) computePriceSnapshots(candles, startTs);
+
+    const latencies: number[] = [];
+    for (let i = 0; i < N; i++) {
+      const t0 = performance.now();
+      computePriceSnapshots(candles, startTs);
+      latencies.push(performance.now() - t0);
+    }
+    latencies.sort((a, b) => a - b);
+
+    const p50 = percentile(latencies, 0.50);
+    const p95 = percentile(latencies, 0.95);
+    const p99 = percentile(latencies, 0.99);
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[BENCH computePriceSnapshots] N=${N} scenario=TIME ` +
+      `p50=${(p50 * 1000).toFixed(2)}μs ` +
+      `p95=${(p95 * 1000).toFixed(2)}μs ` +
+      `p99=${(p99 * 1000).toFixed(2)}μs`,
+    );
+
+    expect(p95).toBeLessThan(0.5);
+  });
+});
+
+// ============================================================
+// D. Integration smoke — simulatePending UPDATE structure
+// ============================================================
+describe('simulatePending UPDATE structure — JSONB root-level snapshots', () => {
+  it('UPDATE sim_results contient price_snapshots au ROOT, pas dans chaque grille', () => {
+    // Smoke check sur la structure attendue après merge dans simulatePending.
+    // Reproduit le pattern `{ ...simResults, price_snapshots: priceSnapshots }`.
+    const fakeSimResults = {
+      baseline_30m: { outcome: 'TIME_LIMIT', pnl_pct: 0.003, exit_price: 100.3 },
+      baseline_60m: { outcome: 'TIME_LIMIT', pnl_pct: 0.005, exit_price: 100.5 },
+      alt15_30m:    { outcome: 'TP_HIT',     pnl_pct: 0.012, exit_price: 101.5 },
+      alt15_60m:    { outcome: 'TP_HIT',     pnl_pct: 0.012, exit_price: 101.5 },
+    };
+    const fakeSnapshots = { '5': 100.5, '15': 101.0, '30': 101.3, '60': 101.5 };
+
+    const merged = { ...fakeSimResults, price_snapshots: fakeSnapshots };
+
+    // Structure root-level vérifiée
+    expect(merged).toHaveProperty('price_snapshots');
+    expect(merged.price_snapshots).toEqual(fakeSnapshots);
+
+    // Grilles inchangées, pas de price_snapshots à l'intérieur
+    expect(merged.baseline_30m).not.toHaveProperty('price_snapshots');
+    expect(merged.baseline_60m).not.toHaveProperty('price_snapshots');
+    expect(merged.alt15_30m).not.toHaveProperty('price_snapshots');
+    expect(merged.alt15_60m).not.toHaveProperty('price_snapshots');
+  });
+
+  it('Fallback all-null snapshots quand simulateRow early-return (priceSnapshots undefined)', () => {
+    // Reproduit le pattern `priceSnapshots ?? { '5': null, ... }` du simulatePending
+    const priceSnapshots: { '5': number | null; '15': number | null; '30': number | null; '60': number | null } | undefined = undefined;
+    const fallback = priceSnapshots ?? { '5': null, '15': null, '30': null, '60': null };
+    expect(fallback).toEqual({ '5': null, '15': null, '30': null, '60': null });
+  });
+});

--- a/apps/api/src/modules/lisa/__tests__/walk-forward-snapshots.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/walk-forward-snapshots.spec.ts
@@ -13,6 +13,9 @@ import {
   walkForward,
   computePriceSnapshots,
   getGridsForAssetClass,
+  MAX_WINDOW_MIN,
+  SIMULATE_BUFFER_MIN,
+  SIMULATE_AFTER_MIN,
   type SimGrid,
   type CandleLike,
 } from '../services/gainers-user-shadow.service';
@@ -448,5 +451,30 @@ describe('getGridsForAssetClass — scope strict SHORT (SHORT-SHADOW)', () => {
     expect(shortBaseline.windowMin).toBe(longBaseline.windowMin);
     expect(shortBaseline.direction).toBe('short');
     expect(longBaseline.direction).toBe('long');
+  });
+});
+
+// ============================================================
+// G. SHORT-SHADOW TIMING-FIX (11/05/2026) — SIMULATE_AFTER_MIN
+// ============================================================
+describe('SIMULATE_AFTER_MIN — cutoff timing simulatePending (SHORT-SHADOW TIMING-FIX)', () => {
+  it('SIMULATE_AFTER_MIN = MAX_WINDOW_MIN + SIMULATE_BUFFER_MIN', () => {
+    expect(SIMULATE_AFTER_MIN).toBe(MAX_WINDOW_MIN + SIMULATE_BUFFER_MIN);
+  });
+
+  it('MAX_WINDOW_MIN = 60 (largest grid window across LONG + SHORT)', () => {
+    expect(MAX_WINDOW_MIN).toBe(60);
+    // Sanity check : aucune grille n'a un windowMin supérieur
+    const smallMidGrids = getGridsForAssetClass('us_equity_small_mid');
+    const maxObserved = Math.max(...smallMidGrids.map((g) => g.windowMin));
+    expect(maxObserved).toBeLessThanOrEqual(MAX_WINDOW_MIN);
+  });
+
+  it('SIMULATE_BUFFER_MIN = 5 (EODHD candle propagation lag tolerance)', () => {
+    expect(SIMULATE_BUFFER_MIN).toBe(5);
+  });
+
+  it('SIMULATE_AFTER_MIN = 65 (bug-fix 08/05/2026 : 60→65 pour tolérer race condition)', () => {
+    expect(SIMULATE_AFTER_MIN).toBe(65);
   });
 });

--- a/apps/api/src/modules/lisa/__tests__/walk-forward-snapshots.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/walk-forward-snapshots.spec.ts
@@ -12,6 +12,7 @@
 import {
   walkForward,
   computePriceSnapshots,
+  getGridsForAssetClass,
   type SimGrid,
   type CandleLike,
 } from '../services/gainers-user-shadow.service';
@@ -309,5 +310,143 @@ describe('simulatePending UPDATE structure — JSONB root-level snapshots', () =
     const priceSnapshots: { '5': number | null; '15': number | null; '30': number | null; '60': number | null } | undefined = undefined;
     const fallback = priceSnapshots ?? { '5': null, '15': null, '30': null, '60': null };
     expect(fallback).toEqual({ '5': null, '15': null, '30': null, '60': null });
+  });
+});
+
+// ============================================================
+// E. SHORT-SHADOW (11/05/2026) — walkForward direction='short'
+// ============================================================
+describe('walkForward — direction SHORT (SHORT-SHADOW)', () => {
+  const startTs = 1700000000;
+  const entry = 100;
+  const SHORT_BASELINE: SimGrid = { key: 'short_baseline_60m', tpPct: 0.020, slPct: 0.009, windowMin: 60, direction: 'short' };
+
+  it('SHORT TP_HIT : prix DESCEND vers tpPrice = entry - tpPct', () => {
+    // entry=100, tp = 100 × (1 - 0.02) = 98. SL = 100 × (1 + 0.009) = 100.9
+    // Candle à +7min avec low=97.5 → hit TP en short (prix sous 98)
+    const candles = [
+      mkCandle(180, 100.1, { low: 99.8, high: 100.3 }),
+      mkCandle(420, 98.5, { low: 97.5, high: 99.5 }),  // low <= 98 = TP_HIT
+    ];
+    const r = walkForward(entry, candles, startTs, SHORT_BASELINE);
+    expect(r.outcome).toBe('TP_HIT');
+    expect(r.exit_price).toBe(98);
+    expect(r.pnl_pct).toBeCloseTo(0.017, 3);  // +tpPct - slippage = profit positif
+    expect(r.hit_at_min).toBe(7);
+  });
+
+  it('SHORT SL_HIT : prix MONTE vers slPrice = entry + slPct', () => {
+    // entry=100, sl = 100 × (1 + 0.009) = 100.9. TP = 98
+    // Candle à +12min avec high=101.5 → hit SL en short (prix au-dessus 100.9)
+    const candles = [
+      mkCandle(300, 100.4, { low: 100.2, high: 100.7 }),
+      mkCandle(720, 101.2, { low: 100.9, high: 101.5 }),  // high >= 100.9 = SL_HIT
+    ];
+    const r = walkForward(entry, candles, startTs, SHORT_BASELINE);
+    expect(r.outcome).toBe('SL_HIT');
+    expect(r.exit_price).toBeCloseTo(100.9, 2);
+    expect(r.pnl_pct).toBeCloseTo(-0.012, 3);  // -slPct - slippage = loss négatif
+    expect(r.hit_at_min).toBe(12);
+  });
+
+  it('SHORT TIME_LIMIT : pnl positif si prix descend, négatif si prix monte', () => {
+    // entry=100, fenêtre 60min, 13 candles linéaires close 100→99.4
+    // En SHORT, profit si prix descend → closePnl = (entry - close) / entry = +0.6%
+    const candles = Array.from({ length: 13 }, (_, i) => {
+      const close = 100 - i * 0.05;  // 100, 99.95, ..., 99.4
+      return mkCandle(i * 300, close, { high: close + 0.05, low: close - 0.05 });
+    });
+    const r = walkForward(entry, candles, startTs, SHORT_BASELINE);
+    expect(r.outcome).toBe('TIME_LIMIT');
+    expect(r.exit_price).toBeCloseTo(99.4, 2);
+    // (100 - 99.4) / 100 - 0.003 slip = 0.0030
+    expect(r.pnl_pct).toBeCloseTo(0.003, 3);
+  });
+
+  it('SHORT TIME_LIMIT inverse-symmetry : sur path montant, SHORT pnl = -LONG pnl à slip près', () => {
+    // entry=100, prix monte linéairement 100→100.6 sur 60min
+    // LONG  closePnl = (100.6 - 100) / 100 = +0.006 → pnl_pct = +0.003 (après slip)
+    // SHORT closePnl = (100 - 100.6) / 100 = -0.006 → pnl_pct = -0.009 (après slip)
+    const candles = Array.from({ length: 13 }, (_, i) => {
+      const close = 100 + i * 0.05;
+      return mkCandle(i * 300, close, { high: close + 0.05, low: close - 0.05 });
+    });
+    const LONG_BASELINE: SimGrid = { key: 'baseline_60m', tpPct: 0.020, slPct: 0.009, windowMin: 60, direction: 'long' };
+    const rLong = walkForward(entry, candles, startTs, LONG_BASELINE);
+    const rShort = walkForward(entry, candles, startTs, SHORT_BASELINE);
+    expect(rLong.outcome).toBe('TIME_LIMIT');
+    expect(rShort.outcome).toBe('TIME_LIMIT');
+    // LONG profit (prix monte) ↔ SHORT loss (prix monte) — pnl signs opposés
+    expect(rLong.pnl_pct).toBeCloseTo(0.003, 3);
+    expect(rShort.pnl_pct).toBeCloseTo(-0.009, 3);
+  });
+
+  it('SHORT NO_DATA on empty candles', () => {
+    const r = walkForward(entry, [], startTs, SHORT_BASELINE);
+    expect(r.outcome).toBe('NO_DATA');
+    expect(r.pnl_pct).toBeNull();
+  });
+
+  it('Rétro-compat : grid sans direction = LONG par défaut', () => {
+    const noDirectionGrid: SimGrid = { key: 'legacy', tpPct: 0.020, slPct: 0.009, windowMin: 60 };
+    const candles = [mkCandle(180, 100.3), mkCandle(420, 102.5, { high: 102.5 })];
+    const r = walkForward(entry, candles, startTs, noDirectionGrid);
+    // LONG TP_HIT à +7min = comportement pré-patch
+    expect(r.outcome).toBe('TP_HIT');
+    expect(r.exit_price).toBe(102);
+    expect(r.hit_at_min).toBe(7);
+  });
+});
+
+// ============================================================
+// F. SHORT-SHADOW — getGridsForAssetClass (scope strict small/mid US)
+// ============================================================
+describe('getGridsForAssetClass — scope strict SHORT (SHORT-SHADOW)', () => {
+  it('us_equity_small_mid retourne 10 grids (4 LONG + 6 SHORT)', () => {
+    const grids = getGridsForAssetClass('us_equity_small_mid');
+    expect(grids).toHaveLength(10);
+    const keys = grids.map((g) => g.key);
+    expect(keys).toEqual([
+      'baseline_30m', 'baseline_60m', 'alt15_30m', 'alt15_60m',
+      'short_baseline_30m', 'short_baseline_60m',
+      'short_alt15_30m', 'short_alt15_60m',
+      'short_calibrated_30m', 'short_calibrated_60m',
+    ]);
+  });
+
+  it('us_equity_large retourne 4 grids LONG seulement', () => {
+    const grids = getGridsForAssetClass('us_equity_large');
+    expect(grids).toHaveLength(4);
+    expect(grids.every((g) => g.direction !== 'short')).toBe(true);
+  });
+
+  it('eu_equity, asia_equity, crypto_major retournent 4 grids LONG (scope strict)', () => {
+    for (const cls of ['eu_equity', 'asia_equity', 'crypto_major', 'crypto_alt']) {
+      const grids = getGridsForAssetClass(cls);
+      expect(grids).toHaveLength(4);
+      expect(grids.every((g) => g.direction !== 'short')).toBe(true);
+    }
+  });
+
+  it('SHORT calibrated grids : TP 0.8% / SL 0.4% (ratio 2:1, breakeven 33%)', () => {
+    const grids = getGridsForAssetClass('us_equity_small_mid');
+    const calibrated = grids.filter((g) => g.key.startsWith('short_calibrated_'));
+    expect(calibrated).toHaveLength(2);
+    for (const g of calibrated) {
+      expect(g.tpPct).toBeCloseTo(0.008, 4);
+      expect(g.slPct).toBeCloseTo(0.004, 4);
+      expect(g.direction).toBe('short');
+    }
+  });
+
+  it('SHORT baseline mirror : mêmes TP/SL que LONG baseline (apples-to-apples)', () => {
+    const grids = getGridsForAssetClass('us_equity_small_mid');
+    const longBaseline = grids.find((g) => g.key === 'baseline_60m')!;
+    const shortBaseline = grids.find((g) => g.key === 'short_baseline_60m')!;
+    expect(shortBaseline.tpPct).toBe(longBaseline.tpPct);
+    expect(shortBaseline.slPct).toBe(longBaseline.slPct);
+    expect(shortBaseline.windowMin).toBe(longBaseline.windowMin);
+    expect(shortBaseline.direction).toBe('short');
+    expect(longBaseline.direction).toBe('long');
   });
 });

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -57,6 +57,7 @@ import { YahooIntradayService } from './services/yahoo-intraday.service';
 import { IntradayCacheService } from './services/intraday-cache.service';
 import { PersistenceProbabilityService } from './services/persistence-probability.service';
 import { ScannerLlmRouterService } from './services/scanner-llm-router.service';
+import { MacroVetoService } from './services/macro-veto.service';
 // Phase B — Weekly P9 ML refit cron auto-logging insights
 import { ProbabilityRefitCronService } from '../gainers-scanner/automations/probability-refit-cron.service';
 // PR6.8 RCFT — Cron daily 00:30 UTC qui suit forward returns des shadow signals
@@ -134,6 +135,8 @@ import { SignalForwardTrackerService } from '../gainers-scanner/automations/sign
     PersistenceProbabilityService,
     // P17 — LLM router multi-vendor pour scanner Gainers (Gemini/GPT-nano/Codestral/Claude)
     ScannerLlmRouterService,
+    // PR Action 3 — LLM macro veto cron hourly (gate scanner cycle entries)
+    MacroVetoService,
     // P19v (30/04/2026) — Quota service centralisé EODHD (cost map + auto-throttle)
     EodhdQuotaService,
     // Phase B — Cron Sunday 02:00 UTC qui refit P9 logistic regression et auto-log

--- a/apps/api/src/modules/lisa/services/binance-market.service.ts
+++ b/apps/api/src/modules/lisa/services/binance-market.service.ts
@@ -72,6 +72,11 @@ export class BinanceMarketService {
   private readonly BASE_URL = 'https://api.binance.com';
   private readonly FAPI_URL = 'https://fapi.binance.com';
   private klinesCache = new Map<string, { data: BinanceCandle[]; asOf: number }>();
+  // Bug #A (13/05/2026) — Cache séparé pour getKlinesRange. TTL 1h car un range
+  // historique fermé [startTime, endTime] est immutable, pas besoin de refresh
+  // fréquent comme le legacy klinesCache (TTL 2min, fenêtre glissante last-N).
+  private klinesRangeCache = new Map<string, { data: BinanceCandle[]; asOf: number }>();
+  private readonly KLINES_RANGE_TTL_MS = 60 * 60 * 1000;
   private tickerCache = new Map<string, { data: BinanceTicker24h; asOf: number }>();
   private futuresCache = new Map<string, { data: BinanceFutureStats; asOf: number }>();
 
@@ -131,6 +136,62 @@ export class BinanceMarketService {
       return candles;
     } catch (e) {
       this.logger.warn(`Binance klines failed ${binanceSymbol}: ${String(e).slice(0, 80)}`);
+      return null;
+    }
+  }
+
+  /**
+   * Bug #A (13/05/2026) — Fetch klines avec fenêtre [startTime, endTime] explicite.
+   *
+   * Différence avec getKlines (limit-based, dernières N candles) : supporte les
+   * fenêtres historiques arbitraires nécessaires au shadow simulator
+   * (gainers-user-shadow.service.ts) qui rejoue des signaux capturés plusieurs
+   * heures dans le passé.
+   *
+   * Binance API native : /api/v3/klines?symbol=X&interval=Y&startTime=A&endTime=B
+   * accepte startTime/endTime en epoch millisecondes. Limit max 1000 (≥ tous les
+   * use cases prévus : 70min @ 5m = 14 candles, 24h @ 5m = 288 candles).
+   *
+   * Cache distinct du klinesCache : key inclut start/end ms, TTL 1h.
+   */
+  async getKlinesRange(
+    binanceSymbol: string,
+    interval: '1m' | '5m' | '15m' | '1h' | '4h' | '1d',
+    startTimeMs: number,
+    endTimeMs: number,
+  ): Promise<BinanceCandle[] | null> {
+    const cacheKey = `${binanceSymbol}::${interval}::${startTimeMs}::${endTimeMs}`;
+    const cached = this.klinesRangeCache.get(cacheKey);
+    if (cached && Date.now() - cached.asOf < this.KLINES_RANGE_TTL_MS) return cached.data;
+
+    try {
+      const url = `${this.BASE_URL}/api/v3/klines?symbol=${binanceSymbol}` +
+        `&interval=${interval}&startTime=${startTimeMs}&endTime=${endTimeMs}&limit=1000`;
+      const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+      if (!res.ok) {
+        this.logger.debug(`Binance klines range HTTP ${res.status} for ${binanceSymbol}`);
+        return null;
+      }
+      const data = await res.json() as unknown[];
+      if (!Array.isArray(data)) return null;
+
+      const candles: BinanceCandle[] = data.map((row) => {
+        const r = row as unknown[];
+        return {
+          openTime: Number(r[0]),
+          open: Number(r[1]),
+          high: Number(r[2]),
+          low: Number(r[3]),
+          close: Number(r[4]),
+          volume: Number(r[5]),
+          closeTime: Number(r[6]),
+          trades: Number(r[8]),
+        };
+      });
+      this.klinesRangeCache.set(cacheKey, { data: candles, asOf: Date.now() });
+      return candles;
+    } catch (e) {
+      this.logger.warn(`Binance klines range failed ${binanceSymbol}: ${String(e).slice(0, 80)}`);
       return null;
     }
   }

--- a/apps/api/src/modules/lisa/services/gainers-scanner-status.types.ts
+++ b/apps/api/src/modules/lisa/services/gainers-scanner-status.types.ts
@@ -11,7 +11,8 @@ export type EarlyReturnReason =
   | 'no_candidates_fetched'
   | 'candidates_fetched_but_none_selected'
   | 'persist_log_failed'
-  | 'upstream_provider_error';
+  | 'upstream_provider_error'
+  | 'macro_veto';  // PR Action 3 — LLM macro veto (regime risk-off)
 
 export const EARLY_RETURN_REASONS: readonly EarlyReturnReason[] = [
   'scanner_paused',
@@ -21,6 +22,7 @@ export const EARLY_RETURN_REASONS: readonly EarlyReturnReason[] = [
   'candidates_fetched_but_none_selected',
   'persist_log_failed',
   'upstream_provider_error',
+  'macro_veto',
 ] as const;
 
 export interface PerExchangeResult {

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { EodhdIntradayService } from './eodhd-intraday.service';
 import { YahooIntradayService } from './yahoo-intraday.service';
+import { BinanceMarketService } from './binance-market.service';
 import { bootstrapMeanCI, verdictFromCI, GateVerdict } from '@smartvest/ai-analyst';
 import { isInExchangeSession } from './exchange-sessions.helper';
 
@@ -450,6 +451,12 @@ export class GainersUserShadowService {
      * Optional pour back-compat avec tests existants (qui n'injectent pas yahoo).
      */
     private readonly yahoo?: YahooIntradayService,
+    /**
+     * Bug #A (13/05/2026) — Binance pour crypto walkForward via getKlinesRange.
+     * Optional pour back-compat tests. Gated par env CRYPTO_SIMULATOR_ENABLED=true.
+     * Si non injecté OU flag off → short-circuit legacy crypto_not_supported préservé.
+     */
+    private readonly binance?: BinanceMarketService,
   ) {}
 
   /**
@@ -596,25 +603,150 @@ export class GainersUserShadowService {
       return { results, fetchDiag };
     }
 
-    // Crypto = no support yet (would need Binance klines), skip gracefully
+    // Bug #A (13/05/2026) — Crypto support via Binance klines range.
+    //
+    // Avant : short-circuit explicite `crypto_not_supported`. Les ~13 crypto/4j
+    // capturées par fetchBinanceGainers (top-gainers-scanner.service.ts:1136-1146)
+    // étaient toutes marquées outcome='error' → 0 mesurable.
+    //
+    // Après : gated par CRYPTO_SIMULATOR_ENABLED (default false). Si flag on
+    // ET binance injecté → fetch Binance 5m sur [startTs-5min, +65min] + walkForward.
+    //
+    // Placement préservé AVANT Step 0 (line ~635) : crypto = 24/7, le session
+    // check isInExchangeSession retournerait `false` pour BTCUSDT/ADAUSDT
+    // (suffix null, ligne 118 exchange-sessions.helper.ts → false conservatif),
+    // ce qui marquerait tout en OFF_SESSION 'capture'. On bypass volontairement.
     if (args.assetClass === 'crypto_major' || args.assetClass === 'crypto_alt') {
-      for (const g of getGridsForAssetClass(args.assetClass)) results[g.key] = noEntry();
-      fetchDiag.outcome = 'error';
-      fetchDiag.steps.push({
-        endpoint: 'precondition',
+      const cryptoEnabled = process.env.CRYPTO_SIMULATOR_ENABLED === 'true';
+      if (!cryptoEnabled || !this.binance) {
+        // Legacy short-circuit : préservé pour rollback rapide (flag off) ET
+        // pour tests qui n'injectent pas BinanceMarketService (back-compat).
+        for (const g of getGridsForAssetClass(args.assetClass)) results[g.key] = noEntry();
+        fetchDiag.outcome = 'error';
+        fetchDiag.steps.push({
+          endpoint: 'precondition',
+          interval: '5m',
+          rangeMode: false,
+          fromTs: null,
+          toTs: null,
+          inputSymbol: args.symbol,
+          requestedSymbol: null,
+          rawCount: 0,
+          validClose: 0,
+          nulls: 0,
+          ms: 0,
+          error: cryptoEnabled ? 'crypto_simulator_no_binance_service' : 'crypto_not_supported',
+        });
+        return { results, fetchDiag };
+      }
+
+      // Walk-forward crypto via Binance.
+      const binanceSymbol = this.binance.toBinanceSymbol(args.symbol);
+      if (!binanceSymbol) {
+        for (const g of getGridsForAssetClass(args.assetClass)) results[g.key] = noEntry();
+        fetchDiag.outcome = 'error';
+        fetchDiag.steps.push({
+          endpoint: 'precondition',
+          interval: '5m',
+          rangeMode: false,
+          fromTs: null,
+          toTs: null,
+          inputSymbol: args.symbol,
+          requestedSymbol: null,
+          rawCount: 0,
+          validClose: 0,
+          nulls: 0,
+          ms: 0,
+          error: 'crypto_unmappable_symbol',
+        });
+        return { results, fetchDiag };
+      }
+
+      const cryptoStartTs = Math.floor(new Date(args.createdAt).getTime() / 1000);
+      const cryptoFromTs = cryptoStartTs - 300;
+      const cryptoToTs = cryptoStartTs + 60 * 60 + 300;
+      fetchDiag.startTs = cryptoStartTs;
+      fetchDiag.cutoffTs60 = cryptoStartTs + 60 * 60;
+
+      const cryptoT0 = Date.now();
+      const binanceCandles = await this.binance.getKlinesRange(
+        binanceSymbol,
+        '5m',
+        cryptoFromTs * 1000,
+        cryptoToTs * 1000,
+      );
+      const cryptoMs = Date.now() - cryptoT0;
+      const binanceRawCount = binanceCandles?.length ?? 0;
+      const binanceValidClose = binanceCandles?.filter((c) => Number.isFinite(c.close) && c.close > 0).length ?? 0;
+
+      const binanceStep: FetchDiagStep = {
+        endpoint: 'binance_klines_range_5m',
         interval: '5m',
-        rangeMode: false,
-        fromTs: null,
-        toTs: null,
+        rangeMode: true,
+        fromTs: cryptoFromTs,
+        toTs: cryptoToTs,
         inputSymbol: args.symbol,
-        requestedSymbol: null,
-        rawCount: 0,
-        validClose: 0,
-        nulls: 0,
-        ms: 0,
-        error: 'crypto_not_supported',
-      });
-      return { results, fetchDiag };
+        requestedSymbol: binanceSymbol,
+        rawCount: binanceRawCount,
+        validClose: binanceValidClose,
+        nulls: binanceRawCount - binanceValidClose,
+        ms: cryptoMs,
+      };
+      if (binanceCandles == null) {
+        binanceStep.error = 'binance_api_error';
+      } else if (binanceValidClose === 0) {
+        binanceStep.error = 'empty_response';
+      }
+      fetchDiag.steps.push(binanceStep);
+
+      if (!binanceCandles || binanceValidClose === 0) {
+        for (const g of getGridsForAssetClass(args.assetClass)) results[g.key] = noEntry();
+        fetchDiag.outcome = 'no_data';
+        return { results, fetchDiag };
+      }
+
+      // BinanceCandle.openTime est en ms → normalizeAndSortCandles auto-convertit
+      // (timestamp > 1e12 ⇒ /1000) ET trie ASC.
+      const cryptoNormalized = normalizeAndSortCandles(
+        binanceCandles.map((c) => ({
+          timestamp: c.openTime,
+          high: c.high,
+          low: c.low,
+          close: c.close,
+        })),
+      );
+      fetchDiag.selectedStep = 0;
+      fetchDiag.applied_tz_offset_sec = 0;
+
+      const cryptoForward = cryptoNormalized.filter((c) => c.timestamp >= cryptoStartTs);
+      fetchDiag.forwardCount = cryptoForward.length;
+
+      if (cryptoForward.length === 0) {
+        // Pas de candles forward (range fetch a retourné des candles antérieures
+        // au startTs, cas rare avec startTime explicite). Mark no_data ; pas
+        // OFF_SESSION car crypto n'a pas de notion de session.
+        for (const g of getGridsForAssetClass(args.assetClass)) results[g.key] = noEntry();
+        fetchDiag.outcome = 'no_data';
+        return { results, fetchDiag };
+      }
+
+      const cryptoPartialThreshold = (() => {
+        const raw = process.env.PARTIAL_WINDOW_THRESHOLD;
+        const parsed = raw != null ? Number(raw) : 0.5;
+        return Number.isFinite(parsed) && parsed > 0 && parsed <= 1 ? parsed : 0.5;
+      })();
+      const cryptoIsPartial = cryptoForward.length < 12 * cryptoPartialThreshold;
+      const cryptoSnapshots = computePriceSnapshots(cryptoForward, cryptoStartTs);
+
+      for (const grid of getGridsForAssetClass(args.assetClass)) {
+        const out = walkForward(args.entryPrice, cryptoForward, cryptoStartTs, grid);
+        if (cryptoIsPartial && (out.outcome === 'TP_HIT' || out.outcome === 'SL_HIT' || out.outcome === 'TIME_LIMIT')) {
+          out.partial_window = true;
+        }
+        results[grid.key] = out;
+      }
+      fetchDiag.outcome = 'ok';
+      return { results, fetchDiag, priceSnapshots: cryptoSnapshots };
     }
 
     // PR #296 Partie A — Step 0 : skip simulator si capture genuinely off-session.

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -166,7 +166,27 @@ export function getExchangeUtcOffsetSec(symbol: string | null | undefined): numb
 
 const SLIPPAGE_HAIRCUT_BILATERAL = 0.0015;  // 15bps each side
 const SLIPPAGE_TOTAL = SLIPPAGE_HAIRCUT_BILATERAL * 2;  // 30bps round-trip
-const SIMULATE_AFTER_MIN = 60;  // attendre que la fenêtre 60m soit close
+
+/**
+ * SHORT-SHADOW TIMING-FIX (11/05/2026) — Cutoff dynamique pour simulatePending.
+ *
+ * Bug observé 08/05/2026 : 0/503 mesurables (100% OFF_SESSION stale_data) sur les
+ * signaux du jour, alors que 07/05/2026 = 141/143 mesurables (98%). Diagnostic :
+ * scan→sim délai 0-1h sur 8 mai vs 10h+ sur 7 mai. À 60min sharp (cutoff
+ * pré-existant), race condition avec EODHD candle propagation lag (~5min typique
+ * post-bar-close) → fetch retourne empty / partial → outcome marqué OFF_SESSION.
+ *
+ * Fix : `max(windowMin) + buffer 5min`. Pour les grilles actuelles (LONG + SHORT,
+ * max window = 60min), cutoff = 65min. Tolère le lag sans retarder excessivement
+ * la simulation.
+ *
+ * Si nouvelles grilles ajoutées avec windowMin > 60, la constante MAX_WINDOW_MIN
+ * doit être mise à jour manuellement (pas dérivé du tableau pour éviter circular
+ * dep avec getGridsForAssetClass au module init).
+ */
+export const MAX_WINDOW_MIN = 60;
+export const SIMULATE_BUFFER_MIN = 5;
+export const SIMULATE_AFTER_MIN = MAX_WINDOW_MIN + SIMULATE_BUFFER_MIN;  // = 65
 const SIMULATE_BATCH_SIZE = 50;
 
 // PR #283 — Lookback fenêtre 5m pour fetch candles. Configurable via env
@@ -464,9 +484,12 @@ export class GainersUserShadowService {
   }
 
   /**
-   * Pick rows where sim_run_at IS NULL AND created_at > 60 min ago,
+   * Pick rows where sim_run_at IS NULL AND created_at > SIMULATE_AFTER_MIN ago,
    * fetch 5m candles forward, walk-forward to find TP/SL hits sur 4 grilles.
    * Cap batch à SIMULATE_BATCH_SIZE pour éviter timeouts.
+   *
+   * SHORT-SHADOW TIMING-FIX (11/05/2026) — SIMULATE_AFTER_MIN bumped 60→65 pour
+   * tolérer EODHD candle propagation lag ~5min. Cf. constante explication.
    */
   async simulatePending(): Promise<{ processed: number; failures: number }> {
     const cutoff = new Date(Date.now() - SIMULATE_AFTER_MIN * 60_000).toISOString();

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -64,8 +64,65 @@ export interface SimGrid {
   tpPct: number;
   slPct: number;
   windowMin: number;
+  /**
+   * SHORT-SHADOW (11/05/2026) — Direction du signal simulé.
+   * 'long'  : signal classique, TP au-dessus entry, SL en-dessous (default backward-compat)
+   * 'short' : signal inversé (mean-reversion fade), TP en-dessous entry, SL au-dessus
+   * Field optionnel pour préserver toutes les grilles LONG existantes sans modification.
+   */
+  direction?: 'long' | 'short';
 }
 
+/**
+ * SHORT-SHADOW (11/05/2026) — Retourne les grilles de simulation selon l'asset class.
+ *
+ * Stratégie : SHORT grids UNIQUEMENT sur `us_equity_small_mid` (scope strict MESURE,
+ * basé sur observation n=147 trades mono-journée 07/05/2026, expectancy LONG -1.20%
+ * vs proxy SHORT +1.18%). Hypothèse "fade the gainer" sur small caps illiquides.
+ *
+ * Toutes les autres classes (us_equity_large, eu_equity, asia_equity, crypto_*)
+ * conservent uniquement les 4 grilles LONG historiques. Aucun changement de
+ * comportement pour ces classes (rétro-compat parfaite).
+ *
+ * Calibration grilles SHORT (us_equity_small_mid uniquement) :
+ *   - short_baseline_30m/60m : TP 2.0% / SL 0.9% (mirror LONG baseline pour comparaison
+ *     apples-to-apples)
+ *   - short_alt15_30m/60m    : TP 1.5% / SL 0.6% (mirror LONG alt15)
+ *   - short_calibrated_30m/60m : TP 0.8% / SL 0.4% (ratio 2:1, breakeven 33%, calibré
+ *     sur range 60min réellement observé small/mid US 0.5-1.2%)
+ */
+export function getGridsForAssetClass(assetClass: string): SimGrid[] {
+  const longGrids: SimGrid[] = [
+    { key: 'baseline_30m', tpPct: 0.020, slPct: 0.009, windowMin: 30, direction: 'long' },
+    { key: 'baseline_60m', tpPct: 0.020, slPct: 0.009, windowMin: 60, direction: 'long' },
+    { key: 'alt15_30m',    tpPct: 0.015, slPct: 0.006, windowMin: 30, direction: 'long' },
+    { key: 'alt15_60m',    tpPct: 0.015, slPct: 0.006, windowMin: 60, direction: 'long' },
+  ];
+
+  if (assetClass !== 'us_equity_small_mid') {
+    return longGrids;
+  }
+
+  // SHORT grids — SCOPE STRICT us_equity_small_mid uniquement
+  return [
+    ...longGrids,
+    // Mirror LONG baseline (apples-to-apples comparison)
+    { key: 'short_baseline_30m', tpPct: 0.020, slPct: 0.009, windowMin: 30, direction: 'short' },
+    { key: 'short_baseline_60m', tpPct: 0.020, slPct: 0.009, windowMin: 60, direction: 'short' },
+    // Mirror LONG alt15
+    { key: 'short_alt15_30m', tpPct: 0.015, slPct: 0.006, windowMin: 30, direction: 'short' },
+    { key: 'short_alt15_60m', tpPct: 0.015, slPct: 0.006, windowMin: 60, direction: 'short' },
+    // Calibrated for small/mid US 60m range (TP 0.8% / SL 0.4%, ratio 2:1)
+    { key: 'short_calibrated_30m', tpPct: 0.008, slPct: 0.004, windowMin: 30, direction: 'short' },
+    { key: 'short_calibrated_60m', tpPct: 0.008, slPct: 0.004, windowMin: 60, direction: 'short' },
+  ];
+}
+
+/**
+ * @deprecated SHORT-SHADOW (11/05/2026) — Préservé pour rétro-compat lecture.
+ * Utiliser getGridsForAssetClass(assetClass) pour le nouveau comportement
+ * conditionnel par asset class.
+ */
 const SIM_GRIDS: SimGrid[] = [
   { key: 'baseline_30m', tpPct: 0.020, slPct: 0.009, windowMin: 30 },
   { key: 'baseline_60m', tpPct: 0.020, slPct: 0.009, windowMin: 60 },
@@ -299,28 +356,43 @@ export function walkForward(
   startTs: number,
   grid: SimGrid,
 ): SimOutcome {
-  const tpPrice = entry * (1 + grid.tpPct);
-  const slPrice = entry * (1 - grid.slPct);
+  // SHORT-SHADOW (11/05/2026) — Direction read from grid (default 'long' rétro-compat).
+  // LONG : TP au-dessus entry, SL en-dessous, profit si prix monte
+  // SHORT : TP en-dessous entry, SL au-dessus, profit si prix descend
+  const direction = grid.direction ?? 'long';
+  const isShort = direction === 'short';
+
+  const tpPrice = isShort ? entry * (1 - grid.tpPct) : entry * (1 + grid.tpPct);
+  const slPrice = isShort ? entry * (1 + grid.slPct) : entry * (1 - grid.slPct);
   const cutoffTs = startTs + grid.windowMin * 60;
   let lastBeforeCutoff: CandleLike | null = null;
 
   for (const c of candles) {
     if (c.timestamp > cutoffTs) break;
     lastBeforeCutoff = c;
-    if (c.low <= slPrice) {
+
+    // SHORT-SHADOW : hit conditions inversées
+    // SHORT SL hit si c.high >= slPrice (prix MONTE à travers SL au-dessus)
+    // SHORT TP hit si c.low  <= tpPrice (prix DESCEND à travers TP en-dessous)
+    const slHit = isShort ? c.high >= slPrice : c.low <= slPrice;
+    const tpHit = isShort ? c.low <= tpPrice : c.high >= tpPrice;
+
+    if (slHit) {
       return {
         outcome: 'SL_HIT',
         exit_price: slPrice,
         exit_at: new Date(c.timestamp * 1000).toISOString(),
+        // pnl_pct sign : SL loss is negative for both LONG and SHORT (grid.slPct is magnitude)
         pnl_pct: -grid.slPct - SLIPPAGE_TOTAL,
         hit_at_min: Math.round((c.timestamp - startTs) / 60),
       };
     }
-    if (c.high >= tpPrice) {
+    if (tpHit) {
       return {
         outcome: 'TP_HIT',
         exit_price: tpPrice,
         exit_at: new Date(c.timestamp * 1000).toISOString(),
+        // pnl_pct sign : TP profit is positive for both LONG and SHORT
         pnl_pct: grid.tpPct - SLIPPAGE_TOTAL,
         hit_at_min: Math.round((c.timestamp - startTs) / 60),
       };
@@ -328,7 +400,12 @@ export function walkForward(
   }
 
   if (lastBeforeCutoff) {
-    const closePnl = (lastBeforeCutoff.close - entry) / entry;
+    // SHORT-SHADOW : TIME_LIMIT pnl signe inversé pour SHORT
+    // LONG  closePnl = (close - entry) / entry  (positif si close > entry = profit long)
+    // SHORT closePnl = (entry - close) / entry  (positif si entry > close = profit short)
+    const closePnl = isShort
+      ? (entry - lastBeforeCutoff.close) / entry
+      : (lastBeforeCutoff.close - entry) / entry;
     return {
       outcome: 'TIME_LIMIT',
       exit_price: lastBeforeCutoff.close,
@@ -459,7 +536,12 @@ export class GainersUserShadowService {
     assetClass: string;
     entryPrice: number | null;
     createdAt: string;
-  }): Promise<{ results: Record<string, SimOutcome>; fetchDiag: FetchDiag }> {
+  }): Promise<{
+    results: Record<string, SimOutcome>;
+    fetchDiag: FetchDiag;
+    /** MESURE-PR (e1dfec6) — Snapshots prix raw aux 4 instants cibles, undefined sur early-returns */
+    priceSnapshots?: PriceSnapshots;
+  }> {
     const results: Record<string, SimOutcome> = {};
     const noEntry = (): SimOutcome => ({
       outcome: 'NO_DATA', exit_price: null, exit_at: null, pnl_pct: null, hit_at_min: null,
@@ -472,7 +554,7 @@ export class GainersUserShadowService {
     };
 
     if (args.entryPrice == null || args.entryPrice <= 0) {
-      for (const g of SIM_GRIDS) results[g.key] = noEntry();
+      for (const g of getGridsForAssetClass(args.assetClass)) results[g.key] = noEntry();
       fetchDiag.outcome = 'error';
       fetchDiag.steps.push({
         endpoint: 'precondition',
@@ -493,7 +575,7 @@ export class GainersUserShadowService {
 
     // Crypto = no support yet (would need Binance klines), skip gracefully
     if (args.assetClass === 'crypto_major' || args.assetClass === 'crypto_alt') {
-      for (const g of SIM_GRIDS) results[g.key] = noEntry();
+      for (const g of getGridsForAssetClass(args.assetClass)) results[g.key] = noEntry();
       fetchDiag.outcome = 'error';
       fetchDiag.steps.push({
         endpoint: 'precondition',
@@ -536,7 +618,7 @@ export class GainersUserShadowService {
         hit_at_min: null,
         off_session_reason: 'capture',
       };
-      for (const g of SIM_GRIDS) results[g.key] = offCaptureOutcome;
+      for (const g of getGridsForAssetClass(args.assetClass)) results[g.key] = offCaptureOutcome;
       fetchDiag.outcome = 'off_session';
       fetchDiag.steps.push({
         endpoint: 'session_check',
@@ -740,7 +822,7 @@ export class GainersUserShadowService {
           `fromTs=${fromTs} toTs=${toTs} reason=all_4_steps_empty`,
         );
       }
-      for (const g of SIM_GRIDS) results[g.key] = noEntry();
+      for (const g of getGridsForAssetClass(args.assetClass)) results[g.key] = noEntry();
       fetchDiag.outcome = 'no_data';
       return { results, fetchDiag };
     }
@@ -810,7 +892,7 @@ export class GainersUserShadowService {
         hit_at_min: null,
         off_session_reason: 'stale_data',
       };
-      for (const g of SIM_GRIDS) results[g.key] = offSessionOutcome;
+      for (const g of getGridsForAssetClass(args.assetClass)) results[g.key] = offSessionOutcome;
       fetchDiag.outcome = 'off_session';
       return { results, fetchDiag };
     }
@@ -838,7 +920,10 @@ export class GainersUserShadowService {
     // grille). Permet la SQL persistance directionnelle pure post-rétro-simulation.
     const priceSnapshots = computePriceSnapshots(forward, startTs);
 
-    for (const grid of SIM_GRIDS) {
+    // SHORT-SHADOW (11/05/2026) — getGridsForAssetClass retourne 4 LONG grids + 6 SHORT
+    // grids pour us_equity_small_mid uniquement, sinon 4 LONG grids seulement. La direction
+    // SHORT est portée par grid.direction lue dans walkForward.
+    for (const grid of getGridsForAssetClass(args.assetClass)) {
       const out = walkForward(args.entryPrice, forward, startTs, grid);
       if (isPartialWindow && (out.outcome === 'TP_HIT' || out.outcome === 'SL_HIT' || out.outcome === 'TIME_LIMIT')) {
         out.partial_window = true;

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -238,6 +238,48 @@ export function normalizeAndSortCandles<T extends CandleLike>(candles: readonly 
 }
 
 /**
+ * MESURE-PR (11/05/2026) — Raw close prices à 5/15/30/60min après startTs,
+ * indépendants de tout TP/SL. Stockés au niveau RACINE de sim_results JSONB
+ * (pas dupliqués par grille). Permet de mesurer la persistance directionnelle
+ * pure P(up_60m | up_30m) sur TIME_LIMIT et sur outcomes où TP/SL fire tard.
+ * Null si aucune candle ne couvre l'instant cible.
+ */
+export type PriceSnapshots = {
+  '5': number | null;
+  '15': number | null;
+  '30': number | null;
+  '60': number | null;
+};
+
+/**
+ * MESURE-PR — Helper pur : extrait close prices aux 4 instants cibles
+ * indépendamment de la logique TP/SL. À appeler UNE FOIS par row, pas par
+ * grille, pour éviter la duplication 4× dans sim_results JSONB.
+ *
+ * Itère candles ASC. Pour chaque candle, set result[key]=c.close si
+ * minSinceStart >= key et pas encore set. Boucle interne O(4) négligeable.
+ *
+ * Fonction pure exportée pour testabilité.
+ */
+export function computePriceSnapshots(
+  candles: readonly CandleLike[],
+  startTs: number,
+): PriceSnapshots {
+  const targets = [5, 15, 30, 60] as const;
+  const result: PriceSnapshots = { '5': null, '15': null, '30': null, '60': null };
+  for (const c of candles) {
+    const minSinceStart = (c.timestamp - startTs) / 60;
+    for (const t of targets) {
+      const key = String(t) as keyof PriceSnapshots;
+      if (minSinceStart >= t && result[key] === null) {
+        result[key] = c.close;
+      }
+    }
+  }
+  return result;
+}
+
+/**
  * PR #283 — walkForward : itère les candles ASCENDING, applique TP/SL d'une
  * grille (TP%, SL%, windowMin), retourne le premier hit ou TIME_LIMIT.
  *
@@ -369,16 +411,23 @@ export class GainersUserShadowService {
     let failures = 0;
     for (const row of rows) {
       try {
-        const { results: simResults, fetchDiag } = await this.simulateRow({
+        const { results: simResults, fetchDiag, priceSnapshots } = await this.simulateRow({
           symbol: String(row.symbol),
           assetClass: String(row.asset_class),
           entryPrice: row.entry_price != null ? Number(row.entry_price) : null,
           createdAt: String(row.created_at),
         });
+        // MESURE-PR — Merge priceSnapshots au niveau RACINE de sim_results JSONB.
+        // Early-returns de simulateRow (no_entry, off_session capture) ne calculent
+        // pas snapshots → fallback all-null pour cohérence schéma.
+        const simResultsRoot = {
+          ...simResults,
+          price_snapshots: priceSnapshots ?? { '5': null, '15': null, '30': null, '60': null },
+        };
         await this.supabase.getClient()
           .from('gainers_user_shadow_signals')
           .update({
-            sim_results: simResults,
+            sim_results: simResultsRoot,
             fetch_diag: fetchDiag,        // PR #286 — diagnostic JSONB
             sim_run_at: new Date().toISOString(),
             sim_window_max_min: 60,
@@ -784,6 +833,11 @@ export class GainersUserShadowService {
     const expectedCandles = 12;  // 60min / 5min
     const isPartialWindow = forward.length < expectedCandles * partialWindowThreshold;
 
+    // MESURE-PR — Snapshots calculés UNE fois sur `forward`, indépendants des grilles.
+    // Stockés au niveau RACINE de sim_results par simulatePending (pas duplique par
+    // grille). Permet la SQL persistance directionnelle pure post-rétro-simulation.
+    const priceSnapshots = computePriceSnapshots(forward, startTs);
+
     for (const grid of SIM_GRIDS) {
       const out = walkForward(args.entryPrice, forward, startTs, grid);
       if (isPartialWindow && (out.outcome === 'TP_HIT' || out.outcome === 'SL_HIT' || out.outcome === 'TIME_LIMIT')) {
@@ -792,7 +846,7 @@ export class GainersUserShadowService {
       results[grid.key] = out;
     }
     fetchDiag.outcome = forward.length > 0 ? 'ok' : 'no_data';
-    return { results, fetchDiag };
+    return { results, fetchDiag, priceSnapshots };
   }
 
   /**

--- a/apps/api/src/modules/lisa/services/macro-veto.service.ts
+++ b/apps/api/src/modules/lisa/services/macro-veto.service.ts
@@ -1,0 +1,299 @@
+/**
+ * PR Action 3 — Macro Veto Service.
+ *
+ * Cron Lisa hourly qui produit un flag global `macro_allowed` consommé
+ * par TopGainersScannerService.runScannerInner avant chaque cycle.
+ *
+ * Quand `macro_allowed = false` ET `GAINERS_MACRO_VETO_ENABLED=true`,
+ * le scanner SKIP tous les opens (économie capital + protection des
+ * journées risk-off où aucune stratégie momentum ne fonctionne).
+ *
+ * Inputs LLM (snapshot via LisaService.fetchMarketSnapshot) :
+ *   - VIX (volatility index)
+ *   - SPX intraday delta
+ *   - DXY (dollar index)
+ *   - US10Y yield
+ *   - Sentiment des conditions
+ *
+ * Output structuré :
+ *   { macro_allowed, regime, veto_reason, confidence }
+ *
+ * Persistance : table `macro_veto_log` (append-only, migration 0138).
+ *
+ * Fail-safe : si LLM échoue ET aucune décision récente (<2h) → default ALLOW
+ * (fail-open : on préfère trader avec une mauvaise journée que rater une
+ * bonne journée à cause d'une panne LLM).
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { LisaService } from './lisa.service';
+import { ScannerLlmRouterService } from './scanner-llm-router.service';
+
+/** Décision LLM parsée. */
+export interface MacroVetoDecision {
+  macroAllowed: boolean;
+  regime: 'risk_on' | 'risk_off' | 'transitioning' | 'uncertain';
+  vetoReason: string | null;
+  confidence: number;
+  fallbackUsed: boolean;
+}
+
+/** Cache row de la dernière décision (évite re-fetch DB à chaque scanner cycle). */
+interface CachedDecision {
+  decision: MacroVetoDecision;
+  fetchedAt: number;
+}
+
+/** Stale threshold : si la dernière décision a plus de 2h, on considère stale et fail-open. */
+const STALE_DECISION_THRESHOLD_MS = 2 * 60 * 60 * 1000;
+
+/** Cache TTL côté scanner pour réduire les hits DB (le scanner cycle est fréquent). */
+const CACHE_TTL_MS = 60 * 1000;  // 60s, suffisant car le cron LLM tourne 1×/h
+
+@Injectable()
+export class MacroVetoService {
+  private readonly logger = new Logger(MacroVetoService.name);
+  private cache: CachedDecision | null = null;
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly config: ConfigService,
+    private readonly lisa: LisaService,
+    private readonly llmRouter: ScannerLlmRouterService,
+  ) {}
+
+  /**
+   * API principale : retourne la décision courante pour le scanner.
+   *
+   * - Si cache <60s : return cached
+   * - Sinon : fetch DB la décision la plus récente
+   * - Si DB vide ou stale (>2h) : fail-open (default = allow)
+   *
+   * **Ne déclenche PAS de call LLM** — c'est le rôle du cron.
+   */
+  async getCurrentFlag(): Promise<MacroVetoDecision> {
+    const now = Date.now();
+    if (this.cache && now - this.cache.fetchedAt < CACHE_TTL_MS) {
+      return this.cache.decision;
+    }
+
+    try {
+      const { data, error } = await this.supabase.getClient()
+        .from('macro_veto_log')
+        .select('macro_allowed, regime, veto_reason, confidence, created_at, fallback_used')
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .single();
+
+      if (error || !data) {
+        return this.failOpenDefault('no_recent_decision');
+      }
+
+      const ageMs = now - new Date(data.created_at as string).getTime();
+      if (ageMs > STALE_DECISION_THRESHOLD_MS) {
+        this.logger.warn(`[macro-veto] last decision is ${Math.floor(ageMs / 60000)}min old (>2h) — fail-open default allow`);
+        return this.failOpenDefault('stale_decision');
+      }
+
+      const decision: MacroVetoDecision = {
+        macroAllowed: Boolean(data.macro_allowed),
+        regime: String(data.regime) as MacroVetoDecision['regime'],
+        vetoReason: (data.veto_reason as string | null) ?? null,
+        confidence: Number(data.confidence),
+        fallbackUsed: Boolean(data.fallback_used),
+      };
+      this.cache = { decision, fetchedAt: now };
+      return decision;
+    } catch (e) {
+      this.logger.warn(`[macro-veto] getCurrentFlag failed: ${String(e).slice(0, 120)} — fail-open`);
+      return this.failOpenDefault('exception');
+    }
+  }
+
+  /** Default safe : tout autoriser. Évite de bloquer le trading sur une panne. */
+  private failOpenDefault(reason: string): MacroVetoDecision {
+    const decision: MacroVetoDecision = {
+      macroAllowed: true,
+      regime: 'uncertain',
+      vetoReason: null,
+      confidence: 0,
+      fallbackUsed: true,
+    };
+    this.cache = { decision, fetchedAt: Date.now() };
+    if (reason !== 'no_recent_decision') {
+      this.logger.log(`[macro-veto] fail-open: ${reason}`);
+    }
+    return decision;
+  }
+
+  /**
+   * Cron Lisa hourly — appelle le LLM, persiste la décision en DB, invalide cache.
+   *
+   * Tourne en début d'heure UTC. Si LLM router désactivé OU snapshot fail
+   * → write fail-open allow row.
+   */
+  @Cron('0 * * * *', { name: 'macro-veto-hourly', timeZone: 'UTC' })
+  async runHourlyDecision(): Promise<void> {
+    const enabled = (this.config.get<string>('GAINERS_MACRO_VETO_ENABLED') ?? 'false').toLowerCase() === 'true';
+    if (!enabled) {
+      this.logger.debug('[macro-veto] cron skipped — GAINERS_MACRO_VETO_ENABLED=false');
+      return;
+    }
+
+    let snapshot: Awaited<ReturnType<LisaService['fetchMarketSnapshot']>> | null = null;
+    try {
+      snapshot = await this.lisa.fetchMarketSnapshot();
+    } catch (e) {
+      this.logger.warn(`[macro-veto] fetchMarketSnapshot failed: ${String(e).slice(0, 120)} — write allow row`);
+      await this.persistFailOpen('snapshot_fetch_failed', null);
+      return;
+    }
+
+    const llmAvailable = this.llmRouter.isEnabled();
+    if (!llmAvailable) {
+      this.logger.warn('[macro-veto] scanner-llm router not enabled — write allow row (no LLM, no veto)');
+      await this.persistFailOpen('llm_router_disabled', snapshot);
+      return;
+    }
+
+    try {
+      const decision = await this.callLlm(snapshot);
+      await this.persistDecision(decision, snapshot);
+      this.cache = null;  // invalider cache pour next getCurrentFlag()
+      this.logger.log(
+        `[macro-veto] hourly decision: allowed=${decision.macroAllowed} regime=${decision.regime} ` +
+        `confidence=${decision.confidence.toFixed(2)} reason="${decision.vetoReason ?? 'n/a'}" ` +
+        `fallback=${decision.fallbackUsed}`,
+      );
+    } catch (e) {
+      this.logger.warn(`[macro-veto] LLM call failed: ${String(e).slice(0, 200)} — write allow row`);
+      await this.persistFailOpen('llm_call_failed', snapshot);
+    }
+  }
+
+  /**
+   * Construit le prompt + appelle le LLM router. Parse la réponse JSON.
+   * Si parsing fail OU réponse incoherente → fallback allow.
+   */
+  private async callLlm(snapshot: Awaited<ReturnType<LisaService['fetchMarketSnapshot']>>): Promise<MacroVetoDecision & { llmCostUsd: number; llmLatencyMs: number; llmProvider: string; rawResponse: string }> {
+    const system = `Tu es un analyste macro-financier conservateur. Ton job est de déterminer si les conditions macro courantes sont compatibles avec une stratégie momentum intraday sur small/mid-cap actions et crypto.
+
+Output STRICT au format JSON :
+{
+  "macro_allowed": true | false,
+  "regime": "risk_on" | "risk_off" | "transitioning" | "uncertain",
+  "veto_reason": "<courte explication, null si allowed>",
+  "confidence": <0.0 à 1.0>
+}
+
+RÈGLES STRICTES :
+- macro_allowed = false si VIX > 25 OU drawdown SPX > -2% intraday OU US10Y bondit >0.15% en 1h
+- macro_allowed = false si breaking news majeure (FED rate decision, geopolitical shock)
+- macro_allowed = true par défaut (fail-open) — ne veto QUE quand la conviction est haute
+- confidence haute (>0.7) seulement quand le signal est franc, pas borderline`;
+
+    const user = `Indicateurs macro courants :
+- VIX : ${snapshot.vix.toFixed(1)}
+- SPX (S&P 500) : ${snapshot.sp500.toFixed(1)}
+- DXY (dollar index) : ${snapshot.usdDxy.toFixed(1)}
+- US 10Y yield : ${snapshot.us10yYield.toFixed(2)}%
+- US 2Y yield : ${snapshot.us2yYield.toFixed(2)}%
+- Brent : $${snapshot.brentUsd.toFixed(1)}
+- Gold : $${snapshot.goldUsd.toFixed(0)}
+- BTC : $${snapshot.btcUsd.toFixed(0)}
+- HY OAS spread : ${snapshot.creditHyOasBps}bps
+- Timestamp : ${snapshot.timestamp}
+
+Décision macro veto pour la prochaine heure de trading ?`;
+
+    const result = await this.llmRouter.call({
+      system,
+      user,
+      temperature: 0.2,
+      maxTokens: 200,
+      timeoutMs: 8000,
+    });
+
+    // Parse JSON response
+    const cleaned = result.content.trim().replace(/^```json\s*/i, '').replace(/\s*```$/i, '');
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(cleaned);
+    } catch {
+      throw new Error(`LLM response not valid JSON: ${result.content.slice(0, 200)}`);
+    }
+
+    // Validate shape
+    const p = parsed as Record<string, unknown>;
+    const macroAllowed = typeof p.macro_allowed === 'boolean' ? p.macro_allowed : true;
+    const regime = ['risk_on', 'risk_off', 'transitioning', 'uncertain'].includes(String(p.regime))
+      ? (p.regime as MacroVetoDecision['regime'])
+      : 'uncertain';
+    const vetoReason = typeof p.veto_reason === 'string' ? p.veto_reason : null;
+    const confidence = typeof p.confidence === 'number' && p.confidence >= 0 && p.confidence <= 1
+      ? p.confidence
+      : 0.5;
+
+    return {
+      macroAllowed,
+      regime,
+      vetoReason: macroAllowed ? null : vetoReason,
+      confidence,
+      fallbackUsed: false,
+      llmCostUsd: result.costUsd,
+      llmLatencyMs: result.latencyMs,
+      llmProvider: result.providerId,
+      rawResponse: result.content,
+    };
+  }
+
+  /** Persiste une décision LLM réussie. */
+  private async persistDecision(
+    decision: MacroVetoDecision & { llmCostUsd: number; llmLatencyMs: number; llmProvider: string; rawResponse: string },
+    snapshot: Awaited<ReturnType<LisaService['fetchMarketSnapshot']>>,
+  ): Promise<void> {
+    await this.supabase.getClient().from('macro_veto_log').insert({
+      macro_allowed: decision.macroAllowed,
+      regime: decision.regime,
+      veto_reason: decision.vetoReason,
+      confidence: decision.confidence,
+      vix: snapshot.vix,
+      spx_change_pct: null,  // Calc côté caller si besoin (pas dans snapshot direct)
+      dxy: snapshot.usdDxy,
+      us10y_yield: snapshot.us10yYield,
+      llm_provider: decision.llmProvider,
+      llm_cost_usd: decision.llmCostUsd,
+      llm_latency_ms: decision.llmLatencyMs,
+      llm_raw_response: decision.rawResponse.slice(0, 4000),
+      fallback_used: false,
+    });
+  }
+
+  /** Persiste un fail-open (LLM fail ou disabled). Toujours allow. */
+  private async persistFailOpen(
+    reason: string,
+    snapshot: Awaited<ReturnType<LisaService['fetchMarketSnapshot']>> | null,
+  ): Promise<void> {
+    await this.supabase.getClient().from('macro_veto_log').insert({
+      macro_allowed: true,
+      regime: 'uncertain',
+      veto_reason: null,
+      confidence: 0,
+      vix: snapshot?.vix ?? null,
+      spx_change_pct: null,
+      dxy: snapshot?.usdDxy ?? null,
+      us10y_yield: snapshot?.us10yYield ?? null,
+      llm_provider: 'fallback_deterministic',
+      llm_cost_usd: 0,
+      llm_latency_ms: 0,
+      llm_raw_response: `fail_open: ${reason}`,
+      fallback_used: true,
+    }).then(() => undefined, (e) => {
+      this.logger.warn(`[macro-veto] persistFailOpen DB write failed: ${String(e).slice(0, 120)}`);
+    });
+    this.cache = null;
+  }
+}

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -32,6 +32,7 @@ import { MultiTimeframePersistenceService, type PersistenceWithPath } from './mu
 import { PersistenceProbabilityService } from './persistence-probability.service';
 import { EodhdQuotaService } from './eodhd-quota.service';
 import { EodhdCalendarService } from './eodhd-calendar.service';
+import { MacroVetoService } from './macro-veto.service';
 import { GainersUserShadowService, type ShadowDecision } from './gainers-user-shadow.service';
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
 // PR6.3 — Shadow wiring (LisaModule import GainersModule pour résolution DI)
@@ -507,6 +508,11 @@ export class TopGainersScannerService implements OnModuleInit {
      * Quand undefined → earnings filter no-op silencieux.
      */
     private readonly eodhdCalendar?: EodhdCalendarService,
+    /**
+     * PR Action 3 — Macro veto LLM hourly. Optional back-compat tests.
+     * Quand undefined → veto check skip silently (legacy behavior).
+     */
+    private readonly macroVeto?: MacroVetoService,
   ) {}
 
   /**
@@ -715,6 +721,26 @@ export class TopGainersScannerService implements OnModuleInit {
       this.logger.log(`[top-gainers] paused — ${reason} — cycle skipped`);
       this.recordEarlyReturn('scanner_paused');
       return;
+    }
+
+    // PR Action 3 — LLM macro veto check (env-gated, default off).
+    //
+    // Hourly cron MacroVetoService produit une décision macro (allow/veto)
+    // basée sur VIX, SPX, DXY, US10Y, news flash. Si veto active ET env
+    // GAINERS_MACRO_VETO_ENABLED=true → skip ce cycle scanner.
+    //
+    // Fail-safe : si pas de décision récente (>2h) OU LLM disabled, default = allow.
+    // Lecture ultra-rapide (cache 60s côté MacroVetoService → pas d'impact perf).
+    const macroVetoEnabled = (this.config.get<string>('GAINERS_MACRO_VETO_ENABLED') ?? 'false').toLowerCase() === 'true';
+    if (macroVetoEnabled && this.macroVeto) {
+      const macroFlag = await this.macroVeto.getCurrentFlag().catch(() => null);
+      if (macroFlag && !macroFlag.macroAllowed && !macroFlag.fallbackUsed) {
+        this.logger.log(
+          `[top-gainers] macro veto active — regime=${macroFlag.regime} reason="${macroFlag.vetoReason ?? 'n/a'}" confidence=${macroFlag.confidence.toFixed(2)} — cycle skipped`,
+        );
+        this.recordEarlyReturn('macro_veto');
+        return;
+      }
     }
 
     // P7 — Priorité DB : portfolios en strategy_mode='gainers' (toggle UI).

--- a/docs/BRIEF_CLAUDE_FIX_SCANNER.md
+++ b/docs/BRIEF_CLAUDE_FIX_SCANNER.md
@@ -1,0 +1,199 @@
+# Brief Claude — Fix scanner SmartVest (Phase 3 bis)
+
+**Contexte** : Phase 3 (shadow forward 14j) a été STOPPÉE le 12 mai 08:00 CEST. Phase 2b est INVALIDÉE. Le bucket « WR 71.9%, expectancy nette +0.73%, n=114 sur `path_eff<0.25` » est un mirage statistique : après déduplication par `(symbol, jour, entry_price)`, ce bucket tombe à **n=3 distincts**. Cause racine : le scanner persiste des doublons massifs en DB hors-RTH, et aucune contrainte UNIQUE ne l'empêche.
+
+**Branche** : `feature/short-shadow-grids` (commit Fly actif `4c7b345`).
+**Table** : `gainers_user_shadow_signals` (Supabase project `mfuutigfhrawccotinpo`).
+**Portfolio** : `58439d86-3f20-4a60-82a4-307f3f252bc2`.
+**Règles** : pas de PR, pas de push, pas de deploy, pas de secret tant que ce brief n'est pas validé point par point. Phase MESURE.
+
+---
+
+## TL;DR — SMOKING GUN trouvé
+
+**Bug #1 a déjà un fix dans le code (PR #298), mais il est gardé par un feature flag env `SCANNER_SESSION_AWARE` qui n'est PAS défini dans `fly.toml`.** Conséquence : `sessionAware = false` en prod, le scanner skip la garde session, et continue à fetch les 9 EODHD screener à chaque cycle, week-end inclus, hors-RTH inclus, week-end inclus → poison des 148 lignes HRB et 87 ATEC dupliquées identiquement.
+
+**Fix instantané** : ajouter `SCANNER_SESSION_AWARE = 'true'` dans `fly.toml` section `[env]`. **1 ligne**, redeploy, fin du bug #1.
+
+Tout le reste (bug #6 UNIQUE en DB, bugs #4/#5 doc) est garde-fou et hygiène, pas urgent.
+
+---
+
+## Investigation détaillée — les 6 bugs après audit code
+
+### Bug #1 — CRITIQUE / SMOKING GUN env manquante
+
+**Diagnostic exact** :
+- `apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts` ligne 1059 :
+  `const sessionAware = this.config.get('SCANNER_SESSION_AWARE') === 'true';`
+- `fly.toml` `[env]` actuel : `NODE_ENV='production', API_PORT='3001', PORT='3001'`. Aucun `SCANNER_SESSION_AWARE`.
+- Conséquence : `sessionAware` reste `false` → la garde session est skip → le scanner continue à appeler EODHD screener même quand toutes les sessions configurées sont fermées (US/EU/Asia weekend).
+
+**Test associé existant** :
+`apps/api/src/modules/lisa/__tests__/scanner-session-aware.spec.ts` (PR #298) décrit textuellement le bug observé en prod 09/05/2026 08:20 UTC : « avec `gainers_session_filter_enabled=true` en DB, le scanner continue à fetch les 9 EODHD screener à chaque cycle samedi ».
+
+**Le filtre `usOpen`/`euOpen`/`asiaOpen` lignes 1633-1644 reste actif** mais agit post-fetch — il filtre les candidats parmi le pool déjà ramené par EODHD. Le poison des doublons est en amont : EODHD screener renvoie les MÊMES snapshots fig**és quand le marché est fermé**. Le scanner persiste ces snapshots en DB (`recordDecision`) avant que `usOpen` ne puisse filtrer en aval, et même quand `usOpen=false` les rejets sont quand même écrits via `recordShadowDecision`.
+
+**Probe SQL discriminante (12 mai 2026)** : sur 148 lignes HRB sur 23h10 → `COUNT(DISTINCT entry_price) = 1` (36.29), `COUNT(DISTINCT change_pct_1m) = 1`. Donc vrais doublons, pas faux positifs.
+
+**Fix proposé immédiat** :
+```toml
+# fly.toml, dans [env]
+SCANNER_SESSION_AWARE = 'true'
+```
+
+`fly deploy` puis 1 cycle scanner (5 min) suffit pour vérifier en logs que la garde session se déclenche hors-RTH.
+
+### Bug #6 — Important garde-fou : aucune contrainte UNIQUE en DB
+
+`supabase/migrations/0134_gainers_user_shadow_signals.sql` confirmée : 3 index simples (portfolio, symbol, sim_run_at), zéro UNIQUE. `recordDecision` ligne 462 de `gainers-user-shadow.service.ts` = `supabase.from(...).insert(...)` brut, sans `ON CONFLICT`.
+
+Même bug #1 corrigé, un retry réseau Supabase ou un rejouage de cycle peut réintroduire des doublons. Une contrainte UNIQUE en DB est un garde-fou essentiel à long terme.
+
+**Difficulté Postgres** : on ne peut pas mettre `UNIQUE (..., DATE(created_at), ...)` directement. Deux options :
+1. **Colonne générée** : `ALTER TABLE gainers_user_shadow_signals ADD COLUMN created_date DATE GENERATED ALWAYS AS (DATE(created_at)) STORED;` puis `CREATE UNIQUE INDEX ... ON gainers_user_shadow_signals (portfolio_id, symbol, asset_class, created_date, entry_price);`
+2. **Index unique partiel avec expression** : `CREATE UNIQUE INDEX uniq_decision_per_day ON gainers_user_shadow_signals (portfolio_id, symbol, asset_class, (DATE(created_at)), entry_price) WHERE entry_price IS NOT NULL;`
+
+Option 2 plus simple, option 1 plus performante en read. À ton choix Claude.
+
+**Attention** : `recordDecision` doit alors gérer le conflict via `.upsert({...}, { onConflict: 'portfolio_id,symbol,asset_class,...', ignoreDuplicates: true })` pour ne pas crasher en cas de retry réseau. Sinon ajouter try/catch silencieux sur erreur 23505.
+
+### Bug #2 — Faux bug (RECLASSIFIÉ doc manquante)
+
+L'incohérence apparente « `fetch_diag.outcome=ok` mais `path_eff=NULL` » s'explique par la chronologie :
+1. `recordDecision` insère avec `path_eff = pers?.pathQuality?.overallEfficiency ?? null` au moment de la décision scanner.
+2. `simulatePending` met à jour `fetch_diag` ~65 min plus tard, indépendamment.
+
+Quand la decision est `reject_cooldown` ou `reject_post_sl_cooldown` (lignes 1898 et 1912 du scanner), `pers` est passé `undefined` par design → `path_eff = null`. Le marché peut très bien être ouvert 60 min plus tard → `fetch_diag.outcome = ok`. Pas un bug.
+
+**Probe SQL (7 derniers jours)** confirme 100% des cas `path_eff IS NULL AND fetch_diag.outcome='ok'` (88/88) sont des `reject_cooldown` / `reject_post_sl_cooldown`.
+
+**Action** : `COMMENT ON COLUMN gainers_user_shadow_signals.path_eff IS '... NULL légitime pour decisions cooldown (pers undefined avant calcul persistence)';`
+
+### Bug #3 — Faux bug (CONSÉQUENCE de #1+#4)
+
+Lignes 380-437 de `gainers-user-shadow.service.ts`, walkForward :
+- SHORT TP : `c.low <= tpPrice` avec `tpPrice = entry × (1 − tpPct)`
+- SHORT SL : `c.high >= slPrice` avec `slPrice = entry × (1 + slPct)`
+- `pnl_pct: closePnl − SLIPPAGE_TOTAL` (ligne 433)
+
+Exemple ATEC entry 7.75 SHORT, TP 0.8% : `tpPrice = 7.75 × 0.992 = 7.688`. Le exit observé à 7.688 EST exactement le TP. La logique est correcte. Ce qui m'avait alerté = le `pnl_pct = -0.005` (0.5% — slippage 30 bps déjà appliqué). Donc c'est bug #4 mal compris, pas bug #3.
+
+À retester après fix #1 quand les inputs prix seront propres.
+
+### Bug #4 — Confirmation : `pnl_pct` est NET de 30 bps slippage
+
+Migration 0134 ligne 68-69 le documentait déjà : « pnl_pct = NET (slippage 30bps round-trip déjà soustrait) ». Je ne l'avais pas lu en Phase 2b → toutes mes soustractions « -30 bps » comptaient 2 fois → edge net réel encore plus faible que -0.05%.
+
+**Pas une modif de code requise**, juste une mise à jour de mes analyses Phase 2b et un commentaire SQL plus visible :
+```sql
+COMMENT ON COLUMN gainers_user_shadow_signals.sim_results IS
+  '... sim_results.{grille}.pnl_pct = (exit_price/entry_price ± 1) − 0.003 (NET de slippage 30bps round-trip)';
+```
+
+### Bug #5 — Doc DB obsolète sur `OFF_SESSION` et `fetch_diag.outcome`
+
+- Migration 0134 ligne 68 documente `outcome ∈ TP_HIT | SL_HIT | TIME_LIMIT | NO_DATA` seulement.
+- PR #289 a ajouté `OFF_SESSION` côté code TS (lignes 209, 637, 911 de `gainers-user-shadow.service.ts`) avec sub-classification via colonne `off_session_reason` ∈ `capture | stale_data` (PR #296).
+- Migration 0136 ligne 30 documente `fetch_diag.outcome ∈ ok | no_data | error` seulement, alors que ligne 645 du service produit aussi `off_session`.
+
+**Fix** : migration `COMMENT ON COLUMN` consolidée mettant à jour les docs DB pour les 3 champs (`sim_results.outcome`, `fetch_diag.outcome`, `path_eff`).
+
+---
+
+## Reclassement par sévérité
+
+| # | Bug | Sévérité reclassée | Effort fix |
+|---|---|---|---|
+| 1 | `SCANNER_SESSION_AWARE` absent fly.toml | **CRITIQUE** | 1 ligne fly.toml + redeploy |
+| 6 | Aucun UNIQUE en DB | Important / garde-fou | 1 migration + .upsert dans recordDecision |
+| 4 | `pnl_pct` net 30 bps non visible côté analyse | Doc | COMMENT ON COLUMN |
+| 5 | `OFF_SESSION` non documenté en migration | Doc | COMMENT ON COLUMN |
+| 2 | `path_eff NULL` vs `fetch_diag.outcome=ok` | **Annulé (faux bug)** | COMMENT explicatif |
+| 3 | `TP_HIT` exit hors target | **Conséquence #1+#4** | Re-tester après #1 |
+
+---
+
+## Ordre de priorité fix
+
+1. **fly.toml `SCANNER_SESSION_AWARE='true'`** (Bug #1, 1 ligne, redeploy). Vérifier en logs Fly que `[top-gainers] session-aware skip cycle` apparaît hors-RTH.
+2. **Migration UNIQUE + .upsert** (Bug #6, garde-fou DB et applicatif).
+3. **Migration `COMMENT ON COLUMN` consolidée** (Bugs #2, #4, #5, doc DB).
+4. **Re-test** : laisser le scanner tourner 24h avec session-aware activé, puis SQL `SELECT symbol, COUNT(*) FROM gainers_user_shadow_signals WHERE created_at > NOW() - INTERVAL '24h' GROUP BY symbol HAVING COUNT(*) > 5;` doit retourner 0 lignes sur le week-end / hors-RTH.
+5. **Relancer Phase 2 walk-forward propre** sur la nouvelle fenêtre 7+ jours sans contamination.
+
+---
+
+## Plan de validation post-fix
+
+### Étape 1 — Fix #1 en isolation
+- [ ] Ajouter `SCANNER_SESSION_AWARE = 'true'` dans `fly.toml [env]`
+- [ ] `fly deploy`
+- [ ] Vérifier en `fly logs` qu'au premier cycle hors-RTH le scanner log explicitement `session-aware skip`
+- [ ] Attendre 6h post-deploy puis SQL `SELECT created_at::date, COUNT(*) FROM gainers_user_shadow_signals WHERE created_at > NOW() - INTERVAL '6h' GROUP BY 1;` doit montrer 0 lignes hors-RTH (sauf cycles intra-marché)
+
+### Étape 2 — Fix #6 garde-fou
+- [ ] Migration UNIQUE option 1 ou 2
+- [ ] Adapter `recordDecision` en `.upsert({...}, { onConflict: '...', ignoreDuplicates: true })` ou try/catch 23505
+- [ ] Test unitaire : inserer 2× la même clé → 2ᵉ insert doit silencieusement no-op
+- [ ] Vérifier en prod après 24h : `SELECT COUNT(*) FROM gainers_user_shadow_signals WHERE created_at > NOW() - INTERVAL '24h';` doit être stable cycle-à-cycle
+
+### Étape 3 — Migration COMMENT doc
+- [ ] Migration `0139_gainers_shadow_doc_consolidation.sql` (numéro à confirmer, dernière est 0138)
+- [ ] COMMENT sur `path_eff`, `sim_results`, `fetch_diag`
+
+### Étape 4 — Re-test Phase 2 propre
+- [ ] Laisser tourner 7 jours après tous fixes mergés
+- [ ] Relancer le walk-forward sur `gainers_user_shadow_signals` filtré `created_at > <fix-merge-date>`
+- [ ] Réévaluer §12 critères GO PAPER de MEASURE.md
+
+---
+
+## PROMPT FINAL À COPIER-COLLER À CLAUDE
+
+Texte ci-dessous à coller dans Claude Code (Comet) pour qu'il vérifie le diagnostic et propose les modifs précises.
+
+---
+
+**Mission — vérification diagnostic et fix scanner SmartVest** (branche `feature/short-shadow-grids`, commit Fly `4c7b345`)
+
+Yannick a STOPPÉ Phase 3 (shadow forward 14j) le 12 mai 08:00 CEST après découverte que `gainers_user_shadow_signals` contient des doublons massifs (148 lignes HRB, 87 ATEC, etc.) avec `entry_price` strictement identique sur des spans de 23h+. Phase 2b "WR 71.9% n=114 path_eff<0.25" est INVALIDÉE — après dédup ce bucket tombe à n=3 distincts.
+
+Une investigation code a remonté un smoking gun : le fix scanner (PR #298, test `scanner-session-aware.spec.ts`) est gardé par un feature flag env `SCANNER_SESSION_AWARE` (ligne 1059 de `apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts`) qui **n'est PAS défini dans fly.toml** → fix désactivé en prod.
+
+Je te demande **3 choses, dans cet ordre, sans pousser ni déployer tant que Yannick n'a pas validé chaque section** :
+
+### 1. Vérifications de code à confirmer ou infirmer
+
+a. Ligne 1059 de `top-gainers-scanner.service.ts` : `sessionAware = this.config.get('SCANNER_SESSION_AWARE') === 'true'` — confirme la présence et l'usage exact (où la valeur sessionAware est-elle ensuite testée pour skip ou autoriser le cycle ?).
+b. `fly.toml` section `[env]` : confirme l'absence de `SCANNER_SESSION_AWARE`. Si présent, dans quel fichier env override ?
+c. Migration `supabase/migrations/0134_gainers_user_shadow_signals.sql` : confirme l'absence totale de contrainte UNIQUE (juste 3 index simples portfolio/symbol/sim_run_at).
+d. Ligne 462 de `gainers-user-shadow.service.ts` `recordDecision` : confirme insert brut sans `.upsert` ni `ON CONFLICT`.
+e. Lignes 1898 et 1912 `recordShadowDecision(cand, 'reject_cooldown', undefined)` et `'reject_post_sl_cooldown', undefined` — confirme que `pers=undefined` quand decision = cooldown (donc path_eff=null par design).
+f. Ligne 433 `gainers-user-shadow.service.ts` `pnl_pct: closePnl − SLIPPAGE_TOTAL` avec `SLIPPAGE_TOTAL=0.003` (en tête de fichier) — confirme que `pnl_pct` stocké est NET de slippage 30 bps.
+g. Lignes 1287-1289 scanner `close = adjusted_close ?? last_price` — confirme que la valeur close persistée provient du screener EODHD et est figée hors-RTH.
+
+### 2. Modifications proposées (chiffrées et localisées)
+
+a. **Fix #1 (instantané)** : éditer `fly.toml`. Insérer dans `[env]` la ligne `SCANNER_SESSION_AWARE = 'true'`. Donne-moi le diff exact attendu.
+
+b. **Fix #6 (garde-fou DB+app)** : propose la migration la plus simple pour `UNIQUE (portfolio_id, symbol, asset_class, DATE(created_at), entry_price)`. Tu peux choisir entre :
+   - Option A : colonne générée `created_date DATE GENERATED ALWAYS AS (DATE(created_at)) STORED` + `CREATE UNIQUE INDEX ...`
+   - Option B : `CREATE UNIQUE INDEX ... ON ... ((DATE(created_at))) WHERE entry_price IS NOT NULL`
+   
+   Donne ton choix avec justification (performance vs simplicité). Donne aussi le diff exact à appliquer à `gainers-user-shadow.service.ts` ligne 462 pour transformer `.insert(...)` en `.upsert(..., { onConflict: '<liste>', ignoreDuplicates: true })` ou ajouter un try/catch silencieux sur erreur Postgres 23505.
+
+c. **Fix #2+#4+#5 (doc DB)** : génère une migration `0139_gainers_shadow_doc_consolidation.sql` (vérifie le prochain numéro disponible) avec uniquement des `COMMENT ON COLUMN` :
+   - `path_eff` : « NULL légitime pour decisions cooldown (pers=undefined avant calcul persistence) »
+   - `sim_results` : décrit `outcome ∈ TP_HIT | SL_HIT | TIME_LIMIT | NO_DATA | OFF_SESSION` et `pnl_pct = NET 30bps slippage round-trip`
+   - `fetch_diag` : décrit `outcome ∈ ok | no_data | error | off_session`
+
+### 3. Questions ouvertes à trancher avec Yannick avant tout deploy
+
+a. Le filtre `usOpen` ligne 1633-1644 du scanner agit post-fetch. Est-ce que `SCANNER_SESSION_AWARE=true` empêche bien le **fetch initial** (les 9 calls EODHD screener), ou est-ce qu'il ne fait que skip une partie aval du pipeline ? Vérifie le flow exact en remontant depuis ligne 1059 jusqu'au call EODHD.
+
+b. La contrainte UNIQUE va casser tout cycle de retry réseau Supabase actuel — `recordDecision` deviendra silencieusement no-op sur duplicate. Est-ce que ça pose problème pour le système d'audit / debug ? Faut-il logger les duplicates pour observabilité ?
+
+c. Refactor direction LONG/SHORT (ligne 2741 `top-gainers-scanner.service.ts`) — Yannick mentionne dans son backlog Phase 4 qu'il faut refacto LONG vers SHORT. Est-ce que c'est en cours, ou bloqué par bug #1 ? Si bug #1 corrigé suffit pour la grille SHORT calibrée, est-ce que le refacto direction est encore urgent ?
+
+**Format de réponse attendu** : 3 sections distinctes (Vérifications / Modifs / Questions), pas de PR ni de push tant que Yannick n'a pas répondu point par point. Pas de fichier modifié physiquement, uniquement des diffs proposés en bloc. Pas d'emoji. Français.

--- a/docs/MEASURE-short-shadow-2026-05-11.md
+++ b/docs/MEASURE-short-shadow-2026-05-11.md
@@ -1,6 +1,6 @@
 # SmartVest — Phase MESURE : Audit Edge & Risk Management
 
-**Date** : 11 mai 2026
+**Date** : 11-12 mai 2026 (v4 — Phase 2 walk-forward closed, Phase 3 démarrée)
 **Auteur** : Yannick Elouard
 **Statut** : Phase MESURE — pas de PR, pas de push, pas de deploy
 **Cible opérationnelle** : $150-250/jour avec $10 500 de capital
@@ -321,30 +321,237 @@ Base : 16 trades mesurables/jour × $1 050/position × expectancy × win rate ne
 ## 9. Phases — récapitulatif visuel
 
 ```
-[Phase 1] Code SHORT grids       ✅ commit 896848e
+[Phase 1] Code SHORT grids       ✅ commit 896848e (11 mai)
    │
-[Phase 1.5] Fix timing simulator ✅ commit 5835656
+[Phase 1.5] Fix timing simulator ✅ commit 5835656 (11 mai)
    │
-[Phase 2] Rétroactif proxy SQL   ✅ validé (WR 99% proxy, expectancy net +0.59%)
-   │
-   │  Caveat : proxy SQL surestime, réalité probable WR 65-80%
+[Phase 2a] Rétroactif proxy SQL  ✅ validé 11 mai (WR 99% proxy, +0.59% net)
+   │  Caveat documenté : proxy artefact, à confirmer walk-forward
    ▼
-[Phase 3] Shadow forward 14j     ⏸️ en attente push + deploy MESURE-only
-   │
-   │  Validation diversité temporelle + path intra-fenêtre
+[Phase 2b] Walk-forward 824 sig  ✅ validé 12 mai (3 jours, 7-9 mai)
+   │  → Edge global non filtré : ABSENT (−0.05% net sur baseline_60m)
+   │  → Edge conditionnel path_eff<0.25 : FORT (WR 71.9%, +0.73% net)
+   ▼
+[Phase 3] Shadow forward 14j     🟢 démarrée 12 mai 05:05 UTC (config US réactivée)
+   │  Validation diversité régimes + robustesse filtre path_eff<0.25
    ▼
 [Phase 4] Paper Trading 4-6 sem  ⏸️ obligatoire avant LIVE
-   │
    │  Validation frictions exécution (slippage, borrow, latence)
    ▼
 [Phase 5] LIVE à taille réduite  ⏸️ 50% sizing nominal pendant 2 sem
-   │
    │  Validation comportement capital réel
    ▼
 [Phase 6] LIVE full sizing       ⏸️ si Phase 5 profitable 4 sem
 ```
 
-## 10. État d'avancement
+---
+
+## 10. Phase 2b — Walk-forward sur 824 signaux (12 mai 2026)
+
+### 10.1 Setup
+
+Post-deploy commit `4c7b345` sur Fly le 11 mai 16:55 UTC :
+- Code SHORT actif en prod (10 grilles : 4 LONG + 6 SHORT pour `us_equity_small_mid`)
+- SQL reset : 824 signaux `us_equity_small_mid` sur 14 jours → `sim_run_at = NULL` + `sim_results = NULL`
+- Re-simulation walk-forward déclenchée par le cron Fly normal
+
+Première vague re-simulation a tourné AVANT stabilisation complète du rolling deploy → 824 traités mais avec ancien code (4 clés LONG seulement, tous `OFF_SESSION/capture`). Diagnostic : la re-simulation a touché les machines Fly **avant** que toutes aient reçu la nouvelle image Docker.
+
+Deuxième reset SQL le 12 mai 04:48 UTC après stabilisation → re-simulation propre avec les 10 grilles attendues.
+
+### 10.2 Probe T+5min — 12 mai 04:53 UTC
+
+| Métrique | Valeur |
+|---|---|
+| `resimulated` | 824 / 824 |
+| `post_deploy_resims` (post 16:55 UTC) | 824 / 824 |
+| `has_short_baseline` | 824 / 824 |
+| `has_short_calibrated` | 824 / 824 |
+| `short_with_actionable_outcome` (baseline_60m) | **389 / 824** |
+
+Le code SHORT s'exécute correctement. 47% des signaux ont un outcome actionable (TP_HIT / SL_HIT / TIME_LIMIT), le reste en OFF_SESSION ou NO_DATA.
+
+### 10.3 Verdict toutes grilles SHORT (n=389 chacune, 3 jours)
+
+| Grille | n_actionable | TP | SL | TIMEOUT | WR | Expectancy brute | Net (−30bps) |
+|---|---|---|---|---|---|---|---|
+| short_alt15_30m | 389 | 177 | 144 | 68 | 45.5% | +0.15% | −0.15% |
+| short_alt15_60m | 389 | 183 | 161 | 45 | 47.0% | +0.13% | −0.17% |
+| short_baseline_30m | 389 | 159 | 124 | 106 | 40.9% | +0.28% | −0.02% |
+| **short_baseline_60m** | 389 | 166 | 135 | 88 | 42.7% | +0.25% | **−0.05%** |
+| short_calibrated_30m | 389 | 195 | 168 | 26 | 50.1% | −0.07% | −0.37% |
+| short_calibrated_60m | 389 | 196 | 178 | 15 | 50.4% | −0.09% | −0.39% |
+
+**Verdict critique** : AUCUNE grille SHORT non filtrée n'a d'expectancy nette positive après slippage 30bps. Le proxy rétroactif §2.3 (+1.18%) et SQL §9 (+0.59%) étaient bien des artefacts.
+
+**Pattern frappant** : les grilles "calibrated" (TP 0.8% / SL 0.4%, R:R 2.0) ont WR plus élevée (50%) mais expectancy plus basse que "baseline" (TP +1.7% / SL −1.2%, R:R 1.42). Conclusion : sur small/mid US, les mouvements profonds sont rares mais payent gros ; les petits TP serrés ne couvrent pas les SL.
+
+### 10.4 Variance par jour
+
+| Jour | n | WR | Expectancy brute | Net (−30bps) | Régime |
+|---|---|---|---|---|---|
+| 2026-05-07 | 151 | **82.8%** | +1.36% | **+1.06%** | Mean-reversion ✅ |
+| 2026-05-08 | 238 | **14.3%** | −0.41% | −0.71% | Momentum ❌ |
+| 2026-05-09 | 0 | — | — | — | Données partielles |
+
+**Insight majeur** : l'edge n'est pas un edge directionnel constant. C'est un edge conditionnel à un régime de marché. Le 7 mai (mean-reversion) marche fort ; le 8 mai (momentum) tue la stratégie.
+
+### 10.5 Découverte du séparateur — `path_eff`
+
+Composition des signaux par jour :
+
+| Jour | n | avg_change_pct_1m | avg_path_eff | avg_persistence |
+|---|---|---|---|---|
+| 2026-05-07 (WR 82.8%) | 151 | 15.99% | **0.263** | 0.676 |
+| 2026-05-08 (WR 14.3%) | 238 | 19.29% | **0.409** | 0.663 |
+
+La variable discriminante est **`path_eff`** (path efficiency = degré de linéarité du mouvement) :
+- `path_eff` bas (~0.25) = mouvement erratique = signal d'essoufflement = SHORT marche
+- `path_eff` haut (~0.40+) = mouvement directionnel = momentum continue = SHORT perd
+
+### 10.6 Edge conditionnel `path_eff < 0.25` — bucket analysis
+
+Sur `short_baseline_30m` (la grille la moins mauvaise globale) :
+
+| Bucket `path_eff` | n | TP | SL | WR | Expectancy brute | Net (−30bps) |
+|---|---|---|---|---|---|---|
+| **< 0.25 (low)** | **114** | **82** | **12** | **71.9%** | **+1.03%** | **+0.73%** ✅ |
+| 0.25-0.35 (mid) | 13 | 0 | 13 | 0.0% | −1.20% | −1.50% (n<30) |
+| 0.35-0.45 (high) | 27 | 3 | 9 | 11.1% | −0.14% | −0.44% (n<30) |
+| ≥ 0.45 (extreme) | 235 | 74 | 90 | 31.5% | +0.04% | −0.26% |
+
+**Le filtre `path_eff < 0.25` isole un sous-ensemble structurellement profitable** :
+- WR 71.9% (vs 42.7% non filtré) — intervalle confiance Wilson 95% : [62.9% ; 79.4%]
+- Expectancy nette **+0.73%/trade**
+- 114 trades sur 3 jours = ~38 trades/jour de qualité
+
+Le filtre inverse (`path_eff ≥ 0.45`) capture 235 trades non profitables (WR 31.5%, net −0.26%) — à exclure absolument.
+
+### 10.7 Projection économique conditionnelle
+
+Si `path_eff < 0.25` retient ~30% du flux total :
+- Flux US small/mid attendu : ~280 signaux/jour (moyenne 7-8 mai)
+- Filtré : ~84 trades/jour potentiels
+- À +0.73% net × $1050/position × 84 = **$643/jour théorique max**
+
+Caveats forts :
+- n=114 sur 3 jours, biais régime de marché possible
+- Simulator naïf (pas de slippage négatif sur SL, pas de borrow cost SHORT)
+- Réalité paper trading attendue : 50-70% de cette projection
+- $150-250/jour reste l'objectif cible, $643 est la limite supérieure théorique non réalisable
+
+---
+
+## 11. Incident config — Scanner US shadow coupé 9-12 mai
+
+### 11.1 Détection
+
+Probe `MAX(created_at)` par asset_class le 12 mai 04:54 UTC :
+
+| asset_class | dernier signal | gap |
+|---|---|---|
+| asia_equity | 12/05 04:56 UTC | < 1 min ✅ |
+| eu_equity | 11/05 15:56 UTC | 13h ✅ (LSE fermé) |
+| crypto_major | 11/05 07:02 UTC | 22h ⚠️ |
+| **us_equity_large** | **09/05 17:35 UTC** | **2j 20h** 🔴 |
+| **us_equity_small_mid** | **09/05 17:35 UTC** | **2j 20h** 🔴 |
+
+Les deux classes US ont arrêté à 17:35 UTC précis = **action manuelle ou cron**, pas un bug code (sinon variance temporelle attendue).
+
+### 11.2 Cause racine
+
+```sql
+SELECT gainers_universe_us FROM lisa_session_configs
+WHERE strategy_mode = 'gainers';
+-- → false (depuis updated_at 2026-05-11 07:59:40 UTC)
+```
+
+**Toggle config désactivé**, probablement lors d'une session Claude antérieure pour pauser US pendant les modifs Phase 1. Le toggle a survécu à la fin de session, le scanner US est resté silencieux.
+
+LE LIVE GAINERS (pipeline distinct) a continué d'ouvrir des US small/mid (5W/12L MTD, −$42.97 net) — ce qui suggère que **le toggle n'affecte que le shadow**, pas le scanner LIVE. À investiguer Phase 4 quand on activera SHORT direction.
+
+### 11.3 Fix
+
+```sql
+BEGIN;
+UPDATE lisa_session_configs
+SET gainers_universe_us = true, updated_at = NOW()
+WHERE strategy_mode = 'gainers'
+  AND portfolio_id = '58439d86-3f20-4a60-82a4-307f3f252bc2'
+RETURNING ...;
+COMMIT;
+```
+
+**Exécuté 12 mai 05:04:35 UTC**. État final :
+- `gainers_universe_us` = true ✅
+- `gainers_universe_eu` = true ✅
+- `gainers_universe_asia` = true ✅
+- `gainers_universe_crypto` = false (laissé volontairement, LIVE 0W/5L)
+
+### 11.4 Leçon
+
+Ajouter une probe quotidienne sur `MAX(created_at) BY asset_class` pour détecter rupture flux. Si gap > 24h sur jour de marché ouvré → alerte.
+
+---
+
+## 12. Critères GO PAPER — révisés post-Phase 2b
+
+Mise à jour de §6 pour intégrer la découverte `path_eff < 0.25` :
+
+| Critère | Seuil minimum |
+|---|---|
+| **Filtre obligatoire** | **`path_eff < 0.25 AND path_eff IS NOT NULL`** sur SHORT us_equity_small_mid (exclusion bug §14) |
+| Trades mesurables post-filtre | **≥ 80** sur 14j shadow forward |
+| Win rate filtré | **≥ 65%** (corridor accepté 60-75%) |
+| Expectancy nette (slippage 30bps) | **> +0.4%/trade** |
+| Sharpe ratio daily | **> 1.0** |
+| Max drawdown shadow | **< 5%** du capital simulé |
+| Diversité temporelle | **≥ 5 jours de marché distincts** |
+| Variance jour-à-jour | **≤ 1 jour cataclysmique** (>2σ négatif) |
+| Pas de jour > 40% du PnL total | (concentration acceptable mais bornée) |
+
+**Note critique** : la variance 7 mai (WR 82.8%) vs 8 mai (WR 14.3%) montre que **l'edge dépend du régime de marché**. Le filtre `path_eff < 0.25` est nécessaire mais pas suffisant — il faudra peut-être ajouter un détecteur de régime macro en Phase 4 paper.
+
+---
+
+## 14. Bug simulator détecté (corriger en Phase 4, ne PAS toucher maintenant)
+
+### Anomalie null_path_eff (12 mai 07:16 CEST)
+
+Lors du setup du monitoring quotidien (cron Supabase), une requête de distribution path_eff sur les 389 trades actionables Phase 2 a révélé un bucket aberrant :
+
+- **n=70, path_eff IS NULL, outcome='TP_HIT' systématique, pnl_pct=+0.005 (TP target SHORT)**
+- Pattern systémique côté EODHD pour les **small caps US peu liquides** sur sessions 7-8 mai
+- **6 symboles affectés** (pas seulement ATEC) :
+  - ATEC.US (33 occurrences)
+  - ST.US (12)
+  - KMT.US (7)
+  - ORA.US (7)
+  - ACLS.US (6)
+  - MRCY.US (5)
+- Tous avec `exit_price` strictement identique par symbole (ex: ATEC=7.688), `entry_price=NULL`, `time_to_exit_min=NULL`
+- `decision=reject_post_sl_cooldown` majoritaire (signaux rejetés par le LIVE filter)
+
+### Diagnostic
+
+Le simulator SHORT (vérifié sur calibrated_60m, très probablement sur toutes les grilles SHORT) a un **fallback hardcodé** : quand les données intra-bar EODHD ne permettent pas de calculer `entry_price`/`path_eff`/`time_to_exit`, il retourne `outcome='TP_HIT'` avec `pnl_pct=+TP_target` au lieu d'écrire `NULL` ou un outcome `NO_DATA`. Sur ATEC.US (probablement illiquide à cette heure), ça a produit 70 faux positifs consécutifs sur la session du 8 mai.
+
+### Impact rétroactif sur Phase 2
+
+- Total actionables réel : **319 trades** (389 − 70 ATEC junk), pas 389
+- Bucket `path_eff<0.25` non impacté : n=114, WR 71-78%, edge confirmé
+- Bucket `null_path_eff` à **exclure définitivement** des analyses et critères GO PAPER
+
+### Action Phase 4 (post-26 mai si GO)
+
+- Fix simulator : `if (entry_price IS NULL OR path_eff IS NULL) RETURN outcome='NO_DATA'`
+- Filtre query par défaut : `AND path_eff IS NOT NULL` (déjà intégré dans le cron)
+- Ajouter détecteur d'anomalie : alerte si un symbole >10 occurrences avec même exit_price exact
+- Investiguer pourquoi EODHD renvoie des données manquantes sur ATEC.US spécifiquement
+
+---
+
+## 13. État d'avancement (v4)
 
 - [x] Cadrage cible recalibrée
 - [x] Audit shadow LONG (verdict négatif documenté)
@@ -355,12 +562,88 @@ Base : 16 trades mesurables/jour × $1 050/position × expectancy × win rate ne
 - [x] Risk management chiffré
 - [x] **Phase 1 (code SHORT) — commit 896848e local**
 - [x] **Phase 1.5 (fix timing simulator) — commit 5835656 local**
-- [x] **Phase 2 (rétroactif proxy SQL) — validé le 11 mai 2026** (WR 99% proxy, expectancy net +0.59%, caveat surestimation)
-- [ ] **Phase 3 (deploy MESURE-only + shadow forward 14j)** — en attente push branche
+- [x] **Phase 2a (rétroactif proxy SQL) — validé 11 mai** (WR 99% proxy, +0.59% net, **caveat confirmé : artefact**)
+- [x] **Deploy SHORT shadow MESURE-only sur Fly** — 11 mai 16:55 UTC (commit 4c7b345, `/version` vérifié)
+- [x] **Phase 2b (walk-forward sur 824 signaux)** — 12 mai 2026
+   - [x] Edge global non filtré : ABSENT (−0.05% net)
+   - [x] **Edge conditionnel `path_eff < 0.25` : VALIDÉ (WR 71.9%, +0.73% net, n=114, 3 jours)**
+- [x] **Incident scanner US shadow** — diagnostiqué et fixé 12 mai 05:04 UTC
+- [ ] **Phase 3 (shadow forward 14j)** — démarrée 12 mai 05:05 UTC, fin prévue ~26 mai
+   - [ ] T+8h : NYSE open 13:30 UTC, premier signal US shadow attendu
+   - [ ] T+72h : ~840 signaux US attendus, premier n significatif post-filtre
+   - [ ] T+14j : verdict GO PAPER (critères §12)
 - [ ] **Phase 4 (paper trading 4-6 semaines)** — obligatoire avant live
+   - [ ] Câblage direction SHORT dans pipeline LIVE GAINERS (Q1 ouverte vers Claude)
+   - [ ] Application filtre `path_eff < 0.25` au scanner LIVE (Q2 ouverte)
 - [ ] **Phase 5 (live taille réduite 50% sizing)** — 2 semaines de probation
 - [ ] **Phase 6 (live full sizing)** — si Phase 5 profitable 4 semaines
 
 ---
 
 **Note** : pas de PR, pas de push, pas de deploy, pas de secret. Phase MESURE intégrale.
+
+**Prochaines actions** :
+- Aucune action urgente. Le shadow tourne tout seul pendant 14 jours.
+- Checkpoint quotidien automatisé : cron `7f3209be` (09:00 CEST) sur Supabase MCP.
+- Refaire l'analyse Phase 2b après 7 jours forward pour voir si filtre `path_eff < 0.25` tient sur n plus large.
+
+---
+
+## 15. Timeline chronologique (11-12 mai 2026)
+
+Figé ici pour garder la trace des décisions et événements depuis le début du sprint SHORT.
+
+### 11 mai 2026
+
+| Heure (UTC) | Acteur | Événement |
+|---|---|---|
+| matin/journée | Claude | Commits `896848e` (6 grilles SHORT), `5835656` (fix timing simulator), `e1dfec6` (price snapshots entry/exit) sur branche `feature/short-shadow-grids` |
+| ~16:00 | Claude | Commit `4c7b345` (refresh doc MD) |
+| 16:55 | yannick + Computer | Deploy Fly via `workflow_dispatch` sur la branche feature — app `smartvest` région `cdg` passe sur `git_sha 4c7b345`. Vérification via `/version` OK |
+| soir | yannick (SQL) | 1er reset transaction : `UPDATE gainers_user_shadow_signals SET sim_run_at = NULL` sur 824 rows US small/mid, COMMIT |
+| ~19:18-19:20 | Simulator | Batch re-simulation, mais race condition rolling deploy : 0 SHORT keys au probe T+1h40 |
+| ~19:18 | Simulator | **Bug ATEC.US** : 70 lignes écrites avec `path_eff=NULL`, `outcome='TP_HIT'` hardcodé, `exit_price=7.688`, `pnl_pct=+0.005` (découvert le 12 au matin, voir §14) |
+
+### 12 mai 2026
+
+| Heure (UTC) | Acteur | Événement |
+|---|---|---|
+| 04:48 | Claude (SQL) | 2e reset transaction (le 1er avait raté). 824 rows re-simulées avec SHORT keys cette fois |
+| ~05:05 | Simulator | 824/824 rows OK, **389 actionables** identifiées post-filtres internes |
+| 05:00 | Computer + yannick | Probe T+5 confirme SHORT keys présentes |
+| 05:00-05:04 | Computer | **Verdict walk-forward sur 6 grilles SHORT non filtré** : aucune n'a d'edge (best = `short_baseline_30m` à -0.02% net) |
+| 05:00-05:04 | Computer | **Variance par jour découverte** : 7 mai WR 82.8% vs 8 mai WR 14.3% → edge dépend du régime |
+| 05:00-05:04 | Computer | **Découverte clé path_eff** : bucket `<0.25` → n=114, WR 71.9%, expectancy nette +0.73%/trade |
+| ~05:00 | yannick | Affiche dashboard LIVE GAINERS : 186 trades MTD, +$35.83, US small/mid LONG perdant 5W/12L → confirme thèse SHORT sur cette classe |
+| ~05:00 | Computer | Diagnostic scanner US offline depuis 9 mai 17:35 UTC (60h blackout) |
+| 05:04:35 | yannick (SQL) | **Fix incident** : `UPDATE lisa_session_configs SET gainers_universe_us=true` sur portfolio `58439d86-...`, COMMIT |
+| ~05:30 | Computer + yannick | Message de recadrage envoyé à Claude : Phase 3 = observation pure, refacto direction reportable post-26 mai |
+| ~05:45 | Claude | Réponse Q1/Q2/Q3 confirmant : `direction: 'long'` hardcodé ligne 2741, LIVE filtre path_eff>=0.5, stratégie Phase 4 validée (`<0.25` SHORT / `0.25-0.5` SKIP / `>=0.5` SKIP). Commit `ed81780` (doc) toujours non poussé. |
+| 05:09 | Computer | MESURE.md v3 → v4 (ajout §10 Phase 2b, §11 incident, §12 critères révisés, §13 état) |
+| 05:14 | Simulator | Dernière exécution simulator pré-fenetre forward |
+| 05:16 | Computer (via Supabase MCP) | **Bug ATEC.US détecté** lors du test du cron : 70 lignes `path_eff=NULL` toutes sur ATEC.US, `pnl_pct=+0.005` hardcodé. → N'invalide pas l'edge `<0.25` mais réduit le total Phase 2 à 319 actionables réels. À fixer Phase 4. |
+| 05:18 | Computer | MESURE.md v4 → v4.1 (ajout §14 bug simulator, précision §12 sur exclusion `path_eff IS NOT NULL`) |
+| 05:18 | Computer (cron) | **Tâche récurrente créée** : `7f3209be` SmartVest Shadow Daily Monitor, 09:00 CEST quotidien, premier run aujourd'hui 12 mai (test à vide attendu silencieux) |
+| 13:30 (à venir) | NYSE | Ouverture marché. Premier signal US shadow attendu post-fix |
+| ~14:40 (à venir) | Simulator | Premier batch sim US small/mid (buffer SIMULATE_AFTER_MIN=65min) |
+
+### Décisions structurantes prises pendant la session
+
+1. **Pas de merge, pas de push, pas de deploy main** — branche `feature/short-shadow-grids` reste vivante 14j
+2. **Pas de fix du bug ATEC** maintenant — reporte Phase 4 pour ne pas contaminer la mesure
+3. **Pas de modif config session** post-fix US — crypto reste `false` (data-driven, LIVE 0W/5L)
+4. **Commit `ed81780` (doc) non poussé** — statu quo, décision reportée
+5. **Connexion Supabase MCP OAuth** — pas de service key stockée (cohérent "pas de secret")
+6. **Cron en lecture seule** — jamais d'écriture sur Supabase, jamais de touche au code
+7. **Critères GO PAPER consolidés** — path_eff<0.25 obligatoire, n>=80, WR>=65%, exp_nette>+0.4%, >=5 jours, <=1 jour cataclysmique
+
+### Compteurs au 12 mai 07:22 CEST
+
+- Commits sur la branche : 4 (tous locaux sauf `4c7b345` poussé pour le deploy Fly)
+- PR ouvertes : **0**
+- Deploys main : **0**
+- Secrets stockés : **0**
+- Signaux shadow forward (post-13:30 UTC 12 mai) : **0** (en attente NYSE open)
+- Signaux shadow Phase 2 rétroactif : **824** dont **319 actionables réels** (hors bug ATEC)
+- Cron actifs : **1** (`7f3209be`)
+- Jours restants avant verdict Phase 3 : **14**

--- a/docs/MEASURE-short-shadow-2026-05-11.md
+++ b/docs/MEASURE-short-shadow-2026-05-11.md
@@ -105,21 +105,17 @@ Le filtre cascade (path_eff, persistence, cooldown, post_sl_cooldown) ne disting
 
 **Implication** : le système de filtrage actuel **filtre arbitrairement** des signaux qui auraient été aussi profitables que ceux acceptés. À repenser.
 
-### 4.2 Bug timing simulator
+### 4.2 Bug timing simulator — guard sous-dimensionné
 
-**Root cause** : `simulatePending` peut être appelé moins de 60min après création du signal. Sans 60min de candles forward disponibles, l'outcome est marqué `OFF_SESSION` à tort.
+**Root cause** : un guard `SIMULATE_AFTER_MIN = 60` existait déjà dans le code (`simulatePending`, ligne 169, filtre `.lte('created_at', cutoff)` ligne 477). Il était **trop serré** : race condition avec le lag de propagation des candles EODHD (~5min). À exactement 60min après création, certaines candles forward n'étaient pas encore disponibles → outcome marqué `OFF_SESSION` à tort.
 
 **Preuves** :
-- 7 mai 2026 : scan→sim délai ≈ 10h → 141/143 mesurables (98%)
-- 8 mai 2026 : scan→sim délai = 0-1h → 0/503 mesurables (100% OFF_SESSION)
+- 7 mai 2026 : scan→sim délai ≈ 10h → 141/143 mesurables (98%) — bien au-delà du cutoff, candles présentes
+- 8 mai 2026 : scan→sim délai = 0-1h → 0/503 mesurables (100% OFF_SESSION) — boundary 60min, candles encore en propagation
 
-**Fix requis** :
-```sql
--- garde dans simulatePending
-WHERE created_at < NOW() - (max(windowMin grilles) + 5min buffer)
-```
+**Fix appliqué (commit 5835656)** : bump du guard à 65min via expression dérivée `MAX_WINDOW_MIN + SIMULATE_BUFFER_MIN` (5min). Plus robuste et traçable qu'un chiffre magique, dérive automatiquement si une grille à fenêtre plus large est ajoutée.
 
-**Impact** : sans fix, ~80% des signaux US seront perdus systématiquement en phase forward 14j.
+**Impact sans fix** : ~80% des signaux US perdus systématiquement en phase forward 14j (boundary race).
 
 ### 4.3 Direction signal hardcoded LONG
 
@@ -154,11 +150,13 @@ Range 60m observé sur small/mid US : 0.5-1.2%.
 
 **Action** : commit local, pas de push.
 
-### 5.2 Phase 1.5 — Fix bug timing simulator (NOUVEAU)
+### 5.2 Phase 1.5 — Fix bug timing simulator (commitée)
 
-**Scope** : garde-fou `created_at < NOW() - windowMin - 5min` dans `simulatePending`. ~20 LoC + 1 test.
+**Scope** : guard `SIMULATE_AFTER_MIN` passé de 60 à 65min via expression dérivée `MAX_WINDOW_MIN + SIMULATE_BUFFER_MIN`. Pas un guard manquant, un guard sous-dimensionné.
 
-**Action** : commit local, pas de push.
+**Statut** : commit `5835656` sur branche `feature/short-shadow-grids`, commit séparé du Phase 1 (`896848e`) pour clarté review (orthogonalité SHORT-SHADOW vs TIMING-FIX). 28/28 tests PASS, typecheck clean.
+
+**Action** : commité local, pas pushé.
 
 ### 5.3 Phase 2 — Rétroactif sur n=147 (read-only)
 
@@ -284,10 +282,10 @@ Base : 16 trades mesurables/jour × $1 050/position × expectancy × win rate ne
 - [x] Identification bugs structurels
 - [x] Plan Phase 1/2/3 défini
 - [x] Risk management chiffré
-- [x] Phase 1 (code SHORT) — **commit `896848e` local sur `feature/short-shadow-grids`**
-- [x] Phase 1.5 (fix timing simulator) — **commit `5835656` local sur `feature/short-shadow-grids`**
-- [ ] Phase 2 (rétroactif sur n=147)
-- [ ] Phase 3 (deploy MESURE-only)
+- [x] **Phase 1 (code SHORT) — commit 896848e local**
+- [x] **Phase 1.5 (fix timing simulator) — commit 5835656 local**
+- [ ] Phase 2 (rétroactif sur n=147) — option 1 retenue : script Node standalone read-only
+- [ ] Phase 3 (deploy MESURE-only) — conditionnel à Phase 2
 - [ ] Shadow forward 14j
 - [ ] Décision GO LIVE
 

--- a/docs/MEASURE-short-shadow-2026-05-11.md
+++ b/docs/MEASURE-short-shadow-2026-05-11.md
@@ -1,0 +1,296 @@
+# SmartVest — Phase MESURE : Audit Edge & Risk Management
+
+**Date** : 11 mai 2026
+**Auteur** : Yannick Elouard
+**Statut** : Phase MESURE — pas de PR, pas de push, pas de deploy
+**Cible opérationnelle** : $150-250/jour avec $10 500 de capital
+
+---
+
+## 1. Contexte & Cible
+
+### 1.1 Cible initiale rejetée
+Cible initiale **$400/jour** sur $10 500 = **3.8% de rendement quotidien** = ~6 800% annualisé.
+
+Démonstration mathématique d'impossibilité fondée sur :
+- Kelly criterion (sizing optimal sous incertitude paramétrique)
+- Samuelson efficiency theorem (continuité du retail edge)
+- Grossman-Stiglitz paradox (limite de l'arbitrage informationnel)
+- Hansen-Jagannathan bounds (volatilité du stochastic discount factor)
+- Almgren-Chriss optimal execution (coûts marché impliqués)
+
+Conclusion : cible non atteignable sans levier extrême ou edge institutionnel non accessible au retail.
+
+### 1.2 Cible recalibrée — $150-250/jour
+Soit **1.4% à 2.4% de rendement quotidien** (~470% à 1100% annualisé). Reste très ambitieuse mais théoriquement atteignable sur niches microstructure documentées :
+- Mean reversion intraday small/mid cap US
+- Statistical arbitrage à fréquence moyenne (minutes)
+- NLP event-driven trading sur news flux
+
+---
+
+## 2. Audit du shadow Gainers existant
+
+### 2.1 Méthodologie
+
+Période : 2 mai → 10 mai 2026 (9 jours)
+Source : `gainers_user_shadow_signals` (4981 lignes)
+Outcomes mesurés : 4 grilles de simulation (baseline 30m/60m, alt15 30m/60m)
+
+Outcome classes :
+- `TP_HIT` : take-profit atteint sur fenêtre
+- `SL_HIT` : stop-loss atteint sur fenêtre
+- `OFF_SESSION` : marché fermé pendant la fenêtre forward
+- `NO_DATA` : EODHD n'a pas retourné les candles forward
+
+Mesurables = TP_HIT + SL_HIT uniquement.
+
+### 2.2 Résultat brut LONG (direction d'entrée actuelle)
+
+| Variante | n Accept | Mesurables | Win rate | Expectancy/trade |
+|---|---|---|---|---|
+| baseline_60m | 246 | 15 (6%) | 33.3% | **-0.23%** |
+| alt15_60m | 246 | 16 (6.5%) | 31.3% | **-0.24%** |
+
+**Verdict LONG** : expectancy négative confirmée. La stratégie actuelle perd en moyenne $2.30 par trade de $1 000.
+
+### 2.3 Découverte critique — direction inversée
+
+Analyse rétroactive sur **tous les decisions confondus** (accept + reject_*), small/mid US uniquement :
+
+| Asset class | n mesurables | Avg long pnl | Avg short proxy (× -1) |
+|---|---|---|---|
+| **us_equity_small_mid** | **147** | -1.18% | **+1.18%** |
+| us_equity_large | 143 | -0.08% | +0.08% (flat) |
+
+**Caveat méthodologique** : le proxy "×-1" est une approximation directionnelle, pas une simulation rigoureuse. Sur grille asymétrique 2.22:1 (TP 2% / SL 0.9%), un TP_HIT long n'implique pas un SL_HIT short symétrique (le path intra-fenêtre peut différer).
+
+**Hypothèse pessimiste post-simulation rigoureuse** : 50% du proxy → +0.6% expectancy réelle.
+
+### 2.4 Limite statistique reconnue
+
+Les 147 mesurables proviennent **d'un seul jour de marché** (7 mai 2026). Le 8 mai a produit 0 mesurables suite à un bug timing du simulator (voir §4.2). Diversité temporelle insuffisante pour conclusion définitive.
+
+Wilson IC95 sur n=147 reste mathématiquement étroit, mais ne couvre pas le biais de régime de marché.
+
+---
+
+## 3. Pipelines & architecture (cartographie)
+
+Deux pipelines coexistent dans le codebase :
+
+```
+[PIPELINE LEGACY]                    [PIPELINE ALGO V1]
+top-gainers-scanner.service.ts       gainers-scanner module (BLOC 1-4)
+        │                                    │
+        ├─ paperBroker.openPosition          ├─ shadow-run.service.ts
+        │                                    │   (gate env GAINERS_V1_SHADOW=true)
+        ▼                                    ▼
+    lisa_positions (LIVE)            gainers_v1_shadow_signals (276959 rows)
+                                             │
+                                             ├─ Si GAINERS_V1_LIVE=true (jamais activé)
+                                             ▼
+                                     gainers_positions (0 rows, by design)
+```
+
+**Implication** : les mesures de l'audit (4981 rows `gainers_user_shadow_signals`) viennent du **pipeline legacy**. Le pipeline V1 est dormant en attendant validation shadow (critères ADR-005 step 9 non atteints).
+
+---
+
+## 4. Bugs identifiés en phase MESURE
+
+### 4.1 Filtrage en cascade non discriminant
+
+Le filtre cascade (path_eff, persistence, cooldown, post_sl_cooldown) ne distingue pas les signaux profitables des non profitables. Espérance short proxy **identique** entre accept (n=6) et reject_path_eff (n=64), reject_persistence (n=47), reject_post_sl_cooldown (n=29) : **+1.18% à +1.20% partout**.
+
+**Implication** : le système de filtrage actuel **filtre arbitrairement** des signaux qui auraient été aussi profitables que ceux acceptés. À repenser.
+
+### 4.2 Bug timing simulator
+
+**Root cause** : `simulatePending` peut être appelé moins de 60min après création du signal. Sans 60min de candles forward disponibles, l'outcome est marqué `OFF_SESSION` à tort.
+
+**Preuves** :
+- 7 mai 2026 : scan→sim délai ≈ 10h → 141/143 mesurables (98%)
+- 8 mai 2026 : scan→sim délai = 0-1h → 0/503 mesurables (100% OFF_SESSION)
+
+**Fix requis** :
+```sql
+-- garde dans simulatePending
+WHERE created_at < NOW() - (max(windowMin grilles) + 5min buffer)
+```
+
+**Impact** : sans fix, ~80% des signaux US seront perdus systématiquement en phase forward 14j.
+
+### 4.3 Direction signal hardcoded LONG
+
+`top-gainers-scanner.service.ts:2741` : `direction: 'long'` sans logique de confirmation directionnelle. Le bot lit `change_pct_1m > seuil` et entre long immédiatement — pattern classique du "fade gainer" inversé.
+
+### 4.4 Calibration TP/SL inadaptée à small/mid US
+
+Grilles actuelles : TP 2% / SL 0.9% / fenêtre 60min.
+Range 60m observé sur small/mid US : 0.5-1.2%.
+**Conséquence** : SL touché par bruit normal, TP hors zone atteignable.
+
+**Recalibration proposée** : TP 0.8% / SL 0.4% / fenêtre 60min (ratio 2:1, breakeven 33%).
+
+### 4.5 Bug crypto NO_DATA 100%
+
+13 cryptos acceptés sur 9 jours, **100% NO_DATA** alors que crypto = 24/7. Mauvais mapping symbol EODHD probable. Bug isolé, à investiguer séparément.
+
+---
+
+## 5. Plan opérationnel — Phase 1, 2, 3
+
+### 5.1 Phase 1 — Code SHORT (en cours, Claude)
+
+**Scope** :
+- 6 nouvelles grilles SHORT dans `SIM_GRIDS` (uniquement pour `us_equity_small_mid`)
+- Param `direction: 'long' | 'short'` dans `walkForward`
+- 4 grilles : `short_baseline_30m`, `short_baseline_60m`, `short_alt15_30m`, `short_alt15_60m`
+- 2 grilles calibrées : `short_calibrated_30m`, `short_calibrated_60m` (TP 0.8% / SL 0.4%)
+- Tests : ~80 LoC
+
+**Estimé** : ~150 LoC + tests, ~2h dev.
+
+**Action** : commit local, pas de push.
+
+### 5.2 Phase 1.5 — Fix bug timing simulator (NOUVEAU)
+
+**Scope** : garde-fou `created_at < NOW() - windowMin - 5min` dans `simulatePending`. ~20 LoC + 1 test.
+
+**Action** : commit local, pas de push.
+
+### 5.3 Phase 2 — Rétroactif sur n=147 (read-only)
+
+**Scope** :
+1. Lancer simulator local contre snapshot DB (read-only) sur les 147 mesurables small/mid US du 7 mai
+2. Pour chaque grille SHORT, calculer outcome rigoureux (walk-forward sur candles déjà persistées)
+3. Produire tableau : grille × WR × expectancy × n mesurables
+
+**Critère décision** :
+- Si **au moins une grille SHORT a expectancy nette > +0.5%** → GO Phase 3
+- Sinon → STOP, pas de deploy, documentation échec, pivot
+
+**Action** : aucun écriture DB, aucun deploy.
+
+### 5.4 Phase 3 — Deploy MESURE-only (conditionnel)
+
+**Pré-requis** : Phase 2 validée par toi seul.
+
+**Scope** :
+1. Push branche `feature/short-shadow-grids`
+2. Review diff sur GitHub
+3. Deploy via pipeline standard (Fly.io)
+4. SQL : `UPDATE gainers_user_shadow_signals SET sim_run_at = NULL WHERE asset_class = 'us_equity_small_mid' AND created_at > NOW() - INTERVAL '14 days'`
+5. Shadow forward 14 jours démarre
+
+**Caveat** : ce deploy est **additif et passif** (nouvelles clés JSON dans `sim_results`, zéro impact sur scanner LIVE, zéro nouvelle position ouverte). Pas un "deploy de trading", un "deploy de télémétrie".
+
+---
+
+## 6. Critères GO LIVE — décision finale après 14j shadow forward
+
+Le shadow forward 14j produit des données. À J+15, vérifier :
+
+| Critère | Seuil minimum |
+|---|---|
+| Trades mesurables SHORT small/mid US | **≥ 80** |
+| Win rate | **≥ 50%** (à n=80, IC95 inférieur > 40%) |
+| Expectancy nette (post-slippage 30bps) | **> +0.4%/trade** |
+| Sharpe ratio daily | **> 1.0** |
+| Max drawdown shadow | **< 5%** du capital simulé |
+| Diversité temporelle | **≥ 5 jours de marché distincts** |
+| Pas de jour > 30% du PnL total | (sinon trop concentré) |
+
+**Si tous critères atteints** → ouverture discussion live trading.
+**Si un critère échoue** → STOP, documentation, pivot.
+
+---
+
+## 7. Risk Management — règles opérationnelles LIVE
+
+### 7.1 Sizing
+
+| Paramètre | Valeur | Justification |
+|---|---|---|
+| Capital initial | $10 500 | Donnée |
+| Fraction Kelly | 0.25 × Kelly | Kelly fractionné prudent |
+| Taille par position | **$1 050** (10% capital) | Cohérent avec `notional_usd` observé |
+| Positions simultanées max | **10** | Notional total = 100% capital |
+| Max positions par secteur | **5** | Limite concentration sectorielle |
+
+### 7.2 Limites & circuit breakers
+
+| Limite | Seuil | Action |
+|---|---|---|
+| Daily loss limit | -$210 (-2%) | Arrêt trading journée |
+| Kill switch global | -$1 050 (-10%) cumulé | Arrêt système + audit forcé |
+| Max consecutive losses | 8 trades | Pause 1h forcée |
+
+### 7.3 Plage temporelle
+
+| Borne | Heure UTC | Heure CEST |
+|---|---|---|
+| Start trading | 14:00 UTC | 16:00 CEST |
+| Stop new entries | 19:00 UTC | 21:00 CEST |
+| Force close all | 19:30 UTC | 21:30 CEST |
+
+**Aucun nouveau trade hors plage.** Le bug timing simulator (§4.2) devient moot avec cette règle.
+
+### 7.4 TP/SL par trade
+
+| Paramètre | Valeur SHORT |
+|---|---|
+| TP target | -0.8% (gain) |
+| SL stop | +0.4% (perte) |
+| Time limit | 60 min → close marché |
+| Ratio R:R | 2:1 |
+| Win rate breakeven | 33% |
+
+### 7.5 Projection PnL théorique
+
+| Expectancy mesurée | PnL/jour théorique | Annualisé (252j) |
+|---|---|---|
+| +0.5% | $84/jour | +20% |
+| +0.7% | $117/jour | +28% |
+| +1.0% | $168/jour | **+40%** ✅ cible basse |
+| +1.2% | $202/jour | **+48%** ✅ cible haute |
+| +1.5% | $252/jour | +60% |
+
+Base : 16 trades mesurables/jour × $1 050/position × expectancy × win rate net.
+
+---
+
+## 8. Tickets dérivés à traiter
+
+| ID | Description | Priorité | Phase |
+|---|---|---|---|
+| T-1 | Fix bug timing simulator (§4.2) | **P0** | Phase 1.5 |
+| T-2 | Filtrage cascade non discriminant (§4.1) | P1 | Post-validation |
+| T-3 | Direction signal hardcoded LONG (§4.3) | **P0** | Phase 1 (couvert) |
+| T-4 | Recalibration TP/SL small/mid US (§4.4) | **P0** | Phase 1 (couvert) |
+| T-5 | Bug crypto NO_DATA 100% (§4.5) | P2 | Hors scope MESURE |
+| T-6 | Retry anti-pattern (000500.KO 1832×) | P2 | Hors scope MESURE |
+| T-7 | NSE 404 loop (9 tickers délistés/mal mappés) | P3 | Hors scope MESURE |
+
+---
+
+## 9. État d'avancement
+
+- [x] Cadrage cible recalibrée
+- [x] Audit shadow LONG (verdict négatif documenté)
+- [x] Découverte direction inversée (proxy à valider)
+- [x] Cartographie pipelines V1 vs legacy
+- [x] Identification bugs structurels
+- [x] Plan Phase 1/2/3 défini
+- [x] Risk management chiffré
+- [x] Phase 1 (code SHORT) — **commit `896848e` local sur `feature/short-shadow-grids`**
+- [x] Phase 1.5 (fix timing simulator) — **commit `5835656` local sur `feature/short-shadow-grids`**
+- [ ] Phase 2 (rétroactif sur n=147)
+- [ ] Phase 3 (deploy MESURE-only)
+- [ ] Shadow forward 14j
+- [ ] Décision GO LIVE
+
+---
+
+**Note** : pas de PR, pas de push, pas de deploy, pas de secret. Phase MESURE intégrale.

--- a/docs/MEASURE-short-shadow-2026-05-11.md
+++ b/docs/MEASURE-short-shadow-2026-05-11.md
@@ -1,9 +1,19 @@
 # SmartVest — Phase MESURE : Audit Edge & Risk Management
 
-**Date** : 11-12 mai 2026 (v4 — Phase 2 walk-forward closed, Phase 3 démarrée)
+**Date** : 11-12 mai 2026 (v5 — Phase 3 STOPPÉE, Phase 2b INVALIDÉE, bugs scanner critiques découverts)
 **Auteur** : Yannick Elouard
-**Statut** : Phase MESURE — pas de PR, pas de push, pas de deploy
+**Statut** : Phase MESURE — pas de PR, pas de push, pas de deploy. Cron monitoring SUPPRIMÉ le 12 mai 08:02 CEST.
 **Cible opérationnelle** : $150-250/jour avec $10 500 de capital
+
+---
+
+## AVERTISSEMENT EN TÊTE — v5 (12 mai 2026 08:00 CEST)
+
+**Phase 2b est INVALIDÉE.** Les chiffres §10 (WR 71.9%, expectancy nette +0.73%, n=114 sur bucket `path_eff<0.25`) sont **un artefact statistique** causé par des doublons massifs dans le scanner. Après déduplication par `(symbol, jour, entry_price)`, le bucket chaotic tombe à **n=3 distincts** — pas un edge, un mirage.
+
+**Voir §16 ci-dessous pour le détail des 6 bugs scanner/simulator découverts.**
+
+**Critères §12 GO PAPER : INVALIDÉS.** À réécrire après fix scanner et nouvelle Phase 2 propre.
 
 ---
 
@@ -514,6 +524,183 @@ Mise à jour de §6 pour intégrer la découverte `path_eff < 0.25` :
 
 ---
 
+## 16. INVALIDATION PHASE 2b — bugs scanner critiques découverts (12 mai 2026)
+
+### 16.1 Découverte fatale
+
+En approfondissant l'anomalie `null_path_eff` (§14) après une suggestion d'investigation poussée (logs Fly EODHD trouées sur Asia), une série de requêtes Supabase MCP a révélé que **le scanner persiste des doublons massifs sur certains symboles small/mid US peu liquides**, avec `change_pct_1m` EXACTEMENT figé entre les occurrences. Cela contamine toutes les analyses Phase 2b en gonflant artificiellement le `n` de chaque bucket.
+
+### 16.2 Inventaire des doublons (Supabase, table `gainers_user_shadow_signals`)
+
+Sur la fenêtre 7-9 mai, après comptage `COUNT(*) GROUP BY symbol`, les symboles suivants sont massivement dupliqués avec `change_pct_1m` strictement identique sur toutes les lignes :
+
+| Symbole | n lignes | change_pct_1m figé | Notes |
+|---|---|---|---|
+| ATEC.US | 87 | 10.87% | Aussi présent §14 (33 lignes `path_eff=NULL`) |
+| GEO.US | 25 | 20.92% | entry 22.20 répété |
+| ACLS.US | 21 | 22.41% | entry 171.x répété |
+| MRCY.US | 18 | 10.49% | entry 91.66 répété |
+| KMT.US | 17 | 15.36% | entry 43.27 répété |
+| HRB.US | 14 | 23.77% | entry 36.29, outcomes mixés TP/SL |
+| CCRN.US | 13 | — | outcomes mixés SL/TIMEOUT |
+| ST.US, ORA.US, ANGI.US | <10 chacun | — | bruit résiduel |
+
+Aucune contrainte `UNIQUE (symbol, day, entry_price)` n'existe en DB. Le scanner peut donc écrire 87× la même opportunité ATEC sur 3 jours sans broncher.
+
+### 16.3 Liste consolidée des 6 bugs (par sévérité)
+
+| # | Bug | Sévérité | Détails |
+|---|---|---|---|
+| 1 | **Scanner persiste doublons massifs** | **CRITIQUE** | 87 ATEC, 25 GEO, 21 ACLS, 18 MRCY, 17 KMT, 14 HRB avec `change_pct_1m` exactement figé. Cause directe de l'invalidation Phase 2b. |
+| 2 | `path_eff` / `score` / `persistence_score` = NULL malgré `fetch_diag.outcome=ok` | Bloquant | 70 lignes sur 6 symboles (ATEC, ST, KMT, ORA, ACLS, MRCY). Incohérence : fetch_diag dit OK mais sortie naïve manquante. |
+| 3 | `TP_HIT` déclenché alors que prix n'atteint pas le target | Logique cassée | Exemple : ATEC entry 7.75, exit 7.688 → -0.8% marqué `TP_HIT` (TP target SHORT était -2%). |
+| 4 | `pnl_pct` stocké = brut MOINS 30 bps slippage déjà appliqué | Doc manquante | Toutes mes soustractions "-30bps" en Phase 2b ont compté le slippage **2 fois**. Edge net réel encore plus faible que -0.05%. |
+| 5 | 430 lignes `OFF_SESSION` non documentées | Mineur | Sur 749 total avec `path_eff` non null. Outcome inconnu du modèle de comptage. |
+| 6 | Aucune contrainte `UNIQUE (symbol, day, entry_price)` en DB | Cause racine #1 | Permet la duplication décrite bug #1. |
+
+### 16.4 Recalcul Phase 2b après déduplication
+
+Requête de dédup : `SELECT DISTINCT ON (symbol, DATE(created_at), entry_price) ...` sur grille `short_baseline_30m`, fenêtre 7-9 mai, asset_class = `us_equity_small_mid`, `path_eff IS NOT NULL`.
+
+| Bucket path_eff | n distincts (vs annoncé Phase 2b) | TP | SL | WR | avg pnl_net |
+|---|---|---|---|---|---|
+| **< 0.25 (chaotic)** | **3** (vs 114) | 3 | 0 | 100% IC95 Wilson [29.2% ; 100%] | +0.5% |
+| 0.25-0.5 (mid) | 3 (vs 114 cumulés mid+high) | 1 | 1 | 50% | -0.17% |
+| ≥ 0.5 (directional) | 7 (vs 91) | 4 | 3 | 57% | -0.01% |
+
+**Verdict** : l'edge "WR 71.9%, +0.73% net, n=114" du §10.6 est **un mirage statistique**. Sur n=3 réels, l'intervalle de confiance Wilson IC95 commence à 29% — pas un edge prouvable. Toutes les conclusions §10.6, §10.7 (projection $643/jour théorique), §12 (critères GO PAPER `path_eff<0.25`) sont **caduques**.
+
+### 16.5 Impact sur Phases 2a, 2b, 3
+
+- **Phase 2a (proxy SQL, WR 99% +0.59%)** : déjà documenté comme artefact dans §10 (le proxy ×-1 sur grille asymétrique n'était pas rigoureux). Confirmé.
+- **Phase 2b (walk-forward, WR 71.9% +0.73% sur path_eff<0.25)** : INVALIDÉE. Doublons + slippage compté 2× = chiffres faux.
+- **Phase 3 (shadow forward 14j)** : **STOPPÉE** à la décision du 12 mai 08:00 CEST. Continuer à mesurer sur un scanner cassé biaise tout. Cron `7f3209be` SUPPRIMÉ à 08:02 CEST.
+
+### 16.6 Décision opérationnelle
+
+**STOP Phase 3. Fix scanner d'abord.** Aucun deploy, aucun trade, aucun nouvel échantillonnage tant que les 6 bugs ne sont pas corrigés et qu'une nouvelle Phase 2 propre n'a pas redonné une mesure fiable.
+
+Ordre de priorité fix proposé (à valider avec Claude) :
+
+1. Bug #6 — ajouter contrainte `UNIQUE (symbol, DATE(created_at), entry_price, asset_class)` ou cooldown applicatif côté scanner → empêche le poison à la source.
+2. Bug #1 — corriger la logique scanner qui re-soumet le même `change_pct_1m` figé. Probable cause : cache stale ou absence de déduplication intra-batch.
+3. Bug #2 — résoudre l'incohérence `fetch_diag.outcome=ok` vs `path_eff NULL`. Soit le simulator déclare `NO_DATA`, soit il calcule réellement.
+4. Bug #3 — fix logique TP_HIT : ne marquer TP que si `prix atteint ≥ target` (pour LONG) ou `prix atteint ≤ target` (pour SHORT). Bug actuel marque TP au moindre signe de dérive.
+5. Bug #4 — documenter explicitement que `pnl_pct` est net de 30 bps slippage, ou refactorer pour stocker brut et appliquer slippage en analyse uniquement. Préférence : stocker brut, appliquer en aval.
+6. Bug #5 — documenter outcome `OFF_SESSION` et l'intégrer au modèle de comptage actionables.
+
+Une fois ces 6 fixes mergés et redeployés, **relancer Phase 2 walk-forward propre** sur une nouvelle fenêtre 7+ jours, sans contamination doublons. Reévaluer §12 critères GO PAPER à ce moment-là.
+
+### 16.7 Schéma table actuel (référence)
+
+```
+gainers_user_shadow_signals
+  id uuid, created_at timestamptz, portfolio_id uuid,
+  symbol text, asset_class text,
+  change_pct_1m numeric, score numeric,
+  path_eff numeric, persistence_score numeric, persistence_count text,
+  entry_price numeric, notional_usd numeric, decision text,
+  cfg_min_path_eff, cfg_min_persistence, cfg_asia_boost, cfg_tp_pct, cfg_sl_pct,
+  is_asia bool,
+  sim_results jsonb, sim_run_at timestamptz, sim_window_max_min int,
+  fetch_diag jsonb
+```
+
+Aucune contrainte UNIQUE en place — bug #6.
+
+### 16.8 Investigation code post-probe (12 mai 2026, après-midi)
+
+L'investigation s'est poursuivie après la décision STOP en clonant le repo `feature/short-shadow-grids` et en grep-pointant ligne à ligne. Voici les conclusions précises sur chaque bug, avec pointeurs code et rectifications de la liste initiale §16.3.
+
+#### Bug #1 — SMOKING GUN identifié : `SCANNER_SESSION_AWARE` absent de fly.toml
+
+- **Le fix existe déjà dans le code.** PR #298 (test `apps/api/src/modules/lisa/__tests__/scanner-session-aware.spec.ts`) décrit exactement ce bug : « avec `gainers_session_filter_enabled=true` en DB, le scanner continue à fetch les 9 EODHD screener à chaque cycle samedi ».
+- **Le fix est gardé par un feature flag env.** Ligne 1059 de `apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts` : `sessionAware = this.config.get('SCANNER_SESSION_AWARE') === 'true'`.
+- **Le flag n'est PAS défini dans fly.toml.** Section `[env]` actuelle = `NODE_ENV='production', API_PORT='3001', PORT='3001'`. Conséquence : `sessionAware` reste `false` en prod, le scanner skip la garde session, et continue à fetch hors-RTH → poison des 148 lignes HRB.
+- **Le filtre `usOpen` reste actif lignes 1633-1644** mais n'empêche pas le fetch initial des screeners EODHD ; il filtre les candidats post-fetch. Or les 9 calls EODHD screener sont déjà partis et la duplication a lieu en amont.
+
+**Fix immédiat = ajouter une ligne dans fly.toml** : `SCANNER_SESSION_AWARE = 'true'` dans le bloc `[env]`. 1 char de config, fix instantané sans modifier le code.
+
+#### Bug #6 — Confirmation : aucune contrainte UNIQUE en DB
+
+Migration `supabase/migrations/0134_gainers_user_shadow_signals.sql` confirmée : 3 index simples (portfolio, symbol, sim_run_at), zéro UNIQUE. `recordDecision` ligne 462 = `supabase.from('gainers_user_shadow_signals').insert(...)` brut, sans `ON CONFLICT`. Même si bug #1 est corrigé, un bug futur (rejouage cycle, retry réseau) peut réintroduire des doublons. Garde-fou DB nécessaire en complément.
+
+#### Bug #2 — RECLASSIFIÉ : pas un bug, doc manquante
+
+L'incohérence apparente « `fetch_diag.outcome=ok` mais `path_eff=NULL` » s'explique par la séquence d'écriture :
+
+1. **À la décision** (cycle scanner) : `recordDecision` insère la ligne avec `path_eff = pers?.pathQuality?.overallEfficiency ?? null`.
+2. **~65 min plus tard** (simulator job) : `simulatePending` met à jour la même ligne avec `fetch_diag` calculé indépendamment.
+
+Quand la décision est `reject_cooldown` ou `reject_post_sl_cooldown` (lignes 1898 et 1912 du scanner), `pers` est explicitement passé `undefined` → `path_eff` enregistré = `null`, par design. Le simulator ultérieur peut très bien fetcher des bars valides 60 min plus tard (`fetch_diag.outcome=ok`) car le marché est ouvert : les deux champs sont **disjoints fonctionnellement**.
+
+Probe Supabase confirmant l'hypothèse, 7 derniers jours :
+
+| Decision | n | n_path_null | n_fetch_ok | n_path_null & fetch_ok |
+|---|---|---|---|---|
+| reject_persistence | 3323 | 875 | 929 | **0** |
+| reject_path_eff | 1898 | 0 | 419 | **0** |
+| reject_post_sl_cooldown | 436 | 436 | 80 | **80** |
+| accept | 267 | 4 | 22 | **0** |
+| reject_cooldown | 62 | 62 | 8 | **8** |
+
+100% des `path_eff IS NULL AND fetch_diag.outcome=ok` (88/88) sont des `reject_cooldown` / `reject_post_sl_cooldown`. Comportement attendu, pas un bug. Action : **ajouter un commentaire SQL** sur `path_eff` documentant que NULL est légitime pour les decisions cooldown.
+
+Les 875 NULL sur `reject_persistence` ont une autre cause (légitime aussi) : `pathQuality` peut être lui-même `null` côté `persistence-probability.service.ts` quand le calcul de smoothness ne dispose pas de données suffisantes. Pas un bug non plus.
+
+#### Bug #3 — `TP_HIT` exemple ATEC entry 7.75 exit 7.688
+
+Lignes 380-437 de `gainers-user-shadow.service.ts`, walkForward :
+
+- SHORT TP teste `c.low <= tpPrice` (TP target pour SHORT = entry × (1 − tpPct))
+- SHORT SL teste `c.high >= slPrice` (SL pour SHORT = entry × (1 + slPct))
+- `pnl_pct: closePnl − SLIPPAGE_TOTAL` ligne 433
+- En grille short_calibrated TP 0.8% / SL 0.6% : ATEC 7.75 SHORT → TP price = 7.75 × 0.992 = **7.688**
+
+**Verdict** : la logique TP/SL elle-même est correcte. ATEC exit à 7.688 EST le TP price exact (8 décimales sont arrondies en colonne). Le pnl_pct affiché −0.005 = +0.8% − 0.3% slippage round-trip = bug #4 mal compté, pas bug #3.
+
+Ce que je croyais être un bug TP_HIT est en fait l'effet conjoint de :
+- input prix figé (bug #1, scanner persiste close=adjusted_close pourri hors-RTH ligne 1287-1289)
+- slippage déjà appliqué (bug #4, doc manquante)
+
+Donc **bug #3 est REQUALIFIÉ comme conséquence de bugs #1+#4**. À retester après fix #1.
+
+#### Bug #4 — Confirmation `pnl_pct` est NET de 30 bps slippage
+
+Ligne 433 de `gainers-user-shadow.service.ts` : `pnl_pct: closePnl − SLIPPAGE_TOTAL`. `SLIPPAGE_TOTAL = 0.003` (constante en tête de fichier). Documentation Phase 2b incorrecte : toutes mes soustractions « -30 bps » comptaient le slippage 2 fois. Edge réel "brut" sur la grille short_calibrated TP 0.8% / SL 0.6% = `+0.5%` net en TP, `−0.9%` net en SL.
+
+Action : commenter `pnl_pct` en SQL et dans le doc-comment du field `sim_results` (migration 0134 ligne 68-69 dit déjà « pnl_pct = NET (slippage 30bps round-trip déjà soustrait) » — le commentaire DB existe, c'est moi qui ne l'avais pas lu).
+
+#### Bug #5 — `OFF_SESSION` outcome non documenté en migration 0134
+
+- Migration 0134 ligne 68 documente seulement `outcome ∈ 'TP_HIT' | 'SL_HIT' | 'TIME_LIMIT' | 'NO_DATA'`.
+- PR #289 a ajouté `OFF_SESSION` côté TS (lignes 209, 637, 911 de `gainers-user-shadow.service.ts`) avec sub-classification `off_session_reason` ∈ `capture | stale_data`.
+- Aucune migration n'a mis à jour la doc DB.
+- Aussi : `fetch_diag.outcome` peut valoir `off_session` (ligne 645 service) en plus de `ok | no_data | error` documenté en migration 0136.
+
+Action : migration noop type `COMMENT ON COLUMN` pour mettre à jour les deux docs (`sim_results.outcome` et `fetch_diag.outcome`). Cosmétique mais important pour audit futur.
+
+### 16.9 Reclassement par sévérité après investigation code
+
+| # | Bug | Sévérité reclassée | Action |
+|---|---|---|---|
+| 1 | `SCANNER_SESSION_AWARE` absent fly.toml | **CRITIQUE / 1 ligne fix** | Ajouter env dans fly.toml et redeploy |
+| 6 | Aucun UNIQUE en DB | Important / garde-fou | Migration `UNIQUE (symbol, DATE(created_at), entry_price, asset_class)` ou applicatif |
+| 4 | `pnl_pct` net 30 bps non documenté côté analyse | Doc / mes calculs Phase 2b | Refaire les soustractions sans redoubler le slippage |
+| 5 | `OFF_SESSION` et `fetch_diag.outcome=off_session` non documentés en DB | Doc / cosmétique | Migration `COMMENT ON COLUMN` |
+| 2 | `path_eff NULL` vs `fetch_diag.outcome=ok` | **Annulé (faux bug)** | Commentaire DB sur `path_eff` legitimate NULL pour decisions cooldown |
+| 3 | `TP_HIT` exit hors target | **Requalifié conséquence #1+#4** | Re-tester après fix #1 |
+
+### 16.10 Plan fix consolidé
+
+1. Fix #1 (instantané) : éditer `fly.toml` `[env]` → ajouter `SCANNER_SESSION_AWARE = 'true'`. `fly deploy` → 1 cycle scanner (5 min) suffit pour vérifier qu'aucun nouveau doublon n'apparaît hors-RTH.
+2. Fix #6 (garde-fou) : migration Supabase `ALTER TABLE gainers_user_shadow_signals ADD CONSTRAINT uniq_decision_per_symbol_day UNIQUE (portfolio_id, symbol, asset_class, DATE(created_at), entry_price)`. Attention : DATE(...) n'est pas indexable directement en contrainte unique Postgres, donc soit colonne générée `created_date GENERATED ALWAYS AS (DATE(created_at)) STORED` puis UNIQUE dessus, soit index unique partiel avec expression. À discuter avec Claude.
+3. Fix #4+#5 : migration `COMMENT ON COLUMN` consolidée mettant à jour les docs (`path_eff` legitimate NULL conditions, `sim_results.outcome` ajout `OFF_SESSION`, `fetch_diag.outcome` ajout `off_session`). Cosmétique mais audit-critical.
+4. Re-test : après deploy fix #1, attendre 24h de scanner propre puis recompter `COUNT(*) GROUP BY symbol` 7-9 jours forward.
+5. Relancer Phase 2 walk-forward propre sur la nouvelle fenêtre. Réévaluer §12 critères GO PAPER.
+
+---
+
 ## 14. Bug simulator détecté (corriger en Phase 4, ne PAS toucher maintenant)
 
 ### Anomalie null_path_eff (12 mai 07:16 CEST)
@@ -521,37 +708,36 @@ Mise à jour de §6 pour intégrer la découverte `path_eff < 0.25` :
 Lors du setup du monitoring quotidien (cron Supabase), une requête de distribution path_eff sur les 389 trades actionables Phase 2 a révélé un bucket aberrant :
 
 - **n=70, path_eff IS NULL, outcome='TP_HIT' systématique, pnl_pct=+0.005 (TP target SHORT)**
-- Pattern systémique côté EODHD pour les **small caps US peu liquides** sur sessions 7-8 mai
-- **6 symboles affectés** (pas seulement ATEC) :
-  - ATEC.US (33 occurrences)
-  - ST.US (12)
-  - KMT.US (7)
-  - ORA.US (7)
-  - ACLS.US (6)
-  - MRCY.US (5)
-- Tous avec `exit_price` strictement identique par symbole (ex: ATEC=7.688), `entry_price=NULL`, `time_to_exit_min=NULL`
-- `decision=reject_post_sl_cooldown` majoritaire (signaux rejetés par le LIVE filter)
+- Réparti sur **6 symboles small/mid US peu liquides** (pas seulement ATEC) :
+  - ATEC.US (33), ST.US (12), KMT.US (7), ORA.US (7), ACLS.US (6), MRCY.US (5)
+- Période concentrée : 7-8 mai 2026 (sessions à forte volatilité vs faible liquidité EODHD)
+- Tous avec `exit_price` identique au sein du symbole, `entry_price=NULL`, `time_to_exit_min=NULL`
+- `decision=reject_post_sl_cooldown` (signaux rejetés par le LIVE filter)
+- Donc **pattern systémique**, pas une anomalie ATEC isolée
 
 ### Diagnostic
 
-Le simulator SHORT (vérifié sur calibrated_60m, très probablement sur toutes les grilles SHORT) a un **fallback hardcodé** : quand les données intra-bar EODHD ne permettent pas de calculer `entry_price`/`path_eff`/`time_to_exit`, il retourne `outcome='TP_HIT'` avec `pnl_pct=+TP_target` au lieu d'écrire `NULL` ou un outcome `NO_DATA`. Sur ATEC.US (probablement illiquide à cette heure), ça a produit 70 faux positifs consécutifs sur la session du 8 mai.
+Le simulator SHORT (vérifié sur calibrated_60m, très probablement sur toutes les grilles SHORT) a un **fallback hardcodé** : quand les données intra-bar EODHD ne permettent pas de calculer `entry_price`/`path_eff`/`time_to_exit`, il retourne `outcome='TP_HIT'` avec `pnl_pct=+TP_target` au lieu d'écrire `NULL` ou un outcome `NO_DATA`. **Confirmé sur 6 symboles small/mid US**, tous peu liquides hors RTH ou avec données EODHD trouées. Les logs Fly Asia (12 mai 05:50 UTC) montrent un pattern similaire (149 candles brutes / 13 closes valides / 136 nulls) sans nécessairement déclencher le fake TP_HIT — à surveiller.
 
 ### Impact rétroactif sur Phase 2
 
-- Total actionables réel : **319 trades** (389 − 70 ATEC junk), pas 389
+- Total actionables réel : **319 trades** (389 − 70 lignes corrompues), pas 389
 - Bucket `path_eff<0.25` non impacté : n=114, WR 71-78%, edge confirmé
 - Bucket `null_path_eff` à **exclure définitivement** des analyses et critères GO PAPER
+- **Risque Phase 3 forward** : les 6 symboles peuvent réapparaître dans le scanner US small/mid au cours des 14 jours. Le filtre `path_eff IS NOT NULL` du cron `7f3209be` les exclut automatiquement.
+- **Risque résiduel à surveiller** : si EODHD renvoie des données partielles permettant un `path_eff` calculé mais erroné, le bucket `chaotic<0.25` pourrait être contaminé par des faux positifs. À vérifier au T+3 jours par cross-check sur les symboles récurrents.
 
 ### Action Phase 4 (post-26 mai si GO)
 
-- Fix simulator : `if (entry_price IS NULL OR path_eff IS NULL) RETURN outcome='NO_DATA'`
+- Fix simulator : `if (entry_price IS NULL OR path_eff IS NULL OR validClose < threshold) RETURN outcome='NO_DATA'`
 - Filtre query par défaut : `AND path_eff IS NOT NULL` (déjà intégré dans le cron)
 - Ajouter détecteur d'anomalie : alerte si un symbole >10 occurrences avec même exit_price exact
-- Investiguer pourquoi EODHD renvoie des données manquantes sur ATEC.US spécifiquement
+- Investiguer pourquoi EODHD renvoie des données trouées sur ATEC/ST/KMT/ORA/ACLS/MRCY (probablement small caps hors RTH ou volume insuffisant pour ticks)
+- Évaluer un fallback **Intrinio** ou **Yahoo extended hours** pour ces symboles
 
 ---
 
-## 13. État d'avancement (v4)
+## 13. État d'avancement (v5)
 
 - [x] Cadrage cible recalibrée
 - [x] Audit shadow LONG (verdict négatif documenté)
@@ -562,19 +748,24 @@ Le simulator SHORT (vérifié sur calibrated_60m, très probablement sur toutes 
 - [x] Risk management chiffré
 - [x] **Phase 1 (code SHORT) — commit 896848e local**
 - [x] **Phase 1.5 (fix timing simulator) — commit 5835656 local**
-- [x] **Phase 2a (rétroactif proxy SQL) — validé 11 mai** (WR 99% proxy, +0.59% net, **caveat confirmé : artefact**)
+- [~] **Phase 2a (rétroactif proxy SQL)** — confirmé artefact (proxy ×-1 non rigoureux)
 - [x] **Deploy SHORT shadow MESURE-only sur Fly** — 11 mai 16:55 UTC (commit 4c7b345, `/version` vérifié)
-- [x] **Phase 2b (walk-forward sur 824 signaux)** — 12 mai 2026
-   - [x] Edge global non filtré : ABSENT (−0.05% net)
-   - [x] **Edge conditionnel `path_eff < 0.25` : VALIDÉ (WR 71.9%, +0.73% net, n=114, 3 jours)**
+- [~] **Phase 2b (walk-forward sur 824 signaux)** — **INVALIDÉE le 12 mai 08:00 CEST**
+   - [x] Edge global non filtré : ABSENT (−0.05% net) — ce chiffre lui-même est sous-estimé à cause du bug #4 (double slippage)
+   - [~] Edge conditionnel `path_eff < 0.25` : **MIRAGE** (n=3 distincts réels vs 114 annoncés, doublons scanner)
 - [x] **Incident scanner US shadow** — diagnostiqué et fixé 12 mai 05:04 UTC
-- [ ] **Phase 3 (shadow forward 14j)** — démarrée 12 mai 05:05 UTC, fin prévue ~26 mai
-   - [ ] T+8h : NYSE open 13:30 UTC, premier signal US shadow attendu
-   - [ ] T+72h : ~840 signaux US attendus, premier n significatif post-filtre
-   - [ ] T+14j : verdict GO PAPER (critères §12)
-- [ ] **Phase 4 (paper trading 4-6 semaines)** — obligatoire avant live
-   - [ ] Câblage direction SHORT dans pipeline LIVE GAINERS (Q1 ouverte vers Claude)
-   - [ ] Application filtre `path_eff < 0.25` au scanner LIVE (Q2 ouverte)
+- [x] **Découverte 6 bugs scanner/simulator** — 12 mai 07:30-08:00 CEST (§16)
+- [x] **STOP Phase 3** — décision 12 mai 08:00 CEST, cron `7f3209be` supprimé 08:02 CEST
+- [ ] **Phase 3 bis (fix scanner)** — brief Claude en cours
+   - [ ] Bug #6 contrainte UNIQUE / cooldown applicatif
+   - [ ] Bug #1 logique scanner anti-doublons
+   - [ ] Bug #2 cohérence fetch_diag vs path_eff
+   - [ ] Bug #3 logique TP_HIT (target réellement touché)
+   - [ ] Bug #4 doc/refactor pnl_pct slippage
+   - [ ] Bug #5 doc OFF_SESSION
+- [ ] **Phase 2 bis (walk-forward propre)** — après fix scanner, nouvelle fenêtre 7+ jours
+- [ ] **Critères §12 GO PAPER** — à réécrire post-Phase 2 bis (caducs sur path_eff<0.25)
+- [ ] **Phase 4 (paper trading 4-6 semaines)** — obligatoire avant live, bloquée tant que Phase 2 bis non validée
 - [ ] **Phase 5 (live taille réduite 50% sizing)** — 2 semaines de probation
 - [ ] **Phase 6 (live full sizing)** — si Phase 5 profitable 4 semaines
 
@@ -582,10 +773,11 @@ Le simulator SHORT (vérifié sur calibrated_60m, très probablement sur toutes 
 
 **Note** : pas de PR, pas de push, pas de deploy, pas de secret. Phase MESURE intégrale.
 
-**Prochaines actions** :
-- Aucune action urgente. Le shadow tourne tout seul pendant 14 jours.
-- Checkpoint quotidien automatisé : cron `7f3209be` (09:00 CEST) sur Supabase MCP.
-- Refaire l'analyse Phase 2b après 7 jours forward pour voir si filtre `path_eff < 0.25` tient sur n plus large.
+**Prochaines actions (v5)** :
+- Ne plus lancer aucune analyse Phase 2b/3 sur les données actuelles (contaminées par doublons et double slippage).
+- Brief comprehensive à envoyer à Claude listant les 6 bugs + ordre de priorité (voir §16.6).
+- Décider du sort de la connexion Supabase MCP : garder (pour re-valider après fix) ou disconnect (cohabitation "pas de secret").
+- Aucune réactivation de cron monitoring tant que le scanner n'est pas fixé.
 
 ---
 
@@ -624,8 +816,15 @@ Figé ici pour garder la trace des décisions et événements depuis le début d
 | 05:16 | Computer (via Supabase MCP) | **Bug ATEC.US détecté** lors du test du cron : 70 lignes `path_eff=NULL` toutes sur ATEC.US, `pnl_pct=+0.005` hardcodé. → N'invalide pas l'edge `<0.25` mais réduit le total Phase 2 à 319 actionables réels. À fixer Phase 4. |
 | 05:18 | Computer | MESURE.md v4 → v4.1 (ajout §14 bug simulator, précision §12 sur exclusion `path_eff IS NOT NULL`) |
 | 05:18 | Computer (cron) | **Tâche récurrente créée** : `7f3209be` SmartVest Shadow Daily Monitor, 09:00 CEST quotidien, premier run aujourd'hui 12 mai (test à vide attendu silencieux) |
-| 13:30 (à venir) | NYSE | Ouverture marché. Premier signal US shadow attendu post-fix |
-| ~14:40 (à venir) | Simulator | Premier batch sim US small/mid (buffer SIMULATE_AFTER_MIN=65min) |
+| 13:30 (à venir) | NYSE | Ouverture marché. Premier signal US shadow attendu post-fix — **rendu moot par STOP Phase 3** |
+| ~14:40 (à venir) | Simulator | Premier batch sim US small/mid (buffer SIMULATE_AFTER_MIN=65min) — **rendu moot** |
+| 07:16-07:55 | Computer + yannick | Logs Fly partagés : EODHD massives failures sur Asia (149 candles / 13 closes / 136 nulls). Suggestion d'approfondir |
+| 07:30-08:00 | Computer (Supabase MCP) | **Découverte fatale** : scanner persiste 87 ATEC, 25 GEO, 21 ACLS, 18 MRCY, 17 KMT, 14 HRB avec `change_pct_1m` exactement figé. Aucune contrainte UNIQUE en DB |
+| 07:55 | Computer | Recalcul Phase 2b avec `DISTINCT ON (symbol, day, entry_price)` : bucket chaotic tombe à **n=3** vs 114 annoncés |
+| 07:58 | Computer | Découverte bug #3 (TP_HIT à -0.8% alors que target -2%), bug #4 (pnl_pct stocké déjà net de 30 bps), bug #5 (430 OFF_SESSION non documentés) |
+| 08:00 | yannick | **Décision : STOP Phase 3, fix scanner d'abord** |
+| 08:02 | Computer | Cron `7f3209be` SUPPRIMÉ |
+| 08:05 | Computer | MESURE.md v4.3 → v5 (§16 INVALIDATION, mise à jour §13 et §15) |
 
 ### Décisions structurantes prises pendant la session
 

--- a/docs/MEASURE-short-shadow-2026-05-11.md
+++ b/docs/MEASURE-short-shadow-2026-05-11.md
@@ -186,26 +186,71 @@ Range 60m observé sur small/mid US : 0.5-1.2%.
 
 ---
 
-## 6. Critères GO LIVE — décision finale après 14j shadow forward
+## 6. Critères GO PAPER — décision après 14j shadow forward
 
 Le shadow forward 14j produit des données. À J+15, vérifier :
 
 | Critère | Seuil minimum |
 |---|---|
 | Trades mesurables SHORT small/mid US | **≥ 80** |
-| Win rate | **≥ 50%** (à n=80, IC95 inférieur > 40%) |
+| Win rate | **≥ 65%** (revu après proxy SQL Phase 2) |
 | Expectancy nette (post-slippage 30bps) | **> +0.4%/trade** |
 | Sharpe ratio daily | **> 1.0** |
 | Max drawdown shadow | **< 5%** du capital simulé |
 | Diversité temporelle | **≥ 5 jours de marché distincts** |
 | Pas de jour > 30% du PnL total | (sinon trop concentré) |
 
-**Si tous critères atteints** → ouverture discussion live trading.
+**Si tous critères atteints** → GO Phase 4 (paper trading).
 **Si un critère échoue** → STOP, documentation, pivot.
+
+## 6 bis. Phase 4 — Paper Trading (4-6 semaines minimum)
+
+Étape **obligatoire** entre shadow et live. Le shadow mesure l'edge sans exécution ; le paper trading capture les frictions d'exécution réelles **sans risque de capital**.
+
+### Frictions à mesurer en paper
+
+| Friction | Impact attendu | Comment c'est mesuré |
+|---|---|---|
+| Slippage réel | 10-50bps selon liquidité | Comparer prix shadow vs prix paper fill |
+| Latence broker | 100-500ms | Délai signal → ordre filled |
+| Partial fills | 5-20% des ordres | Compter ordres incomplets |
+| Short borrow rate | 1-5%/an sur small/mid US | Frais quotidiens table positions |
+| Hard-to-borrow | Refus brokerage | Compter signaux non exécutables |
+| Pre-market/after-hours | Volatilité × 2-3 | Restriction plage horaire confirmée |
+
+### Critères GO LIVE — après 4-6 semaines paper
+
+| Critère | Seuil minimum |
+|---|---|
+| Période paper trading | **≥ 4 semaines pleines** (≥20 jours marché) |
+| Trades paper mesurables | **≥ 200** |
+| Win rate paper | **≥ 60%** (admettant -5pp vs shadow par friction) |
+| Expectancy nette paper | **> +0.3%/trade** (admettant -10bps slippage réel) |
+| Sharpe ratio daily paper | **> 0.8** |
+| Max drawdown paper | **< 8%** du capital simulé |
+| Hard-to-borrow rate | **< 15%** des signaux |
+| Cohérence shadow vs paper | divergence WR < 15pp, divergence expectancy < 30% |
+
+**Le dernier critère est critique** : si paper trading donne un edge significativement plus faible que le shadow 14j, ça signifie que les frictions d'exécution mangent une grande partie de l'edge. Dans ce cas, soit on optimise l'exécution, soit on accepte l'edge réduit, soit on stoppe.
+
+## 6 ter. Critères GO LIVE — décision finale post-paper
+
+À partir du moment où Phase 4 paper trading est validée :
+
+| Critère | Seuil |
+|---|---|
+| Tous les critères §6 bis atteints | **Obligatoire** |
+| Période ininterrompue paper sans bug majeur | **≥ 2 semaines** |
+| Risk management documenté et testé en paper | DLL, kill switch, max positions tous déclenchés au moins 1× sans dégât |
+| Plan de retour arrière prêt | Si live perd > 5% en 1 semaine, retour paper |
+| Capital initial live ≤ paper capital | Pas de scale-up avant 4 semaines live profitable |
+
+**Si tous critères atteints** → GO LIVE à taille réduite (50% du sizing nominal pendant 2 premières semaines).
+**Si un critère échoue** → retour Phase 4 paper, pas de live.
 
 ---
 
-## 7. Risk Management — règles opérationnelles LIVE
+## 7. Risk Management — règles opérationnelles (applicables paper ET live)
 
 ### 7.1 Sizing
 
@@ -273,21 +318,48 @@ Base : 16 trades mesurables/jour × $1 050/position × expectancy × win rate ne
 
 ---
 
-## 9. État d'avancement
+## 9. Phases — récapitulatif visuel
+
+```
+[Phase 1] Code SHORT grids       ✅ commit 896848e
+   │
+[Phase 1.5] Fix timing simulator ✅ commit 5835656
+   │
+[Phase 2] Rétroactif proxy SQL   ✅ validé (WR 99% proxy, expectancy net +0.59%)
+   │
+   │  Caveat : proxy SQL surestime, réalité probable WR 65-80%
+   ▼
+[Phase 3] Shadow forward 14j     ⏸️ en attente push + deploy MESURE-only
+   │
+   │  Validation diversité temporelle + path intra-fenêtre
+   ▼
+[Phase 4] Paper Trading 4-6 sem  ⏸️ obligatoire avant LIVE
+   │
+   │  Validation frictions exécution (slippage, borrow, latence)
+   ▼
+[Phase 5] LIVE à taille réduite  ⏸️ 50% sizing nominal pendant 2 sem
+   │
+   │  Validation comportement capital réel
+   ▼
+[Phase 6] LIVE full sizing       ⏸️ si Phase 5 profitable 4 sem
+```
+
+## 10. État d'avancement
 
 - [x] Cadrage cible recalibrée
 - [x] Audit shadow LONG (verdict négatif documenté)
 - [x] Découverte direction inversée (proxy à valider)
 - [x] Cartographie pipelines V1 vs legacy
 - [x] Identification bugs structurels
-- [x] Plan Phase 1/2/3 défini
+- [x] Plan Phase 1/2/3/4/5 défini
 - [x] Risk management chiffré
 - [x] **Phase 1 (code SHORT) — commit 896848e local**
 - [x] **Phase 1.5 (fix timing simulator) — commit 5835656 local**
-- [ ] Phase 2 (rétroactif sur n=147) — option 1 retenue : script Node standalone read-only
-- [ ] Phase 3 (deploy MESURE-only) — conditionnel à Phase 2
-- [ ] Shadow forward 14j
-- [ ] Décision GO LIVE
+- [x] **Phase 2 (rétroactif proxy SQL) — validé le 11 mai 2026** (WR 99% proxy, expectancy net +0.59%, caveat surestimation)
+- [ ] **Phase 3 (deploy MESURE-only + shadow forward 14j)** — en attente push branche
+- [ ] **Phase 4 (paper trading 4-6 semaines)** — obligatoire avant live
+- [ ] **Phase 5 (live taille réduite 50% sizing)** — 2 semaines de probation
+- [ ] **Phase 6 (live full sizing)** — si Phase 5 profitable 4 semaines
 
 ---
 

--- a/fly.toml
+++ b/fly.toml
@@ -31,6 +31,12 @@ primary_region = 'cdg'
   NODE_ENV = 'production'
   API_PORT = '3001'
   PORT = '3001'
+  # Fix #1 (12/05/2026) — Active le gate session-aware dans top-gainers-scanner
+  # ligne 1059 (PR #298 + test scanner-session-aware.spec.ts). Sans ce flag,
+  # le scanner appelait les 9 EODHD screener à chaque cycle hors-RTH et écrivait
+  # des doublons figés (148 HRB, 87 ATEC, etc.) dans gainers_user_shadow_signals.
+  # Voir MEASURE-short-shadow-2026-05-11.md §16.8 pour l'investigation complète.
+  SCANNER_SESSION_AWARE = 'true'
 
 [http_service]
   internal_port = 3001

--- a/scripts/phase2-short-retro.ts
+++ b/scripts/phase2-short-retro.ts
@@ -1,0 +1,361 @@
+/**
+ * SHORT-SHADOW Phase 2 — Rétroactif rigoureux sur 147 mesurables small/mid US (07/05/2026).
+ *
+ * Objectif :
+ *   Re-simuler les 147 signaux US small/mid de la journée 07/05/2026 avec direction='short'
+ *   sur les 6 grilles SHORT, puis comparer expectancy vs hypothèse Phase 2 (>+0.5% ?).
+ *
+ * Méthodologie :
+ *   1. SELECT 147 mesurables (TP_HIT ou SL_HIT en baseline_60m LONG) du 07/05/2026
+ *   2. Pour chaque row, re-fetch candles EODHD 5m autour de createdAt (fenêtre +65min)
+ *   3. Run walkForward direction='short' sur les 6 grilles SHORT (4 mirror + 2 calibrated)
+ *   4. Output : phase2-retro-results.json (raw) + aggregated stats console
+ *   5. Verdict GO/STOP Phase 3 sur critères (expectancy >+0.5% ET WR ≥50% ET IC95 lo >40%)
+ *
+ * NO DB WRITES (read-only). Standalone, indépendant du runtime NestJS.
+ *
+ * Usage :
+ *   SUPABASE_URL=https://xxx.supabase.co \
+ *   SUPABASE_SERVICE_ROLE_KEY=eyJ... \
+ *   EODHD_API_KEY=xxx \
+ *   ./node_modules/.bin/ts-node scripts/phase2-short-retro.ts
+ *
+ * Output local (non commité) : phase2-retro-results.json
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { writeFileSync } from 'fs';
+import {
+  walkForward,
+  getGridsForAssetClass,
+  type CandleLike,
+} from '../apps/api/src/modules/lisa/services/gainers-user-shadow.service';
+
+// ───────────────────────── EODHD client minimal ─────────────────────────
+
+async function fetchEodhdCandles(
+  symbol: string,
+  fromTs: number,
+  toTs: number,
+  apiKey: string,
+): Promise<CandleLike[] | null> {
+  const url =
+    `https://eodhd.com/api/intraday/${encodeURIComponent(symbol)}` +
+    `?api_token=${apiKey}&interval=5m&fmt=json&from=${fromTs}&to=${toTs}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.error(`  [eodhd] HTTP ${res.status} for ${symbol}`);
+      return null;
+    }
+    const data = (await res.json()) as Array<Record<string, unknown>>;
+    if (!Array.isArray(data) || data.length === 0) return null;
+    return data
+      .map((d) => {
+        let ts = Number(d.timestamp ?? 0);
+        if (ts > 1e12) ts = Math.floor(ts / 1000);
+        return {
+          timestamp: ts,
+          high: Number(d.high ?? 0),
+          low: Number(d.low ?? 0),
+          close: Number(d.close ?? 0),
+        };
+      })
+      .filter(
+        (c) =>
+          Number.isFinite(c.timestamp) &&
+          Number.isFinite(c.close) &&
+          c.close > 0,
+      )
+      .sort((a, b) => a.timestamp - b.timestamp);
+  } catch (e) {
+    console.error(`  [eodhd] fetch error for ${symbol}:`, e);
+    return null;
+  }
+}
+
+// ───────────────────────── Wilson IC95 ─────────────────────────
+
+function wilson95(wins: number, n: number): { lo: number; mid: number; hi: number } {
+  if (n === 0) return { lo: 0, mid: 0, hi: 0 };
+  const z = 1.96;
+  const p = wins / n;
+  const denom = 1 + (z * z) / n;
+  const center = (p + (z * z) / (2 * n)) / denom;
+  const margin = (z * Math.sqrt((p * (1 - p)) / n + (z * z) / (4 * n * n))) / denom;
+  return { lo: Math.max(0, center - margin), mid: p, hi: Math.min(1, center + margin) };
+}
+
+// ───────────────────────── Types ─────────────────────────
+
+type SimResults = {
+  baseline_30m?: { outcome: string; pnl_pct: number | null };
+  baseline_60m?: { outcome: string; pnl_pct: number | null };
+  alt15_30m?: { outcome: string; pnl_pct: number | null };
+  alt15_60m?: { outcome: string; pnl_pct: number | null };
+};
+
+type ResultRow = {
+  signal_id: string;
+  symbol: string;
+  entry_price: number;
+  created_at: string;
+  grid: string;
+  outcome: string;
+  pnl_pct: number | null;
+  hit_at_min: number | null;
+  exit_price: number | null;
+};
+
+// ───────────────────────── Main ─────────────────────────
+
+async function main(): Promise<void> {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const eodhdKey = process.env.EODHD_API_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY env vars');
+    process.exit(1);
+  }
+  if (!eodhdKey) {
+    console.error(
+      'Missing EODHD_API_KEY env var (needed for candle re-fetch; fetch_diag stores no raw candles)',
+    );
+    process.exit(1);
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  console.log('[phase2-retro] Loading small/mid US rows from 7 mai 2026 (UTC)...');
+  const { data: rows, error } = await supabase
+    .from('gainers_user_shadow_signals')
+    .select('id, symbol, asset_class, entry_price, created_at, sim_results')
+    .eq('asset_class', 'us_equity_small_mid')
+    .gte('created_at', '2026-05-07T00:00:00Z')
+    .lt('created_at', '2026-05-08T00:00:00Z')
+    .not('sim_results', 'is', null);
+
+  if (error) {
+    console.error('[phase2-retro] Supabase query error:', error.message);
+    process.exit(1);
+  }
+  if (!rows || rows.length === 0) {
+    console.warn('[phase2-retro] 0 rows loaded — nothing to simulate');
+    process.exit(0);
+  }
+  console.log(`[phase2-retro] Loaded ${rows.length} rows from DB`);
+
+  // Filter to mesurables : baseline_60m a TP_HIT ou SL_HIT (definition utilisateur n=147)
+  const mesurables = rows.filter((r) => {
+    const sim = r.sim_results as SimResults | null;
+    const outcome = sim?.baseline_60m?.outcome;
+    return outcome === 'TP_HIT' || outcome === 'SL_HIT';
+  });
+  console.log(
+    `[phase2-retro] ${mesurables.length} mesurables (TP_HIT/SL_HIT en baseline_60m LONG)`,
+  );
+
+  // 6 SHORT grids (us_equity_small_mid retourne 4 LONG + 6 SHORT)
+  const allGrids = getGridsForAssetClass('us_equity_small_mid');
+  const shortGrids = allGrids.filter((g) => g.direction === 'short');
+  console.log(`[phase2-retro] Re-simulating with ${shortGrids.length} SHORT grids:`);
+  for (const g of shortGrids) {
+    console.log(
+      `  - ${g.key.padEnd(28)} TP=${(g.tpPct * 100).toFixed(2)}% SL=${(g.slPct * 100).toFixed(2)}% window=${g.windowMin}min`,
+    );
+  }
+
+  const results: ResultRow[] = [];
+  let fetchFailures = 0;
+
+  for (let i = 0; i < mesurables.length; i++) {
+    const row = mesurables[i];
+    if (row.entry_price == null) {
+      console.warn(`\n[phase2-retro] Skip row ${row.id}: missing entry_price`);
+      continue;
+    }
+    const startTs = Math.floor(new Date(row.created_at).getTime() / 1000);
+    const fromTs = startTs - 300;
+    const toTs = startTs + 60 * 60 + 300;
+
+    process.stdout.write(
+      `\r[phase2-retro] ${(i + 1).toString().padStart(3)}/${mesurables.length} ${row.symbol.padEnd(12)}`,
+    );
+
+    const candles = await fetchEodhdCandles(row.symbol, fromTs, toTs, eodhdKey);
+    if (!candles || candles.length === 0) {
+      fetchFailures++;
+      for (const grid of shortGrids) {
+        results.push({
+          signal_id: row.id,
+          symbol: row.symbol,
+          entry_price: Number(row.entry_price),
+          created_at: row.created_at,
+          grid: grid.key,
+          outcome: 'NO_DATA_FETCH_FAILED',
+          pnl_pct: null,
+          hit_at_min: null,
+          exit_price: null,
+        });
+      }
+      // Rate limit polite
+      await new Promise((r) => setTimeout(r, 100));
+      continue;
+    }
+
+    for (const grid of shortGrids) {
+      const out = walkForward(Number(row.entry_price), candles, startTs, grid);
+      results.push({
+        signal_id: row.id,
+        symbol: row.symbol,
+        entry_price: Number(row.entry_price),
+        created_at: row.created_at,
+        grid: grid.key,
+        outcome: out.outcome,
+        pnl_pct: out.pnl_pct,
+        hit_at_min: out.hit_at_min,
+        exit_price: out.exit_price,
+      });
+    }
+
+    // Rate limit polite (10 req/s, well under EODHD plan limits)
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  console.log(`\n[phase2-retro] All ${mesurables.length} rows processed.`);
+  if (fetchFailures > 0) {
+    console.warn(`[phase2-retro] ${fetchFailures} fetch failures (NO_DATA_FETCH_FAILED rows)`);
+  }
+
+  // Write raw results
+  const outputPath = 'phase2-retro-results.json';
+  writeFileSync(outputPath, JSON.stringify(results, null, 2));
+  console.log(`[phase2-retro] Raw results written to ${outputPath} (${results.length} rows)`);
+
+  // ───────────────────────── Aggregate per grid ─────────────────────────
+
+  console.log('\n========== PHASE 2 — Aggregated stats per SHORT grid ==========\n');
+
+  type GridStats = {
+    grid: string;
+    n: number;
+    wins: number;
+    losses: number;
+    timeLimit: number;
+    wr: number;
+    wrLo: number;
+    wrHi: number;
+    expectancy: number;
+    stddev: number;
+  };
+  const gridStats: GridStats[] = [];
+
+  for (const grid of shortGrids) {
+    const gridResults = results.filter((r) => r.grid === grid.key);
+    const measurable = gridResults.filter(
+      (r) =>
+        ['TP_HIT', 'SL_HIT', 'TIME_LIMIT'].includes(r.outcome) && r.pnl_pct !== null,
+    );
+    if (measurable.length === 0) {
+      console.log(`${grid.key.padEnd(28)} 0 mesurables`);
+      gridStats.push({
+        grid: grid.key,
+        n: 0,
+        wins: 0,
+        losses: 0,
+        timeLimit: 0,
+        wr: 0,
+        wrLo: 0,
+        wrHi: 0,
+        expectancy: 0,
+        stddev: 0,
+      });
+      continue;
+    }
+    const wins = measurable.filter((r) => (r.pnl_pct ?? 0) > 0).length;
+    const losses = measurable.filter((r) => (r.pnl_pct ?? 0) <= 0).length;
+    const timeLimit = measurable.filter((r) => r.outcome === 'TIME_LIMIT').length;
+    const avgPnl =
+      measurable.reduce((s, r) => s + (r.pnl_pct ?? 0), 0) / measurable.length;
+    const variance =
+      measurable.reduce((s, r) => s + Math.pow((r.pnl_pct ?? 0) - avgPnl, 2), 0) /
+      measurable.length;
+    const stddev = Math.sqrt(variance);
+    const wilson = wilson95(wins, measurable.length);
+
+    gridStats.push({
+      grid: grid.key,
+      n: measurable.length,
+      wins,
+      losses,
+      timeLimit,
+      wr: wilson.mid,
+      wrLo: wilson.lo,
+      wrHi: wilson.hi,
+      expectancy: avgPnl,
+      stddev,
+    });
+
+    console.log(
+      `${grid.key.padEnd(28)} ` +
+        `n=${String(measurable.length).padStart(3)} ` +
+        `W/L=${String(wins).padStart(3)}/${String(losses).padStart(3)} ` +
+        `(${String(timeLimit).padStart(3)} TIME) ` +
+        `WR=${(wilson.mid * 100).toFixed(1)}% [${(wilson.lo * 100).toFixed(1)}, ${(wilson.hi * 100).toFixed(1)}] ` +
+        `E[pnl]=${(avgPnl * 100).toFixed(3)}% σ=${(stddev * 100).toFixed(3)}%`,
+    );
+  }
+
+  // ───────────────────────── Decision verdict ─────────────────────────
+
+  console.log('\n========== DECISION (Phase 2 → Phase 3) ==========\n');
+  console.log('Critères GO Phase 3 :');
+  console.log('  - expectancy nette > +0.5%/trade');
+  console.log('  - WR ≥ 50% (point estimate)');
+  console.log('  - IC95 Wilson lower bound > 40% (robustesse à n=147)\n');
+
+  const THRESHOLD_EXPECTANCY = 0.005;
+  const THRESHOLD_WR = 0.5;
+  const THRESHOLD_WR_LO = 0.4;
+
+  const passing = gridStats.filter(
+    (s) =>
+      s.expectancy > THRESHOLD_EXPECTANCY &&
+      s.wr >= THRESHOLD_WR &&
+      s.wrLo > THRESHOLD_WR_LO,
+  );
+
+  if (passing.length > 0) {
+    console.log(`✅ GO Phase 3 : ${passing.length} grille(s) SHORT passe(nt) TOUS les seuils :`);
+    for (const p of passing) {
+      console.log(
+        `   - ${p.grid.padEnd(28)} ` +
+          `WR=${(p.wr * 100).toFixed(1)}% (IC95 lo=${(p.wrLo * 100).toFixed(1)}%) ` +
+          `expectancy=${(p.expectancy * 100).toFixed(3)}% n=${p.n}`,
+      );
+    }
+    console.log('\nProchaine étape : revue diff, push branche, deploy MESURE-only, shadow 14j forward.');
+  } else {
+    console.log('❌ STOP : aucune grille SHORT ne passe les seuils.');
+    console.log('Documentation échec à compléter, pas de deploy Phase 3.\n');
+    console.log('Détail des grilles qui se sont approchées :');
+    const sorted = [...gridStats].sort((a, b) => b.expectancy - a.expectancy);
+    for (const s of sorted.slice(0, 3)) {
+      const failExp = s.expectancy <= THRESHOLD_EXPECTANCY ? '❌ exp' : '✅ exp';
+      const failWr = s.wr < THRESHOLD_WR ? '❌ WR' : '✅ WR';
+      const failWrLo = s.wrLo <= THRESHOLD_WR_LO ? '❌ IC' : '✅ IC';
+      console.log(
+        `   - ${s.grid.padEnd(28)} ${failExp} ${failWr} ${failWrLo} | ` +
+          `WR=${(s.wr * 100).toFixed(1)}% lo=${(s.wrLo * 100).toFixed(1)}% exp=${(s.expectancy * 100).toFixed(3)}%`,
+      );
+    }
+  }
+
+  console.log('\n[phase2-retro] Done.');
+}
+
+main().catch((e) => {
+  console.error('[phase2-retro] FATAL:', e);
+  process.exit(1);
+});

--- a/supabase/migrations/0138_macro_veto_log.sql
+++ b/supabase/migrations/0138_macro_veto_log.sql
@@ -1,0 +1,54 @@
+-- 0138 — Macro veto log table
+--
+-- PR Action 3 — LLM macro veto pour le scanner gainers.
+--
+-- Une décision Lisa hourly produit un flag `macro_allowed` global qui
+-- gate les opens du scanner. Cette table stocke chaque décision pour :
+--   - Audit trail (pourquoi on a skip / let through)
+--   - Backtest empirique (validate que le veto évite vraiment les bad days)
+--   - UI dashboard (état régime courant)
+--
+-- Table append-only. La décision la plus récente (max created_at) est la valeur
+-- courante du flag. Pas de UPDATE, jamais.
+
+CREATE TABLE IF NOT EXISTS macro_veto_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Décision
+  macro_allowed BOOLEAN NOT NULL,
+  regime TEXT NOT NULL CHECK (regime IN ('risk_on', 'risk_off', 'transitioning', 'uncertain')),
+  veto_reason TEXT,                              -- NULL si macro_allowed=true
+  confidence NUMERIC(3,2) NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+
+  -- Inputs structurés (snapshot indicators au moment de la décision)
+  vix NUMERIC(6,2),
+  spx_change_pct NUMERIC(5,2),
+  dxy NUMERIC(6,2),
+  us10y_yield NUMERIC(4,2),
+
+  -- Provenance LLM
+  llm_provider TEXT,                             -- 'gemini-flash-lite' | 'claude-opus-4-7' | 'fallback_deterministic'
+  llm_cost_usd NUMERIC(8,6),
+  llm_latency_ms INT,
+  llm_raw_response TEXT,                         -- Stocké pour debugging
+  fallback_used BOOLEAN NOT NULL DEFAULT false   -- true si tous les LLM ont fail → règle déterministe
+);
+
+CREATE INDEX IF NOT EXISTS macro_veto_log_created_at_idx
+  ON macro_veto_log (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS macro_veto_log_recent_decision_idx
+  ON macro_veto_log (created_at DESC, macro_allowed);
+
+COMMENT ON TABLE macro_veto_log IS
+  'PR Action 3 — Append-only log des décisions LLM macro veto pour le scanner gainers. La décision courante est la row la plus récente. Lecture via getCurrentFlag() qui retourne flag=allow par défaut si table vide ou décision >2h ago (safety).';
+
+COMMENT ON COLUMN macro_veto_log.macro_allowed IS
+  'true = scanner peut opener positions normalement. false = veto, scanner skip cycle.';
+
+COMMENT ON COLUMN macro_veto_log.confidence IS
+  'Conviction LLM sur la décision [0..1]. Caller peut imposer threshold (ex: ne respect le veto que si confidence > 0.7).';
+
+COMMENT ON COLUMN macro_veto_log.fallback_used IS
+  'true quand tous les LLM ont échoué et qu''on a appliqué une règle déterministe (default = allow, fail-open).';


### PR DESCRIPTION
## Summary

Remplace le short-circuit `crypto_not_supported` (gainers-user-shadow.service.ts:599-618) par un walk-forward réel via Binance klines 5m. Les ~13 crypto/4j capturées par `fetchBinanceGainers` (top-gainers-scanner.service.ts:1136-1146) deviennent mesurables.

## Changes

- **`BinanceMarketService.getKlinesRange(symbol, interval, startMs, endMs)`** : nouveau wrapper sur `/api/v3/klines` avec startTime/endTime natifs. Cache séparé (TTL 1h, range historique immutable). Weight=1 Binance API, ~30 calls/jour attendus, rate limit 1200/min largement OK.
- **`simulateRow` crypto path** : remplace le bloc 599-618. Si `CRYPTO_SIMULATOR_ENABLED=true` ET `binance` injecté → fetch Binance 5m sur `[startTs-5min, +65min]` + walkForward. Sinon → legacy short-circuit préservé (rollback rapide).
- **`toBinanceSymbol`** : 10/10 paires `CRYPTO_PAIRS` (BTCUSDT, ETHUSDT, BNBUSDT, SOLUSDT, XRPUSDT, ADAUSDT, AVAXUSDT, DOTUSDT, LINKUSDT, MATICUSDT) mappées (validation SQL 7/7 paires production : zéro null).
- **fetchDiag** : nouveau endpoint `binance_klines_range_5m` dans steps[], errors `binance_api_error` / `empty_response` / `crypto_unmappable_symbol` / `crypto_simulator_no_binance_service`.

## Flag rollout

`CRYPTO_SIMULATOR_ENABLED` (default `false`). Activer via `fly secrets set CRYPTO_SIMULATOR_ENABLED=true -a smartvest` après deploy validé.

## Tests

- **15 tests** nouveau `crypto-simulator.spec.ts` : flag off/on, mapping, TP/SL/TIME hits, partial_window threshold, conversion ms→sec, priceSnapshots, startTime/endTime en ms.
- **0 régression** : 76/76 suites, 1027/1027 tests lisa pass.
- Typecheck strict (`exactOptionalPropertyTypes: true`) clean.

## Test plan

- [ ] CI typecheck + jest verts
- [ ] Post-merge : `./scripts/deploy.sh` avec flag OFF (comportement legacy préservé)
- [ ] Activation flag : `fly secrets set CRYPTO_SIMULATOR_ENABLED=true -a smartvest`
- [ ] SQL T+15min : majorité `fetch_diag.outcome='ok'` sur crypto_major rows nouvelles
- [ ] Rollback rapide : `fly secrets unset CRYPTO_SIMULATOR_ENABLED -a smartvest`

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_