### PR TITLE
fix(lisa): Bug #H + Bug #I — EODHD propagation lag US 60min + asia_equity 5→60min

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/simulate-buffer-by-class.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/simulate-buffer-by-class.spec.ts
@@ -1,16 +1,22 @@
 /**
- * Bug #H (13/05/2026) — Tests buffer dynamique par asset_class pour simulatePending.
+ * Bug #H + Bug #I (13/05/2026) — Tests buffer dynamique par asset_class pour simulatePending.
  *
- * Diagnostic : 246/246 captures us_equity_large 12/05 13:30-20:00 UTC marquées
+ * Bug #H : 246/246 captures us_equity_large 12/05 13:30-20:00 UTC marquées
  * off_session/stale_data malgré session ouverte. Cause = lag propagation EODHD
- * intraday US live ≫ 65 min. Fix = buffer 60 min pour US (after_min = 120),
- * 5 min pour les autres (after_min = 65, inchangé).
+ * intraday US live ≫ 65 min. Fix = buffer 60 min pour US (after_min = 120).
+ *
+ * Bug #I : 493/493 signaux asia_equity 24h marqués off_session (trace 003550.KO
+ * candle_freshness=90134s). Même cause racine que #H — EODHD live trail lag
+ * touche aussi Korea/HK/SHE/SZSE/TYO. Fix = buffer 60 min pour asia_equity
+ * (after_min = 120, aligné US).
+ *
+ * EU + crypto restent à 5 min (after_min = 65, inchangé).
  *
  * Couvre :
  *   - getSimulateBufferMin par classe (7 cas)
- *   - getSimulateAfterMin par classe (2 cas)
+ *   - getSimulateAfterMin par classe (3 cas)
  *   - simulatePending integration : pre-fetch query MIN cutoff + per-row JS filter
- *     (2 cas : US young row skipped, US mature row picked)
+ *     (US/asia young row skipped, US/asia mature row picked, EU/crypto unchanged)
  */
 import {
   GainersUserShadowService,
@@ -36,8 +42,8 @@ describe('Bug #H — getSimulateBufferMin par asset_class', () => {
     expect(getSimulateBufferMin('eu_equity')).toBe(5);
   });
 
-  it('asia_equity → 5 (TZ shift + session-aware adressent)', () => {
-    expect(getSimulateBufferMin('asia_equity')).toBe(5);
+  it('asia_equity → 60 (Bug #I — lag EODHD live identique US)', () => {
+    expect(getSimulateBufferMin('asia_equity')).toBe(60);
   });
 
   it('crypto_major → 5 (Binance live Bug #A)', () => {
@@ -60,9 +66,14 @@ describe('Bug #H — getSimulateAfterMin par asset_class', () => {
     expect(getSimulateAfterMin('us_equity_large')).toBe(MAX_WINDOW_MIN + 60);
   });
 
-  it('asia_equity → 65 (= MAX_WINDOW_MIN 60 + buffer 5, inchangé)', () => {
-    expect(getSimulateAfterMin('asia_equity')).toBe(65);
-    expect(getSimulateAfterMin('asia_equity')).toBe(MAX_WINDOW_MIN + DEFAULT_SIMULATE_BUFFER_MIN);
+  it('asia_equity → 120 (= MAX_WINDOW_MIN 60 + buffer 60, Bug #I)', () => {
+    expect(getSimulateAfterMin('asia_equity')).toBe(120);
+    expect(getSimulateAfterMin('asia_equity')).toBe(MAX_WINDOW_MIN + 60);
+  });
+
+  it('eu_equity → 65 (= MAX_WINDOW_MIN 60 + buffer 5, inchangé)', () => {
+    expect(getSimulateAfterMin('eu_equity')).toBe(65);
+    expect(getSimulateAfterMin('eu_equity')).toBe(MAX_WINDOW_MIN + DEFAULT_SIMULATE_BUFFER_MIN);
   });
 
   it('legacy SIMULATE_AFTER_MIN = 65 préservé (back-compat tests TIMING-FIX)', () => {
@@ -173,20 +184,54 @@ describe('Bug #H — simulatePending integration per-class filter', () => {
     expect(updateCalls).toContain('us-mature');
   });
 
-  it('asia_equity row created 70 min ago → PICKED (asia buffer 5 → mature at 65)', async () => {
+  it('asia_equity row created 70 min ago → SKIPPED (Bug #I: asia needs 120 min)', async () => {
     const nowMs = Date.now();
     const row: SupabaseRow = {
-      id: 'asia-mature',
+      id: 'asia-young',
       symbol: '005930.KO',
       asset_class: 'asia_equity',
       entry_price: 70000,
       created_at: new Date(nowMs - 70 * 60_000).toISOString(),
     };
     const { svc, updateCalls } = buildServiceWithRows([row]);
+    const { processed, failures } = await svc.simulatePending();
+
+    expect(processed).toBe(0);
+    expect(failures).toBe(0);
+    // Asia row maintenant filtré par JS filter (buffer 60 → mature at 120 min)
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it('asia_equity row created 130 min ago → PICKED (Bug #I: mature at 120)', async () => {
+    const nowMs = Date.now();
+    const row: SupabaseRow = {
+      id: 'asia-mature',
+      symbol: '005930.KO',
+      asset_class: 'asia_equity',
+      entry_price: 70000,
+      created_at: new Date(nowMs - 130 * 60_000).toISOString(),
+    };
+    const { svc, updateCalls } = buildServiceWithRows([row]);
     const { processed } = await svc.simulatePending();
 
     expect(processed).toBe(1);
     expect(updateCalls).toContain('asia-mature');
+  });
+
+  it('eu_equity row created 70 min ago → PICKED (EU buffer 5 → mature at 65, inchangé)', async () => {
+    const nowMs = Date.now();
+    const row: SupabaseRow = {
+      id: 'eu-mature',
+      symbol: 'OR.PA',
+      asset_class: 'eu_equity',
+      entry_price: 400,
+      created_at: new Date(nowMs - 70 * 60_000).toISOString(),
+    };
+    const { svc, updateCalls } = buildServiceWithRows([row]);
+    const { processed } = await svc.simulatePending();
+
+    expect(processed).toBe(1);
+    expect(updateCalls).toContain('eu-mature');
   });
 
   it('query SQL cutoff = MIN_SIMULATE_AFTER_MIN (65 min, permissive)', async () => {
@@ -201,24 +246,31 @@ describe('Bug #H — simulatePending integration per-class filter', () => {
     expect(Math.abs(cutoffMs - expectedMs)).toBeLessThan(2000);
   });
 
-  it('mixed batch : us_young skipped, us_mature + asia processed', async () => {
+  it('mixed batch : us/asia young skipped, us/asia mature + eu processed', async () => {
     const nowMs = Date.now();
     const rows: SupabaseRow[] = [
-      // Sera filtré par query (créé il y a 80 min seulement, query cutoff 65 → passe)
-      // mais JS filter (US needs 120) le skip
+      // us_young : query cutoff 65 → passe, JS filter (US needs 120) le skip
       { id: 'us-young', symbol: 'QCOM.US', asset_class: 'us_equity_large',
         entry_price: 150, created_at: new Date(nowMs - 80 * 60_000).toISOString() },
       { id: 'us-mature', symbol: 'AAPL.US', asset_class: 'us_equity_large',
         entry_price: 150, created_at: new Date(nowMs - 125 * 60_000).toISOString() },
-      { id: 'asia-mature', symbol: '005930.KO', asset_class: 'asia_equity',
+      // asia_young : query cutoff 65 → passe, JS filter (asia needs 120) le skip (Bug #I)
+      { id: 'asia-young', symbol: '005930.KO', asset_class: 'asia_equity',
         entry_price: 70000, created_at: new Date(nowMs - 70 * 60_000).toISOString() },
+      { id: 'asia-mature', symbol: '003550.KO', asset_class: 'asia_equity',
+        entry_price: 50000, created_at: new Date(nowMs - 125 * 60_000).toISOString() },
+      // eu_mature : passe à 65 min comme avant
+      { id: 'eu-mature', symbol: 'OR.PA', asset_class: 'eu_equity',
+        entry_price: 400, created_at: new Date(nowMs - 70 * 60_000).toISOString() },
     ];
     const { svc, updateCalls } = buildServiceWithRows(rows);
     const { processed } = await svc.simulatePending();
 
-    expect(processed).toBe(2);  // us-mature + asia-mature, us-young skipped
+    expect(processed).toBe(3);  // us-mature + asia-mature + eu-mature
     expect(updateCalls).toContain('us-mature');
     expect(updateCalls).toContain('asia-mature');
+    expect(updateCalls).toContain('eu-mature');
     expect(updateCalls).not.toContain('us-young');
+    expect(updateCalls).not.toContain('asia-young');
   });
 });

--- a/apps/api/src/modules/lisa/__tests__/simulate-buffer-by-class.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/simulate-buffer-by-class.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Bug #H (13/05/2026) — Tests buffer dynamique par asset_class pour simulatePending.
+ *
+ * Diagnostic : 246/246 captures us_equity_large 12/05 13:30-20:00 UTC marquées
+ * off_session/stale_data malgré session ouverte. Cause = lag propagation EODHD
+ * intraday US live ≫ 65 min. Fix = buffer 60 min pour US (after_min = 120),
+ * 5 min pour les autres (after_min = 65, inchangé).
+ *
+ * Couvre :
+ *   - getSimulateBufferMin par classe (7 cas)
+ *   - getSimulateAfterMin par classe (2 cas)
+ *   - simulatePending integration : pre-fetch query MIN cutoff + per-row JS filter
+ *     (2 cas : US young row skipped, US mature row picked)
+ */
+import {
+  GainersUserShadowService,
+  MAX_WINDOW_MIN,
+  SIMULATE_BUFFER_MIN,
+  SIMULATE_AFTER_MIN,
+  SIMULATE_BUFFER_BY_CLASS,
+  DEFAULT_SIMULATE_BUFFER_MIN,
+  getSimulateBufferMin,
+  getSimulateAfterMin,
+} from '../services/gainers-user-shadow.service';
+
+describe('Bug #H — getSimulateBufferMin par asset_class', () => {
+  it('us_equity_large → 60 (lag EODHD live constaté)', () => {
+    expect(getSimulateBufferMin('us_equity_large')).toBe(60);
+  });
+
+  it('us_equity_small_mid → 60 (même plan EODHD US)', () => {
+    expect(getSimulateBufferMin('us_equity_small_mid')).toBe(60);
+  });
+
+  it('eu_equity → 5 (baseline)', () => {
+    expect(getSimulateBufferMin('eu_equity')).toBe(5);
+  });
+
+  it('asia_equity → 5 (TZ shift + session-aware adressent)', () => {
+    expect(getSimulateBufferMin('asia_equity')).toBe(5);
+  });
+
+  it('crypto_major → 5 (Binance live Bug #A)', () => {
+    expect(getSimulateBufferMin('crypto_major')).toBe(5);
+  });
+
+  it('crypto_alt → 5', () => {
+    expect(getSimulateBufferMin('crypto_alt')).toBe(5);
+  });
+
+  it('unknown class → DEFAULT_SIMULATE_BUFFER_MIN (5)', () => {
+    expect(getSimulateBufferMin('forex_majors')).toBe(DEFAULT_SIMULATE_BUFFER_MIN);
+    expect(getSimulateBufferMin('xxx')).toBe(5);
+  });
+});
+
+describe('Bug #H — getSimulateAfterMin par asset_class', () => {
+  it('us_equity_large → 120 (= MAX_WINDOW_MIN 60 + buffer 60)', () => {
+    expect(getSimulateAfterMin('us_equity_large')).toBe(120);
+    expect(getSimulateAfterMin('us_equity_large')).toBe(MAX_WINDOW_MIN + 60);
+  });
+
+  it('asia_equity → 65 (= MAX_WINDOW_MIN 60 + buffer 5, inchangé)', () => {
+    expect(getSimulateAfterMin('asia_equity')).toBe(65);
+    expect(getSimulateAfterMin('asia_equity')).toBe(MAX_WINDOW_MIN + DEFAULT_SIMULATE_BUFFER_MIN);
+  });
+
+  it('legacy SIMULATE_AFTER_MIN = 65 préservé (back-compat tests TIMING-FIX)', () => {
+    expect(SIMULATE_AFTER_MIN).toBe(65);
+    expect(SIMULATE_BUFFER_MIN).toBe(5);
+    expect(MAX_WINDOW_MIN).toBe(60);
+  });
+
+  it('SIMULATE_BUFFER_BY_CLASS lookup is read-only frozen-shape', () => {
+    // Sanity : la table est typée Readonly mais on vérifie qu'aucune mutation
+    // accidentelle au runtime ne change les valeurs entre 2 lectures.
+    const first = { ...SIMULATE_BUFFER_BY_CLASS };
+    const second = { ...SIMULATE_BUFFER_BY_CLASS };
+    expect(first).toEqual(second);
+  });
+});
+
+// ============================================================================
+// Integration : simulatePending pre-fetch + per-class filter
+// ============================================================================
+
+type SupabaseRow = {
+  id: string;
+  symbol: string;
+  asset_class: string;
+  entry_price: number;
+  created_at: string;
+};
+
+function buildServiceWithRows(rows: SupabaseRow[]): {
+  svc: GainersUserShadowService;
+  capturedLteCutoff: { value: string | null };
+  updateCalls: string[];
+} {
+  const captured = { value: null as string | null };
+  const updateCalls: string[] = [];
+  // Mock supabase chain: from(...).select(...).is(...).lte(...).order(...).limit(...)
+  // Also from(...).update(...).eq(...) for UPDATE.
+  const supabaseMock = {
+    getClient: () => ({
+      from: () => ({
+        select: () => ({
+          is: () => ({
+            lte: (_col: string, cutoff: string) => {
+              captured.value = cutoff;
+              return {
+                order: () => ({
+                  limit: async () => ({ data: rows, error: null }),
+                }),
+              };
+            },
+          }),
+        }),
+        update: (_payload: unknown) => ({
+          eq: async (_col: string, id: string) => {
+            updateCalls.push(String(id));
+            return { error: null };
+          },
+        }),
+      }),
+    }),
+  };
+  // EODHD mock : retourne null partout — simulateRow va early-return no_data
+  // mais ce qui compte est de tracer quelles row.id atteignent update.
+  const eodhdMock = {
+    getCandles: jest.fn(async () => null),
+    getCandlesViaTicks: jest.fn(async () => null),
+  };
+  const svc = new GainersUserShadowService(supabaseMock as never, eodhdMock as never);
+  return { svc, capturedLteCutoff: captured, updateCalls };
+}
+
+describe('Bug #H — simulatePending integration per-class filter', () => {
+  it('us_equity_large row created 70 min ago → SKIPPED (needs 120 min)', async () => {
+    const nowMs = Date.now();
+    const row: SupabaseRow = {
+      id: 'us-young',
+      symbol: 'QCOM.US',
+      asset_class: 'us_equity_large',
+      entry_price: 150,
+      created_at: new Date(nowMs - 70 * 60_000).toISOString(),
+    };
+    const { svc, updateCalls } = buildServiceWithRows([row]);
+    const { processed, failures } = await svc.simulatePending();
+
+    expect(processed).toBe(0);
+    expect(failures).toBe(0);
+    // Le row n'a PAS été touché (pas d'UPDATE), sera repris au prochain cycle
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it('us_equity_large row created 130 min ago → PICKED + processed', async () => {
+    const nowMs = Date.now();
+    const row: SupabaseRow = {
+      id: 'us-mature',
+      symbol: 'QCOM.US',
+      asset_class: 'us_equity_large',
+      entry_price: 150,
+      // Created 130 min ago : 130 > 120 → mature for US
+      created_at: new Date(nowMs - 130 * 60_000).toISOString(),
+    };
+    const { svc, updateCalls } = buildServiceWithRows([row]);
+    const { processed } = await svc.simulatePending();
+
+    // simulateRow processes (EODHD mock returns null → outcome no_data,
+    // but the row IS picked + UPDATE fired).
+    expect(processed).toBe(1);
+    expect(updateCalls).toContain('us-mature');
+  });
+
+  it('asia_equity row created 70 min ago → PICKED (asia buffer 5 → mature at 65)', async () => {
+    const nowMs = Date.now();
+    const row: SupabaseRow = {
+      id: 'asia-mature',
+      symbol: '005930.KO',
+      asset_class: 'asia_equity',
+      entry_price: 70000,
+      created_at: new Date(nowMs - 70 * 60_000).toISOString(),
+    };
+    const { svc, updateCalls } = buildServiceWithRows([row]);
+    const { processed } = await svc.simulatePending();
+
+    expect(processed).toBe(1);
+    expect(updateCalls).toContain('asia-mature');
+  });
+
+  it('query SQL cutoff = MIN_SIMULATE_AFTER_MIN (65 min, permissive)', async () => {
+    const nowMs = Date.now();
+    const { svc, capturedLteCutoff } = buildServiceWithRows([]);
+    await svc.simulatePending();
+
+    expect(capturedLteCutoff.value).not.toBeNull();
+    const cutoffMs = new Date(capturedLteCutoff.value!).getTime();
+    const expectedMs = nowMs - 65 * 60_000;
+    // Tolérance ±2s pour Date.now() drift entre captures
+    expect(Math.abs(cutoffMs - expectedMs)).toBeLessThan(2000);
+  });
+
+  it('mixed batch : us_young skipped, us_mature + asia processed', async () => {
+    const nowMs = Date.now();
+    const rows: SupabaseRow[] = [
+      // Sera filtré par query (créé il y a 80 min seulement, query cutoff 65 → passe)
+      // mais JS filter (US needs 120) le skip
+      { id: 'us-young', symbol: 'QCOM.US', asset_class: 'us_equity_large',
+        entry_price: 150, created_at: new Date(nowMs - 80 * 60_000).toISOString() },
+      { id: 'us-mature', symbol: 'AAPL.US', asset_class: 'us_equity_large',
+        entry_price: 150, created_at: new Date(nowMs - 125 * 60_000).toISOString() },
+      { id: 'asia-mature', symbol: '005930.KO', asset_class: 'asia_equity',
+        entry_price: 70000, created_at: new Date(nowMs - 70 * 60_000).toISOString() },
+    ];
+    const { svc, updateCalls } = buildServiceWithRows(rows);
+    const { processed } = await svc.simulatePending();
+
+    expect(processed).toBe(2);  // us-mature + asia-mature, us-young skipped
+    expect(updateCalls).toContain('us-mature');
+    expect(updateCalls).toContain('asia-mature');
+    expect(updateCalls).not.toContain('us-young');
+  });
+});

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -210,12 +210,21 @@ const SIMULATE_BATCH_SIZE = 50;
  *   curl ".../intraday/QCOM.US?...&from=1778596418&to=1778600618"
  *   → 14 candles propres, volumes réalistes (14M sur 15:00-15:05).
  *
- * Conclusion : EODHD intraday US live lag de propagation ≫ 65 min. Pour Asia
- * (TZ shift + session-aware pre-fetch déjà déployés) et crypto (Binance live
- * via Bug #A), 5 min suffisent. EU baseline modéré.
+ * Conclusion : EODHD intraday US live lag de propagation ≫ 65 min.
  *
- * Trade-off US : signaux attendent 120 min avant simulation (vs 65 min). Délai
- * +55 min sur shadow verdict, accepté car alternative = 100% off_session.
+ * Bug #I (13/05/2026) — même cause racine étendue à asia_equity. SQL preuve
+ * 493/493 signaux asia_equity 24h outcome=off_session (100%). Trace probante
+ * 003550.KO 05:56:13 UTC : selectedStep=3 default, candle_freshness=90134s
+ * (~25h stale), forwardCountAfterFilter=0. L'hypothèse initiale 'session-aware
+ * pre-fetch + TZ shift suffisent pour Asia' est invalidée — le lag EODHD live
+ * touche aussi Korea/HK/SHE/SZSE/TYO. Asia aligné sur US (buffer 60min).
+ *
+ * Pour crypto (Binance live via Bug #A) et EU (baseline ~17% pass rate), 5 min
+ * suffisent.
+ *
+ * Trade-off US+Asia : signaux attendent 120 min avant simulation (vs 65 min).
+ * Délai +55 min sur shadow verdict, accepté car alternative = 100% off_session
+ * sur ces deux classes. EU + crypto inchangés (~25% du volume signaux).
  */
 export const SIMULATE_BUFFER_BY_CLASS: Readonly<Record<string, number>> = {
   us_equity_large:     60,  // lag EODHD live constaté ≫ 65 min (Bug #H)

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -187,8 +187,75 @@ const SLIPPAGE_TOTAL = SLIPPAGE_HAIRCUT_BILATERAL * 2;  // 30bps round-trip
  */
 export const MAX_WINDOW_MIN = 60;
 export const SIMULATE_BUFFER_MIN = 5;
+/**
+ * @deprecated Bug #H (13/05/2026) — Conservé pour rétro-compat (tests
+ * TIMING-FIX SHORT-SHADOW référencent SIMULATE_AFTER_MIN === 65). Le code
+ * de simulatePending utilise désormais `getSimulateAfterMin(assetClass)`
+ * qui retourne 120 pour US, 65 pour les autres.
+ */
 export const SIMULATE_AFTER_MIN = MAX_WINDOW_MIN + SIMULATE_BUFFER_MIN;  // = 65
 const SIMULATE_BATCH_SIZE = 50;
+
+/**
+ * Bug #H (13/05/2026) — Buffer dynamique par asset_class pour absorber le lag
+ * de propagation EODHD intraday US live.
+ *
+ * Observation 12/05/2026 : 246/246 captures us_equity_large session ouverte
+ * 13:30-20:00 UTC marquées off_session/stale_data. Trace fetch_diag QCOM.US :
+ *   - Step1-3 (range mode, fenêtre [startTs-5min, +65min]) → rawCount=0
+ *   - Step4 (default mode latest) → rawCount=210, lastCandleTs J-1 close
+ *     (~20h stale vs startTs), forwardCountAfterFilter=0
+ *
+ * Test empirique curl T+22h sur EXACTEMENT la même fenêtre échouée :
+ *   curl ".../intraday/QCOM.US?...&from=1778596418&to=1778600618"
+ *   → 14 candles propres, volumes réalistes (14M sur 15:00-15:05).
+ *
+ * Conclusion : EODHD intraday US live lag de propagation ≫ 65 min. Pour Asia
+ * (TZ shift + session-aware pre-fetch déjà déployés) et crypto (Binance live
+ * via Bug #A), 5 min suffisent. EU baseline modéré.
+ *
+ * Trade-off US : signaux attendent 120 min avant simulation (vs 65 min). Délai
+ * +55 min sur shadow verdict, accepté car alternative = 100% off_session.
+ */
+export const SIMULATE_BUFFER_BY_CLASS: Readonly<Record<string, number>> = {
+  us_equity_large:     60,  // lag EODHD live constaté ≫ 65 min (Bug #H)
+  us_equity_small_mid: 60,  // même plan EODHD, même lag présumé
+  eu_equity:            5,  // baseline ~17% pass rate
+  asia_equity:          5,  // pre-fetch session-aware + TZ shift adressent l'essentiel
+  crypto_major:         5,  // Binance live (Bug #A)
+  crypto_alt:           5,  // idem
+};
+export const DEFAULT_SIMULATE_BUFFER_MIN = 5;
+
+/**
+ * Bug #H — Retourne le buffer post-window pour la classe donnée. Default 5 min
+ * pour les classes non listées (rétro-compat + future-proof).
+ */
+export function getSimulateBufferMin(assetClass: string): number {
+  return SIMULATE_BUFFER_BY_CLASS[assetClass] ?? DEFAULT_SIMULATE_BUFFER_MIN;
+}
+
+/**
+ * Bug #H — Délai total post-création (MAX_WINDOW + buffer) avant qu'un row
+ * soit éligible à la simulation. US = 120, autres = 65.
+ */
+export function getSimulateAfterMin(assetClass: string): number {
+  return MAX_WINDOW_MIN + getSimulateBufferMin(assetClass);
+}
+
+/**
+ * Bug #H — MIN des seuils par classe. Sert de cutoff SQL côté simulatePending
+ * pour récupérer tous les candidats potentiellement matures ; le filtre per-row
+ * applique ensuite le seuil exact (US 120 vs autres 65).
+ *
+ * Choix MIN plutôt que MAX : MAX (120) délaierait inutilement Asia/EU/crypto
+ * de 55 min — régression sur 95% du volume signaux. MIN (65) préserve la
+ * latence existante pour les autres classes, tighten via JS uniquement pour US.
+ */
+const MIN_SIMULATE_AFTER_MIN = MAX_WINDOW_MIN + Math.min(
+  DEFAULT_SIMULATE_BUFFER_MIN,
+  ...Object.values(SIMULATE_BUFFER_BY_CLASS),
+);
 
 // PR #283 — Lookback fenêtre 5m pour fetch candles. Configurable via env
 // `USER_SHADOW_5M_LOOKBACK_MIN` (default 150 min). Couvre largement la sim
@@ -491,20 +558,26 @@ export class GainersUserShadowService {
   }
 
   /**
-   * Pick rows where sim_run_at IS NULL AND created_at > SIMULATE_AFTER_MIN ago,
+   * Pick rows where sim_run_at IS NULL AND created_at > getSimulateAfterMin(asset_class) ago,
    * fetch 5m candles forward, walk-forward to find TP/SL hits sur 4 grilles.
    * Cap batch à SIMULATE_BATCH_SIZE pour éviter timeouts.
    *
    * SHORT-SHADOW TIMING-FIX (11/05/2026) — SIMULATE_AFTER_MIN bumped 60→65 pour
-   * tolérer EODHD candle propagation lag ~5min. Cf. constante explication.
+   * tolérer EODHD candle propagation lag ~5min.
+   *
+   * Bug #H (13/05/2026) — Cutoff dynamique par classe via getSimulateAfterMin.
+   * Query SQL utilise MIN_SIMULATE_AFTER_MIN (= 65) pour récupérer tous les
+   * candidats potentiellement matures, filtre per-row JS applique le seuil exact
+   * (US = 120 min pour absorber lag EODHD live, autres = 65 min inchangé).
    */
   async simulatePending(): Promise<{ processed: number; failures: number }> {
-    const cutoff = new Date(Date.now() - SIMULATE_AFTER_MIN * 60_000).toISOString();
+    // Bug #H — Query cutoff permissif (MIN) ; filtre JS tightens per-class.
+    const queryCutoff = new Date(Date.now() - MIN_SIMULATE_AFTER_MIN * 60_000).toISOString();
     const { data: rows, error } = await this.supabase.getClient()
       .from('gainers_user_shadow_signals')
       .select('id, symbol, asset_class, entry_price, created_at')
       .is('sim_run_at', null)
-      .lte('created_at', cutoff)
+      .lte('created_at', queryCutoff)
       .order('created_at', { ascending: true })
       .limit(SIMULATE_BATCH_SIZE);
 
@@ -516,7 +589,18 @@ export class GainersUserShadowService {
 
     let processed = 0;
     let failures = 0;
+    let skippedNotMature = 0;
+    const nowMs = Date.now();
     for (const row of rows) {
+      // Bug #H — Skip row si pas encore mature pour sa classe (US needs 120 min
+      // vs 65 min query cutoff). Sera repris au prochain cycle quand mûr.
+      const assetClass = String(row.asset_class);
+      const matureThresholdMs = nowMs - getSimulateAfterMin(assetClass) * 60_000;
+      const createdMs = new Date(String(row.created_at)).getTime();
+      if (createdMs > matureThresholdMs) {
+        skippedNotMature++;
+        continue;
+      }
       try {
         const { results: simResults, fetchDiag, priceSnapshots } = await this.simulateRow({
           symbol: String(row.symbol),
@@ -555,8 +639,10 @@ export class GainersUserShadowService {
         } catch { /* nothing */ }
       }
     }
-    if (processed > 0 || failures > 0) {
-      this.logger.log(`[user-shadow] simulated ${processed} rows (${failures} failures)`);
+    if (processed > 0 || failures > 0 || skippedNotMature > 0) {
+      this.logger.log(
+        `[user-shadow] simulated ${processed} rows (${failures} failures, ${skippedNotMature} skipped not-mature per class buffer)`,
+      );
     }
     return { processed, failures };
   }

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -221,7 +221,7 @@ export const SIMULATE_BUFFER_BY_CLASS: Readonly<Record<string, number>> = {
   us_equity_large:     60,  // lag EODHD live constaté ≫ 65 min (Bug #H)
   us_equity_small_mid: 60,  // même plan EODHD, même lag présumé
   eu_equity:            5,  // baseline ~17% pass rate
-  asia_equity:          5,  // pre-fetch session-aware + TZ shift adressent l'essentiel
+  asia_equity:         60,  // Bug #I — lag EODHD live identique US (trace 003550.KO candle_freshness=90134s, 493/493 signaux off_session sur 24h)
   crypto_major:         5,  // Binance live (Bug #A)
   crypto_alt:           5,  // idem
 };


### PR DESCRIPTION
## Diagnostic Bug #H — EODHD US live propagation lag

**Observation 12/05/2026** : 246/246 captures `us_equity_large` session ouverte 13:30-20:00 UTC marquées `outcome='off_session'` / sub-reason `stale_data`. PnL US 7j = -$121 (us_large -$36, us_small_mid -$85). 148 accepts générés sans data simulator → positions ouvertes sur données J-1 (SL EVC.US, INTC.US).

**Trace fetch_diag QCOM.US** capturé 12/05 14:38:38 UTC (10:38 NY pleine session), simulator tournant ~65 min après (≈ 15:43 UTC) :

| Step | Endpoint | Mode | rawCount | lastCandleTs |
|---|---|---|---|---|
| 1 | eodhd_getCandles_5m_range | range [-5min,+65min] | 0 | — |
| 2 | eodhd_ticks_5m_range | range | 0 | — |
| 3 | eodhd_getCandles_1m_range | range | 0 | — |
| 4 | eodhd_getCandles_5m_default | latest | 210 | 1778529600 (J-1 close, ~20h stale) |

→ `forwardCountAfterFilter=0` → `forward.length===0` → `isOffSession=true`.

**Preuve formelle curl T+22h** sur EXACTEMENT la même fenêtre échouée :

```bash
curl "https://eodhd.com/api/intraday/QCOM.US?api_token=$KEY&fmt=json&interval=5m&from=1778596418&to=1778600618"
# → 14 candles propres (14:35:00 → 15:40:00 UTC), volumes 14M sur 15:00-15:05.
```

Idem AAOI.US, GLW.US. EODHD intraday US live a un lag de propagation **≫ 65 min**, possiblement plusieurs heures. Le rejet n'est PAS le session_check Step 0 (PR #296) — seulement 14/260 rejetés à ce niveau. C'est le **post-fetch isOffSession** ligne 1008-1010 : EODHD finit par servir les candles propres, mais avec un délai bien supérieur à 65 min.

**Pas un bug code, pas un bug plan EODHD : pur lag temporel.**

## Diagnostic Bug #I — asia_equity affecté par le même lag

**Observation 13/05/2026** : 493/493 signaux `asia_equity` sur 24h marqués `outcome='off_session'` (100%) avec buffer=5min. Hypothèse initiale "session-aware pre-fetch + TZ shift suffisent" invalidée par la donnée.

**Trace probante 003550.KO** capturée 13/05 05:56:13 UTC (14:56 Séoul, session KRX bien ouverte) :
- `selectedStep=3` (default latest, fallback dernier recours)
- `candle_freshness=90134s` = ~25h stale (close veille)
- `forwardCountAfterFilter=0`

Pattern identique à Bug #H : EODHD intraday live trail lag concerne aussi Korea/HK/SHE/SZSE/TYO, pas seulement les US. Le buffer 5 min hérité de la conception initiale ("Asia OK pre-fetch") est insuffisant.

**SQL preuve agrégée** :

```sql
SELECT asset_class, COUNT(*) AS total,
       COUNT(*) FILTER (WHERE fetch_diag::jsonb->>'outcome'='off_session') AS off
FROM gainers_user_shadow_signals
WHERE created_at >= NOW() - INTERVAL '24 hours'
  AND asset_class = 'asia_equity' AND fetch_diag IS NOT NULL;
-- → total=493, off=493 (100%)
```

## Fix combiné

`apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts` :

```ts
export const SIMULATE_BUFFER_BY_CLASS: Readonly<Record<string, number>> = {
  us_equity_large:     60,  // Bug #H — lag EODHD live constaté ≫ 65 min
  us_equity_small_mid: 60,  // Bug #H — même plan EODHD, même lag présumé
  eu_equity:            5,  // baseline ~17% pass rate
  asia_equity:         60,  // Bug #I — trace 003550.KO + 493/493 off_session
  crypto_major:         5,  // Binance live (Bug #A)
  crypto_alt:           5,
};
export const DEFAULT_SIMULATE_BUFFER_MIN = 5;

export function getSimulateBufferMin(assetClass: string): number {
  return SIMULATE_BUFFER_BY_CLASS[assetClass] ?? DEFAULT_SIMULATE_BUFFER_MIN;
}

export function getSimulateAfterMin(assetClass: string): number {
  return MAX_WINDOW_MIN + getSimulateBufferMin(assetClass);
}
```

**simulatePending refactor** :
- Query SQL `.lte('created_at', cutoff)` utilise `MIN_SIMULATE_AFTER_MIN` (= 65, MIN des classes restantes à 5) → permissif, récupère tous les candidats potentiellement matures
- Filtre per-row JS dans la boucle : skip si `createdMs > nowMs - getSimulateAfterMin(class) * 60_000` (US+Asia needs 120 min vs 65 min query cutoff) → row repris au prochain cycle quand mûr

**Décision MIN vs MAX cutoff SQL** :
- MAX (120 min) délaierait EU/crypto de +55 min — régression sur le volume non-affecté
- MIN (65 min) + filtre JS tightens US+Asia uniquement → préserve la latence existante pour EU/crypto

**Back-compat préservée** : `SIMULATE_AFTER_MIN = 65` exporté en `@deprecated`, les tests TIMING-FIX (commit `5835656`) continuent de passer.

## Trade-off accepté

US+Asia shadow verdict latency : **65 min → 120 min (+55 min)**. EU et crypto inchangés (~25% du volume signaux). Acceptable car alternative actuelle = 100% off_session/stale_data = 0% mesurable = 100% inexploitable sur ces deux classes.

Buffer 60 min = **borne supérieure conservative**. Curl test US prouve T+22h fonctionne, T+65min échoue ; seuil exact non mesuré (pas testé T+90, T+105). Si T+120 reste insuffisant en prod, escalader à 90/120 min ou activer Yahoo fallback (PR #297 future).

## Impact $/jour estimé

| Bug | Avant pct_ok | Cible pct_ok | Gain $/jour |
|---|---|---|---|
| #H us_equity_large | 0% | ≥ 30% | +$10-15 |
| #H us_equity_small_mid | 0% | ≥ 25% | +$8-11 |
| #I asia_equity | 0% | ≥ 15% | +$30-50 |

Combiné : **+$48-76/jour** (en complément du gain Bug #C Yahoo UA estimé +$30-60/jour).

## Tests

**16 cas** dans `simulate-buffer-by-class.spec.ts` :
- 7 unit `getSimulateBufferMin` par classe (us_large=60, us_small_mid=60, asia=60, eu/crypto=5, unknown→default=5)
- 4 unit `getSimulateAfterMin` + back-compat `SIMULATE_AFTER_MIN`=65
- 5 integration `simulatePending` : us young (70min) → SKIPPED, us mature (130min) → PICKED, asia 70min → SKIPPED (nouveau), asia 130min → PICKED, mixed batch

**Régression** : 76/76 suites, 1043/1043 tests lisa pass. Typecheck strict (`exactOptionalPropertyTypes: true`) clean.

## Validation post-deploy

T+24h après deploy + au moins 1 cycle US + 1 cycle Asia complet :

```sql
SELECT
  asset_class,
  COUNT(*) AS total,
  COUNT(*) FILTER (WHERE fetch_diag::jsonb->>'outcome' = 'ok') AS ok,
  COUNT(*) FILTER (WHERE fetch_diag::jsonb->>'outcome' = 'off_session') AS off,
  ROUND(100.0 * COUNT(*) FILTER (WHERE fetch_diag::jsonb->>'outcome' = 'ok')
        / NULLIF(COUNT(*), 0), 1) AS ok_pct
FROM gainers_user_shadow_signals
WHERE created_at >= NOW() - INTERVAL '24 hours'
  AND fetch_diag IS NOT NULL
GROUP BY asset_class
ORDER BY asset_class;
```

**Cibles post-fix** :

| asset_class | ok_pct avant | ok_pct cible |
|---|---|---|
| us_equity_large | 0% | ≥ 30% |
| us_equity_small_mid | 0% | ≥ 25% |
| eu_equity | ~17% | ≥ 17% (préservation) |
| asia_equity | 0% (493/493 off) | ≥ 15% |
| crypto_major | ~13.8% (Bug #A déployé) | ≥ 13% (préservation) |

Si us_equity_large ou asia_equity < 10% post-fix : escalader buffer à 90 min ou investiguer Yahoo fallback.

## Pending follow-ups

- **Bug #D** (`b773056`, branche `fix/bug-d-session-gate` dormante) : gate `session_closed` simulator-level pour equity (lunch breaks Asia, buffer post-close, fail-open). En attente Phase 3 Bug #A validation.
- **Bug #C** (PR #309) : Yahoo Finance 429 UA rotation — chemin de fallback indépendant, mergeable en parallèle.

## Test plan

- [ ] CI typecheck + jest verts
- [ ] Revue diff (notamment décision MIN cutoff vs MAX dans la spec initiale)
- [ ] Merge squash après validation revue
- [ ] Deploy via `./scripts/deploy.sh` (pas via fly.yml workflow auto pour préserver GIT_SHA injection)
- [ ] SQL validation T+24h post-deploy (cibles ci-dessus)

## Commits

- `41c6252` — fix(lisa): bug #H — buffer simulatePending dynamique par asset_class (lag EODHD US live)
- `161cbb0` — fix(lisa): Bug #I — asia_equity SIMULATE_BUFFER 5→60min

---
_Bug #H généré initialement via Claude Code, Bug #I appliqué directement par Perplexity Computer après diagnostic SQL._