### PR TITLE
Bug #G2 — MATIC → POL rebrand (CRYPTO_PAIRS scanner + RealtimePrice WS)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/crypto-pairs-pol-rebrand.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/crypto-pairs-pol-rebrand.spec.ts
@@ -10,9 +10,11 @@
  *   - CRYPTO_PAIRS ne contient plus MATICUSDT (mort)
  *   - Cardinality du pool préservée (toujours 10 paires)
  *   - toBinanceSymbol mapping POL/POLUSDT/MATIC tous → 'POLUSDT'
+ *   - RealtimePriceService.toBinanceSymbol (WS live price) idem (Bug #G2 ext)
  */
 import { CRYPTO_PAIRS } from '../services/top-gainers-scanner.service';
 import { BinanceMarketService } from '../services/binance-market.service';
+import { RealtimePriceService } from '../services/realtime-price.service';
 
 describe('Bug #G2 — CRYPTO_PAIRS rebrand MATIC → POL', () => {
   it('contains POLUSDT (remplaçant post-rebrand)', () => {
@@ -60,5 +62,48 @@ describe('Bug #G2 — BinanceMarketService.toBinanceSymbol POL aliases', () => {
     // Bug #A simulator l'appellera sur Binance qui retournera 0 candles (ticker
     // dead) → outcome no_data 'empty_response'. Comportement gracieux, pas crash.
     expect(svc.toBinanceSymbol('MATICUSDT')).toBe('MATICUSDT');
+  });
+});
+
+describe('Bug #G2 — RealtimePriceService.toBinanceSymbol POL aliases (WS live price)', () => {
+  // RealtimePriceService.toBinanceSymbol est privé : accès via bracket notation
+  // pour test (pattern déjà utilisé dans crypto-simulator.spec.ts). Dependencies
+  // (supabase, config) ne sont pas exercées par la fonction de mapping pure.
+  const supabaseMock = { getClient: () => ({}) };
+  const configMock = { get: () => undefined };
+  const svc = new RealtimePriceService(supabaseMock as never, configMock as never);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const toBinance = (s: string): string | null => (svc as any).toBinanceSymbol(s);
+
+  it('POLUSDT → POLUSDT (passthrough endsWith USDT)', () => {
+    expect(toBinance('POLUSDT')).toBe('POLUSDT');
+  });
+
+  it('POL → POLUSDT (short form ajouté Bug #G2)', () => {
+    expect(toBinance('POL')).toBe('POLUSDT');
+  });
+
+  it('MATIC → POLUSDT (alias migration legacy text, redirige vers ticker live)', () => {
+    expect(toBinance('MATIC')).toBe('POLUSDT');
+  });
+
+  it('lowercase pol → POLUSDT (toUpperCase normalization)', () => {
+    expect(toBinance('pol')).toBe('POLUSDT');
+  });
+
+  it('lowercase matic → POLUSDT (alias migration + normalization)', () => {
+    expect(toBinance('matic')).toBe('POLUSDT');
+  });
+
+  it('LINK → LINKUSDT (autres paires inchangées, sanity)', () => {
+    expect(toBinance('LINK')).toBe('LINKUSDT');
+  });
+
+  it('MATIC-USDT (avec dash) → POLUSDT (dash strip + alias)', () => {
+    // realtime-price.service ligne 153 : s.toUpperCase().replace(/[-\s]/g, '')
+    // → 'MATIC-USDT' devient 'MATICUSDT', qui passe endsWith('USDT') → renvoyé
+    // tel quel. Ce comportement passthrough est préservé (cf. note Bug #G2).
+    // Le test confirme que la chaîne n'est pas cassée par notre fix.
+    expect(toBinance('MATIC-USDT')).toBe('MATICUSDT');
   });
 });

--- a/apps/api/src/modules/lisa/__tests__/crypto-pairs-pol-rebrand.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/crypto-pairs-pol-rebrand.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Bug #G2 (13/05/2026) — Tests rebrand MATIC → POL dans le pool crypto scanner.
+ *
+ * Diagnostic : MATICUSDT figé à change_pct=-0.289% sur 91 captures consécutives
+ * top_gainers_log (12-13/05/2026). Volume Binance gelé depuis rebrand officiel
+ * Polygon (sept 2024). Occupait 1 slot/10 du pool sans signal exploitable.
+ *
+ * Couvre :
+ *   - CRYPTO_PAIRS contient POLUSDT (remplaçant)
+ *   - CRYPTO_PAIRS ne contient plus MATICUSDT (mort)
+ *   - Cardinality du pool préservée (toujours 10 paires)
+ *   - toBinanceSymbol mapping POL/POLUSDT/MATIC tous → 'POLUSDT'
+ */
+import { CRYPTO_PAIRS } from '../services/top-gainers-scanner.service';
+import { BinanceMarketService } from '../services/binance-market.service';
+
+describe('Bug #G2 — CRYPTO_PAIRS rebrand MATIC → POL', () => {
+  it('contains POLUSDT (remplaçant post-rebrand)', () => {
+    expect(CRYPTO_PAIRS).toContain('POLUSDT');
+  });
+
+  it('does NOT contain MATICUSDT (ticker mort post-rebrand)', () => {
+    expect(CRYPTO_PAIRS).not.toContain('MATICUSDT');
+  });
+
+  it('preserves pool cardinality (10 paires)', () => {
+    expect(CRYPTO_PAIRS).toHaveLength(10);
+  });
+
+  it('preserves all other pairs unchanged', () => {
+    const expected = [
+      'BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT',
+      'ADAUSDT', 'AVAXUSDT', 'DOTUSDT', 'LINKUSDT', 'POLUSDT',
+    ];
+    expect([...CRYPTO_PAIRS].sort()).toEqual([...expected].sort());
+  });
+});
+
+describe('Bug #G2 — BinanceMarketService.toBinanceSymbol POL aliases', () => {
+  const svc = new BinanceMarketService();
+
+  it('POLUSDT → POLUSDT (explicit mapping)', () => {
+    expect(svc.toBinanceSymbol('POLUSDT')).toBe('POLUSDT');
+  });
+
+  it('POL → POLUSDT (short form, mirror MATIC pattern)', () => {
+    expect(svc.toBinanceSymbol('POL')).toBe('POLUSDT');
+  });
+
+  it('MATIC → POLUSDT (alias migration legacy text)', () => {
+    expect(svc.toBinanceSymbol('MATIC')).toBe('POLUSDT');
+  });
+
+  it('lowercase pol → POLUSDT (toUpperCase normalization)', () => {
+    expect(svc.toBinanceSymbol('pol')).toBe('POLUSDT');
+  });
+
+  it('MATICUSDT → MATICUSDT (passthrough endsWith USDT preserved for legacy DB rows)', () => {
+    // Si une row historique contient MATICUSDT, toBinanceSymbol la passe encore.
+    // Bug #A simulator l'appellera sur Binance qui retournera 0 candles (ticker
+    // dead) → outcome no_data 'empty_response'. Comportement gracieux, pas crash.
+    expect(svc.toBinanceSymbol('MATICUSDT')).toBe('MATICUSDT');
+  });
+});

--- a/apps/api/src/modules/lisa/services/binance-market.service.ts
+++ b/apps/api/src/modules/lisa/services/binance-market.service.ts
@@ -94,7 +94,12 @@ export class BinanceMarketService {
       'XRP': 'XRPUSDT', 'XRPUSDT': 'XRPUSDT',
       'ADA': 'ADAUSDT', 'ADAUSDT': 'ADAUSDT',
       'DOGE': 'DOGEUSDT', 'DOGEUSDT': 'DOGEUSDT',
-      'DOT': 'DOTUSDT', 'AVAX': 'AVAXUSDT', 'MATIC': 'MATICUSDT',
+      'DOT': 'DOTUSDT', 'AVAX': 'AVAXUSDT',
+      // Bug #G2 (13/05/2026) — MATIC → POL (Polygon rebrand sept 2024).
+      // MATICUSDT figé sur Binance post-rebrand. Alias 'MATIC' redirige vers
+      // POLUSDT pour back-compat (Lisa proposals legacy text). Mirror du pattern
+      // BTC/ETH (alias short + ticker complet + variantes EODHD).
+      'MATIC': 'POLUSDT', 'POL': 'POLUSDT', 'POLUSDT': 'POLUSDT',
       'LINK': 'LINKUSDT', 'ATOM': 'ATOMUSDT', 'UNI': 'UNIUSDT',
       'LTC': 'LTCUSDT',
     };

--- a/apps/api/src/modules/lisa/services/realtime-price.service.ts
+++ b/apps/api/src/modules/lisa/services/realtime-price.service.ts
@@ -159,7 +159,11 @@ export class RealtimePriceService implements OnModuleDestroy {
       'ETHUSD': 'ETHUSDT', 'ETHEUR': 'ETHUSDT', 'ETHSPOT': 'ETHUSDT', 'ETH': 'ETHUSDT',
       'SOL': 'SOLUSDT', 'BNB': 'BNBUSDT', 'XRP': 'XRPUSDT', 'ADA': 'ADAUSDT',
       'DOGE': 'DOGEUSDT', 'DOT': 'DOTUSDT', 'AVAX': 'AVAXUSDT',
-      'MATIC': 'MATICUSDT', 'LINK': 'LINKUSDT', 'LTC': 'LTCUSDT',
+      // Bug #G2 (13/05/2026) — MATIC → POL (Polygon rebrand sept 2024).
+      // MATICUSDT figé sur Binance, redirection vers POLUSDT pour live price WS.
+      // Mirror du fix dans binance-market.service.ts:toBinanceSymbol.
+      'MATIC': 'POLUSDT', 'POL': 'POLUSDT',
+      'LINK': 'LINKUSDT', 'LTC': 'LTCUSDT',
       'ATOM': 'ATOMUSDT', 'UNI': 'UNIUSDT',
     };
     return map[s] ?? null;

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -137,7 +137,12 @@ const EU_EXCHANGES = ['LSE', 'XETRA', 'PA', 'SW', 'MI', 'MC', 'BME', 'AS', 'AMS'
 const NON_EU_EXCHANGES = ['US', 'T', 'HK', 'AU', 'KO', 'KQ', 'TO', 'SHG', 'SHE'];
 /** Watchlists EU dont la session_open_utc / session_close_utc gate l'EODHD scan. */
 const EU_WATCHLIST_NAMES = ['cac40', 'dax40', 'ftse100'];
-const CRYPTO_PAIRS = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT', 'ADAUSDT', 'AVAXUSDT', 'DOTUSDT', 'LINKUSDT', 'MATICUSDT'];
+// Bug #G2 (13/05/2026) — MATICUSDT remplacé par POLUSDT suite au rebrand
+// officiel Polygon (sept 2024). MATICUSDT figé à change_pct = -0.289% sur
+// 91 captures consécutives 12-13/05/2026 (volume Binance gelé post-rebrand),
+// occupait 1 slot/10 du pool crypto sans signal exploitable.
+// Export pour testabilité (Bug #G2 spec).
+export const CRYPTO_PAIRS = ['BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT', 'ADAUSDT', 'AVAXUSDT', 'DOTUSDT', 'LINKUSDT', 'POLUSDT'];
 
 /**
  * PR #266 — Horaires session UTC (approximatifs, ne tient pas compte du DST
@@ -218,7 +223,10 @@ const CRYPTO_MARKET_CAP_USD: Record<string, number> = {
   AVAXUSDT:    15_000_000_000,
   DOTUSDT:      8_000_000_000,
   LINKUSDT:    10_000_000_000,
-  MATICUSDT:    8_000_000_000,
+  // Bug #G2 — MATICUSDT → POLUSDT. Valeur conservée à 8B (Phase MESURE :
+  // pas de modif config / gates scanner). POL market cap réel ~$4-5B mais
+  // gate sort-by-mcap reste cohérente avec le pool alt existant.
+  POLUSDT:      8_000_000_000,
 };
 
 /**


### PR DESCRIPTION
## Contexte

Polygon a opéré son rebrand officiel **MATIC → POL** en septembre 2024. Sur Binance, le ticker `MATICUSDT` est désormais figé : volume gelé, change_pct constant `-0.289%` sur 91 captures consécutives observées dans `top_gainers_log` (12-13/05/2026). Il occupait 1 slot/10 du pool crypto scanner sans jamais déclencher de signal exploitable.

Cross-check SQL Supabase production (`gainers_user_shadow_signals` 7j) :

| Symbol | n signaux 7j |
|---|---|
| ADAUSDT | 194 |
| AVAXUSDT | 177 |
| BNBUSDT | 9 |
| DOTUSDT | 206 |
| LINKUSDT | 224 |
| SOLUSDT | 190 |
| XRPUSDT | 86 |
| **MATICUSDT** | **0 exploitable** (figé) |

→ Remplacement `MATICUSDT` par `POLUSDT` (ticker live actuel) + alias migration MATIC→POL pour back-compat.

## Fichiers modifiés (3)

### `top-gainers-scanner.service.ts` (commit `2ac1338`)

- Ligne 140 `CRYPTO_PAIRS` : `MATICUSDT` → `POLUSDT`. **Export const ajouté** pour testabilité.
- Ligne 221 `CRYPTO_MARKET_CAP_USD` : rename key `MATICUSDT` → `POLUSDT`. Valeur conservée à 8B (Phase MESURE : pas de modif config / gates scanner ; POL réel ~$4-5B mais sort-by-mcap reste cohérent avec le pool alt).

### `binance-market.service.ts` (commit `2ac1338`)

- `toBinanceSymbol` mapping :
  - `'MATIC': 'MATICUSDT'` → `'MATIC': 'POLUSDT'` (alias migration legacy text Lisa proposals)
  - **Ajout** `'POL': 'POLUSDT'` (nouveau short form)
  - **Ajout** `'POLUSDT': 'POLUSDT'` (explicit, mirror BTC/ETH pattern)

### `realtime-price.service.ts` (commit `72af9c3`)

- Ligne 162 `toBinanceSymbol` (private, WS subscription map) :
  - `'MATIC': 'MATICUSDT'` → `'MATIC': 'POLUSDT'`
  - **Ajout** `'POL': 'POLUSDT'`

## Tests

**16 cas** dans `crypto-pairs-pol-rebrand.spec.ts` :
- 4 unit CRYPTO_PAIRS (contient POLUSDT, pas MATICUSDT, cardinalité 10, liste exacte)
- 5 unit BinanceMarketService.toBinanceSymbol (POLUSDT/POL/MATIC/lowercase + MATICUSDT legacy passthrough)
- 7 unit RealtimePriceService.toBinanceSymbol (POLUSDT/POL/MATIC + lowercase/dash-strip + LINK sanity)

**Régression** : 76/76 suites, **1043/1043 tests lisa pass**. Typecheck strict (`exactOptionalPropertyTypes: true`) clean.

## Hors scope — skipped intentionnellement (follow-up Bug #G2-bis si besoin)

| Fichier:ligne | Code | Raison skip |
|---|---|---|
| `lisa.service.ts:2812` | `'MATIC': 'MATIC-USD.CC'` | EODHD CC ticker. EODHD peut maintenir alias MATIC-USD.CC via redirect Yahoo (à vérifier curl POL-USD.CC vs MATIC-USD.CC avant swap). Risque régression si POL-USD.CC pas listé EODHD. |
| `stocktwits.service.ts:60` | `'MATIC'` tag social | Tags retail StockTwits suivent rarement les rebrands ; `$MATIC` reste actif comme sentiment indicator. Pas d'impact trading. **Skip définitif**. |

## Validation post-deploy (T+1h après deploy)

```sql
SELECT symbol, COUNT(*) AS captures, ROUND(AVG(change_pct), 3) AS avg_change
FROM top_gainers_log
WHERE created_at >= NOW() - INTERVAL '1 hour'
  AND market = 'crypto_major'
GROUP BY symbol
ORDER BY symbol;
```

**Attendu** :
- `POLUSDT` apparaît avec `captures > 0` et `avg_change` non figé (volatilité réelle vs -0.289% gelé)
- `MATICUSDT` n'apparaît plus (sauf rows historiques antérieures au deploy)

## Test plan

- [ ] CI typecheck + jest verts
- [ ] Revue diff (commits `2ac1338` + `72af9c3`)
- [ ] Merge squash
- [ ] Deploy via `./scripts/deploy.sh`
- [ ] SQL T+1h validation (POLUSDT actif, MATICUSDT absent)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_