### PR TITLE
fix(lisa): Bug #C — Yahoo Finance 429 (User-Agent blacklist) — UA rotation + retry single-shot

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/yahoo-intraday.p19h.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/yahoo-intraday.p19h.spec.ts
@@ -87,8 +87,10 @@ describe('YahooIntradayService — P19h circuit breaker', () => {
 
     const breakerWarn = warnSpy.mock.calls.filter((c) => String(c[0]).includes('[yahoo:circuit]'));
     expect(breakerWarn.length).toBe(1);
-    expect(String(breakerWarn[0][0])).toContain('HTTP 429');
-    expect(String(breakerWarn[0][0])).toContain('60s');
+    // P19k / Bug #C — 429 trigger now goes through UA rotation retry → reason
+    // distincte. Cooldown 60s → 15s (DEFAULT_BASE_COOLDOWN_MS reduced).
+    expect(String(breakerWarn[0][0])).toContain('HTTP 429 after UA rotation retry');
+    expect(String(breakerWarn[0][0])).toContain('15s');
   });
 
   it('HTTP 403 trips circuit', async () => {
@@ -138,7 +140,9 @@ describe('YahooIntradayService — P19h circuit breaker', () => {
     mockHttp(429);
     const svc = new YahooIntradayService();
     await svc.getCandles('AAPL.US', '5m'); // trips circuit
-    expect((global.fetch as jest.Mock).mock.calls.length).toBe(1);
+    // Bug #C : 429 trigger UA rotation retry → 2 fetch calls (primary + retry)
+    // avant que le circuit s'ouvre. Le 2e 429 trip le breaker.
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(2);
 
     // Subsequent calls during cooldown : no fetch, no extra warn
     warnSpy.mockClear();
@@ -146,36 +150,36 @@ describe('YahooIntradayService — P19h circuit breaker', () => {
     const r3 = await svc.getCandles('NVDA.US', '5m');
     expect(r2).toBeNull();
     expect(r3).toBeNull();
-    expect((global.fetch as jest.Mock).mock.calls.length).toBe(1); // still 1
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(2); // still 2
     expect(warnSpy.mock.calls.length).toBe(0); // no spam
   });
 
-  it('exponential backoff : 60s → 120s → 240s → 480s (cap 1800s/30min)', async () => {
+  it('exponential backoff : 15s → 30s → 60s → 120s (Bug #C reduced base 60→15s, cap 1800s/30min)', async () => {
     jest.useFakeTimers();
     mockHttp(503);
     const svc = new YahooIntradayService();
 
-    // Failure 1 → 60s
+    // Failure 1 → 15s
+    await svc.getCandles('AAPL.US', '5m');
+    expect(warnSpy.mock.calls.find((c) => String(c[0]).includes('15s'))).toBeDefined();
+
+    // Advance past cooldown 1, failure 2 → 30s
+    jest.advanceTimersByTime(16_000);
+    warnSpy.mockClear();
+    await svc.getCandles('AAPL.US', '5m');
+    expect(warnSpy.mock.calls.find((c) => String(c[0]).includes('30s'))).toBeDefined();
+
+    // Advance past cooldown 2, failure 3 → 60s
+    jest.advanceTimersByTime(31_000);
+    warnSpy.mockClear();
     await svc.getCandles('AAPL.US', '5m');
     expect(warnSpy.mock.calls.find((c) => String(c[0]).includes('60s'))).toBeDefined();
 
-    // Advance past cooldown 1, failure 2 → 120s
+    // Advance past cooldown 3, failure 4 → 120s
     jest.advanceTimersByTime(61_000);
     warnSpy.mockClear();
     await svc.getCandles('AAPL.US', '5m');
     expect(warnSpy.mock.calls.find((c) => String(c[0]).includes('120s'))).toBeDefined();
-
-    // Advance past cooldown 2, failure 3 → 240s
-    jest.advanceTimersByTime(121_000);
-    warnSpy.mockClear();
-    await svc.getCandles('AAPL.US', '5m');
-    expect(warnSpy.mock.calls.find((c) => String(c[0]).includes('240s'))).toBeDefined();
-
-    // Advance past cooldown 3, failure 4 → 480s (cap 1800s/30min raised in PR #268)
-    jest.advanceTimersByTime(241_000);
-    warnSpy.mockClear();
-    await svc.getCandles('AAPL.US', '5m');
-    expect(warnSpy.mock.calls.find((c) => String(c[0]).includes('480s'))).toBeDefined();
   });
 
   it('reset on success after cooldown: probe succeeds → circuit closes + LOG line', async () => {
@@ -186,8 +190,8 @@ describe('YahooIntradayService — P19h circuit breaker', () => {
     expect(svc.getCircuitStatus().state).toBe('open');
     expect(svc.getCircuitStatus().consecutiveFailures).toBe(1);
 
-    // Pass cooldown
-    jest.advanceTimersByTime(61_000);
+    // Pass cooldown (Bug #C : 15s base, was 60s)
+    jest.advanceTimersByTime(16_000);
     // Yahoo recovers
     mockOk();
     logSpy.mockClear();
@@ -233,8 +237,8 @@ describe('YahooIntradayService — P19h circuit breaker', () => {
     await svc.getCandles('AAPL.US', '5m');
     expect(svc.getCircuitStatus().openCount).toBe(1);
 
-    // Recover, then re-fail
-    jest.advanceTimersByTime(61_000);
+    // Recover, then re-fail (Bug #C : 15s base, was 60s)
+    jest.advanceTimersByTime(16_000);
     mockOk();
     await svc.getCandles('AAPL.US', '5m');
     expect(svc.getCircuitStatus().state).toBe('closed');

--- a/apps/api/src/modules/lisa/services/__tests__/yahoo-intraday.p19k-ua-rotation.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/yahoo-intraday.p19k-ua-rotation.spec.ts
@@ -1,0 +1,305 @@
+/**
+ * P19k / Bug #C (13/05/2026) — Tests UA rotation + single-shot retry sur 429.
+ *
+ * Contexte : Yahoo maintient une blocklist UA statique. Le UA prod
+ * (Chrome 120 Linux x86_64, PR #268) est banni → 100% des requêtes 429
+ * depuis le 7 mai 2026. Fix : pool de 4 UAs validés 200 OK + rotation
+ * round-robin + 1 retry sur 429 avec UA suivant.
+ *
+ * Comportement attendu :
+ *   - 3 appels successifs envoient 3 UA différents (round-robin)
+ *   - 429 first + 200 retry : fetch 2x avec UA différents, circuit fermé, non-null
+ *   - 429 + 429 : openCircuit appelé 1x (raison "HTTP 429 after UA rotation retry")
+ *   - 200 first : pas de retry, 1 seul fetch, circuit fermé
+ *   - 403 first : pas de retry, openCircuit immédiate (P19h inchangé)
+ *   - 404 first : silent null sans trip
+ *   - DEFAULT_BASE_COOLDOWN_MS = 15s (était 60s avant Bug #C)
+ */
+
+import { Logger } from '@nestjs/common';
+import { YahooIntradayService } from '../yahoo-intraday.service';
+
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.useRealTimers();
+});
+beforeEach(() => {
+  warnSpy.mockClear();
+  logSpy.mockClear();
+});
+
+type FetchCall = { url: string; userAgent: string };
+
+/**
+ * Mock fetch qui capture les User-Agent envoyés + permet de répondre
+ * statiquement OU séquentiellement selon les besoins du test.
+ */
+function captureFetch(responses: Array<{ status: number; ok: boolean; body?: unknown }>): {
+  fetchMock: jest.Mock;
+  calls: FetchCall[];
+} {
+  const calls: FetchCall[] = [];
+  let idx = 0;
+  const fetchMock = jest.fn().mockImplementation(async (url: string, init: RequestInit) => {
+    const ua = (init.headers as Record<string, string>)?.['User-Agent'] ?? '<none>';
+    calls.push({ url, userAgent: ua });
+    const r = responses[Math.min(idx++, responses.length - 1)];
+    return {
+      ok: r.ok,
+      status: r.status,
+      json: async () => r.body ?? {},
+      text: async () => '',
+    };
+  });
+  global.fetch = fetchMock as never;
+  return { fetchMock, calls };
+}
+
+function okBody(closes: number[] = [180, 181, 182]) {
+  const baseTs = 1761830400;
+  return {
+    chart: {
+      result: [{
+        meta: { symbol: 'AAPL' },
+        timestamp: closes.map((_, i) => baseTs + i * 300),
+        indicators: { quote: [{ close: closes, open: closes, high: closes, low: closes, volume: closes.map(() => 1000) }] },
+      }],
+      error: null,
+    },
+  };
+}
+
+describe('Bug #C / P19k — UA rotation round-robin', () => {
+  it('3 appels successifs envoient 3 UA différents (pool round-robin)', async () => {
+    const { calls } = captureFetch([
+      { ok: true, status: 200, body: okBody() },
+      { ok: true, status: 200, body: okBody() },
+      { ok: true, status: 200, body: okBody() },
+    ]);
+    const svc = new YahooIntradayService();
+
+    await svc.getCandles('AAPL.US', '5m');
+    await svc.getCandles('MSFT.US', '5m');
+    await svc.getCandles('GOOG.US', '5m');
+
+    expect(calls).toHaveLength(3);
+    const uas = calls.map((c) => c.userAgent);
+    // 3 UA distincts
+    expect(new Set(uas).size).toBe(3);
+    // Tous non-vides + structure UA (vérif minimale)
+    for (const ua of uas) {
+      expect(ua).toMatch(/Mozilla\/5\.0/);
+    }
+  });
+
+  it('appel 1 = UA[0], appel 2 = UA[1], etc. (ordre round-robin déterministe)', async () => {
+    const { calls } = captureFetch([
+      { ok: true, status: 200, body: okBody() },
+      { ok: true, status: 200, body: okBody() },
+    ]);
+    const svc = new YahooIntradayService();
+
+    await svc.getCandles('AAPL.US', '5m');
+    await svc.getCandles('MSFT.US', '5m');
+
+    expect(calls[0].userAgent).not.toBe(calls[1].userAgent);
+  });
+
+  it('pool de 4 UAs : appel 5 reprend le UA du appel 1 (modulo 4)', async () => {
+    const { calls } = captureFetch(Array(5).fill({ ok: true, status: 200, body: okBody() }));
+    const svc = new YahooIntradayService();
+
+    for (let i = 0; i < 5; i++) {
+      await svc.getCandles(`AAPL.US`, '5m');
+    }
+
+    expect(calls).toHaveLength(5);
+    // Call 5 wraps around to UA[0] (= same as call 1)
+    expect(calls[4].userAgent).toBe(calls[0].userAgent);
+  });
+});
+
+describe('Bug #C / P19k — single-shot retry sur 429', () => {
+  it('429 first + 200 retry : fetch 2x avec UA différents, circuit reste fermé, return non-null', async () => {
+    const { calls } = captureFetch([
+      { ok: false, status: 429 },           // attempt 1: 429
+      { ok: true, status: 200, body: okBody() },  // retry: 200 OK
+    ]);
+    const svc = new YahooIntradayService();
+
+    const result = await svc.getCandles('AAPL.US', '5m');
+
+    expect(result).not.toBeNull();
+    expect(calls).toHaveLength(2);
+    // UA différents entre l'attempt 1 et la retry
+    expect(calls[0].userAgent).not.toBe(calls[1].userAgent);
+    // Circuit reste fermé après succès retry
+    expect(svc.getCircuitStatus().state).toBe('closed');
+    expect(svc.getCircuitStatus().consecutiveFailures).toBe(0);
+  });
+
+  it('429 + 429 (double échec) : openCircuit appelé 1x avec raison Bug #C', async () => {
+    const { calls } = captureFetch([
+      { ok: false, status: 429 },
+      { ok: false, status: 429 },
+    ]);
+    const svc = new YahooIntradayService();
+
+    const result = await svc.getCandles('AAPL.US', '5m');
+
+    expect(result).toBeNull();
+    expect(calls).toHaveLength(2);
+    expect(svc.getCircuitStatus().state).toBe('open');
+    expect(svc.getCircuitStatus().openCount).toBe(1);
+    // Raison logs : "HTTP 429 after UA rotation retry"
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0] ?? ''));
+    expect(warnCalls.some((m) => m.includes('HTTP 429 after UA rotation retry'))).toBe(true);
+  });
+
+  it('200 first : pas de retry, 1 seul fetch, circuit fermé', async () => {
+    const { calls } = captureFetch([
+      { ok: true, status: 200, body: okBody() },
+    ]);
+    const svc = new YahooIntradayService();
+
+    const result = await svc.getCandles('AAPL.US', '5m');
+
+    expect(result).not.toBeNull();
+    expect(calls).toHaveLength(1);  // PAS de retry sur 200 first
+    expect(svc.getCircuitStatus().state).toBe('closed');
+  });
+
+  it('403 first : pas de retry, openCircuit immédiate (P19h inchangé)', async () => {
+    const { calls } = captureFetch([
+      { ok: false, status: 403 },
+    ]);
+    const svc = new YahooIntradayService();
+
+    const result = await svc.getCandles('AAPL.US', '5m');
+
+    expect(result).toBeNull();
+    expect(calls).toHaveLength(1);  // PAS de retry sur 403 (seul 429 trigger retry)
+    expect(svc.getCircuitStatus().state).toBe('open');
+    expect(svc.getCircuitStatus().openCount).toBe(1);
+    // Message log = "HTTP 403", pas "after UA rotation retry"
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0] ?? ''));
+    expect(warnCalls.some((m) => m.includes('HTTP 403'))).toBe(true);
+    expect(warnCalls.some((m) => m.includes('after UA rotation retry'))).toBe(false);
+  });
+
+  it('500 first : pas de retry, openCircuit immédiate', async () => {
+    const { calls } = captureFetch([
+      { ok: false, status: 500 },
+    ]);
+    const svc = new YahooIntradayService();
+
+    const result = await svc.getCandles('AAPL.US', '5m');
+
+    expect(result).toBeNull();
+    expect(calls).toHaveLength(1);
+    expect(svc.getCircuitStatus().state).toBe('open');
+  });
+
+  it('404 first (ticker unknown) : pas de retry, silent null, circuit reste fermé', async () => {
+    const { calls } = captureFetch([
+      { ok: false, status: 404 },
+    ]);
+    const svc = new YahooIntradayService();
+
+    const result = await svc.getCandles('AAPL.US', '5m');
+
+    expect(result).toBeNull();
+    expect(calls).toHaveLength(1);
+    expect(svc.getCircuitStatus().state).toBe('closed');  // PAS trip
+    expect(svc.getCircuitStatus().consecutiveFailures).toBe(0);
+  });
+
+  it('chart.error (symbol not found) : pas de retry, silent null, circuit fermé', async () => {
+    const { calls } = captureFetch([
+      { ok: true, status: 200, body: { chart: { error: { code: 'Not Found', description: 'No data' } } } },
+    ]);
+    const svc = new YahooIntradayService();
+
+    const result = await svc.getCandles('UNKNOWN.US', '5m');
+
+    expect(result).toBeNull();
+    expect(calls).toHaveLength(1);
+    expect(svc.getCircuitStatus().state).toBe('closed');
+  });
+
+  it('429 retry returns 200 → consecutiveFailures reste à 0 (success path)', async () => {
+    captureFetch([
+      { ok: false, status: 429 },
+      { ok: true, status: 200, body: okBody() },
+    ]);
+    const svc = new YahooIntradayService();
+
+    await svc.getCandles('AAPL.US', '5m');
+
+    // closeCircuitOnSuccess reset consecutiveFailures even si le primary a "échoué"
+    expect(svc.getCircuitStatus().consecutiveFailures).toBe(0);
+    expect(svc.getCircuitStatus().state).toBe('closed');
+  });
+});
+
+describe('Bug #C / P19k — DEFAULT_BASE_COOLDOWN_MS reduced to 15s', () => {
+  it('1st failure cooldown ~15s (was 60s avant Bug #C)', async () => {
+    jest.useFakeTimers();
+    captureFetch([
+      { ok: false, status: 403 },  // 403 → open immédiat sans retry
+    ]);
+    const svc = new YahooIntradayService();
+    await svc.getCandles('AAPL.US', '5m');
+
+    const status = svc.getCircuitStatus();
+    expect(status.state).toBe('open');
+    // openUntilMs - Date.now() ~ 15_000 ms (1st failure, no backoff exp yet)
+    const remainMs = status.openUntilMs - Date.now();
+    expect(remainMs).toBeGreaterThan(14_000);
+    expect(remainMs).toBeLessThanOrEqual(15_000);
+  });
+
+  it('2nd failure cooldown ~30s (exp backoff base*2)', async () => {
+    jest.useFakeTimers();
+    // First failure : 15s
+    captureFetch([{ ok: false, status: 403 }]);
+    const svc = new YahooIntradayService();
+    await svc.getCandles('AAPL.US', '5m');
+
+    // Advance past 15s cooldown to allow probe
+    jest.advanceTimersByTime(16_000);
+
+    // Probe failure (2nd consecutive)
+    captureFetch([{ ok: false, status: 403 }]);
+    await svc.getCandles('AAPL.US', '5m');
+
+    const status = svc.getCircuitStatus();
+    expect(status.state).toBe('open');
+    expect(status.consecutiveFailures).toBe(2);
+    const remainMs = status.openUntilMs - Date.now();
+    // ~30s (15_000 * 2^1)
+    expect(remainMs).toBeGreaterThan(28_000);
+    expect(remainMs).toBeLessThanOrEqual(30_000);
+  });
+});
+
+describe('Bug #C / P19k — regression toYahooSymbol mapping (sanity)', () => {
+  // Vérifie que le mapping n'a pas été touché par les changements UA
+  it('AAPL.US → AAPL (US suffix stripped)', () => {
+    const svc = new YahooIntradayService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((svc as any).toYahooSymbol('AAPL.US')).toBe('AAPL');
+  });
+
+  it('199820.KO → 199820.KS (KO → KS)', () => {
+    const svc = new YahooIntradayService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((svc as any).toYahooSymbol('199820.KO')).toBe('199820.KS');
+  });
+});

--- a/apps/api/src/modules/lisa/services/yahoo-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/yahoo-intraday.service.ts
@@ -64,13 +64,52 @@ interface YahooChartResponse {
 }
 
 /**
- * P19g — User-Agent réaliste obligatoire pour éviter Cloudflare 403 sur
- * `query1.finance.yahoo.com`. Le UA Mozilla est utilisé par les SDK Yahoo
- * officieux et n'est pas blacklisté.
+ * P19g (avant Bug #C) — Un seul User-Agent fixe (Chrome 120 Linux x86_64).
+ * P19k / Bug #C (13/05/2026) — Pool de 4 UAs validés 200 OK + rotation
+ * round-robin par appel + single-shot retry sur 429.
+ *
+ * Diagnostic : depuis le 7 mai 2026 (commit 22e276b PR #268), 100% des
+ * requêtes prod Yahoo retournent 429. Tests empiriques agent depuis sandbox
+ * datacenter (IP 34.19.49.124, le 13/05/2026) :
+ *   - Chrome 120 Linux x86_64 (prod actuel)  → 429 banni
+ *   - Chrome 131 Mac                          → 429 banni
+ *   - Firefox 121 Mac                         → 429 banni
+ *   - Chrome 124 Windows NT 10.0              → 200 OK
+ *   - Chrome 126 Windows NT 10.0              → 200 OK
+ *   - iPhone Safari iOS 17                    → 200 OK
+ *   - Googlebot/2.1                           → 200 OK
+ *
+ * Ce n'est PAS un problème d'IP datacenter (mêmes IPs, UA différents =
+ * comportements différents). Yahoo maintient une blocklist UA statique sur
+ * les patterns "dev bot common" (Linux x86_64, Firefox Mac, Chrome Mac avec
+ * dernière version).
+ *
+ * Impact prod (SQL gainers_user_shadow_signals 24h) : 1026 signaux passent
+ * par step yahoo_intraday_5m → tous null → tous OFF_SESSION. Yahoo en
+ * PRIMAIRE dans multi-tf-persistence ET en fallback dans simulator → cascade
+ * vers EODHD aggrave Bug #H/#I.
+ *
+ * UAs bannis statiquement par Yahoo le 13/05/2026 (NE PAS RÉINTRODUIRE) :
+ *   - Chrome Linux x86_64 (toutes versions ≥ 120)
+ *   - Chrome 131 Mac
+ *   - Firefox 121 Mac
+ *
+ * Retry single-shot sur 429 : avec rotation UA, un 429 isolé n'est plus
+ * représentatif d'une panne provider — c'est souvent un UA particulier qui
+ * vient d'être banni. On retry une fois avec l'UA suivant avant de tripper
+ * le circuit breaker. Sur 403/5xx (sans 429), comportement P19h inchangé
+ * (open circuit immédiat).
  */
-const YAHOO_USER_AGENT =
-  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
-  'Chrome/120.0.0.0 Safari/537.36';
+const YAHOO_USER_AGENTS: ReadonlyArray<string> = [
+  // Chrome 124 Windows NT 10.0 — validé 200 OK 13/05/2026
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  // Chrome 126 Windows NT 10.0 — validé 200 OK 13/05/2026
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+  // iPhone Safari iOS 17.0 — validé 200 OK 13/05/2026
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+  // iPhone Safari iOS 17.2 — validé 200 OK 13/05/2026
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
+];
 
 /**
  * P19h — Circuit breaker config.
@@ -97,7 +136,11 @@ const YAHOO_USER_AGENT =
  * En cas de back online ponctuel, le probe se fait toujours après 30 min, on
  * récupère le service automatiquement sans intervention.
  */
-const DEFAULT_BASE_COOLDOWN_MS = 60_000;       // 60s
+// P19k / Bug #C — Réduit 60s → 15s. Avec rotation UA + single-shot retry, un
+// 429 isolé n'est plus représentatif d'une panne provider. Backoff exp 15s
+// → 30s → 60s → ... → 30min reste protecteur. Sur panne réelle, on atteint
+// la cap 30min après ~7 échecs consécutifs (vs ~5 pré-Bug #C, ~+30s).
+const DEFAULT_BASE_COOLDOWN_MS = 15_000;       // 15s (était 60s avant Bug #C)
 const DEFAULT_MAX_COOLDOWN_MS = 1_800_000;     // 30 min
 
 @Injectable()
@@ -112,6 +155,11 @@ export class YahooIntradayService {
   private consecutiveFailures = 0;
   /** P19h — Cumulative breaker openings (observability). */
   private circuitOpenCount = 0;
+  /**
+   * P19k / Bug #C — Index round-robin pour rotation User-Agent. Incrémenté
+   * à chaque sélection d'UA dans getCandles (call principal + retry 429).
+   */
+  private uaIndex = 0;
 
   /** P19h — Allow tests / external code to read state. */
   getCircuitStatus(): { state: 'closed' | 'open'; openUntilMs: number; consecutiveFailures: number; openCount: number } {
@@ -189,10 +237,66 @@ export class YahooIntradayService {
     // sera tronqué au 60 dernières candles côté caller).
     const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?interval=${interval}&range=1d`;
 
+    // P19k / Bug #C — Attempt 1 avec UA rotaté.
+    const ua1 = YAHOO_USER_AGENTS[this.uaIndex++ % YAHOO_USER_AGENTS.length];
+    const attempt1 = await this.fetchAttempt(url, ua1, eodhdTicker, yahooSymbol);
+
+    if (attempt1.kind === 'ok') {
+      this.closeCircuitOnSuccess();
+      return attempt1.candles;
+    }
+    if (attempt1.kind === 'silent_null') {
+      return null;
+    }
+    if (attempt1.kind === 'open_circuit') {
+      // 403 / 5xx / fetch_error sur premier appel → open immédiat (P19h inchangé).
+      this.openCircuit(attempt1.reason);
+      return null;
+    }
+    // attempt1.kind === 'retry_on_429' — P19k / Bug #C single-shot retry avec UA suivant.
+    const ua2 = YAHOO_USER_AGENTS[this.uaIndex++ % YAHOO_USER_AGENTS.length];
+    const attempt2 = await this.fetchAttempt(url, ua2, eodhdTicker, yahooSymbol);
+
+    if (attempt2.kind === 'ok') {
+      this.closeCircuitOnSuccess();
+      return attempt2.candles;
+    }
+    if (attempt2.kind === 'silent_null') {
+      // Retry returned 404 / chart.error / empty payload → ticker unknown, pas d'open.
+      return null;
+    }
+    // attempt2.kind in {'retry_on_429', 'open_circuit'} — la retry a échoué, on
+    // ouvre le breaker avec la raison Bug #C explicite (peu importe que ce soit
+    // 429 récidive, 403, 5xx, ou network error : on a déjà retry le coup UA).
+    this.openCircuit('HTTP 429 after UA rotation retry');
+    return null;
+  }
+
+  /**
+   * P19k / Bug #C — Tentative unique de fetch + parse. Séparée de getCandles
+   * pour permettre la rotation UA + retry single-shot sans duplication de logic.
+   *
+   * Retourne un discriminated union pour que getCandles décide quoi faire :
+   *   - 'ok'              : 200 + payload valide → success path
+   *   - 'silent_null'     : 404, chart.error, empty payload → null sans trip
+   *   - 'retry_on_429'    : 429 spécifique → caller peut retry avec next UA
+   *   - 'open_circuit'    : 403 / 5xx / fetch_error → caller doit open circuit
+   */
+  private async fetchAttempt(
+    url: string,
+    userAgent: string,
+    eodhdTicker: string,
+    yahooSymbol: string,
+  ): Promise<
+    | { kind: 'ok'; candles: YahooCandle[] }
+    | { kind: 'silent_null' }
+    | { kind: 'retry_on_429' }
+    | { kind: 'open_circuit'; reason: string }
+  > {
     try {
       const res = await fetch(url, {
         headers: {
-          'User-Agent': YAHOO_USER_AGENT,
+          'User-Agent': userAgent,
           'Accept': 'application/json',
           'Accept-Language': 'en-US,en;q=0.9',
         },
@@ -200,32 +304,33 @@ export class YahooIntradayService {
       });
 
       if (!res.ok) {
-        // P19h — Specific HTTP statuses that indicate provider-level failure
-        // (vs ticker-not-found which is just 404 and should NOT trip breaker)
-        if (res.status === 429 || res.status === 403 || res.status >= 500) {
-          this.openCircuit(`HTTP ${res.status}`);
-        } else {
-          this.logger.debug(
-            `[yahoo-intraday] ${eodhdTicker}→${yahooSymbol} HTTP ${res.status}`,
-          );
+        if (res.status === 429) {
+          // P19k / Bug #C — 429 isolé : caller peut tenter retry avec autre UA.
+          return { kind: 'retry_on_429' };
         }
-        return null;
+        if (res.status === 403 || res.status >= 500) {
+          // P19h — 403 / 5xx : panne provider claire, open circuit immédiat.
+          return { kind: 'open_circuit', reason: `HTTP ${res.status}` };
+        }
+        // Autres 4xx (404, etc.) : ticker unknown, silent null.
+        this.logger.debug(
+          `[yahoo-intraday] ${eodhdTicker}→${yahooSymbol} HTTP ${res.status}`,
+        );
+        return { kind: 'silent_null' };
       }
 
       const json = (await res.json()) as YahooChartResponse;
 
-      // Path Yahoo : json.chart.result[0]
       const chartErr = json?.chart?.error;
       if (chartErr) {
-        // chart.error = symbol not found in Yahoo; ne pas tripper le breaker
-        // (provider OK, ticker unknown). Retour null silently.
-        return null;
+        // chart.error = symbol not found in Yahoo; ne pas tripper le breaker.
+        return { kind: 'silent_null' };
       }
       const result = json?.chart?.result?.[0];
-      if (!result) return null;
+      if (!result) return { kind: 'silent_null' };
       const timestamps = result.timestamp ?? [];
       const quote = result.indicators?.quote?.[0];
-      if (!quote || timestamps.length === 0) return null;
+      if (!quote || timestamps.length === 0) return { kind: 'silent_null' };
 
       const opens = quote.open ?? [];
       const highs = quote.high ?? [];
@@ -252,13 +357,12 @@ export class YahooIntradayService {
           volume,
         });
       }
-      // P19h — Successful response → close breaker, reset failures counter
-      this.closeCircuitOnSuccess();
-      return out.length > 0 ? out : null;
+      return out.length > 0
+        ? { kind: 'ok', candles: out }
+        : { kind: 'silent_null' };
     } catch (e) {
-      // P19h — Network error / timeout / abort / parse → trip breaker
-      this.openCircuit(`fetch error: ${String(e).slice(0, 60)}`);
-      return null;
+      // P19h — Network error / timeout / abort / parse → open circuit.
+      return { kind: 'open_circuit', reason: `fetch error: ${String(e).slice(0, 60)}` };
     }
   }
 


### PR DESCRIPTION
## Contexte

Yahoo Finance bloque **100% des requêtes** du fallback `YahooIntradayService` depuis le 7 mai 2026 (commit `22e276b` PR #268). Le UA codé en dur Chrome 120 Linux x86_64 est statiquement blacklisté par Yahoo.

## Diagnostic empirique (13/05/2026 14:55 CEST)

Tests curl depuis sandbox IP datacenter `34.19.49.124` :

| User-Agent | HTTP |
|---|---|
| Chrome 120 Linux x86_64 (prod actuel) | **429 banni** |
| Chrome 131 Mac | **429 banni** |
| Firefox 121 Mac | **429 banni** |
| Chrome 124 Windows NT 10.0 | 200 OK |
| Chrome 126 Windows NT 10.0 | 200 OK |
| iPhone Safari iOS 17 | 200 OK |
| Googlebot/2.1 | 200 OK |

Ce n'est **PAS** un problème d'IP datacenter (mêmes IPs, UA différents = comportements différents). Yahoo maintient une blocklist UA statique sur les patterns "dev bot common".

## Architecture cascade Yahoo → EODHD

`MultiTimeframePersistenceService` utilise Yahoo en **PRIMAIRE** (ligne 374 du callsite), EODHD en fallback. Avec Yahoo banni 100% → cascade systématique vers EODHD → aggrave les bugs #H et #I (lag EODHD en session ouverte).

`GainersUserShadowService.simulatePending` (`gainers-user-shadow.service.ts:871-884`) ajoute aussi un step `yahoo_intraday_5m` en dernier recours sur `OFF_SESSION_STALE_DATA` → tous retournent null.

## Impact mesuré (SQL `gainers_user_shadow_signals` 24h)

- 1026 signaux passent par step `yahoo_intraday_5m` → tous null
- 800-1000 signaux/jour potentiellement récupérables côté shadow simulator
- Estimation gain PnL : **+$30-60/jour** côté live (cascade vers EODHD résolue)

## Fix — pool UA rotation + retry single-shot 429

Fichier : `apps/api/src/modules/lisa/services/yahoo-intraday.service.ts`

1. **`YAHOO_USER_AGENT`** (single string banni) → **`YAHOO_USER_AGENTS`** (pool 4 UA validés 200 OK le 13/05/2026)
2. `private uaIndex = 0`, round-robin par appel `getCandles()`
3. Extraction `fetchAttempt()` helper (discriminated union pour le résultat : `ok` / `silent_null` / `retry_on_429` / `open_circuit`)
4. **Sur 429 attempt 1** : retry single-shot avec UA suivant.
   - Si succès → `closeCircuitOnSuccess`
   - Si retry → 429/403/5xx/network → `openCircuit` reason `"HTTP 429 after UA rotation retry"`
   - Si retry → 404 → silent null
5. **Sur 403/5xx attempt 1** (pas 429) : pas de retry, `openCircuit` immédiate (P19h inchangé)
6. **Sur 404 / `chart.error`** : silent null sans tripper le breaker
7. **`DEFAULT_BASE_COOLDOWN_MS`** `60_000` → `15_000` (15s). Cap max inchangé 30 min.

**UAs bannis statiquement par Yahoo le 13/05/2026 (NE PAS RÉINTRODUIRE)** : Chrome Linux x86_64, Chrome 131 Mac, Firefox 121 Mac.

## Tests

- **15 nouveaux** dans `yahoo-intraday.p19k-ua-rotation.spec.ts` :
  - Round-robin 3 calls = 3 UAs différents, wrap-around modulo 4
  - 429 + 200 retry : 2 fetch UA différents, circuit fermé, non-null
  - 429 + 429 : `openCircuit` 1x, reason `"after UA rotation retry"`
  - 200 first : pas de retry, 1 fetch, circuit fermé
  - 403/500 first : pas de retry, `openCircuit` immédiat
  - 404 / `chart.error` : silent null sans trip
  - Retry success → `consecutiveFailures` reste à 0
  - Cooldown 15s base + 30s exp 2nd failure
  - Régression `toYahooSymbol` mapping (AAPL.US → AAPL, .KO → .KS)
- **3 P19h updates** : cooldown messages 60s → 15s, backoff 60→120→240→480 → 15→30→60→120, 429 trip = 2 fetches au lieu de 1
- **44/44** tests Yahoo (P19e + P19g + P19h + P19k)
- **1042/1042** régression lisa (76 suites)
- **Typecheck strict** : clean

**Signature publique `getCandles(eodhdTicker, interval)` inchangée**. Pas de modif côté `MultiTimeframePersistenceService` ni `GainersUserShadowService`.

## Validation post-deploy attendue (24h après merge des 3 PRs #G2 + #H/#I + #C)

SQL `gainers_user_shadow_signals` 24h — cibles `ok_pct` :

| asset_class | actuel | cible |
|---|---|---|
| us_equity_large | 0% | ≥ 30% (combiné avec #H) |
| us_equity_small_mid | 0% | ≥ 25% |
| asia_equity | 0% | ≥ 15% (combiné avec #I) |
| eu_equity | ~8.6% | ≥ 17% (récup partielle Yahoo) |
| crypto_major | ~13.8% | préservé ≥ 7% |

**Diff stats** : 3 fichiers, +462 / -49
**SHA** : `a353798`

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_