### PR TITLE
fix(risk-monitor): Bug #M — guard against zero/fallback live price (SEE.LSE incident -$1574)

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -185,9 +185,12 @@ export class LisaService {
     this.riskMonitor = new RiskMonitorService(
       this.supabase.getClient(),
       this.paperBroker,
+      // Bug #M (14/05/2026) — expose `source` au risk-monitor pour qu'il puisse
+      // skipper les prix fallback corrompus (incident SEE.LSE exit_price=0).
+      // fetchLivePrice retourne déjà { symbol, price, asOf, source } (cf. l.2676).
       async (symbol) => {
         const q = await this.fetchLivePrice(symbol);
-        return { price: q.price };
+        return { price: q.price, source: q.source };
       },
     );
   }

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -2382,9 +2382,15 @@ export class TopGainersScannerService implements OnModuleInit {
       if (ageMs < STAGNANT_MIN_AGE_MS) continue;
       const quote = await this.lisa.getLivePrice(String(pos.symbol)).catch(() => null);
       if (!quote || !quote.price) continue;
+      // 🛡️ BUG #M (cohérence) — skip fallback source pour la rotation stagnante
+      // (incident SEE.LSE : source='fallback_unknown' renvoie sentinel '0').
+      if (quote.source && quote.source.startsWith('fallback')) {
+        this.logger.warn(`[stagnant-rotation] ${pos.symbol}: source=${quote.source} → skip`);
+        continue;
+      }
       const livePrice = parseFloat(quote.price);
       const entry = parseFloat(String(pos.entry_price));
-      if (!Number.isFinite(livePrice) || !Number.isFinite(entry) || entry <= 0) continue;
+      if (!Number.isFinite(livePrice) || livePrice <= 0 || !Number.isFinite(entry) || entry <= 0) continue;
       const pnlPct = ((livePrice - entry) / entry) * 100;
       if (Math.abs(pnlPct) > STAGNANT_PNL_PCT) continue;
       stagnants.push({ pos, pnlPct, ageMs, currentPrice: livePrice });
@@ -2521,6 +2527,14 @@ export class TopGainersScannerService implements OnModuleInit {
       if (!quote || !quote.price) {
         this.logger.warn(
           `[force-close] ${portfolioId.slice(0, 8)} ${pos.symbol}: no live price — skip (will retry next cycle)`,
+        );
+        continue;
+      }
+      // 🛡️ BUG #M (cohérence) — skip fallback source pour le force-close before
+      // close (incident SEE.LSE : source='fallback_unknown' renvoie sentinel '0').
+      if (quote.source && quote.source.startsWith('fallback')) {
+        this.logger.warn(
+          `[force-close] ${portfolioId.slice(0, 8)} ${pos.symbol}: source=${quote.source} (fallback) → skip`,
         );
         continue;
       }

--- a/packages/ai-analyst/src/simulation/__tests__/risk-monitor.spec.ts
+++ b/packages/ai-analyst/src/simulation/__tests__/risk-monitor.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Bug #M (14/05/2026) — Tests garde-fou anti-prix-0 dans RiskMonitorService.
+ *
+ * Incident reproductible : 14/05 09:54 UTC, position SEE.LSE clôturée à
+ * exit_price=0.0000 sur SL trigger faussé. Perte -$1574.18 / -99.95%.
+ *
+ * Cause racine : le producer lisa.service.ts retourne un sentinel
+ * { price: '0', source: 'fallback_unknown' } quand le symbole est inconnu
+ * de la table fallback. Le consumer risk-monitor n'appliquait AUCUNE garde
+ * → new Decimal('0') ≤ stopLossPrice → close à 0.
+ *
+ * Fix : checkPositionLimits skippe le cycle si source commence par 'fallback'
+ * OU si livePrice est zero/negative/non-finite.
+ */
+
+import { RiskMonitorService } from '../risk-monitor.service';
+
+describe('Bug #M — fallback price guard (RiskMonitorService.checkPositionLimits)', () => {
+  let mockBroker: { closePosition: jest.Mock; getPositions: jest.Mock };
+  // Supabase n'est pas exercé par checkPositionLimits — mock minimal.
+  const mockSupabase = { from: jest.fn() } as never;
+
+  beforeEach(() => {
+    mockBroker = {
+      closePosition: jest.fn().mockResolvedValue({ id: 'p1' }),
+      getPositions: jest.fn().mockResolvedValue([]),
+    };
+  });
+
+  it('does NOT close position when fetchLivePrice returns price=0 source=fallback_unknown', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ price: '0', source: 'fallback_unknown' });
+    const svc = new RiskMonitorService(mockSupabase, mockBroker as never, mockFetch);
+    const pos = {
+      id: 'p1', symbol: 'SEE.LSE', direction: 'long',
+      entryPrice: '5.01', stopLossPrice: '4.89', takeProfitPrice: '5.14',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (svc as any).checkPositionLimits(pos, { actionsApplied: [], violations: [] });
+    expect(mockBroker.closePosition).not.toHaveBeenCalled();
+  });
+
+  it('does NOT close position when fetchLivePrice returns price="NaN"', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ price: 'NaN', source: 'eodhd' });
+    const svc = new RiskMonitorService(mockSupabase, mockBroker as never, mockFetch);
+    const pos = {
+      id: 'p2', symbol: 'AAA.US', direction: 'long',
+      entryPrice: '10', stopLossPrice: '9.5', takeProfitPrice: '11',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (svc as any).checkPositionLimits(pos, { actionsApplied: [], violations: [] });
+    expect(mockBroker.closePosition).not.toHaveBeenCalled();
+  });
+
+  it('DOES close position on legitimate stop trigger (source=eodhd, price < SL)', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ price: '4.80', source: 'eodhd' });
+    const svc = new RiskMonitorService(mockSupabase, mockBroker as never, mockFetch);
+    const pos = {
+      id: 'p3', symbol: 'BBB.US', direction: 'long',
+      entryPrice: '5.01', stopLossPrice: '4.89', takeProfitPrice: '5.14',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (svc as any).checkPositionLimits(pos, { actionsApplied: [], violations: [] });
+    expect(mockBroker.closePosition).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'closed_stop' }),
+    );
+  });
+});

--- a/packages/ai-analyst/src/simulation/risk-monitor.service.ts
+++ b/packages/ai-analyst/src/simulation/risk-monitor.service.ts
@@ -62,7 +62,12 @@ export class RiskMonitorService {
   constructor(
     private readonly supabase: SupabaseClient,
     private readonly paperBroker: PaperBrokerService,
-    private readonly fetchLivePrice: (symbol: string) => Promise<{ price: string }>,
+    /**
+     * Bug #M (14/05/2026) — La signature expose `source` pour que le
+     * risk-monitor puisse skipper les prix fallback corrompus (incident
+     * SEE.LSE -$1574 le 14/05 : exit_price=0 sur source='fallback_unknown').
+     */
+    private readonly fetchLivePrice: (symbol: string) => Promise<{ price: string; source: string }>,
   ) {}
 
   /**
@@ -162,11 +167,24 @@ export class RiskMonitorService {
     result: RiskCheckResult,
   ): Promise<void> {
     let livePrice: Decimal;
+    let quote: { price: string; source: string };
     try {
-      const quote = await this.fetchLivePrice(pos.symbol);
+      quote = await this.fetchLivePrice(pos.symbol);
       livePrice = new Decimal(quote.price);
     } catch {
       return;  // skip si prix indisponible
+    }
+
+    // 🛡️ BUG #M (14/05/2026) — garde-fou anti-prix-0 (incident SEE.LSE -$1574
+    // sur exit_price=0 : source='fallback_unknown' producer retournait sentinel
+    // '0' que le consumer interprétait comme prix réel → SL trigger faux).
+    if (quote.source && quote.source.startsWith('fallback')) {
+      console.warn(`[risk-monitor] ${pos.symbol}: source=${quote.source} (fallback) — skip cycle (no SL/TP check)`);
+      return;
+    }
+    if (livePrice.isZero() || livePrice.isNegative() || !livePrice.isFinite()) {
+      console.warn(`[risk-monitor] ${pos.symbol}: invalid livePrice ${quote.price} — skip cycle`);
+      return;
     }
 
     const entryPx = new Decimal(pos.entryPrice);
@@ -286,11 +304,20 @@ export class RiskMonitorService {
     for (const pos of openPositions) {
       try {
         const quote = await this.fetchLivePrice(pos.symbol);
+        // 🛡️ BUG #M (14/05/2026) — anti-prix-0 sur HARD KILL : si le quote est
+        // corrompu (source fallback, NaN, ≤0) on ferme à entry_price (pnl=0)
+        // plutôt qu'au prix corrompu qui produirait un exit_price=0 + perte -100%.
+        const priceNum = parseFloat(quote.price);
+        const corrupt =
+          (quote.source != null && quote.source.startsWith('fallback')) ||
+          !Number.isFinite(priceNum) ||
+          priceNum <= 0;
+        const liquidationPx = corrupt ? pos.entryPrice : quote.price;
         const closedPos = await this.paperBroker.closePosition({
           positionId: pos.id,
           reason,
-          livePrice: quote.price,
-          rationale,
+          livePrice: liquidationPx,
+          rationale: rationale + (corrupt ? ' [Bug#M-guard: closed at entry_price]' : ''),
         });
         closed.push(closedPos);
       } catch (e) {


### PR DESCRIPTION
## 🔥 Bug #M CRITIQUE — exit_price=0 sur SL fallback prix

Fixes #310

### Incident

14/05/2026 09:54 UTC, position **SEE.LSE** clôturée à `exit_price=0.0000` sur SL trigger faussé. Perte **-$1574.18 / -99.95%** sur un seul trade (= 42 jours d'objectif baseline effacés en 42 minutes).

### Cause racine — Producer correct, Consumer fautif

Le producer `lisa.service.ts:2747-2754` retourne **intentionnellement** un sentinel `{ price: '0', source: 'fallback_unknown' }` quand le symbole est inconnu de la table fallback (commentaire explicite : *"consumer DOIT skipper"*).

Le consumer `risk-monitor.service.ts` n'appliquait **aucune garde** :
- Signature `fetchLivePrice` n'exposait pas `source` → impossible de checker
- `new Decimal('0')` accepté sans broncher → `0 ≤ stopLossPrice 4.8929` → TRUE → close à 0

Le prix précédent (4.9573) était +1.32% **au-dessus** du stop. Sans le bug, le stop ne se serait jamais déclenché.

### 6 modifs appliquées

| # | Fichier | Modif |
|---|---|---|
| 1 | `risk-monitor.service.ts` | Signature `fetchLivePrice` expose `source: string` |
| 2 | `risk-monitor.service.ts` `checkPositionLimits` | Garde-fou : skip si `source.startsWith('fallback')` OU `livePrice` zero/negative/non-finite |
| 3 | `risk-monitor.service.ts` `liquidateAll` | HARD KILL : ferme à `entry_price` (pnl=0) si quote corrompu, rationale taggé `[Bug#M-guard]` |
| 4 | `lisa.service.ts` | Binding risk-monitor propage `q.source` |
| 5 | `top-gainers-scanner.service.ts` | Skip fallback source sur stagnant-rotation (l.2383) + force-close (l.2520) — cohérence |
| 6 | `risk-monitor.spec.ts` (NEW) | 3 tests unitaires |

Pattern aligné sur `rebound-monitor.service.ts:113` (référence correcte) et `CLAUDE.md §"Garde-fous prix fallback — règles immuables"`.

### Tests

- **3 nouveaux** `risk-monitor.spec.ts` :
  - `price=0 source=fallback_unknown` → **NE close PAS**
  - `price=NaN source=eodhd` → **NE close PAS** (`!livePrice.isFinite()`)
  - legit stop trigger (`source=eodhd, price 4.80 < SL 4.89`) → **DOES close** `reason: closed_stop`
- **ai-analyst** : 367/367 (364 baseline + 3 Bug #M)
- **api** : 1727 passed, 2 todo, 0 failures
- **typecheck** `tsc -b` : clean
- **lint** : 0 error sur les 4 fichiers modifiés (49 warnings pré-existants sur lignes non touchées)

### Validation post-deploy (SQL surveillance J+1/J+3/J+7)

```sql
-- Cible : 0
SELECT COUNT(*) FROM lisa_positions
WHERE exit_price = 0 AND status != 'open'
  AND exit_timestamp >= NOW() - INTERVAL '7 days';

-- Cible : 0
SELECT id, symbol, exit_price, realized_pnl_pct, exit_reason
FROM lisa_positions
WHERE realized_pnl_pct < -10
  AND exit_timestamp >= NOW() - INTERVAL '7 days'
ORDER BY exit_timestamp DESC;
```

Logs Fly attendus si garde-fou fonctionne (~1×/semaine) :
```
[risk-monitor] {symbol}: source=fallback_unknown (fallback) — skip cycle (no SL/TP check)
[risk-monitor] {symbol}: invalid livePrice 0 — skip cycle
```

### Note

Fix sécurité (pas optimisation) → déploiement autorisé en dérogation Phase MESURE 12-17 mai per issue #310 §7.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_