### PR TITLE
fix(lisa): Bug #M Part 3 — fallback price guards on 5 critical close paths

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/bug-m-part3-fallback-guards.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/bug-m-part3-fallback-guards.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Bug #M Part 3 (issue #313) — Tests garde-fou fallback price sur 5 sites
+ * critiques résiduels (kill-switches + cron + Lisa).
+ *
+ * Tous identiques en symptôme au Bug #M original : si EODHD fallback retourne
+ * `{ price: '0', source: 'fallback_unknown' }`, le code fermait des positions
+ * à $0 = perte maximale.
+ *
+ * Pattern de test : reproduction en isolation de la logique de garde insérée
+ * à chaque site (norme du repo, cf. mechanical-trading.batch-cap.spec.ts —
+ * les services sont trop lourds en DI NestJS pour être instanciés proprement).
+ * Chaque test rejoue la décision exacte du code patché, alimenté par le quote
+ * sentinel fallback, et vérifie l'issue (close at entry_price OU skip).
+ */
+
+type Quote = { price: string; source: string } | null;
+
+const FALLBACK_QUOTE: Quote = { price: '0', source: 'fallback_unknown' };
+const LEGIT_QUOTE: Quote = { price: '4.80', source: 'eodhd' };
+
+// ---------------------------------------------------------------------------
+// #C1 — mechanical-trading P4.1 kill-switch auto : corrupt → entry_price + tag
+// ---------------------------------------------------------------------------
+function c1ResolveClosePx(quote: Quote, entryPrice: string): { px: string; corrupt: boolean } {
+  // Reproduit mechanical-trading.service.ts P4.1 kill-switch loop (#C1).
+  // Le quote null est filtré en amont (`if (!quote) continue`), ici on teste
+  // le cas quote présent mais corrompu.
+  const priceNum = parseFloat(quote!.price);
+  const corrupt =
+    !quote!.source || quote!.source.startsWith('fallback') ||
+    !Number.isFinite(priceNum) ||
+    priceNum <= 0;
+  return { px: corrupt ? entryPrice : quote!.price, corrupt };
+}
+
+describe('Bug #M Part 3 #C1 — P4.1 kill-switch auto fallback guard', () => {
+  it('fallback_unknown quote → ferme à entry_price (pas à 0)', () => {
+    const { px, corrupt } = c1ResolveClosePx(FALLBACK_QUOTE, '5.0182');
+    expect(corrupt).toBe(true);
+    expect(px).toBe('5.0182');
+  });
+
+  it('quote legit eodhd → ferme au prix live normal', () => {
+    const { px, corrupt } = c1ResolveClosePx(LEGIT_QUOTE, '5.0182');
+    expect(corrupt).toBe(false);
+    expect(px).toBe('4.80');
+  });
+
+  it('quote price=NaN → corrupt, ferme à entry_price', () => {
+    const { px, corrupt } = c1ResolveClosePx({ price: 'NaN', source: 'eodhd' }, '5.0182');
+    expect(corrupt).toBe(true);
+    expect(px).toBe('5.0182');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #C2 — lisa.service triggerKillSwitch (user) : corrupt → entry_price + tag
+// ---------------------------------------------------------------------------
+function c2ResolveLiquidationPx(quote: { price: string; source?: string }, entryPrice: string): {
+  px: string;
+  corrupt: boolean;
+} {
+  // Reproduit lisa.service.ts triggerKillSwitch loop (#C2).
+  const priceNum = parseFloat(quote.price);
+  const corrupt =
+    (quote.source != null && quote.source.startsWith('fallback')) ||
+    !Number.isFinite(priceNum) ||
+    priceNum <= 0;
+  return { px: corrupt ? entryPrice : quote.price, corrupt };
+}
+
+describe('Bug #M Part 3 #C2 — user kill-switch fallback guard', () => {
+  it('fallback_unknown quote → ferme à entry_price (le bouton de protection ne détruit pas)', () => {
+    const { px, corrupt } = c2ResolveLiquidationPx(FALLBACK_QUOTE!, '5.0182');
+    expect(corrupt).toBe(true);
+    expect(px).toBe('5.0182');
+  });
+
+  it('quote legit → ferme au prix live', () => {
+    const { px, corrupt } = c2ResolveLiquidationPx(LEGIT_QUOTE!, '5.0182');
+    expect(corrupt).toBe(false);
+    expect(px).toBe('4.80');
+  });
+
+  it('quote price≤0 explicite → corrupt', () => {
+    const { corrupt } = c2ResolveLiquidationPx({ price: '0.00', source: 'eodhd' }, '5.0182');
+    expect(corrupt).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #C3 — option-broker cron : expiration → entry_underlying_price ; TP → skip
+// ---------------------------------------------------------------------------
+function c3ResolveOptionAction(
+  quote: Quote,
+  entryUnderlyingPrice: number,
+): { spotForExpiry: number; tpSkipped: boolean } {
+  // Reproduit option-broker.service.ts cron loop (#C3).
+  const isFallback = quote != null && quote.source != null && quote.source.startsWith('fallback');
+  const priceNum = quote != null ? parseFloat(quote.price) : NaN;
+  const reliable = quote != null && !isFallback && Number.isFinite(priceNum) && priceNum > 0;
+  const spotForExpiry = reliable ? priceNum : entryUnderlyingPrice;
+  // Pour le TP : skip ce cycle si pas de prix fiable
+  const tpSkipped = !reliable;
+  return { spotForExpiry, tpSkipped };
+}
+
+describe('Bug #M Part 3 #C3 — option-broker cron fallback guard', () => {
+  it('fallback quote → expiration close à entry_underlying_price (pas spot=0)', () => {
+    const { spotForExpiry } = c3ResolveOptionAction(FALLBACK_QUOTE, 102.5);
+    expect(spotForExpiry).toBe(102.5);
+  });
+
+  it('fallback quote → TP check skippé ce cycle (option reste vivante)', () => {
+    const { tpSkipped } = c3ResolveOptionAction(FALLBACK_QUOTE, 102.5);
+    expect(tpSkipped).toBe(true);
+  });
+
+  it('quote legit → spot fiable utilisé, TP évalué', () => {
+    const { spotForExpiry, tpSkipped } = c3ResolveOptionAction({ price: '110.0', source: 'eodhd' }, 102.5);
+    expect(spotForExpiry).toBe(110.0);
+    expect(tpSkipped).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #C4 — mechanical-trading AutonomyRule close : fallback → skip (pas de close)
+// ---------------------------------------------------------------------------
+function c4ShouldClose(quote: Quote): boolean {
+  // Reproduit mechanical-trading.service.ts evaluateAutonomyRules close (#C4).
+  // isFallbackSource : source absente OU commençant par 'fallback' = fallback.
+  const isFallback = !quote || !quote.source || quote.source.startsWith('fallback');
+  return quote != null && !isFallback;
+}
+
+describe('Bug #M Part 3 #C4 — AutonomyRule close fallback guard', () => {
+  it('fallback_unknown quote → NE ferme PAS (skip, retry next cycle)', () => {
+    expect(c4ShouldClose(FALLBACK_QUOTE)).toBe(false);
+  });
+
+  it('quote null → NE ferme PAS', () => {
+    expect(c4ShouldClose(null)).toBe(false);
+  });
+
+  it('quote legit eodhd → ferme normalement', () => {
+    expect(c4ShouldClose(LEGIT_QUOTE)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #C5 — lisa.service SWAP + close recommendation : fallback → skip
+// ---------------------------------------------------------------------------
+function c5ShouldSkip(quote: { price: string; source?: string }): boolean {
+  // Reproduit lisa.service.ts SWAP (L~1956) + close recommendation (L~1769).
+  return quote.source != null && quote.source.startsWith('fallback');
+}
+
+describe('Bug #M Part 3 #C5 — Lisa SWAP + recommendation fallback guard', () => {
+  it('fallback_unknown quote → skip (pas de close sur prix sentinel)', () => {
+    expect(c5ShouldSkip(FALLBACK_QUOTE!)).toBe(true);
+  });
+
+  it('quote legit eodhd → close exécuté', () => {
+    expect(c5ShouldSkip(LEGIT_QUOTE!)).toBe(false);
+  });
+
+  it('quote source binance_ws → close exécuté (source fiable non-fallback)', () => {
+    expect(c5ShouldSkip({ price: '60000', source: 'binance_ws' })).toBe(false);
+  });
+});

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1767,6 +1767,15 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       }
       try {
         const quote = await this.fetchLivePrice(pos.symbol);
+        // 🛡️ Bug #M Part 3 (#C5) — skip si quote fallback corrompu : ne pas
+        // fermer sur un prix sentinel '0'. La recommandation Lisa sera
+        // ré-évaluée au prochain cycle quand un prix fiable sera disponible.
+        if (quote.source && quote.source.startsWith('fallback')) {
+          this.logger.warn(
+            `[FALLBACK_GUARD_LISA] close recommendation ${pos.symbol} skip — source=${quote.source}`,
+          );
+          continue;
+        }
         await this.paperBroker.closePosition({
           positionId: pos.id,
           reason: 'closed_invalidated',
@@ -1954,6 +1963,15 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         // Swap : on ferme la position weakest avant d'ouvrir la nouvelle
         try {
           const swapQuote = await this.fetchLivePrice(String(swapTarget.symbol));
+          // 🛡️ Bug #M Part 3 (#C5) — skip swap si quote fallback corrompu : ne
+          // pas fermer la position weakest sur un prix sentinel '0'. On n'ouvre
+          // pas la nouvelle non plus (cap toujours plein) → break, retry next cycle.
+          if (swapQuote.source && swapQuote.source.startsWith('fallback')) {
+            this.logger.warn(
+              `[FALLBACK_GUARD_LISA] SWAP ${swapTarget.symbol} skip — source=${swapQuote.source}`,
+            );
+            break;
+          }
           await this.paperBroker.closePosition({
             positionId: String(swapTarget.id),
             reason: 'closed_invalidated',
@@ -2491,14 +2509,25 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     for (const pos of openPositions) {
       try {
         const quote = await this.fetchLivePrice(pos.symbol);
+        // 🛡️ Bug #M Part 3 (#C2) — garde fallback : le kill-switch user est un
+        // geste de protection. Si EODHD est down, quote.price='0' (sentinel
+        // fallback_unknown) → fermerait tout à $0. On ferme à entry_price
+        // (pnl≈0) plutôt qu'au prix corrompu. Pattern risk-monitor.liquidateAll.
+        const priceNum = parseFloat(quote.price);
+        const corrupt =
+          (quote.source != null && quote.source.startsWith('fallback')) ||
+          !Number.isFinite(priceNum) ||
+          priceNum <= 0;
+        const liquidationPx = corrupt ? pos.entryPrice : quote.price;
         await this.paperBroker.closePosition({
           positionId: pos.id,
           reason: 'closed_kill',
-          livePrice: quote.price,
-          rationale: `User kill switch: ${reason}`,
+          livePrice: liquidationPx,
+          rationale: `User kill switch: ${reason}`
+            + (corrupt ? ' [Bug#M-guard: closed at entry_price]' : ''),
         });
         // Phase 5 — capture outcome (kill switch)
-        this.tradeOutcomeRecorder.recordOutcome(pos.id, quote.price, 'closed_kill')
+        this.tradeOutcomeRecorder.recordOutcome(pos.id, liquidationPx, 'closed_kill')
           .catch(() => null);
       } catch (e) {
         this.logger.error(`Kill switch close failed for ${pos.symbol}: ${String(e)}`);

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -1604,11 +1604,22 @@ export class MechanicalTradingService {
         const quote = await this.lisa.getLivePrice(pos.symbol).catch(() => null);
         if (!quote) continue;
         try {
+          // 🛡️ Bug #M Part 3 (#C1) — garde fallback : si le quote est corrompu
+          // (source fallback, NaN, ≤0) on ferme à entry_price (pnl≈0) plutôt
+          // qu'au sentinel '0' qui produirait une perte maximale. Pattern aligné
+          // sur risk-monitor.liquidateAll.
+          const priceNum = parseFloat(quote.price);
+          const corrupt =
+            this.isFallbackSource(quote.source) ||
+            !Number.isFinite(priceNum) ||
+            priceNum <= 0;
+          const closePx = corrupt ? pos.entryPrice : quote.price;
           await this.closePosition(
             pos.id,
-            quote.price,
+            closePx,
             'closed_invalidated',
-            `[P4.1 KILL-SWITCH] Drawdown intraday ${drawdownPct.toFixed(2)}% > ${killDD.toFixed(2)}% — fermeture auto`,
+            `[P4.1 KILL-SWITCH] Drawdown intraday ${drawdownPct.toFixed(2)}% > ${killDD.toFixed(2)}% — fermeture auto`
+              + (corrupt ? ' [Bug#M-guard: closed at entry_price]' : ''),
           );
           closedCount++;
         } catch (e) {
@@ -2131,7 +2142,12 @@ export class MechanicalTradingService {
 
     // Pré-fetch VIX une fois pour tous les checks (évite N appels)
     const vixQuote = await this.lisa.getLivePrice('VIX').catch(() => null);
-    const vixLevel = vixQuote ? Number(vixQuote.price) : null;
+    // 🛡️ Bug #M Part 3 (#m1) — null si source fallback : un VIX corrompu
+    // fausserait les règles autonomy basées sur vix. Pattern aligné sur
+    // material-change-detector.service.ts:224.
+    const vixLevel = vixQuote && !this.isFallbackSource(vixQuote.source)
+      ? Number(vixQuote.price)
+      : null;
 
     for (const pos of positionsWithRules) {
       for (const rule of pos.autonomy_rules ?? []) {
@@ -2162,7 +2178,10 @@ export class MechanicalTradingService {
           // Exécution de l'action
           if (rule.action === 'close' || rule.action === 'take_profit') {
             const quote = await this.lisa.getLivePrice(pos.symbol).catch(() => null);
-            if (quote) {
+            // 🛡️ Bug #M Part 3 (#C4) — skip si quote fallback corrompu : ne pas
+            // fermer sur un prix sentinel '0'. La règle sera ré-évaluée au
+            // prochain cycle quand un prix fiable sera disponible.
+            if (quote && !this.isFallbackSource(quote.source)) {
               await this.closePosition(
                 pos.id,
                 quote.price,
@@ -2170,6 +2189,10 @@ export class MechanicalTradingService {
                 `AutonomyRule: ${rule.reason}`.slice(0, 500),
               );
               break; // position fermée, plus la peine d'évaluer ses autres règles
+            } else {
+              this.logger.warn(
+                `[FALLBACK_GUARD] AutonomyRule close ${pos.symbol} skip — source=${quote?.source ?? 'no_quote'}`,
+              );
             }
           } else if (rule.action === 'tighten_stop') {
             // Déplace le stop à breakeven (entry price)
@@ -2197,11 +2220,17 @@ export class MechanicalTradingService {
     if (metric === 'vix') return vixCached;
     if (metric === 'price') {
       const q = await this.lisa.getLivePrice(pos.symbol).catch(() => null);
-      return q ? Number(q.price) : null;
+      // 🛡️ Bug #M Part 3 (#m2) — null si source fallback : un prix corrompu
+      // déclencherait faussement les règles autonomy 'price'.
+      if (!q || this.isFallbackSource(q.source)) return null;
+      return Number(q.price);
     }
     if (metric === 'pnl_pct') {
       const q = await this.lisa.getLivePrice(pos.symbol).catch(() => null);
       if (!q) return null;
+      // 🛡️ Bug #M Part 3 (#m2) — null si source fallback : un pnl_pct calculé
+      // sur prix corrompu déclencherait faussement les règles autonomy.
+      if (this.isFallbackSource(q.source)) return null;
       const entry = Number(pos.entryPrice);
       const live = Number(q.price);
       const isLong = pos.direction === 'long' || pos.direction === 'long_call' || pos.direction === 'long_put';

--- a/apps/api/src/modules/lisa/services/option-broker.service.ts
+++ b/apps/api/src/modules/lisa/services/option-broker.service.ts
@@ -257,11 +257,26 @@ export class OptionBrokerService {
     for (const opt of (opens ?? []) as OptionPositionRow[]) {
       try {
         const quote = await this.lisa.getLivePrice(opt.underlying).catch(() => null);
-        const spot = quote ? Number(quote.price) : Number(opt.entry_underlying_price);
-        // Expiration ?
+        // 🛡️ Bug #M Part 3 (#C3) — garde fallback : si le quote est corrompu
+        // (source fallback, NaN, ≤0) un spot=0 produirait intrinsic=0 → option
+        // fermée à valeur nulle = perte totale du premium.
+        const isFallback = quote != null && quote.source != null && quote.source.startsWith('fallback');
+        const priceNum = quote != null ? parseFloat(quote.price) : NaN;
+        const reliable = quote != null && !isFallback && Number.isFinite(priceNum) && priceNum > 0;
+        // Pour l'expiration : spot fiable sinon entry_underlying_price (meilleur
+        // que 0 — l'option DOIT être fermée car expirée, on ne peut pas skip).
+        const spot = reliable ? priceNum : Number(opt.entry_underlying_price);
         if (todayDate >= opt.expiry) {
           await this.closeOption(opt.id, spot, 'closed_expired');
           expired++;
+          continue;
+        }
+        // Pour le TP : skip ce cycle si pas de prix fiable (l'option reste
+        // vivante, ré-évaluée au prochain cron quand un prix fiable arrive).
+        if (!reliable) {
+          this.logger.warn(
+            `[FALLBACK_GUARD] option ${opt.id} (${opt.underlying}) TP check skip — source=${quote?.source ?? 'no_quote'}`,
+          );
           continue;
         }
         // TP ×2 premium ?


### PR DESCRIPTION
Closes #313

## Contexte

Audit indépendant post-merge PR #311 (commit `33d9dfc`) — **5 sites critiques + 2 mineurs** résiduels qui fermaient des positions à `quote.price` sans vérifier `isFallbackSource(quote.source)`. Tous identiques en symptôme au Bug #M original : si EODHD fallback retourne `{ price: '0', source: 'fallback_unknown' }`, positions closes à $0 = perte maximale.

## Tableau récap des 7 sites corrigés

| Site | Fichier:ligne | Action | Garde appliquée |
|---|---|---|---|
| **#C1** | `mechanical-trading.service.ts` P4.1 kill-switch auto | close kill-switch | `entry_price` si corrupt + tag `[Bug#M-guard]` (pattern `risk-monitor.liquidateAll`) |
| **#C2** | `lisa.service.ts` `triggerKillSwitch` | close kill-switch user | `entry_price` si corrupt + tag — *le bouton de protection ne détruit plus* |
| **#C3** | `option-broker.service.ts` cron expire/TP | close option | expiration → `entry_underlying_price` si pas fiable ; TP → skip ce cycle (option reste vivante) |
| **#C4** | `mechanical-trading.service.ts` `evaluateAutonomyRules` close | close AutonomyRule | skip si fallback (retry next cycle) + log `[FALLBACK_GUARD]` |
| **#C5** | `lisa.service.ts` SWAP (L~1956) + close recommendation (L~1769) | close Lisa | skip si fallback — `break` (SWAP) / `continue` (recommendation) + log `[FALLBACK_GUARD_LISA]` |
| **#m1** | `mechanical-trading.service.ts` VIX dans `evaluateAutonomyRules` | lecture métrique | `null` si fallback (pattern `material-change-detector:224`) |
| **#m2** | `mechanical-trading.service.ts` `fetchMetricForRule` price/pnl_pct | lecture métrique | `null` si fallback |

## Patterns canoniques répliqués (non réinventés)

- **`risk-monitor.liquidateAll`** (`risk-monitor.service.ts:307-321`) → entry_price si corrupt + tag rationale `[Bug#M-guard]` — appliqué sur **#C1**, **#C2**
- **`material-change-detector.service.ts:224`** → null si fallback — appliqué sur **#m1**, **#m2**
- Skip-cycle pattern (consistent avec gardes existantes) — appliqué sur **#C3**, **#C4**, **#C5**

## Tests

`bug-m-part3-fallback-guards.spec.ts` — **15 cas, un bloc `describe` par site critique** (C1-C5). Reproduction en isolation de la logique de garde insérée à chaque site (norme du repo, cf. `mechanical-trading.batch-cap.spec.ts` : *"reproduit la logique en isolation ... services trop lourds en DI NestJS"* — `mechanical-trading` a 14+ deps constructeur). Chaque site : cas fallback (`{ price: '0', source: 'fallback_unknown' }`) + cas legit + cas limite (NaN, price≤0, source binance_ws).

| Test suite | Cas |
|---|---|
| #C1 P4.1 kill-switch | fallback → entry_price, legit → live price, NaN → corrupt |
| #C2 user kill-switch | fallback → entry_price, legit → live, price≤0 → corrupt |
| #C3 option-broker cron | fallback → entry_underlying_price + TP skipped, legit → spot fiable + TP évalué |
| #C4 AutonomyRule close | fallback → no close, null → no close, legit → close |
| #C5 Lisa SWAP + recommendation | fallback → skip, legit → close, binance_ws → close |

## Résultats

- `bug-m-part3-fallback-guards.spec.ts` : **15/15 PASS**
- **api** : 131 suites, **1742 passed / 2 todo / 0 failures**
- **ai-analyst** : **367 passed** — risk-monitor Bug #M Part 1 (PR #311) **intact, aucune régression**
- `npx tsc -b` : **clean**
- 0 warning nouveau

## Critères d'acceptation

- [x] 5 sites critiques + 2 mineurs corrigés avec garde fallback
- [x] 5 tests unitaires ajoutés (un par site critique)
- [x] Aucune régression sur tests Bug #M Part 1 (PR #311)
- [x] Logs `[FALLBACK_GUARD_*]` / `[Bug#M-guard]` cohérents avec patterns existants
- [x] Build TypeScript sans warning nouveau

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_