### PR TITLE
fix(lisa): atomic close UPDATE with double-clause status guard

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/atomic-close-update.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/atomic-close-update.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Bug #314 (PR-A) — Tests UPDATE atomique close avec garde double-clause statut.
+ *
+ * 3 sites corrigés (#M1 mechanical-trading, #M2 option-broker, #m3 rebound-monitor) :
+ * l'UPDATE de fermeture ajoute désormais une clause statut (`.eq('status','open')`
+ * ou `.in('status', [...])`) + `.select()` + détection de race (0 rows touchées).
+ * Sans ça, un acteur concurrent fermant la position entre SELECT et UPDATE
+ * provoquait un double-comptage P&L et polluait l'audit.
+ *
+ * Pattern de test : reproduction en isolation de la logique de garde insérée
+ * (norme du repo, cf. mechanical-trading.batch-cap.spec.ts — services trop
+ * lourds en DI NestJS). Chaque test simule la race double-close via un mock
+ * Supabase qui retourne 0 rows quand la clause statut ne matche plus.
+ */
+
+type UpdateRow = { id: string; status: string };
+
+/**
+ * Mock minimal du builder Supabase `.update().eq().eq().select()` /
+ * `.update().eq().in().select()`. La DB simulée contient une seule position
+ * dont le statut courant est `dbStatus`. L'UPDATE ne touche la row que si la
+ * clause statut matche — exactement comme Postgres.
+ */
+function makeAtomicUpdateMock(dbStatus: string) {
+  const calls: { statusGuard?: string | string[] } = {};
+  const builder = {
+    _idMatch: false,
+    update(_payload: Record<string, unknown>) { return this; },
+    eq(col: string, val: string) {
+      if (col === 'id') this._idMatch = true;
+      if (col === 'status') calls.statusGuard = val;
+      return this;
+    },
+    in(col: string, vals: string[]) {
+      if (col === 'status') calls.statusGuard = vals;
+      return this;
+    },
+    async select(_cols?: string) {
+      // Reproduit Postgres : la row n'est retournée que si id matche ET
+      // la garde statut matche le statut courant en DB.
+      const guard = calls.statusGuard;
+      const guardMatches = Array.isArray(guard)
+        ? guard.includes(dbStatus)
+        : guard === dbStatus;
+      const data: UpdateRow[] = this._idMatch && guardMatches
+        ? [{ id: 'pos-1', status: dbStatus }]
+        : [];
+      return { data, error: null };
+    },
+  };
+  return { builder, calls };
+}
+
+// ---------------------------------------------------------------------------
+// #M1 — mechanical-trading.closePosition : .eq('status','open') + race log
+// ---------------------------------------------------------------------------
+async function m1RunUpdate(dbStatus: string): Promise<{ raceDetected: boolean }> {
+  const { builder } = makeAtomicUpdateMock(dbStatus);
+  const { data: updated } = await builder
+    .update({ status: 'closed_stop' })
+    .eq('id', 'pos-1')
+    .eq('status', 'open')
+    .select('*');
+  return { raceDetected: !updated || updated.length === 0 };
+}
+
+describe('Bug #314 #M1 — mechanical-trading atomic close UPDATE', () => {
+  it('position encore open → UPDATE applique, pas de race', async () => {
+    const { raceDetected } = await m1RunUpdate('open');
+    expect(raceDetected).toBe(false);
+  });
+
+  it('position déjà closed_stop (acteur concurrent) → 0 rows → race détectée', async () => {
+    const { raceDetected } = await m1RunUpdate('closed_stop');
+    expect(raceDetected).toBe(true);
+  });
+
+  it('position déjà closed_kill (kill-switch concurrent) → race détectée', async () => {
+    const { raceDetected } = await m1RunUpdate('closed_kill');
+    expect(raceDetected).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #M2 — option-broker.closeOption : .eq('status','open') + race log
+// ---------------------------------------------------------------------------
+async function m2RunUpdate(dbStatus: string): Promise<{ raceDetected: boolean }> {
+  const { builder } = makeAtomicUpdateMock(dbStatus);
+  const { data: updated } = await builder
+    .update({ status: 'closed_target' })
+    .eq('id', 'pos-1')
+    .eq('status', 'open')
+    .select('*');
+  return { raceDetected: !updated || updated.length === 0 };
+}
+
+describe('Bug #314 #M2 — option-broker atomic close UPDATE', () => {
+  it('option encore open → UPDATE applique', async () => {
+    const { raceDetected } = await m2RunUpdate('open');
+    expect(raceDetected).toBe(false);
+  });
+
+  it('option déjà closed_expired (cron expire vs cron TP même tick) → race détectée', async () => {
+    // Scénario du double-close : la boucle cron expire ferme l'option, puis
+    // la boucle TP du même tick 5min tente de la re-fermer.
+    const { raceDetected } = await m2RunUpdate('closed_expired');
+    expect(raceDetected).toBe(true);
+  });
+
+  it('option déjà closed_target → race détectée', async () => {
+    const { raceDetected } = await m2RunUpdate('closed_target');
+    expect(raceDetected).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #m3 — rebound-monitor.closePosition : .in('status', [non-terminaux]) + race log
+// ---------------------------------------------------------------------------
+async function m3RunUpdate(dbStatus: string): Promise<{ raceDetected: boolean }> {
+  const { builder } = makeAtomicUpdateMock(dbStatus);
+  const { data: updated } = await builder
+    .update({ status: 'TP3_HIT' })
+    .eq('id', 'pos-1')
+    .in('status', ['OPEN', 'TP1_HIT', 'TP2_HIT'])
+    .select('id');
+  return { raceDetected: !updated || updated.length === 0 };
+}
+
+describe('Bug #314 #m3 — rebound-monitor atomic close UPDATE', () => {
+  it('position OPEN → UPDATE applique', async () => {
+    const { raceDetected } = await m3RunUpdate('OPEN');
+    expect(raceDetected).toBe(false);
+  });
+
+  it('position TP1_HIT (partiel) → UPDATE applique encore (non-terminal)', async () => {
+    const { raceDetected } = await m3RunUpdate('TP1_HIT');
+    expect(raceDetected).toBe(false);
+  });
+
+  it('position déjà CLOSED → 0 rows → race détectée (statut terminal)', async () => {
+    const { raceDetected } = await m3RunUpdate('CLOSED');
+    expect(raceDetected).toBe(true);
+  });
+
+  it('position déjà SL_HIT → race détectée (statut terminal)', async () => {
+    const { raceDetected } = await m3RunUpdate('SL_HIT');
+    expect(raceDetected).toBe(true);
+  });
+});

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -2378,7 +2378,12 @@ export class MechanicalTradingService {
     const pnlPct = realizedPnl.div(notional).mul(100).toNumber();
 
     const now = new Date().toISOString();
-    await this.supabase.getClient()
+    // Bug #314 #M1 — UPDATE atomique double-clause. Le SELECT initial (haut de
+    // closePosition) vérifie status='open', mais sans .eq('status','open') sur
+    // l'UPDATE un autre acteur (paper-broker, kill-switch user) pouvait fermer
+    // la position entre SELECT et UPDATE → double comptage P&L + audit pollué.
+    // Pattern canonique : paper-broker.service.ts:611-622.
+    const { data: updated } = await this.supabase.getClient()
       .from('lisa_positions')
       .update({
         status: reason,
@@ -2389,7 +2394,18 @@ export class MechanicalTradingService {
         realized_pnl_pct: pnlPct,
         updated_at: now,
       })
-      .eq('id', positionId);
+      .eq('id', positionId)
+      .eq('status', 'open')
+      .select('*');
+
+    // 0 rows touchées = position déjà fermée par un autre acteur entre le
+    // SELECT et l'UPDATE → retour silencieux pour ne pas double-compter.
+    if (!updated || updated.length === 0) {
+      this.logger.warn(
+        `[MÉCANIQUE] closePosition ${positionId} race detected — already closed by another actor, skipping double-close`,
+      );
+      return;
+    }
 
     // Phase 5 — fire-and-forget : capture l'outcome contextualisé pour
     // l'apprentissage continu Lisa. Ne bloque jamais le close.

--- a/apps/api/src/modules/lisa/services/option-broker.service.ts
+++ b/apps/api/src/modules/lisa/services/option-broker.service.ts
@@ -215,7 +215,11 @@ export class OptionBrokerService {
     const pnlPct =
       pos.premium_paid_usd > 0 ? (pnlUsd / Number(pos.premium_paid_usd)) * 100 : 0;
 
-    await this.supabase
+    // Bug #314 #M2 — UPDATE atomique double-clause. Le cron expire et le cron
+    // TP peuvent fire sur la même option dans le même tick 5min → sans
+    // .eq('status','open') le 2e UPDATE écrase le 1er = double comptage PnL.
+    // Pattern canonique : paper-broker.service.ts:611-622.
+    const { data: updated } = await this.supabase
       .getClient()
       .from('lisa_option_positions')
       .update({
@@ -228,7 +232,18 @@ export class OptionBrokerService {
         realized_pnl_pct: pnlPct,
         updated_at: new Date().toISOString(),
       })
-      .eq('id', positionId);
+      .eq('id', positionId)
+      .eq('status', 'open')
+      .select('*');
+
+    // 0 rows touchées = option déjà fermée par un autre acteur (cron expire vs
+    // cron TP sur le même tick) → retour silencieux pour ne pas double-compter.
+    if (!updated || updated.length === 0) {
+      this.logger.warn(
+        `[option-broker] closeOption ${positionId} race detected — already closed, skipping double-close`,
+      );
+      return;
+    }
 
     this.logger.log(
       `[option-broker] Closed ${pos.kind} ${pos.underlying} reason=${reason} P&L=$${pnlUsd.toFixed(2)} (${pnlPct.toFixed(2)}%)`,

--- a/apps/api/src/modules/lisa/services/rebound-monitor.service.ts
+++ b/apps/api/src/modules/lisa/services/rebound-monitor.service.ts
@@ -205,13 +205,23 @@ export class ReboundMonitorService {
         // Keep specific status (TP3_HIT/SL_HIT/TIMEOUT) for audit
       }
     }
-    const { error } = await this.supabase
+    // Bug #314 m3 — UPDATE atomique avec garde de statut. Race interne
+    // improbable (cron unique 5min) mais on borne l'UPDATE aux statuts
+    // non-terminaux pour ne jamais écraser une position déjà CLOSED /
+    // TP3_HIT / SL_HIT / TIMEOUT. Pattern aligné sur paper-broker:611-622.
+    const { data: updated, error } = await this.supabase
       .getClient()
       .from('rebound_positions')
       .update(updates)
-      .eq('id', id);
+      .eq('id', id)
+      .in('status', ['OPEN', 'TP1_HIT', 'TP2_HIT'])
+      .select('id');
     if (error) {
       this.logger.error(`[rebound-monitor] update ${id} failed: ${error.message}`);
+    } else if (!updated || updated.length === 0) {
+      this.logger.warn(
+        `[rebound-monitor] closePosition ${id} race detected — already in terminal status, skipping`,
+      );
     }
     void exitPrice; // tagué pour audit futur (column exit_price si on l'ajoute)
   }


### PR DESCRIPTION
Refs #314 (PR-A sur 3 — #314 couvre PR-A atomic UPDATE, PR-B helper isLongPosition, PR-C race scanner/autopilot)

## Contexte

Audit indépendant #314 (commit `33d9dfc`) — **3 sites** où l'`UPDATE` de fermeture de position n'avait **pas de garde statut**. Le `SELECT` initial vérifie bien `status = 'open'`, mais l'`UPDATE` final n'a pas la clause. Si un acteur concurrent ferme la position entre `SELECT` et `UPDATE` (paper-broker, kill-switch user, cron parallèle), on écrase silencieusement la fermeture précédente avec un nouveau `exit_price` + PnL → **double comptage P&L** + audit pollué (hash chaîné).

## 3 sites corrigés

| Site | Fichier | Fix |
|---|---|---|
| **#M1** | `mechanical-trading.service.ts:2380` `closePosition` | `.eq('status','open')` + `.select('*')` + race log `[MÉCANIQUE]` |
| **#M2** | `option-broker.service.ts:218` `closeOption` | `.eq('status','open')` + `.select('*')` + race log — protège contre **cron expire vs cron TP sur le même tick 5min** |
| **#m3** | `rebound-monitor.service.ts:208` `closePosition` | `.in('status',['OPEN','TP1_HIT','TP2_HIT'])` + `.select('id')` + race log — borne l'UPDATE aux statuts **non-terminaux** (jamais écraser `CLOSED`/`TP3_HIT`/`SL_HIT`/`TIMEOUT`) |

Pattern canonique répliqué : `paper-broker.service.ts:611-622` (`.eq('id').eq('status','open').select('*')` + `if (!updated || updated.length === 0)` → warn + return silencieux).

## Tests

`atomic-close-update.spec.ts` — **10 cas**, un bloc `describe` par site. Simule la race double-close via un mock Supabase qui retourne `0 rows` quand la clause statut ne matche plus (reproduction isolée, norme du repo cf. `mechanical-trading.batch-cap.spec.ts`).

| Suite | Cas |
|---|---|
| #M1 mechanical-trading | open → UPDATE ok ; closed_stop concurrent → race ; closed_kill concurrent → race |
| #M2 option-broker | open → UPDATE ok ; closed_expired (cron expire vs TP) → race ; closed_target → race |
| #m3 rebound-monitor | OPEN → ok ; TP1_HIT (partiel non-terminal) → ok ; CLOSED → race ; SL_HIT → race |

## Résultats

- `atomic-close-update.spec.ts` : **10/10 PASS**
- **api** : 132 suites, **1752 passed / 2 todo / 0 failures**
- `npx tsc -b` : **clean**
- 0 warning nouveau

## Note Phase MESURE

Fix sécurité (intégrité comptable / audit chain), même nature d'exception que Bug #M Part 1 (#311) et Part 3 (#315). Aucune modif config TP/SL/notional/scanner, aucune modif Fly/scheduling/quota.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_