### PR TITLE
refactor(lisa): centralize isLongPosition helper for options support

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/mechanical-trading.options-direction.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/mechanical-trading.options-direction.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Bug #314 #M4 (PR-B) — Tests helper isLongPosition / isShortPosition centralisé
+ * + vérification que mechanical-trading.checkStopTarget interprète une option
+ * `long_call` / `long_put` dans le bon sens (LONG, pas SHORT).
+ *
+ * Avant le fix : mechanical-trading utilisait `direction === 'long'` strict →
+ * une option (`direction='long_call'`) tombait dans la branche SHORT →
+ * stop/target inversés → perte garantie.
+ *
+ * Pattern de test : le helper est une fonction pure → testée directement.
+ * La logique checkStopTarget est reproduite en isolation (norme repo, cf.
+ * mechanical-trading.batch-cap.spec.ts — service trop lourd en DI NestJS).
+ */
+
+import Decimal from 'decimal.js';
+import { isLongPosition, isShortPosition } from '../../utils/position-direction';
+
+describe('Bug #314 #M4 — isLongPosition helper', () => {
+  it('reconnaît long / long_call / long_put comme LONG', () => {
+    expect(isLongPosition('long')).toBe(true);
+    expect(isLongPosition('long_call')).toBe(true);
+    expect(isLongPosition('long_put')).toBe(true);
+  });
+
+  it('rejette short / short_call / short_put / pair_spread comme non-LONG', () => {
+    expect(isLongPosition('short')).toBe(false);
+    expect(isLongPosition('short_call')).toBe(false);
+    expect(isLongPosition('short_put')).toBe(false);
+    expect(isLongPosition('pair_spread')).toBe(false);
+  });
+});
+
+describe('Bug #314 #M4 — isShortPosition helper', () => {
+  it('reconnaît short / short_call / short_put comme SHORT', () => {
+    expect(isShortPosition('short')).toBe(true);
+    expect(isShortPosition('short_call')).toBe(true);
+    expect(isShortPosition('short_put')).toBe(true);
+  });
+
+  it('rejette long / long_call / long_put / pair_spread comme non-SHORT', () => {
+    expect(isShortPosition('long')).toBe(false);
+    expect(isShortPosition('long_call')).toBe(false);
+    expect(isShortPosition('long_put')).toBe(false);
+    expect(isShortPosition('pair_spread')).toBe(false);
+  });
+
+  it('long et short sont mutuellement exclusifs sur les 6 directions directionnelles', () => {
+    for (const dir of ['long', 'short', 'long_call', 'long_put', 'short_call', 'short_put']) {
+      expect(isLongPosition(dir)).toBe(!isShortPosition(dir));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reproduction isolée de mechanical-trading.checkStopTarget hit logic (L1760)
+// ---------------------------------------------------------------------------
+function checkStopTargetHits(
+  direction: string,
+  currentPrice: number,
+  stopLossPrice: number | null,
+  takeProfitPrice: number | null,
+): { hitStop: boolean; hitTarget: boolean } {
+  const cur = new Decimal(currentPrice);
+  const stopPrice = stopLossPrice != null ? new Decimal(stopLossPrice) : null;
+  const tpPrice = takeProfitPrice != null ? new Decimal(takeProfitPrice) : null;
+  // Logique exacte post-fix #M4 : isLongPosition(direction) au lieu de === 'long'.
+  const isLong = isLongPosition(direction);
+  const hitStop = !!stopPrice && (isLong ? cur.lte(stopPrice) : cur.gte(stopPrice));
+  const hitTarget = !!tpPrice && (isLong ? cur.gte(tpPrice) : cur.lte(tpPrice));
+  return { hitStop, hitTarget };
+}
+
+describe('Bug #314 #M4 — checkStopTarget direction options', () => {
+  it('long_call : prix sous le stop → hitStop (sens LONG, pas inversé)', () => {
+    // entry ~5, stop 4.5, tp 6. Prix tombe à 4.4 → stop touché.
+    const { hitStop, hitTarget } = checkStopTargetHits('long_call', 4.4, 4.5, 6.0);
+    expect(hitStop).toBe(true);
+    expect(hitTarget).toBe(false);
+  });
+
+  it('long_call : prix au-dessus du target → hitTarget (sens LONG)', () => {
+    const { hitStop, hitTarget } = checkStopTargetHits('long_call', 6.1, 4.5, 6.0);
+    expect(hitStop).toBe(false);
+    expect(hitTarget).toBe(true);
+  });
+
+  it('long_put : traité comme LONG (position détenue, stop sous le prix)', () => {
+    const { hitStop, hitTarget } = checkStopTargetHits('long_put', 4.4, 4.5, 6.0);
+    expect(hitStop).toBe(true);
+    expect(hitTarget).toBe(false);
+  });
+
+  it('REGRESSION : avant le fix, long_call à 4.4 (sous stop 4.5) aurait été ' +
+     'interprété SHORT → hitStop = cur.gte(stop) = false → stop manqué', () => {
+    // Démonstration du bug : la logique strict `=== "long"` sur long_call.
+    const buggyIsLong = ('long_call' as string) === 'long'; // false (le bug)
+    const cur = new Decimal(4.4);
+    const stop = new Decimal(4.5);
+    const buggyHitStop = buggyIsLong ? cur.lte(stop) : cur.gte(stop);
+    expect(buggyHitStop).toBe(false); // ← le stop n'aurait JAMAIS déclenché
+
+    // Post-fix : le même scénario déclenche bien le stop.
+    const fixed = checkStopTargetHits('long_call', 4.4, 4.5, 6.0);
+    expect(fixed.hitStop).toBe(true);
+  });
+
+  it('short : prix au-dessus du stop → hitStop (sens SHORT préservé)', () => {
+    // Pour un short, le stop est AU-DESSUS du prix d'entrée.
+    const { hitStop } = checkStopTargetHits('short', 5.6, 5.5, 4.0);
+    expect(hitStop).toBe(true);
+  });
+
+  it('equity long : comportement inchangé (rétro-compat)', () => {
+    const { hitStop, hitTarget } = checkStopTargetHits('long', 4.4, 4.5, 6.0);
+    expect(hitStop).toBe(true);
+    expect(hitTarget).toBe(false);
+  });
+});

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -25,6 +25,7 @@ import {
   type ThesisKind,
 } from '@smartvest/ai-analyst';
 import { mapPositionRows } from '../helpers/position.mapper';
+import { isLongPosition } from '../utils/position-direction';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { PerformanceService } from '../../performance/performance.service';
 import { DecisionLogService } from './decision-log.service';
@@ -1756,7 +1757,9 @@ export class MechanicalTradingService {
     const stopPrice = pos.stopLossPrice ? new Decimal(pos.stopLossPrice) : null;
     const tpPrice = pos.takeProfitPrice ? new Decimal(pos.takeProfitPrice) : null;
 
-    const isLong = pos.direction === 'long';
+    // Bug #314 #M4 — helper centralisé : reconnaît long/long_call/long_put.
+    // Avant : `=== 'long'` strict → options gérées comme SHORT → stop/target inversés.
+    const isLong = isLongPosition(pos.direction);
     const hitStop = stopPrice && (isLong ? currentPrice.lte(stopPrice) : currentPrice.gte(stopPrice));
     const hitTarget = tpPrice && (isLong ? currentPrice.gte(tpPrice) : currentPrice.lte(tpPrice));
 
@@ -1931,7 +1934,8 @@ export class MechanicalTradingService {
     const entryPx = new Decimal(pos.entryPrice);
     if (entryPx.lte(0)) return;
 
-    const isLong = pos.direction === 'long';
+    // Bug #314 #M4 — helper centralisé : reconnaît long/long_call/long_put.
+    const isLong = isLongPosition(pos.direction);
     const pnlPct = isLong
       ? currentPrice.minus(entryPx).div(entryPx).mul(100).toNumber()
       : entryPx.minus(currentPrice).div(entryPx).mul(100).toNumber();
@@ -2279,7 +2283,8 @@ export class MechanicalTradingService {
     const exitPrice = new Decimal(livePrice);
     const entryPrice = new Decimal(pos.entry_price as string);
     const notional = new Decimal(pos.entry_notional_usd as string);
-    const isLong = (pos.direction as string) === 'long';
+    // Bug #314 #M4 — helper centralisé : reconnaît long/long_call/long_put.
+    const isLong = isLongPosition(pos.direction as string);
     const qty = new Decimal(pos.quantity as string);
     const assetClass = (pos.asset_class as string | undefined) ?? undefined;
 

--- a/apps/api/src/modules/lisa/utils/position-direction.ts
+++ b/apps/api/src/modules/lisa/utils/position-direction.ts
@@ -1,0 +1,50 @@
+/**
+ * Bug #314 #M4 — Helper centralisé de direction de position.
+ *
+ * Contexte : `mechanical-trading.service.ts` utilisait `direction === 'long'`
+ * strict à plusieurs endroits (checkStopTarget, checkReactiveSignals,
+ * closePosition), alors que `paper-broker.service.ts` et
+ * `risk-monitor.service.ts` reconnaissent aussi `long_call` / `long_put`.
+ * Conséquence : une option (`direction='long_call'`) gérée par
+ * mechanical-trading était interprétée comme SHORT → stop/target inversés
+ * → perte garantie.
+ *
+ * Ce helper centralise la sémantique pour qu'elle soit cohérente partout
+ * dans le module `lisa` (apps/api). Les services de `packages/ai-analyst`
+ * (paper-broker, risk-monitor) ont déjà la logique correcte inline et ne
+ * peuvent pas importer depuis apps/api (sens de dépendance) — voir audit
+ * dans la PR #314 PR-B.
+ *
+ * Directions reconnues (cf. PaperPosition.direction zod enum) :
+ *   long, short, long_call, long_put, short_call, short_put, pair_spread
+ */
+
+/**
+ * `true` si la position est "longue" au sens P&L : profite d'une hausse du
+ * sous-jacent. Couvre l'equity long ET les options longues (call/put achetés
+ * — un long_put profite d'une baisse du sous-jacent, mais du point de vue de
+ * la POSITION c'est un actif détenu dont la valeur monte ; mechanical-trading
+ * applique les stop/target sur le prix de la position, pas du sous-jacent).
+ *
+ * Aligné sur paper-broker.service.ts:503 et risk-monitor.service.ts:191.
+ */
+export function isLongPosition(direction: string): boolean {
+  return (
+    direction === 'long' ||
+    direction === 'long_call' ||
+    direction === 'long_put'
+  );
+}
+
+/**
+ * `true` si la position est "courte" : short equity ou options vendues.
+ * Complément strict de `isLongPosition` pour les directions short.
+ * `pair_spread` n'est ni long ni short au sens directionnel simple.
+ */
+export function isShortPosition(direction: string): boolean {
+  return (
+    direction === 'short' ||
+    direction === 'short_call' ||
+    direction === 'short_put'
+  );
+}


### PR DESCRIPTION
Refs #314 (PR-B sur 3 — #314 couvre PR-A atomic UPDATE #316, PR-B helper isLongPosition, PR-C race scanner/autopilot)

## Contexte

Audit indépendant #314 #M4 (commit `33d9dfc`) — `mechanical-trading.service.ts` utilisait `direction === 'long'` **strict** à 3 endroits, alors que `paper-broker.service.ts:503` et `risk-monitor.service.ts:191` reconnaissent aussi `long_call` / `long_put`.

**Conséquence** : une option (`direction='long_call'`) gérée par mechanical-trading tombait dans la branche **SHORT** → stop/target inversés → perte garantie. Démonstration dans le test de régression : un `long_call` à 4.4 sous un stop 4.5 → la logique buggée `=== 'long'` évaluait `cur.gte(stop)` = `false` → **le stop ne déclenchait jamais**.

## Changes

### Nouveau `apps/api/src/modules/lisa/utils/position-direction.ts`
- `isLongPosition(direction)` → `true` pour `long` / `long_call` / `long_put`
- `isShortPosition(direction)` → `true` pour `short` / `short_call` / `short_put`

### `mechanical-trading.service.ts` — 3 occurrences strictes remplacées

| Site | Méthode | Impact du bug |
|---|---|---|
| L1760 | `checkStopTarget` | hit stop/target inversés sur options |
| L1937 | `checkReactiveSignals` | `pnlPct` calculé à l'envers |
| L2286 | `closePosition` | `rawPnl` calculé à l'envers |

`fetchMetricForRule` (L2236) avait **déjà** la bonne logique inline → inchangé.

### Audit `paper-broker:503` + `risk-monitor:191`

Les deux ont **déjà** le check sémantiquement correct inline (`long || long_call || long_put`). Ils sont dans `packages/ai-analyst` qui **ne peut pas importer depuis `apps/api`** (sens de dépendance monorepo). → laissés tels quels, **audit conclusion = déjà corrects**. Le helper centralisé sert le module `lisa` d'`apps/api` ; une éventuelle factorisation cross-package serait un refactor séparé (déplacer le helper dans un package partagé) hors scope de cette PR.

## Tests

`mechanical-trading.options-direction.spec.ts` — **11 cas** :
- Helper pur : `isLongPosition` / `isShortPosition` exhaustifs sur les 7 directions + exclusivité mutuelle
- `checkStopTarget` reproduit en isolation avec `long_call` / `long_put` / `short` / `long` equity
- **Test de régression** explicite : démontre que `=== 'long'` strict ratait le stop sur `long_call`, et que le fix le déclenche

## Résultats

- `mechanical-trading.options-direction.spec.ts` : **11/11 PASS**
- **api** : 132 suites, **1753 passed / 2 todo / 0 failures**
- `npx tsc -b` : **clean**
- 0 warning nouveau

## Note Phase MESURE

Refactor de cohérence sécuritaire (stop/target options corrects), aucune modif config TP/SL/notional/scanner, aucune modif Fly/scheduling/quota.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_