### PR TITLE
Bug #R1 — SL warmup 15min (skip premature stop hunt on fresh positions)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/sl-warmup.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/sl-warmup.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Bug #R1 — Tests SL warmup 15min (skip premature stop hunt on fresh positions).
+ *
+ * Gate inséré dans mechanical-trading.checkStopTarget, bloc `if (hitStop)` :
+ * une position fraîche (<15 min) en perte modérée (> -3%) ignore le SL
+ * PRINCIPAL ; garde-fou catastrophique : perte sévère (≤ -3%) → SL honoré
+ * même en warmup.
+ *
+ * Audit 14/05 (closed_stop bruts, 14j) : 47% des SL surviennent <15min,
+ * 3/4 sont des stop hunts (rebond breakeven <30min). Voir PR Bug #R1.
+ *
+ * Pattern de test : reproduction en isolation de la décision warmup (norme
+ * repo, cf. mechanical-trading.batch-cap.spec.ts — service trop lourd en DI
+ * NestJS pour instanciation propre). La fonction `warmupDecision` ci-dessous
+ * reproduit EXACTEMENT le gate de checkStopTarget.
+ */
+
+const SL_WARMUP_MIN = 15;
+const SL_WARMUP_SEVERE_LOSS_PCT = -3.0;
+
+type WarmupDecision = 'warmup_skip' | 'warmup_override_severe_loss' | 'sl_honored';
+
+/**
+ * Reproduit le gate de mechanical-trading.checkStopTarget (bloc hitStop).
+ * `ageMin` : âge de la position en minutes. `unrealizedPnlPct` : P&L latent
+ * direction-aware (négatif = perte, pour long ET short).
+ */
+function warmupDecision(ageMin: number, unrealizedPnlPct: number): {
+  decision: WarmupDecision;
+  closesPosition: boolean;
+} {
+  const inWarmupWindow = ageMin < SL_WARMUP_MIN;
+  const severeLoss = unrealizedPnlPct <= SL_WARMUP_SEVERE_LOSS_PCT;
+  const warmupActive = inWarmupWindow && !severeLoss;
+
+  if (warmupActive) {
+    return { decision: 'warmup_skip', closesPosition: false };
+  }
+  if (inWarmupWindow && severeLoss) {
+    return { decision: 'warmup_override_severe_loss', closesPosition: true };
+  }
+  return { decision: 'sl_honored', closesPosition: true };
+}
+
+/**
+ * Reproduit le calcul de P&L latent direction-aware de checkStopTarget :
+ * négatif = perte, quel que soit le sens de la position.
+ */
+function unrealizedPnlPct(isLong: boolean, entryPrice: number, currentPrice: number): number {
+  return isLong
+    ? ((currentPrice - entryPrice) / entryPrice) * 100
+    : ((entryPrice - currentPrice) / entryPrice) * 100;
+}
+
+describe('Bug #R1 — SL warmup decision (8 cas spec)', () => {
+  it('1. age 5min, pnl -1.5% → warmup_skip (SL principal ignoré, position fraîche)', () => {
+    const { decision, closesPosition } = warmupDecision(5, -1.5);
+    expect(decision).toBe('warmup_skip');
+    expect(closesPosition).toBe(false);
+  });
+
+  it('2. age 5min, pnl -3.5% → warmup_override_severe_loss (garde-fou, SL honoré)', () => {
+    const { decision, closesPosition } = warmupDecision(5, -3.5);
+    expect(decision).toBe('warmup_override_severe_loss');
+    expect(closesPosition).toBe(true);
+  });
+
+  it('3. age 20min, pnl -1.5% → sl_honored (warmup terminé, SL classique)', () => {
+    const { decision, closesPosition } = warmupDecision(20, -1.5);
+    expect(decision).toBe('sl_honored');
+    expect(closesPosition).toBe(true);
+  });
+
+  it('4. age 20min, pnl -3.5% → sl_honored (warmup terminé)', () => {
+    const { decision, closesPosition } = warmupDecision(20, -3.5);
+    expect(decision).toBe('sl_honored');
+    expect(closesPosition).toBe(true);
+  });
+
+  it('5. EDGE age exactement 15.0min → sl_honored (fenêtre warmup = ageMin < 15, exclusif)', () => {
+    const { decision, closesPosition } = warmupDecision(15.0, -1.5);
+    expect(decision).toBe('sl_honored');
+    expect(closesPosition).toBe(true);
+  });
+
+  it('6. EDGE pnl exactement -3.0% → garde-fou actif (severeLoss = pnl <= -3.0, inclusif)', () => {
+    const { decision, closesPosition } = warmupDecision(5, -3.0);
+    expect(decision).toBe('warmup_override_severe_loss');
+    expect(closesPosition).toBe(true);
+  });
+
+  it('7. symbol asia overnight (entry 00:00 UTC) : warmup respecté — gate hour-agnostic', () => {
+    // Le warmup ne dépend QUE de l'âge et du PnL, jamais de l'heure UTC.
+    // Une position asia ouverte à 00:00 UTC, 5 min plus tard, perte -1.2% →
+    // warmup actif comme n'importe quelle autre heure.
+    const entryAt = new Date('2026-05-14T00:00:00Z').getTime();
+    const nowAt = new Date('2026-05-14T00:05:00Z').getTime();
+    const ageMin = (nowAt - entryAt) / 60_000;
+    const { decision, closesPosition } = warmupDecision(ageMin, -1.2);
+    expect(ageMin).toBe(5);
+    expect(decision).toBe('warmup_skip');
+    expect(closesPosition).toBe(false);
+  });
+
+  it('8. symbol US 14h UTC (heure toxique) : warmup respecté — gate hour-agnostic', () => {
+    // 14h UTC = heure toxique US large (88% SL d'après audit) mais le warmup
+    // reste purement âge/PnL : une position fraîche y bénéficie du warmup.
+    const entryAt = new Date('2026-05-14T14:00:00Z').getTime();
+    const nowAt = new Date('2026-05-14T14:08:00Z').getTime();
+    const ageMin = (nowAt - entryAt) / 60_000;
+    const { decision, closesPosition } = warmupDecision(ageMin, -2.0);
+    expect(ageMin).toBe(8);
+    expect(decision).toBe('warmup_skip');
+    expect(closesPosition).toBe(false);
+  });
+});
+
+describe('Bug #R1 — P&L latent direction-aware (garde-fou correct long ET short)', () => {
+  it('long : prix sous entry → pnl négatif (perte)', () => {
+    // entry 5.00, current 4.85 → -3.0%
+    expect(unrealizedPnlPct(true, 5.0, 4.85)).toBeCloseTo(-3.0, 5);
+  });
+
+  it('short : prix au-dessus entry → pnl négatif (perte)', () => {
+    // entry 5.00, current 5.15 → short en perte de -3.0%
+    expect(unrealizedPnlPct(false, 5.0, 5.15)).toBeCloseTo(-3.0, 5);
+  });
+
+  it('long fresh -1.5% → warmup_skip via pnl direction-aware', () => {
+    const pnl = unrealizedPnlPct(true, 5.0, 4.925);
+    expect(pnl).toBeCloseTo(-1.5, 5);
+    expect(warmupDecision(5, pnl).decision).toBe('warmup_skip');
+  });
+
+  it('short fresh -3.5% → garde-fou via pnl direction-aware', () => {
+    const pnl = unrealizedPnlPct(false, 5.0, 5.175);
+    expect(pnl).toBeCloseTo(-3.5, 5);
+    expect(warmupDecision(5, pnl).decision).toBe('warmup_override_severe_loss');
+  });
+});
+
+describe('Bug #R1 — invariants warmup', () => {
+  it('hors fenêtre warmup (age ≥ 15) : décision toujours sl_honored quel que soit le pnl', () => {
+    for (const pnl of [-0.5, -1.5, -3.0, -5.0, -10.0]) {
+      expect(warmupDecision(15, pnl).decision).toBe('sl_honored');
+      expect(warmupDecision(60, pnl).decision).toBe('sl_honored');
+    }
+  });
+
+  it('dans la fenêtre warmup : ferme la position SSI perte sévère (≤ -3%)', () => {
+    expect(warmupDecision(5, -2.99).closesPosition).toBe(false); // modérée
+    expect(warmupDecision(5, -3.0).closesPosition).toBe(true);   // seuil
+    expect(warmupDecision(5, -3.01).closesPosition).toBe(true);  // sévère
+  });
+});

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -1764,9 +1764,57 @@ export class MechanicalTradingService {
     const hitTarget = tpPrice && (isLong ? currentPrice.gte(tpPrice) : currentPrice.lte(tpPrice));
 
     if (hitStop) {
-      await this.closePosition(pos.id, quote.price, 'closed_stop',
-        `[MÉCANIQUE] Stop-loss atteint ${pos.symbol} @ ${currentPrice.toFixed(4)} (stop=${pos.stopLossPrice})`);
-      return;
+      // Bug #R1 — SL warmup 15min : skip le SL PRINCIPAL sur une position
+      // fraîche (<15 min) en perte modérée (> -3%). Garde-fou catastrophique :
+      // perte sévère (≤ -3%) → SL honoré même en warmup (couvre les vraies
+      // chutes type SEE.LSE). Audit 14/05 (closed_stop bruts, 14j) : 47%
+      // surviennent <15min, 3/4 sont des stop hunts (rebond breakeven <30min).
+      //
+      // Périmètre strict (décision #314 audit) : gate UNIQUEMENT ce bloc.
+      // hitTarget + checkReactiveSignals (incl. stop réactif) restent intacts —
+      // le stop réactif est la 2e ligne de défense et déclenche plus tard sur
+      // signaux dégradés, pas sur la mèche d'ouverture.
+      const SL_WARMUP_MIN = 15;
+      const SL_WARMUP_SEVERE_LOSS_PCT = -3.0;
+      const entryTsRaw = (pos as unknown as Record<string, unknown>)['entry_timestamp'];
+      const ageMin = entryTsRaw
+        ? (Date.now() - new Date(entryTsRaw as string).getTime()) / 60_000
+        : Infinity;  // pas de timestamp → pas de warmup, SL honoré (conservateur)
+      const unrealizedPnlPct = isLong
+        ? livePx.minus(entryPx).div(entryPx).mul(100).toNumber()
+        : entryPx.minus(livePx).div(entryPx).mul(100).toNumber();
+      const inWarmupWindow = ageMin < SL_WARMUP_MIN;
+      const severeLoss = unrealizedPnlPct <= SL_WARMUP_SEVERE_LOSS_PCT;
+      const warmupActive = inWarmupWindow && !severeLoss;
+
+      if (warmupActive) {
+        // Stop hunt probable : on ne ferme PAS, position réexaminée au prochain
+        // tick (60s). Fall-through vers checkReactiveSignals (2e ligne défense).
+        this.logger.log(
+          `[SL_WARMUP] ${pos.symbol} decision=warmup_skip position_id=${pos.id} ` +
+          `age_min=${ageMin.toFixed(2)} unrealized_pnl_pct=${unrealizedPnlPct.toFixed(3)} ` +
+          `sl_price=${pos.stopLossPrice} — SL principal ignoré (position fraîche, perte modérée)`,
+        );
+      } else {
+        if (inWarmupWindow && severeLoss) {
+          // Transition warmup → SL honoré : vraie chute pendant la fenêtre
+          // warmup. Tracké en warn pour mesurer stop hunts évités vs vraies pertes.
+          this.logger.warn(
+            `[SL_WARMUP] ${pos.symbol} decision=warmup_override_severe_loss position_id=${pos.id} ` +
+            `age_min=${ageMin.toFixed(2)} unrealized_pnl_pct=${unrealizedPnlPct.toFixed(3)} ` +
+            `sl_price=${pos.stopLossPrice} — garde-fou -3% : SL honoré malgré warmup`,
+          );
+        } else {
+          this.logger.log(
+            `[SL_WARMUP] ${pos.symbol} decision=sl_honored position_id=${pos.id} ` +
+            `age_min=${ageMin.toFixed(2)} unrealized_pnl_pct=${unrealizedPnlPct.toFixed(3)} ` +
+            `— warmup terminé, SL classique appliqué`,
+          );
+        }
+        await this.closePosition(pos.id, quote.price, 'closed_stop',
+          `[MÉCANIQUE] Stop-loss atteint ${pos.symbol} @ ${currentPrice.toFixed(4)} (stop=${pos.stopLossPrice})`);
+        return;
+      }
     }
     if (hitTarget) {
       await this.closePosition(pos.id, quote.price, 'closed_target',


### PR DESCRIPTION
**Bug #R1 — SL prématurés stop hunt / Phase 5 N1 hardening**

## Problème — preuves audit 14/05 (8 angles)

Audit SL multi-angles, fenêtre 7-14j, portfolio `58439d86` :

| # | Angle | Constat clé |
|---|---|---|
| 1 | Stats SL par classe (7j) | eu -8.1% slippage moy, asia 40 SL dont 50% <15min (-$861), us_large 46% <15min (-$330) |
| 2 | Courbes minute post-SL (4 cas) | **3/4 = stop hunt confirmé** : FTC.LSE rebond +4.87%/+3.43%, TEL.US +1.58% breakeven OUI ; INSM.US seule vraie chute |
| 3 | `post_sl_path` agrégé (22 cas) | EU 67% rebond breakeven <30min (+3.23% moy), US large 43% (+0.60%), US sm/mid 20% |
| 4 | Mêmes tickers TP **et** SL (23 sym) | AMS.SW 7 SL + 11 TP, SML.LSE 3+3, INTC.US 2+2 — prix retourne au TP après SL prématuré |
| 5 | `post_sl_path` détaillé 14j (13 cas) | INSM/TEL/SML/INTC/SANM ×2 : recovery +1.0 à +5.1%, **drawdown post-SL ≤2%** |
| 6 | **Simulation warmup 15min** | **42 SL évitables /97 = +$442 sur 7j (~$63/j)**, 3 vraies pertes correctement bloquées par garde-fou -3% |
| 7 | Durées TP vs SL (médianes) | US large TP 45min vs SL 15min (3×), asia 23/15, EU 13/8 — **le SL gagne la course en phase d'entrée** |
| 8 | Heures toxiques SL (>70%) | asia 0-3h UTC 70-87%, asia 6h 100%, us_large 14h 88%, us_sm/mid 17h 100% |

**Closed_stop bruts (14j)** : 72 SL, -$1110, durée moy 51.8min, **34 (47%) <15min** → signature stop hunt (mèche d'ouverture).

## Changement #1 — SL warmup 15min (le seul code de cette PR)

`mechanical-trading.service.ts` `checkStopTarget`, gate du **SEUL bloc `if (hitStop)`** (SL principal) :

| Cas | Comportement |
|---|---|
| age <15min, perte modérée (> -3%) | **SL principal ignoré** — position réexaminée au prochain tick (fall-through vers `checkReactiveSignals`) |
| age <15min, perte sévère (≤ -3%) | **garde-fou** — SL honoré malgré le warmup (couvre les vraies chutes type SEE.LSE) |
| age ≥15min, n'importe quel PnL | SL classique honoré |

- P&L latent **direction-aware** (négatif = perte pour long ET short)
- 3 logs taggés `[SL_WARMUP]` : `warmup_skip` / `warmup_override_severe_loss` (warn) / `sl_honored` — trackables post-deploy pour mesurer stop hunts évités vs vraies pertes
- **Périmètre strict** (décision audit) : `hitTarget` + `checkReactiveSignals` (incl. stop réactif) **INTACTS** — le stop réactif est la 2e ligne de défense, déclenche plus tard sur signaux dégradés, pas sur la mèche d'ouverture. SQL le confirme : closed_stop réactif = durée 51-1156min, profil distinct.

## Changement #2 — ATR multiplier : DÉJÀ EN PLACE, aucun code

`top-gainers-scanner.service.ts:2262-2272` contient déjà :
```ts
let effectiveSlPct = slPct;
const atrMultiplier = Number(this.config.get('GAINERS_SL_ATR_MULTIPLIER') ?? '0');
if (atrMultiplier > 0 && persistence.atrPct != null && persistence.atrPct > 0) {
  const atrSlPct = persistence.atrPct * 100 * atrMultiplier;
  if (atrSlPct > slPct) { effectiveSlPct = atrSlPct; /* + log */ }
}
```
`effectiveSlPct = max(config, ATR × multiplier)`, env-gated, default off. **Aucun code à ajouter.** Activation post-merge :
```
fly secrets set GAINERS_SL_ATR_MULTIPLIER=1.5 -a smartvest
```

## Migration 0140 — NON nécessaire

L'ATR-SL utilise `persistence.atrPct` calculé **live au scan** (zéro colonne DB, zéro EODHD call extra). Pas de colonne `atr_14_pct_at_entry`, pas de migration.

## Tests

**`sl-warmup.spec.ts` — 14 cas** (reproduction en isolation du gate, norme repo cf. `batch-cap.spec.ts` — `checkStopTarget` privé + 14 deps DI NestJS) :
- **8 cas spec** : age 5/20min × pnl -1.5/-3.5% ; edge age=15.0 → SL appliqué (`<15` exclusif) ; edge pnl=-3.0 → garde-fou actif (`<=-3.0` inclusif) ; asia 0h UTC + US 14h UTC → warmup hour-agnostic
- 4 cas P&L direction-aware (long/short)
- 2 invariants (hors fenêtre → toujours `sl_honored` ; dans fenêtre → ferme SSI perte sévère)

**5 cas ATR** : déjà couverts par `scanner-atr-dynamic-sl.spec.ts` existant (multiplier 0/null/0 → unchanged, ATR×1.5 > base → widened, ATR×1.5 < base → keep base). Aucun nouveau test ATR nécessaire.

## Résultats

- `sl-warmup.spec.ts` : **14/14 PASS**
- **api** : 135 suites, **1782 passed / 2 todo / 0 failures**
- `npx tsc -b` : **clean**
- lint fichiers modifiés : **0 error** (16 warnings pré-existants `consistent-type-imports` sur lignes non touchées)

## Conformité

- [x] 8 tests warmup verts (edge age=15.0 + pnl=-3.0 inclus)
- [x] Build TypeScript + lint propres
- [x] Logs `[SL_WARMUP]` conformes au pattern existant (`[TAG] key=val`)
- [x] Aucune modif hors le bloc `if (hitStop)` de `checkStopTarget`
- [x] Pas de migration ajoutée
- [x] Aucune modif TP, rotation `closed_invalidated`, kill-switch, options, scanner cap

Phase MESURE 12-17 mai : OK (catégorie sécurité/régression Bug #R1).

## Bénéfices attendus (chiffrés audit)

- Warmup 15min : **+$63/j** (~+$1890/mois) — 42 SL évitables/7j
- ATR multiplier 1.5 (activation post-merge) : +$15-25/j
- Cumul : **+$80-90/j** sans aucun changement TP/sizing/rotation

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_