### PR TITLE
Bug #R6 — apply R1 warmup to all SL emission sites (risk-monitor leak, -$110/nuit)

### DIFF
--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -21,6 +21,8 @@ import {
   computeAtrStopByKind,
   computeRealisticFee,
   computeVenueFeeDetail,
+  evaluateWarmup,
+  formatWarmupLog,
   resolveFeesAwareBuffer,
   type ThesisKind,
 } from '@smartvest/ai-analyst';
@@ -1764,52 +1766,46 @@ export class MechanicalTradingService {
     const hitTarget = tpPrice && (isLong ? currentPrice.gte(tpPrice) : currentPrice.lte(tpPrice));
 
     if (hitStop) {
-      // Bug #R1 — SL warmup 15min : skip le SL PRINCIPAL sur une position
-      // fraîche (<15 min) en perte modérée (> -3%). Garde-fou catastrophique :
-      // perte sévère (≤ -3%) → SL honoré même en warmup (couvre les vraies
-      // chutes type SEE.LSE). Audit 14/05 (closed_stop bruts, 14j) : 47%
-      // surviennent <15min, 3/4 sont des stop hunts (rebond breakeven <30min).
+      // Bug #R1 + #R2 + #R6 — warmup factorisé via evaluateWarmup (helper
+      // partagé dans ai-analyst). Subsume :
+      //   - PR #319 : logique 15min/-3% inline (R1)
+      //   - PR #320 : env vars GAINERS_SL_WARMUP_MIN/CATASTROPHIC_PCT + bornes (R2)
+      // Bug #R6 ajoute le même appel dans risk-monitor.checkPositionLimits
+      // (autre chemin SL qui contournait le warmup — 3 leaks asia_equity nuit 14→15/05).
       //
-      // Périmètre strict (décision #314 audit) : gate UNIQUEMENT ce bloc.
-      // hitTarget + checkReactiveSignals (incl. stop réactif) restent intacts —
-      // le stop réactif est la 2e ligne de défense et déclenche plus tard sur
-      // signaux dégradés, pas sur la mèche d'ouverture.
-      const SL_WARMUP_MIN = 15;
-      const SL_WARMUP_SEVERE_LOSS_PCT = -3.0;
-      const entryTsRaw = (pos as unknown as Record<string, unknown>)['entry_timestamp'];
-      const ageMin = entryTsRaw
-        ? (Date.now() - new Date(entryTsRaw as string).getTime()) / 60_000
-        : Infinity;  // pas de timestamp → pas de warmup, SL honoré (conservateur)
-      const unrealizedPnlPct = isLong
-        ? livePx.minus(entryPx).div(entryPx).mul(100).toNumber()
-        : entryPx.minus(livePx).div(entryPx).mul(100).toNumber();
-      const inWarmupWindow = ageMin < SL_WARMUP_MIN;
-      const severeLoss = unrealizedPnlPct <= SL_WARMUP_SEVERE_LOSS_PCT;
-      const warmupActive = inWarmupWindow && !severeLoss;
+      // Périmètre strict : gate UNIQUEMENT le SL principal. hitTarget +
+      // checkReactiveSignals (2e ligne défense) restent intacts.
+      const entryTsRaw = (pos as unknown as Record<string, unknown>)['entry_timestamp'] as string | undefined;
+      const warmup = evaluateWarmup(
+        entryTsRaw,
+        entryPx.toNumber(),
+        livePx.toNumber(),
+        isLong,
+        { logger: this.logger },
+      );
 
-      if (warmupActive) {
+      if (!warmup.shouldHonorStop) {
         // Stop hunt probable : on ne ferme PAS, position réexaminée au prochain
         // tick (60s). Fall-through vers checkReactiveSignals (2e ligne défense).
         this.logger.log(
-          `[SL_WARMUP] ${pos.symbol} decision=warmup_skip position_id=${pos.id} ` +
-          `age_min=${ageMin.toFixed(2)} unrealized_pnl_pct=${unrealizedPnlPct.toFixed(3)} ` +
-          `sl_price=${pos.stopLossPrice} — SL principal ignoré (position fraîche, perte modérée)`,
+          formatWarmupLog(warmup, {
+            symbol: pos.symbol,
+            positionId: pos.id,
+            service: 'mechanical-trading',
+            slPrice: pos.stopLossPrice,
+          }) + ' — SL principal ignoré (position fraîche, perte modérée)',
         );
       } else {
-        if (inWarmupWindow && severeLoss) {
-          // Transition warmup → SL honoré : vraie chute pendant la fenêtre
-          // warmup. Tracké en warn pour mesurer stop hunts évités vs vraies pertes.
-          this.logger.warn(
-            `[SL_WARMUP] ${pos.symbol} decision=warmup_override_severe_loss position_id=${pos.id} ` +
-            `age_min=${ageMin.toFixed(2)} unrealized_pnl_pct=${unrealizedPnlPct.toFixed(3)} ` +
-            `sl_price=${pos.stopLossPrice} — garde-fou -3% : SL honoré malgré warmup`,
-          );
+        const log = formatWarmupLog(warmup, {
+          symbol: pos.symbol,
+          positionId: pos.id,
+          service: 'mechanical-trading',
+          slPrice: pos.stopLossPrice,
+        });
+        if (warmup.reason === 'warmup_override_severe_loss') {
+          this.logger.warn(log + ' — garde-fou catastrophique : SL honoré malgré warmup');
         } else {
-          this.logger.log(
-            `[SL_WARMUP] ${pos.symbol} decision=sl_honored position_id=${pos.id} ` +
-            `age_min=${ageMin.toFixed(2)} unrealized_pnl_pct=${unrealizedPnlPct.toFixed(3)} ` +
-            `— warmup terminé, SL classique appliqué`,
-          );
+          this.logger.log(log + ' — warmup terminé, SL classique appliqué');
         }
         await this.closePosition(pos.id, quote.price, 'closed_stop',
           `[MÉCANIQUE] Stop-loss atteint ${pos.symbol} @ ${currentPrice.toFixed(4)} (stop=${pos.stopLossPrice})`);

--- a/packages/ai-analyst/src/simulation/__tests__/sl-warmup.helper.spec.ts
+++ b/packages/ai-analyst/src/simulation/__tests__/sl-warmup.helper.spec.ts
@@ -1,0 +1,279 @@
+/**
+ * Bug #R1 + #R2 + #R6 — Tests du helper warmup SL partagé.
+ *
+ * Le helper subsume :
+ *   - PR #319 (R1) : logique 15min/-3% inline dans mechanical-trading
+ *   - PR #320 (R2) : env vars + validation bornes (PR fermée au profit de R6)
+ *   - Bug #R6 : extension à risk-monitor (2e chemin SL identifié, 3 leaks
+ *     asia_equity la nuit 14→15/05)
+ */
+
+export {};
+
+import { evaluateWarmup, formatWarmupLog } from '../sl-warmup.helper';
+
+/** Helper de test : entry timestamp à N min dans le passé. */
+function tsAgo(ageMin: number): string {
+  return new Date(Date.now() - ageMin * 60_000).toISOString();
+}
+
+/** Capture les warns émis lors de la résolution des env vars. */
+function makeLogger(): { warn: (msg: string) => void; warnings: string[] } {
+  const warnings: string[] = [];
+  return { warn: (msg: string) => warnings.push(msg), warnings };
+}
+
+describe('Bug #R6 — evaluateWarmup decision (spec cases)', () => {
+  // Helper pour passer des paramètres explicites et neutraliser process.env.
+  const cfg = { warmupMin: 15, severeLossPct: -3.0 };
+
+  it('entryTimestamp undefined → shouldHonorStop=true (conservateur)', () => {
+    const d = evaluateWarmup(undefined, 5.0, 4.85, true, cfg);
+    expect(d.shouldHonorStop).toBe(true);
+    expect(d.reason).toBe('no_timestamp');
+    expect(d.ageMin).toBe(Infinity);
+  });
+
+  it('entryTimestamp null → no_timestamp', () => {
+    const d = evaluateWarmup(null, 5.0, 4.85, true, cfg);
+    expect(d.shouldHonorStop).toBe(true);
+    expect(d.reason).toBe('no_timestamp');
+  });
+
+  it('entryTimestamp invalide ("foo") → no_timestamp', () => {
+    const d = evaluateWarmup('foo', 5.0, 4.85, true, cfg);
+    expect(d.shouldHonorStop).toBe(true);
+    expect(d.reason).toBe('no_timestamp');
+  });
+
+  it('ageMin=5, pnl=-2% (long) → warmup_skip (shouldHonorStop=false)', () => {
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, cfg);
+    expect(d.shouldHonorStop).toBe(false);
+    expect(d.reason).toBe('warmup_skip');
+    expect(d.unrealizedPnlPct).toBeCloseTo(-2.0, 5);
+  });
+
+  it('ageMin=5, pnl=-3.5% (long) → warmup_override_severe_loss', () => {
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.825, true, cfg);
+    expect(d.shouldHonorStop).toBe(true);
+    expect(d.reason).toBe('warmup_override_severe_loss');
+    expect(d.unrealizedPnlPct).toBeCloseTo(-3.5, 5);
+  });
+
+  it('ageMin=20, pnl=-2% → sl_honored_post_warmup', () => {
+    const d = evaluateWarmup(tsAgo(20), 5.0, 4.9, true, cfg);
+    expect(d.shouldHonorStop).toBe(true);
+    expect(d.reason).toBe('sl_honored_post_warmup');
+  });
+
+  it('EDGE ageMin exactement 15.0 → sl_honored_post_warmup (fenêtre exclusive)', () => {
+    const d = evaluateWarmup(tsAgo(15.0), 5.0, 4.9, true, cfg);
+    expect(d.reason).toBe('sl_honored_post_warmup');
+  });
+
+  it('EDGE pnl exactement -3.0 → severe override (seuil inclusif)', () => {
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.85, true, cfg);
+    expect(d.unrealizedPnlPct).toBeCloseTo(-3.0, 5);
+    expect(d.reason).toBe('warmup_override_severe_loss');
+  });
+});
+
+describe('Bug #R6 — direction-aware P&L (symétrie long/short)', () => {
+  const cfg = { warmupMin: 15, severeLossPct: -3.0 };
+
+  it('short avec prix AU-DESSUS entry → pnl négatif (perte)', () => {
+    const d = evaluateWarmup(tsAgo(5), 5.0, 5.10, false, cfg);  // short: live > entry = perte
+    expect(d.unrealizedPnlPct).toBeCloseTo(-2.0, 5);
+    expect(d.reason).toBe('warmup_skip');  // perte modérée, fresh → skip
+  });
+
+  it('short avec perte sévère -3.5% → severe override', () => {
+    const d = evaluateWarmup(tsAgo(5), 5.0, 5.175, false, cfg);
+    expect(d.unrealizedPnlPct).toBeCloseTo(-3.5, 5);
+    expect(d.reason).toBe('warmup_override_severe_loss');
+  });
+
+  it('long avec prix sous entry → pnl négatif (perte), même magnitude que short symétrique', () => {
+    const longD = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, cfg);
+    const shortD = evaluateWarmup(tsAgo(5), 5.0, 5.1, false, cfg);
+    expect(longD.unrealizedPnlPct).toBeCloseTo(shortD.unrealizedPnlPct, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bornes env vars — Bug #R2 subsumé dans le helper
+// ---------------------------------------------------------------------------
+describe('Bug #R6 — resolveWarmupMin via env (R2 subsumé)', () => {
+  let originalEnv: string | undefined;
+  beforeEach(() => { originalEnv = process.env.GAINERS_SL_WARMUP_MIN; });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.GAINERS_SL_WARMUP_MIN;
+    else process.env.GAINERS_SL_WARMUP_MIN = originalEnv;
+  });
+
+  it('env absente → fallback 15 (default)', () => {
+    delete process.env.GAINERS_SL_WARMUP_MIN;
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true);
+    expect(d.warmupMin).toBe(15);
+  });
+
+  it('env valide ("20") → 20', () => {
+    process.env.GAINERS_SL_WARMUP_MIN = '20';
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true);
+    expect(d.warmupMin).toBe(20);
+  });
+
+  it('env >60 → capped 60 + warn', () => {
+    process.env.GAINERS_SL_WARMUP_MIN = '120';
+    const logger = makeLogger();
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, { logger });
+    expect(d.warmupMin).toBe(60);
+    expect(logger.warnings.some((w) => w.includes('suspicious') && w.includes('capped'))).toBe(true);
+  });
+
+  it('env <0 → fallback 15 + warn', () => {
+    process.env.GAINERS_SL_WARMUP_MIN = '-5';
+    const logger = makeLogger();
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, { logger });
+    expect(d.warmupMin).toBe(15);
+    expect(logger.warnings.some((w) => w.includes('invalid') && w.includes('fallback 15'))).toBe(true);
+  });
+
+  it('env NaN ("abc") → fallback 15 + warn', () => {
+    process.env.GAINERS_SL_WARMUP_MIN = 'abc';
+    const logger = makeLogger();
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, { logger });
+    expect(d.warmupMin).toBe(15);
+    expect(logger.warnings.some((w) => w.includes('invalid'))).toBe(true);
+  });
+
+  it('env=0 → valide (0 = warmup désactivé), pas de warn', () => {
+    process.env.GAINERS_SL_WARMUP_MIN = '0';
+    const logger = makeLogger();
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, { logger });
+    expect(d.warmupMin).toBe(0);
+    expect(logger.warnings.length).toBe(0);
+  });
+});
+
+describe('Bug #R6 — resolveWarmupCatastrophicPct via env (R2 subsumé)', () => {
+  let originalEnv: string | undefined;
+  beforeEach(() => { originalEnv = process.env.GAINERS_SL_WARMUP_CATASTROPHIC_PCT; });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.GAINERS_SL_WARMUP_CATASTROPHIC_PCT;
+    else process.env.GAINERS_SL_WARMUP_CATASTROPHIC_PCT = originalEnv;
+  });
+
+  it('env absente → fallback -3 (default)', () => {
+    delete process.env.GAINERS_SL_WARMUP_CATASTROPHIC_PCT;
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true);
+    expect(d.severeLossPct).toBe(-3.0);
+  });
+
+  it('env valide ("-2.5") → -2.5', () => {
+    process.env.GAINERS_SL_WARMUP_CATASTROPHIC_PCT = '-2.5';
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true);
+    expect(d.severeLossPct).toBe(-2.5);
+  });
+
+  it('env >0 → fallback -3 + warn', () => {
+    process.env.GAINERS_SL_WARMUP_CATASTROPHIC_PCT = '2.5';
+    const logger = makeLogger();
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, { logger });
+    expect(d.severeLossPct).toBe(-3.0);
+    expect(logger.warnings.some((w) => w.includes('should be negative'))).toBe(true);
+  });
+
+  it('env <-10 → cap -10 + warn', () => {
+    process.env.GAINERS_SL_WARMUP_CATASTROPHIC_PCT = '-15';
+    const logger = makeLogger();
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, { logger });
+    expect(d.severeLossPct).toBe(-10);
+    expect(logger.warnings.some((w) => w.includes('too lenient') && w.includes('capped'))).toBe(true);
+  });
+
+  it('env NaN ("foo") → fallback -3 + warn', () => {
+    process.env.GAINERS_SL_WARMUP_CATASTROPHIC_PCT = 'foo';
+    const logger = makeLogger();
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, { logger });
+    expect(d.severeLossPct).toBe(-3.0);
+    expect(logger.warnings.some((w) => w.includes('invalid'))).toBe(true);
+  });
+
+  it('env=0 → valide (0 = tout est sévère), pas de warn', () => {
+    process.env.GAINERS_SL_WARMUP_CATASTROPHIC_PCT = '0';
+    const logger = makeLogger();
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, { logger });
+    expect(d.severeLossPct).toBe(0);
+    expect(logger.warnings.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatWarmupLog — log enrichi avec config active
+// ---------------------------------------------------------------------------
+describe('Bug #R6 — formatWarmupLog enrichi (R2 subsumé)', () => {
+  it('contient warmup_min_config et warmup_catastrophic_pct_config', () => {
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, { warmupMin: 15, severeLossPct: -3 });
+    const log = formatWarmupLog(d, {
+      symbol: 'AAPL.US',
+      positionId: 'p1',
+      service: 'mechanical-trading',
+      slPrice: '4.85',
+    });
+    expect(log).toContain('warmup_min_config=15');
+    expect(log).toContain('warmup_catastrophic_pct_config=-3');
+  });
+
+  it('contient le tag service= pour identifier le chemin émetteur', () => {
+    const d = evaluateWarmup(tsAgo(5), 5.0, 4.9, true);
+    const logMech = formatWarmupLog(d, { symbol: 'X', positionId: 'p1', service: 'mechanical-trading' });
+    const logRisk = formatWarmupLog(d, { symbol: 'X', positionId: 'p1', service: 'risk-monitor' });
+    expect(logMech).toContain('service=mechanical-trading');
+    expect(logRisk).toContain('service=risk-monitor');
+  });
+
+  it('contient le decision (warmup_skip / sl_honored_post_warmup / etc.)', () => {
+    const skip = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, { warmupMin: 15, severeLossPct: -3 });
+    expect(formatWarmupLog(skip, { symbol: 'X', positionId: 'p1', service: 's' })).toContain('decision=warmup_skip');
+
+    const honored = evaluateWarmup(tsAgo(20), 5.0, 4.9, true, { warmupMin: 15, severeLossPct: -3 });
+    expect(formatWarmupLog(honored, { symbol: 'X', positionId: 'p1', service: 's' })).toContain('decision=sl_honored_post_warmup');
+  });
+
+  it('age_min=Infinity formaté lisiblement (cas no_timestamp)', () => {
+    const d = evaluateWarmup(undefined, 5.0, 4.9, true);
+    const log = formatWarmupLog(d, { symbol: 'X', positionId: 'p1', service: 's' });
+    expect(log).toContain('age_min=Infinity');
+    expect(log).toContain('decision=no_timestamp');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug #R6 — invariants (chemin alternatif risk-monitor doit être protégé)
+// ---------------------------------------------------------------------------
+describe('Bug #R6 — invariant : décision identique quel que soit le caller', () => {
+  it('même paramètres → même décision (mechanical-trading vs risk-monitor)', () => {
+    // Le helper est pure : mêmes inputs → mêmes outputs, quel que soit le service.
+    const d1 = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, { warmupMin: 15, severeLossPct: -3 });
+    const d2 = evaluateWarmup(tsAgo(5), 5.0, 4.9, true, { warmupMin: 15, severeLossPct: -3 });
+    expect(d1.shouldHonorStop).toBe(d2.shouldHonorStop);
+    expect(d1.reason).toBe(d2.reason);
+  });
+
+  it('scénario 222420.KQ leak (6.7min, -2.92%, long) → warmup_skip (fixé par Bug #R6)', () => {
+    // Avant Bug #R6, ce close passait par risk-monitor sans warmup → leak.
+    const d = evaluateWarmup(tsAgo(6.7), 1564.5, 1518.8, true, { warmupMin: 15, severeLossPct: -3 });
+    expect(d.unrealizedPnlPct).toBeLessThan(-2.9);
+    expect(d.unrealizedPnlPct).toBeGreaterThan(-3.0);  // borderline mais > -3 → skip
+    expect(d.reason).toBe('warmup_skip');
+    expect(d.shouldHonorStop).toBe(false);
+  });
+
+  it('scénario 009830.KO (4.8min, -3.86%, long) → severe override (garde-fou OK, déjà bloqué pré-R6)', () => {
+    const d = evaluateWarmup(tsAgo(4.8), 100.0, 96.14, true, { warmupMin: 15, severeLossPct: -3 });
+    expect(d.unrealizedPnlPct).toBeLessThan(-3);
+    expect(d.reason).toBe('warmup_override_severe_loss');
+    expect(d.shouldHonorStop).toBe(true);
+  });
+});

--- a/packages/ai-analyst/src/simulation/index.ts
+++ b/packages/ai-analyst/src/simulation/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './paper-broker.service';
 export * from './risk-monitor.service';
 export * from './venue-fees';
+export * from './sl-warmup.helper';

--- a/packages/ai-analyst/src/simulation/risk-monitor.service.ts
+++ b/packages/ai-analyst/src/simulation/risk-monitor.service.ts
@@ -19,6 +19,7 @@ import Decimal from 'decimal.js';
 import { createHash } from 'node:crypto';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { RiskConstraints } from '../types';
+import { evaluateWarmup, formatWarmupLog } from './sl-warmup.helper';
 import type { PaperBrokerService } from './paper-broker.service';
 import type { PaperPosition, PortfolioSnapshot } from './types';
 
@@ -213,6 +214,40 @@ export class RiskMonitorService {
         ? livePrice.lessThanOrEqualTo(stopPx)
         : livePrice.greaterThanOrEqualTo(stopPx);
       if (triggered) {
+        // 🛡️ Bug #R6 — applique le warmup SL via le helper partagé. Avant ce
+        // fix, ce chemin (risk-monitor) court-circuitait le warmup R1 qui ne
+        // vivait que dans mechanical-trading.checkStopTarget → 3 leaks
+        // asia_equity observés la nuit 14→15/05 (-$110, format de exit_reason
+        // distinct : "Stop-loss X triggered at live price Y").
+        const warmup = evaluateWarmup(
+          pos.entryTimestamp,
+          Number(pos.entryPrice),
+          livePrice.toNumber(),
+          isLong,
+          { logger: console },
+        );
+        if (!warmup.shouldHonorStop) {
+          console.log(
+            formatWarmupLog(warmup, {
+              symbol: pos.symbol,
+              positionId: pos.id,
+              service: 'risk-monitor',
+              slPrice: pos.stopLossPrice,
+            }) + ' — SL ignoré (position fraîche, perte modérée)',
+          );
+          return;  // skip ce cycle, retry au prochain
+        }
+        const log = formatWarmupLog(warmup, {
+          symbol: pos.symbol,
+          positionId: pos.id,
+          service: 'risk-monitor',
+          slPrice: pos.stopLossPrice,
+        });
+        if (warmup.reason === 'warmup_override_severe_loss') {
+          console.warn(log + ' — garde-fou catastrophique : SL honoré malgré warmup');
+        } else {
+          console.log(log);
+        }
         await this.paperBroker.closePosition({
           positionId: pos.id,
           reason: 'closed_stop',

--- a/packages/ai-analyst/src/simulation/sl-warmup.helper.ts
+++ b/packages/ai-analyst/src/simulation/sl-warmup.helper.ts
@@ -1,0 +1,205 @@
+/**
+ * Bug #R1 / #R2 / #R6 — Helper warmup SL partagé.
+ *
+ * Décision unifiée pour TOUS les chemins de fermeture SL (`closed_stop`)
+ * sur les `lisa_positions`. Subsume :
+ *   - Bug #R1 (PR #319) : logique warmup 15 min inline dans
+ *     `mechanical-trading.service.ts checkStopTarget`.
+ *   - Bug #R2 (PR #320 fermée au profit de R6) : paramétrisation env vars
+ *     `GAINERS_SL_WARMUP_MIN` + `GAINERS_SL_WARMUP_CATASTROPHIC_PCT` avec
+ *     validation des bornes.
+ *   - Bug #R6 : extension à `risk-monitor.service.ts checkPositionLimits`,
+ *     2e chemin SL identifié (3 leaks asia_equity la nuit 14→15/05).
+ *
+ * Placement : `packages/ai-analyst` car importé par `risk-monitor` (déjà
+ * dans ai-analyst) ET `mechanical-trading` (apps/api peut importer ai-analyst).
+ * L'inverse n'est pas possible (sens de dépendance) — cf. arbitrage Bug #M4.
+ *
+ * Comportement (cas modéré <15min) : retourne shouldHonorStop=false → le
+ * caller doit SKIP le close et laisser la position être réexaminée au tick
+ * suivant. checkReactiveSignals (2e ligne défense) reste actif.
+ */
+
+const DEFAULT_WARMUP_MIN = 15;
+const DEFAULT_SEVERE_LOSS_PCT = -3.0;
+const MAX_WARMUP_MIN_BOUND = 60;
+const MIN_SEVERE_LOSS_PCT_BOUND = -10;
+
+type WarnLogger = { warn: (msg: string) => void };
+
+/**
+ * Résout `GAINERS_SL_WARMUP_MIN` avec validation. Bug #R2 subsumé.
+ *   - NaN / négatif → fallback 15 (warn si logger fourni)
+ *   - >60 → cap 60 (warn) — suspect mais pas invalide
+ */
+function resolveWarmupMin(rawStr: string | undefined, logger?: WarnLogger): number {
+  const raw = Number(rawStr ?? DEFAULT_WARMUP_MIN);
+  if (!Number.isFinite(raw) || raw < 0) {
+    logger?.warn(
+      `[SL_WARMUP] GAINERS_SL_WARMUP_MIN invalid (${rawStr}) — fallback ${DEFAULT_WARMUP_MIN}min`,
+    );
+    return DEFAULT_WARMUP_MIN;
+  }
+  if (raw > MAX_WARMUP_MIN_BOUND) {
+    logger?.warn(
+      `[SL_WARMUP] GAINERS_SL_WARMUP_MIN=${raw} suspicious — capped at ${MAX_WARMUP_MIN_BOUND}min`,
+    );
+    return MAX_WARMUP_MIN_BOUND;
+  }
+  return raw;
+}
+
+/**
+ * Résout `GAINERS_SL_WARMUP_CATASTROPHIC_PCT` avec validation. Bug #R2 subsumé.
+ *   - NaN / positif → fallback -3 (warn) — doit être négatif (= perte sévère)
+ *   - <-10 → cap -10 (warn) — too lenient, le garde-fou ne se déclencherait plus
+ */
+function resolveWarmupCatastrophicPct(rawStr: string | undefined, logger?: WarnLogger): number {
+  const raw = Number(rawStr ?? DEFAULT_SEVERE_LOSS_PCT);
+  if (!Number.isFinite(raw) || raw > 0) {
+    logger?.warn(
+      `[SL_WARMUP] GAINERS_SL_WARMUP_CATASTROPHIC_PCT invalid (${rawStr}, should be negative) — fallback ${DEFAULT_SEVERE_LOSS_PCT}`,
+    );
+    return DEFAULT_SEVERE_LOSS_PCT;
+  }
+  if (raw < MIN_SEVERE_LOSS_PCT_BOUND) {
+    logger?.warn(
+      `[SL_WARMUP] GAINERS_SL_WARMUP_CATASTROPHIC_PCT=${raw} too lenient — capped at ${MIN_SEVERE_LOSS_PCT_BOUND}`,
+    );
+    return MIN_SEVERE_LOSS_PCT_BOUND;
+  }
+  return raw;
+}
+
+export interface WarmupDecision {
+  /** True = le caller doit fermer (SL honoré). False = caller skip ce cycle. */
+  shouldHonorStop: boolean;
+  /**
+   * - `warmup_skip` : position fraîche, perte modérée → on ignore le SL
+   * - `warmup_override_severe_loss` : position fraîche mais perte sévère →
+   *   garde-fou catastrophique, SL honoré
+   * - `sl_honored_post_warmup` : warmup terminé, SL classique
+   * - `no_timestamp` : entry_timestamp absent / invalide → SL honoré (conservateur)
+   */
+  reason:
+    | 'sl_honored_post_warmup'
+    | 'warmup_skip'
+    | 'warmup_override_severe_loss'
+    | 'no_timestamp';
+  ageMin: number;
+  unrealizedPnlPct: number;
+  /** Valeur résolue de la fenêtre, pour log/traçabilité config active. */
+  warmupMin: number;
+  /** Valeur résolue du seuil catastrophique, pour log. */
+  severeLossPct: number;
+}
+
+/**
+ * Évalue si un SL doit être honoré, sur la base de l'âge de la position et
+ * du P&L latent direction-aware.
+ *
+ * @param entryTimestamp Date ISO string ou Date. Si absent / invalide →
+ *   shouldHonorStop=true (conservateur — on ne masque jamais un SL si on
+ *   ne connaît pas l'âge).
+ * @param entryPrice prix d'entrée (number). Suppose > 0.
+ * @param livePrice prix live (number). Suppose validé par le caller
+ *   (cf. Bug #R5 sanity bounds) avant cet appel.
+ * @param isLong true pour long/long_call/long_put ; false pour short/short_*.
+ *   Détermine le signe du P&L latent (négatif = perte pour les 2 sens).
+ * @param config (optionnel) override des paramètres + logger pour les warns
+ *   de validation des env vars. Si `warmupMin` / `severeLossPct` fournis,
+ *   les env vars sont ignorées (utile pour les tests).
+ */
+export function evaluateWarmup(
+  entryTimestamp: string | Date | null | undefined,
+  entryPrice: number,
+  livePrice: number,
+  isLong: boolean,
+  config?: {
+    warmupMin?: number;
+    severeLossPct?: number;
+    logger?: WarnLogger;
+  },
+): WarmupDecision {
+  const warmupMin = config?.warmupMin
+    ?? resolveWarmupMin(process.env.GAINERS_SL_WARMUP_MIN, config?.logger);
+  const severeLossPct = config?.severeLossPct
+    ?? resolveWarmupCatastrophicPct(process.env.GAINERS_SL_WARMUP_CATASTROPHIC_PCT, config?.logger);
+
+  if (entryTimestamp == null) {
+    return {
+      shouldHonorStop: true,
+      reason: 'no_timestamp',
+      ageMin: Infinity,
+      unrealizedPnlPct: 0,
+      warmupMin,
+      severeLossPct,
+    };
+  }
+  const entryMs = entryTimestamp instanceof Date
+    ? entryTimestamp.getTime()
+    : new Date(entryTimestamp).getTime();
+  if (!Number.isFinite(entryMs)) {
+    return {
+      shouldHonorStop: true,
+      reason: 'no_timestamp',
+      ageMin: Infinity,
+      unrealizedPnlPct: 0,
+      warmupMin,
+      severeLossPct,
+    };
+  }
+
+  const ageMin = (Date.now() - entryMs) / 60_000;
+  const unrealizedPnlPct = isLong
+    ? ((livePrice - entryPrice) / entryPrice) * 100
+    : ((entryPrice - livePrice) / entryPrice) * 100;
+
+  const inWarmup = ageMin < warmupMin;
+  const severeLoss = unrealizedPnlPct <= severeLossPct;
+
+  if (inWarmup && !severeLoss) {
+    return {
+      shouldHonorStop: false,
+      reason: 'warmup_skip',
+      ageMin,
+      unrealizedPnlPct,
+      warmupMin,
+      severeLossPct,
+    };
+  }
+  if (inWarmup && severeLoss) {
+    return {
+      shouldHonorStop: true,
+      reason: 'warmup_override_severe_loss',
+      ageMin,
+      unrealizedPnlPct,
+      warmupMin,
+      severeLossPct,
+    };
+  }
+  return {
+    shouldHonorStop: true,
+    reason: 'sl_honored_post_warmup',
+    ageMin,
+    unrealizedPnlPct,
+    warmupMin,
+    severeLossPct,
+  };
+}
+
+/** Helper de log structuré conforme au pattern `[SL_WARMUP]` du repo. */
+export function formatWarmupLog(
+  decision: WarmupDecision,
+  context: { symbol: string; positionId: string; service: string; slPrice?: string | null },
+): string {
+  return (
+    `[SL_WARMUP] ${context.symbol} decision=${decision.reason} ` +
+    `service=${context.service} position_id=${context.positionId} ` +
+    `age_min=${decision.ageMin === Infinity ? 'Infinity' : decision.ageMin.toFixed(2)} ` +
+    `unrealized_pnl_pct=${decision.unrealizedPnlPct.toFixed(3)} ` +
+    (context.slPrice != null ? `sl_price=${context.slPrice} ` : '') +
+    `warmup_min_config=${decision.warmupMin} ` +
+    `warmup_catastrophic_pct_config=${decision.severeLossPct}`
+  );
+}


### PR DESCRIPTION
**Bug #R6 — warmup R1 contourné par un 2e chemin SL identifié (leak mesuré -$110/nuit)**

Closes PR #320 — env var resolvers déplacés dans le helper partagé.

## Constat

R1 (PR #319, deployé `fabab25f` le 14/05 20:40 UTC) est live mais **3 SL `asia_equity` ont été fermés cette nuit (14→15/05) en 4-11 min avec pnl -1.83% à -2.92%** — ils auraient tous dû être bloqués par le warmup. Format `exit_reason` distinct :

| Symbole | Durée | pnl_pct | exit_reason | Diagnostic |
|---|---|---|---|---|
| 009830.KO | 4.8min | -3.86% | `closed_stop` (brut) | Garde-fou -3% OK (passe par mechanical-trading) |
| **222420.KQ** | **6.7min** | **-2.92%** | `Stop-loss 1536.6 triggered at live price 1519.0` | **Warmup contourné** |
| **078600.KQ** | **10.8min** | **-1.83%** | `Stop-loss 160850.5 triggered at live price 160800.0` | **Warmup contourné** |
| **000370.KO** | **3.8min** | **-2.23%** | `Stop-loss 7141.25 triggered at live price 7110.0` | **Warmup contourné** |

→ **-$109.82 en 12h30**, projection 7j ≈ **-$1500**.

## Cause racine

`grep -rn "Stop-loss.*triggered at live price"` :
- **Site unique** : `packages/ai-analyst/src/simulation/risk-monitor.service.ts:220` (le `grep` côté `apps/api/src/` du spec original ratait ce site — il vit dans `packages/`)

`risk-monitor.checkPositionLimits` ferme les positions sur SL via `paperBroker.closePosition` **sans warmup**. C'est le 2e chemin SL (en plus de `mechanical-trading.checkStopTarget` où R1 vit).

## Fix — Option (a) helper partagé, R2 subsumé

### NEW `packages/ai-analyst/src/simulation/sl-warmup.helper.ts`

- `evaluateWarmup(entryTs, entryPrice, livePrice, isLong, config?) → WarmupDecision`
- Résolveurs **`GAINERS_SL_WARMUP_MIN`** + **`GAINERS_SL_WARMUP_CATASTROPHIC_PCT`** avec validation bornes :
  - `MIN > 60` → cap 60 ; `MIN < 0`/NaN → fallback 15
  - `CATASTROPHIC > 0`/NaN → fallback -3 ; `CATASTROPHIC < -10` → cap -10
- `formatWarmupLog` enrichi : `service=`, `decision=`, `warmup_min_config=`, `warmup_catastrophic_pct_config=`
- Placement `packages/ai-analyst` car `risk-monitor` y vit ; `apps/api` peut importer (cf. arbitrage Bug #M4)

### `mechanical-trading.checkStopTarget`

Refactor du bloc R1 inline (PR #319) pour appeler `evaluateWarmup`. Comportement default identique. Subsume aussi l'env var work prévu par PR #320 R2.

### `risk-monitor.checkPositionLimits` — **le fix du leak**

Nouvel appel `evaluateWarmup` AVANT `paperBroker.closePosition('closed_stop')`. Si `shouldHonorStop=false` → return (skip cycle, position réexaminée).

## Décisions arbitrées avant codage (validées avec toi)

1. **Helper en `packages/ai-analyst`** (pas `apps/api` comme dit le spec) — sens de dépendance
2. **R6 subsume PR #320 R2** — env var work moved into helper, PR #320 à fermer
3. **Env var** : `GAINERS_SL_WARMUP_CATASTROPHIC_PCT` (de R2), pas `SEVERE_PCT` (du spec R6) — un seul nom, cohérence

## Tests

`sl-warmup.helper.spec.ts` — **30 cas** :
- 8 spec : entry undefined/null/invalid → no_timestamp ; age/pnl combinations ; edge age=15.0 + pnl=-3.0
- direction-aware long/short symétrie
- 12 bounds env vars (MIN <0 / >60 / NaN / 0 ; CATASTROPHIC >0 / <-10 / NaN / 0 ; absent → defaults)
- `formatWarmupLog` enrichi (config active, service tag, decision tag, no_timestamp Infinity)
- **Invariants Bug #R6** : décision identique quel que soit le caller ; rejeu des scénarios `222420.KQ` (warmup_skip, fixé par R6) et `009830.KO` (severe override, déjà OK pré-R6)

## Résultats

- `sl-warmup.helper.spec.ts` : **30/30 PASS**
- **ai-analyst** : 25 suites, **397 passed** (367 baseline + 30 helper)
- **api** : 136 suites, **1799 passed / 2 todo / 0 failures**
- `npx tsc -b --force` (build clean = CI) : **clean**
- lint fichiers modifiés : **0 error**

## Validation post-merge

```sql
-- Cible 0
SELECT COUNT(*) FILTER (
  WHERE EXTRACT(EPOCH FROM (exit_timestamp - entry_timestamp))/60 < 15
    AND realized_pnl_pct > -3.0
) AS warmup_leaks
FROM lisa_positions
WHERE portfolio_id='58439d86-3f20-4a60-82a4-307f3f252bc2'
  AND status='closed_stop'
  AND entry_timestamp > '<deploy timestamp>';
```

Logs Fly :
```
fly logs -a smartvest | grep "SL_WARMUP" | grep "service=risk-monitor"
```
→ Si `decision=warmup_skip service=risk-monitor` apparaît, le fix R6 intercepte les SL prématurés sur le 2e chemin. C'est la preuve directe du leak comblé.

Sécurité critique — bypass Phase MESURE (fix d'une fuite mesurée du fix R1). Pas d'auto-merge.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_