### PR TITLE
fix(eodhd): record price_usd for intraday call site (R12)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.r12-price-usd.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.r12-price-usd.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Bug #R12 — Test that EodhdIntradayService.logCall records `price_usd`.
+ *
+ * Pre-R12 prod state (16/05/2026) : 180 751 intraday calls / 14 jours, 0 %
+ * `price_usd` non-null. Cause : the `logCall` payload omitted `price_usd`
+ * AND the success log was emitted BEFORE the response was parsed.
+ *
+ * Fix verified ici :
+ *   - non-empty response → INSERT row with `price_usd` = dernière candle close
+ *   - empty response (HTTP 200, []) → row with `price_usd` = null, success=true
+ *   - HTTP 404 → row with `price_usd` = null, success=false
+ *   - ticks endpoint (`getCandlesViaTicks`) idem (dernière tick price)
+ */
+
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EodhdIntradayService } from '../eodhd-intraday.service';
+import { SupabaseService } from '../../../supabase/supabase.service';
+
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+function makeServiceWithCapture() {
+  const config = {
+    get: jest.fn((k: string) => (k === 'EODHD_API_KEY' ? 'test-key' : undefined)),
+  } as unknown as ConfigService;
+  const inserted: Array<Record<string, unknown>> = [];
+  const insertMock = jest.fn().mockImplementation((row: Record<string, unknown>) => {
+    inserted.push(row);
+    return Promise.resolve({ error: null });
+  });
+  const supabase = {
+    isReady: () => true,
+    getClient: () => ({ from: () => ({ insert: insertMock }) }),
+  } as unknown as SupabaseService;
+  return { svc: new EodhdIntradayService(config, supabase), inserted };
+}
+
+async function flushAsync() {
+  // fire-and-forget log uses Promise microtask — flush twice to be safe
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+describe('Bug #R12 — EodhdIntradayService logs price_usd', () => {
+  afterEach(() => {
+    delete (global as { fetch?: unknown }).fetch;
+  });
+
+  it('getCandles success → INSERT row carries price_usd = last close', async () => {
+    const { svc, inserted } = makeServiceWithCapture();
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { timestamp: 1_700_000_000, open: 100, high: 101, low: 99, close: 100.5, volume: 1000 },
+        { timestamp: 1_700_000_300, open: 100.5, high: 102, low: 100, close: 101.75, volume: 1500 },
+      ],
+      text: async () => '',
+    });
+
+    const res = await svc.getCandles('AAPL.US', '5m', 20);
+    await flushAsync();
+
+    expect(res).not.toBeNull();
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      called_by: 'intraday',
+      success: true,
+      status_code: 200,
+      price_usd: 101.75,
+    });
+  });
+
+  it('getCandles empty response → INSERT row with price_usd=null + success=true', async () => {
+    const { svc, inserted } = makeServiceWithCapture();
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [],
+      text: async () => '[]',
+    });
+
+    const res = await svc.getCandles('AAPL.US', '5m');
+    await flushAsync();
+
+    expect(res).toBeNull();
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      called_by: 'intraday',
+      success: true,
+      status_code: 200,
+      price_usd: null,
+    });
+  });
+
+  it('getCandles HTTP 404 → INSERT row with price_usd=null + success=false', async () => {
+    const { svc, inserted } = makeServiceWithCapture();
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => null,
+      text: async () => 'Not Found',
+    });
+
+    const res = await svc.getCandles('FAKE.US', '5m');
+    await flushAsync();
+
+    expect(res).toBeNull();
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      called_by: 'intraday',
+      success: false,
+      status_code: 404,
+      price_usd: null,
+    });
+  });
+
+  it('getCandlesViaTicks success → INSERT row carries price_usd = last tick price', async () => {
+    const { svc, inserted } = makeServiceWithCapture();
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { timestamp: 1_700_000_000_000, price: 100.5, volume: 100, seq: 1 },
+        { timestamp: 1_700_000_000_100, price: 101.25, volume: 200, seq: 2 },
+      ],
+      text: async () => '',
+    });
+
+    const fromTs = Math.floor(Date.now() / 1000) - 3600;
+    const toTs = Math.floor(Date.now() / 1000);
+    const res = await svc.getCandlesViaTicks('AAPL.US', '5m', 5, { fromTs, toTs });
+    await flushAsync();
+
+    expect(res).not.toBeNull();
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      called_by: 'intraday',
+      success: true,
+      status_code: 200,
+      price_usd: 101.25,
+    });
+  });
+
+  it('getCandles only-zero-close candles (e.g. Asia pre-market) → price_usd=null', async () => {
+    const { svc, inserted } = makeServiceWithCapture();
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { timestamp: 1_700_000_000, open: 0, high: 0, low: 0, close: 0, volume: 0 },
+      ],
+      text: async () => '',
+    });
+
+    const res = await svc.getCandles('AAPL.US', '5m');
+    await flushAsync();
+
+    // data[] non-empty so logCall fires, but all candles filtered → no last close
+    expect(res?.candles).toEqual([]);
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      called_by: 'intraday',
+      success: true,
+      status_code: 200,
+      price_usd: null,
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -97,7 +97,7 @@ export class EodhdIntradayService {
     return k && k !== 'demo' ? k : null;
   }
 
-  private logCall(row: { ticker: string; success: boolean; statusCode?: number; latencyMs?: number; errorMessage?: string }): void {
+  private logCall(row: { ticker: string; success: boolean; statusCode?: number; latencyMs?: number; errorMessage?: string; priceUsd?: number | null }): void {
     (async () => {
       try {
         await this.supabase.getClient().from('eodhd_request_log').insert({
@@ -107,6 +107,9 @@ export class EodhdIntradayService {
           success: row.success,
           status_code: row.statusCode ?? null,
           latency_ms: row.latencyMs ?? null,
+          // Bug #R12 — record parsed price for prix-vs-PnL audits.
+          // Aligned with lisa.service.ts logger (live_price/market_snapshot/yahoo).
+          price_usd: row.priceUsd ?? null,
           called_by: 'intraday',
           error_message: row.errorMessage ?? null,
         });
@@ -299,10 +302,12 @@ export class EodhdIntradayService {
       }
 
       const data = await res.json() as Array<Record<string, unknown>>;
-      this.logCall({ ticker: eodhdTicker, success: true, statusCode: res.status, latencyMs });
 
       if (!Array.isArray(data) || data.length === 0) {
         this.logger.debug(`[eodhd] ${eodhdTicker} empty response (${latencyMs}ms)`);
+        // Bug #R12 — log empty response with success=true (HTTP 200, no payload)
+        // distinguishable from parsed-price rows by price_usd IS NULL.
+        this.logCall({ ticker: eodhdTicker, success: true, statusCode: res.status, latencyMs });
         return null;
       }
 
@@ -322,6 +327,17 @@ export class EodhdIntradayService {
       // les candles utiles au caller). Le serveur EODHD a déjà restreint via
       // les query params from/to.
       const candles = useRange ? allCandles : allCandles.slice(-count);
+
+      // Bug #R12 — log AFTER parse so price_usd carries the last close
+      // (debloque C45 mesure "réponse vide intraday non-404" + audit prix vs PnL).
+      const lastClose = candles.length > 0 ? candles[candles.length - 1].close : null;
+      this.logCall({
+        ticker: eodhdTicker,
+        success: true,
+        statusCode: res.status,
+        latencyMs,
+        priceUsd: lastClose != null && Number.isFinite(lastClose) && lastClose > 0 ? lastClose : null,
+      });
 
       // PR #285 — rawCount = nb candles AVANT filter close>0 ; requestedSymbol
       // = ticker effectivement envoyé dans l'URL EODHD (peut différer de
@@ -440,9 +456,11 @@ export class EodhdIntradayService {
         return null;
       }
       const data = (await res.json()) as Array<Record<string, unknown>>;
-      this.logCall({ ticker: normalized, success: true, statusCode: res.status, latencyMs });
-      if (!Array.isArray(data) || data.length === 0) return null;
-      return data
+      if (!Array.isArray(data) || data.length === 0) {
+        this.logCall({ ticker: normalized, success: true, statusCode: res.status, latencyMs });
+        return null;
+      }
+      const ticks = data
         .map<RawTick>((d) => {
           const tick: RawTick = {
             timestamp: typeof d.timestamp === 'number' ? d.timestamp : Number(d.timestamp ?? 0),
@@ -456,6 +474,16 @@ export class EodhdIntradayService {
           return tick;
         })
         .filter((t) => t.price > 0 && t.timestamp > 0);
+      // Bug #R12 — log AFTER parse so price_usd carries the last tick price.
+      const lastTickPrice = ticks.length > 0 ? ticks[ticks.length - 1].price : null;
+      this.logCall({
+        ticker: normalized,
+        success: true,
+        statusCode: res.status,
+        latencyMs,
+        priceUsd: lastTickPrice != null && Number.isFinite(lastTickPrice) && lastTickPrice > 0 ? lastTickPrice : null,
+      });
+      return ticks;
     } catch (e) {
       this.logger.debug(`[eodhd:ticks] ${normalized} fetch error: ${String(e).slice(0, 80)}`);
       return null;


### PR DESCRIPTION
## Contexte

La table d'observabilité `eodhd_request_log` enregistre tous les appels HTTP sortants vers EODHD avec la colonne `price_usd` censée contenir le prix parsé pour l'audit prix vs PnL. Tous les callers fonctionnent sauf `called_by='intraday'`.

Audit Supabase 16/05/2026 9h59 CEST :

| called_by | calls | % price_usd renseigné |
|---|---|---|
| `intraday` | 180 751 | **0,0 %** ← BUG |
| `live_price` | (var) | 99,6 % |
| `market_snapshot` | (var) | 100 % |
| `yahoo` | (var) | 100 % |

Vérification triple : 24h → 20 691 calls, 0 with price_usd, 20 255 marqués "empty_200" + 666 not_found_404. 72h par heure UTC → 0 % chaque heure, y compris pleine session US vendredi 13h-21h UTC.

**Conséquence métier** : le proxy SQL `success=true AND status_code=200 AND price_usd IS NULL` est biaisé → bloque la mesure C45 (« réponse vide intraday non-404 ») dans `PHASE5_N2_BACKLOG.md`, fausse l'analyse corrélation prix-PnL, empêche le debug par suffixe d'échange.

## Cause root (H1 + H4 combinées)

Hypothèses validées par lecture du code (`apps/api/src/modules/lisa/services/eodhd-intraday.service.ts`) :

**H1 — Colonne `price_usd` absente du INSERT** :
```ts
// Avant — logCall() payload omet price_usd entièrement
private logCall(row: { ticker; success; statusCode?; latencyMs?; errorMessage? }) {
  await ...insert({
    ticker, eodhd_ticker, source: 'eodhd',
    success, status_code, latency_ms,
    called_by: 'intraday', error_message,
    // ← rien sur price_usd
  });
}
```

**H4 — `logCall` succès appelé AVANT le parse** :
```ts
// Avant — log fire avant que data.json() ne soit parsé
const data = await res.json() as Array<...>;
this.logCall({ ticker, success: true, statusCode, latencyMs });  // ← trop tôt
if (!Array.isArray(data) || data.length === 0) return null;
const allCandles = data.map(...).filter(...);
const candles = useRange ? allCandles : allCandles.slice(-count);
```

Comparaison avec le caller `live_price` (référence) dans `lisa.service.ts` ligne 2839 : son INSERT inclut bien `price_usd: row.priceUsd ?? null`. Il fallait juste aligner.

## Diff (3 hunks, +33/-5 lignes)

1. `logCall` row type gagne `priceUsd?: number | null`
2. INSERT payload écrit `price_usd: row.priceUsd ?? null` (aligné `lisa.service.ts:2845`)
3. Success logCall déplacé APRÈS le parse + slice (`getCandles`), passe `candles[last].close` gardé par `Number.isFinite > 0`
4. Empty response (HTTP 200 + `[]`) loggée avec `price_usd=null` + `success=true` (distinguable des rows avec prix)
5. HTTP 404 / network error inchangés (`price_usd` reste `null`, comportement existant préservé)
6. `getCandlesViaTicks` (même `called_by='intraday'`) corrigé symétriquement avec last tick price

## Critère de succès post-merge

Requête de validation à T+2h après deploy :

```sql
SELECT
  called_by,
  COUNT(*) AS calls,
  COUNT(*) FILTER (WHERE price_usd IS NOT NULL AND price_usd > 0) AS with_price,
  ROUND(100.0 * COUNT(*) FILTER (WHERE price_usd IS NOT NULL AND price_usd > 0) / NULLIF(COUNT(*),0), 1) AS pct_with_price
FROM eodhd_request_log
WHERE timestamp >= NOW() - INTERVAL '2 hours'
  AND called_by='intraday' AND success=true AND status_code=200
GROUP BY called_by;
```

- **GO** : `pct_with_price >= 95 %` → débloque C45, ferme R12.
- **NO_GO** : sinon investiguer (Asia pre-market all-zero closes ? exchange-specific parse mismatch ?) + patch supplémentaire.

## Tests (5 nouveaux dans `eodhd-intraday.r12-price-usd.spec.ts`)

```
✓ getCandles success → INSERT row carries price_usd = last close (101.75)
✓ getCandles empty 200 → INSERT row with price_usd=null + success=true
✓ getCandles HTTP 404 → INSERT row with price_usd=null + success=false
✓ getCandlesViaTicks success → INSERT row carries price_usd = last tick price
✓ getCandles all-zero-close edge case → price_usd=null (Asia pre-market)
```

Test totals : **1837 api** (était 1832), 0 failure. `tsc -b --force` ✅ clean.

## Notes

- **Fix instrumentation uniquement, pas d'impact runtime trading** : le scanner consomme déjà `candles[last].close` en mémoire pour ses décisions ; les TP/SL se déclenchent correctement. Ce PR ne touche QUE le payload INSERT fire-and-forget dans `eodhd_request_log`.
- **Phase MESURE invariants préservés** : aucun changement TP/SL/notional/warmup/sanity bounds.
- **Pas de backfill historique** : trou 14 jours accepté (cf. spec R12 — impossible sans re-fetch quota-coûteux).
- **Pas d'auto-merge** : attendre validation utilisateur post-Phase MESURE (après 17/05 20h Paris).

Closes #R12 — débloque mesure C45 (`PHASE5_N2_BACKLOG.md` lignes ~390-459)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_