### PR TITLE
feat(phase5-n1-pr1): Quick Wins sessions + symbols + observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,3 +118,27 @@ ANTHROPIC_API_KEY=
 #   3.0 = très défensif (peut bloquer trop d'ouvertures sur petits TP)
 # Justification 2.0 : closed_target SLV +0.171 % a livré net -$0.92 en J-7.
 FEES_AWARE_BUFFER=2.0
+
+# ─── Phase 5 N1 PR-1 — Quick Wins ────────────────────────────────────────────
+# Master flag : default OFF tant que la PR n'est pas validée mardi 19 mai.
+# Pour activer en prod, flip à `true` (les 5 QW individuels s'activent ensuite
+# selon leurs propres flags ci-dessous).
+QUICK_WINS_PIPELINE_ENABLED=false
+
+# QW#1 — Skip fenêtre horaire par classe (us_large 14-16h UTC absolu Règle D,
+# us_sm 17h UTC, eu 8h UTC sauf Friday, asia 1-2h UTC).
+QW_1_SESSION_FILTER=true
+
+# QW#6 — Blacklist statique d'ouverture (CSV de symbols base, hors suffix).
+QW_6_SYMBOL_BLACKLIST=CGNX,PODD,ORA,QCOM,ST,PRU
+
+# QW#11 — Pause asset class entière (CSV de classes Lisa granulaires).
+PAUSED_ASSET_CLASSES=us_equity_small_mid
+
+# QW#17 — Cap repeat-same-day par classe (short:max,...). Day = Europe/Paris.
+QW_17_REPEAT_CAPS=asia:4,us_sm:1,crypto:1,eu:2,us_large:2
+
+# QW#18 — Asia exchange sizing multiplier (.SHE × 1.5, .KQ × 0.7) + .KQ skip
+# si score < QW_18_KQ_SCORE_MIN (Règle B).
+QW_18_EXCHANGE_MULT=.SHE:1.5,.KQ:0.7
+QW_18_KQ_SCORE_MIN=1.2

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -63,6 +63,16 @@ import { MacroVetoService } from './services/macro-veto.service';
 import { ProbabilityRefitCronService } from '../gainers-scanner/automations/probability-refit-cron.service';
 // PR6.8 RCFT — Cron daily 00:30 UTC qui suit forward returns des shadow signals
 import { SignalForwardTrackerService } from '../gainers-scanner/automations/signal-forward-tracker.service';
+// Phase 5 N1 PR-1 — Quick Wins (sessions + symbols + cleanup)
+import {
+  QuickWinsPipelineService,
+  QwDecisionLoggerService,
+  Qw1SessionFilterService,
+  Qw6SymbolBlacklistService,
+  Qw11AssetClassGateService,
+  Qw17RepeatSymbolCapService,
+  Qw18ExchangeMultiplierService,
+} from './quick-wins';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule, BotLabModule, GainersModule],
@@ -148,6 +158,14 @@ import { SignalForwardTrackerService } from '../gainers-scanner/automations/sign
     // PR6.8 RCFT — Cron daily 00:30 UTC qui suit forward returns shadow signals
     // (T+24h + T+72h) et compute outcome (champion/failure/neutral) pour FP-rate.
     SignalForwardTrackerService,
+    // Phase 5 N1 PR-1 — Quick Wins (sessions + symbols + repeat caps + exchange mult)
+    QwDecisionLoggerService,
+    Qw1SessionFilterService,
+    Qw6SymbolBlacklistService,
+    Qw11AssetClassGateService,
+    Qw17RepeatSymbolCapService,
+    Qw18ExchangeMultiplierService,
+    QuickWinsPipelineService,
   ],
   exports: [
     LisaService,

--- a/apps/api/src/modules/lisa/quick-wins/__tests__/quick-wins-pipeline.spec.ts
+++ b/apps/api/src/modules/lisa/quick-wins/__tests__/quick-wins-pipeline.spec.ts
@@ -1,0 +1,121 @@
+import { ConfigService } from '@nestjs/config';
+import { QuickWinsPipelineService } from '../quick-wins-pipeline.service';
+import { Qw1SessionFilterService } from '../qw-1-session-filter.service';
+import { Qw6SymbolBlacklistService } from '../qw-6-symbol-blacklist.service';
+import { Qw11AssetClassGateService } from '../qw-11-asset-class-gate.service';
+import { Qw17RepeatSymbolCapService } from '../qw-17-repeat-symbol-cap.service';
+import { Qw18ExchangeMultiplierService } from '../qw-18-exchange-multiplier.service';
+import type { QwDecisionLoggerService } from '../qw-decision-logger.service';
+import type { SupabaseService } from '../../../supabase/supabase.service';
+
+function makeConfig(map: Record<string, string>): ConfigService {
+  return { get: (k: string) => map[k] } as unknown as ConfigService;
+}
+function makeLogger(): QwDecisionLoggerService {
+  return { log: () => undefined } as unknown as QwDecisionLoggerService;
+}
+function makeSupabaseNoop(): SupabaseService {
+  return {
+    isReady: () => false,
+    getClient: () => {
+      throw new Error('not ready');
+    },
+  } as unknown as SupabaseService;
+}
+
+function makePipeline(envOverrides: Record<string, string> = {}): QuickWinsPipelineService {
+  const env: Record<string, string> = {
+    QUICK_WINS_PIPELINE_ENABLED: 'true',
+    QW_1_SESSION_FILTER: 'true',
+    ...envOverrides,
+  };
+  const cfg = makeConfig(env);
+  const logger = makeLogger();
+  const supabase = makeSupabaseNoop();
+  return new QuickWinsPipelineService(
+    cfg,
+    new Qw1SessionFilterService(cfg, logger),
+    new Qw6SymbolBlacklistService(cfg, logger),
+    new Qw11AssetClassGateService(cfg, logger),
+    new Qw17RepeatSymbolCapService(cfg, supabase, logger),
+    new Qw18ExchangeMultiplierService(cfg, logger),
+  );
+}
+
+describe('QuickWinsPipelineService', () => {
+  it('master flag disabled → always pass with empty trace', async () => {
+    const pipeline = makePipeline({ QUICK_WINS_PIPELINE_ENABLED: 'false' });
+    const r = await pipeline.evaluate({
+      symbol: 'CGNX',
+      assetClass: 'us_equity_small_mid',
+      timestamp: '2026-05-20T14:30:00Z',
+    });
+    expect(r.decision).toBe('pass');
+    expect(r.qwTrace).toHaveLength(0);
+  });
+
+  it('cascade short-circuits on first block (QW#1 fires before QW#6)', async () => {
+    const pipeline = makePipeline();
+    const r = await pipeline.evaluate({
+      symbol: 'CGNX',
+      assetClass: 'us_equity_large',
+      timestamp: '2026-05-20T14:30:00Z',
+    });
+    expect(r.decision).toBe('block');
+    if (r.decision === 'block') {
+      expect(r.blockedBy).toBe('QW_1');
+    }
+    expect(r.qwTrace).toHaveLength(1);
+  });
+
+  it('passes all gates → pass result with empty modifications', async () => {
+    const pipeline = makePipeline();
+    const r = await pipeline.evaluate({
+      symbol: 'AAPL',
+      assetClass: 'us_equity_large',
+      timestamp: '2026-05-20T16:00:00Z',
+    });
+    expect(r.decision).toBe('pass');
+  });
+
+  it('QW#18 .SHE applies sizing multiplier 1.5 when all upstream pass', async () => {
+    const pipeline = makePipeline();
+    const r = await pipeline.evaluate({
+      symbol: '600519.SHE',
+      assetClass: 'asia_equity',
+      timestamp: '2026-05-20T05:00:00Z',
+      score: 2.0,
+    });
+    expect(r.decision).toBe('modify');
+    if (r.decision === 'modify') {
+      expect(r.sizingMultiplier).toBe(1.5);
+      expect(r.modifications[0]).toContain('QW_18');
+    }
+  });
+
+  it('QW#11 blocks us_equity_small_mid before reaching QW#17', async () => {
+    const pipeline = makePipeline();
+    const r = await pipeline.evaluate({
+      symbol: 'AAPL',
+      assetClass: 'us_equity_small_mid',
+      timestamp: '2026-05-20T16:00:00Z',
+    });
+    expect(r.decision).toBe('block');
+    if (r.decision === 'block') {
+      expect(r.blockedBy).toBe('QW_11');
+    }
+  });
+
+  it('QW#6 blacklist fires after session passes', async () => {
+    const pipeline = makePipeline();
+    const r = await pipeline.evaluate({
+      symbol: 'CGNX',
+      assetClass: 'us_equity_large',
+      timestamp: '2026-05-20T16:00:00Z',
+    });
+    expect(r.decision).toBe('block');
+    if (r.decision === 'block') {
+      expect(r.blockedBy).toBe('QW_6');
+    }
+  });
+});

--- a/apps/api/src/modules/lisa/quick-wins/__tests__/qw-1-session-filter.spec.ts
+++ b/apps/api/src/modules/lisa/quick-wins/__tests__/qw-1-session-filter.spec.ts
@@ -1,0 +1,165 @@
+import { ConfigService } from '@nestjs/config';
+import { Qw1SessionFilterService } from '../qw-1-session-filter.service';
+import type { QwDecisionLoggerService } from '../qw-decision-logger.service';
+
+function makeConfig(map: Record<string, string>): ConfigService {
+  return { get: (k: string) => map[k] } as unknown as ConfigService;
+}
+
+function makeLogger(): QwDecisionLoggerService & { calls: unknown[] } {
+  const calls: unknown[] = [];
+  return {
+    log: (entry: unknown) => {
+      calls.push(entry);
+    },
+    calls,
+  } as unknown as QwDecisionLoggerService & { calls: unknown[] };
+}
+
+describe('Qw1SessionFilterService', () => {
+  describe('us_equity_large — Règle D : skip 14-16h UTC absolu', () => {
+    it.each<[string, string, 'block' | 'pass']>([
+      ['14h UTC Wednesday', '2026-05-20T14:30:00Z', 'block'],
+      ['15h UTC Wednesday', '2026-05-20T15:45:00Z', 'block'],
+      ['14h UTC FRIDAY (pas d exception)', '2026-05-22T14:30:00Z', 'block'],
+      ['13h UTC Wednesday', '2026-05-20T13:30:00Z', 'pass'],
+      ['16h UTC Wednesday', '2026-05-20T16:00:00Z', 'pass'],
+    ])('%s → %s', (_label, ts, expected) => {
+      const svc = new Qw1SessionFilterService(
+        makeConfig({ QW_1_SESSION_FILTER: 'true' }),
+        makeLogger(),
+      );
+      const result = svc.check({ symbol: 'AAPL', assetClass: 'us_equity_large', timestamp: ts });
+      expect(result.decision).toBe(expected);
+    });
+  });
+
+  describe('eu_equity — exception Friday', () => {
+    it('8h UTC Monday → block', () => {
+      const svc = new Qw1SessionFilterService(
+        makeConfig({ QW_1_SESSION_FILTER: 'true' }),
+        makeLogger(),
+      );
+      expect(
+        svc.check({ symbol: 'MC.PA', assetClass: 'eu_equity', timestamp: '2026-05-18T08:30:00Z' }).decision,
+      ).toBe('block');
+    });
+
+    it('8h UTC Friday → pass (exception)', () => {
+      const svc = new Qw1SessionFilterService(
+        makeConfig({ QW_1_SESSION_FILTER: 'true' }),
+        makeLogger(),
+      );
+      expect(
+        svc.check({ symbol: 'MC.PA', assetClass: 'eu_equity', timestamp: '2026-05-22T08:15:00Z' }).decision,
+      ).toBe('pass');
+    });
+
+    it('9h UTC Monday → pass (outside skip window)', () => {
+      const svc = new Qw1SessionFilterService(
+        makeConfig({ QW_1_SESSION_FILTER: 'true' }),
+        makeLogger(),
+      );
+      expect(
+        svc.check({ symbol: 'MC.PA', assetClass: 'eu_equity', timestamp: '2026-05-18T09:30:00Z' }).decision,
+      ).toBe('pass');
+    });
+  });
+
+  describe('asia_equity — skip 1-2h UTC', () => {
+    it('1h UTC → block', () => {
+      const svc = new Qw1SessionFilterService(
+        makeConfig({ QW_1_SESSION_FILTER: 'true' }),
+        makeLogger(),
+      );
+      expect(
+        svc.check({ symbol: '005930.KO', assetClass: 'asia_equity', timestamp: '2026-05-20T01:30:00Z' }).decision,
+      ).toBe('block');
+    });
+
+    it('3h UTC → pass', () => {
+      const svc = new Qw1SessionFilterService(
+        makeConfig({ QW_1_SESSION_FILTER: 'true' }),
+        makeLogger(),
+      );
+      expect(
+        svc.check({ symbol: '005930.KO', assetClass: 'asia_equity', timestamp: '2026-05-20T03:30:00Z' }).decision,
+      ).toBe('pass');
+    });
+  });
+
+  describe('flag disabled', () => {
+    it('pass everything when QW_1_SESSION_FILTER=false', () => {
+      const svc = new Qw1SessionFilterService(
+        makeConfig({ QW_1_SESSION_FILTER: 'false' }),
+        makeLogger(),
+      );
+      const result = svc.check({
+        symbol: 'AAPL',
+        assetClass: 'us_equity_large',
+        timestamp: '2026-05-20T14:30:00Z',
+      });
+      expect(result.decision).toBe('pass');
+      expect(result.reason).toBe('flag_disabled');
+    });
+  });
+
+  describe('observability — Règle E', () => {
+    it('log block decision in qw_decision_log', () => {
+      const logger = makeLogger();
+      const svc = new Qw1SessionFilterService(
+        makeConfig({ QW_1_SESSION_FILTER: 'true' }),
+        logger,
+      );
+      svc.check({ symbol: 'AAPL', assetClass: 'us_equity_large', timestamp: '2026-05-20T14:30:00Z' });
+      expect(logger.calls).toHaveLength(1);
+      expect(logger.calls[0]).toMatchObject({
+        qwId: 'QW_1',
+        decision: 'block',
+        wouldHavePassedWithoutFlag: true,
+      });
+    });
+
+    it('do not log on pass', () => {
+      const logger = makeLogger();
+      const svc = new Qw1SessionFilterService(
+        makeConfig({ QW_1_SESSION_FILTER: 'true' }),
+        logger,
+      );
+      svc.check({ symbol: 'AAPL', assetClass: 'us_equity_large', timestamp: '2026-05-20T13:00:00Z' });
+      expect(logger.calls).toHaveLength(0);
+    });
+  });
+
+  describe('unknown class', () => {
+    it('pass when no rule applies', () => {
+      const svc = new Qw1SessionFilterService(
+        makeConfig({ QW_1_SESSION_FILTER: 'true' }),
+        makeLogger(),
+      );
+      const result = svc.check({
+        symbol: 'EURUSD.FOREX',
+        assetClass: 'fx_major',
+        timestamp: '2026-05-20T14:30:00Z',
+      });
+      expect(result.decision).toBe('pass');
+      expect(result.reason).toBe('no_rule_for_class');
+    });
+  });
+
+  describe('invalid timestamp', () => {
+    it('pass safely on garbage timestamp', () => {
+      const svc = new Qw1SessionFilterService(
+        makeConfig({ QW_1_SESSION_FILTER: 'true' }),
+        makeLogger(),
+      );
+      const result = svc.check({
+        symbol: 'AAPL',
+        assetClass: 'us_equity_large',
+        timestamp: 'not-a-date',
+      });
+      expect(result.decision).toBe('pass');
+      expect(result.reason).toBe('invalid_timestamp');
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/quick-wins/__tests__/qw-11-asset-class-gate.spec.ts
+++ b/apps/api/src/modules/lisa/quick-wins/__tests__/qw-11-asset-class-gate.spec.ts
@@ -1,0 +1,67 @@
+import { ConfigService } from '@nestjs/config';
+import { Qw11AssetClassGateService } from '../qw-11-asset-class-gate.service';
+import type { QwDecisionLoggerService } from '../qw-decision-logger.service';
+
+function makeConfig(map: Record<string, string>): ConfigService {
+  return { get: (k: string) => map[k] } as unknown as ConfigService;
+}
+function makeLogger(): QwDecisionLoggerService & { calls: unknown[] } {
+  const calls: unknown[] = [];
+  return { log: (e: unknown) => calls.push(e), calls } as unknown as QwDecisionLoggerService & {
+    calls: unknown[];
+  };
+}
+
+describe('Qw11AssetClassGateService', () => {
+  it('default: blocks us_equity_small_mid', () => {
+    const svc = new Qw11AssetClassGateService(makeConfig({}), makeLogger());
+    expect(
+      svc.check({ symbol: 'X', assetClass: 'us_equity_small_mid', timestamp: 'now' }).decision,
+    ).toBe('block');
+  });
+
+  it('default: passes us_equity_large', () => {
+    const svc = new Qw11AssetClassGateService(makeConfig({}), makeLogger());
+    expect(svc.check({ symbol: 'X', assetClass: 'us_equity_large', timestamp: 'now' }).decision).toBe(
+      'pass',
+    );
+  });
+
+  it('custom env: pause multiple classes', () => {
+    const svc = new Qw11AssetClassGateService(
+      makeConfig({ PAUSED_ASSET_CLASSES: 'crypto_major,asia_equity' }),
+      makeLogger(),
+    );
+    expect(svc.check({ symbol: 'BTC', assetClass: 'crypto_major', timestamp: 'now' }).decision).toBe(
+      'block',
+    );
+    expect(svc.check({ symbol: 'X.KO', assetClass: 'asia_equity', timestamp: 'now' }).decision).toBe(
+      'block',
+    );
+    expect(
+      svc.check({ symbol: 'X', assetClass: 'us_equity_small_mid', timestamp: 'now' }).decision,
+    ).toBe('pass');
+  });
+
+  it('empty env: no class paused', () => {
+    const svc = new Qw11AssetClassGateService(
+      makeConfig({ PAUSED_ASSET_CLASSES: '' }),
+      makeLogger(),
+    );
+    expect(
+      svc.check({ symbol: 'X', assetClass: 'us_equity_small_mid', timestamp: 'now' }).decision,
+    ).toBe('pass');
+  });
+
+  it('logs block with shadow flag', () => {
+    const logger = makeLogger();
+    const svc = new Qw11AssetClassGateService(makeConfig({}), logger);
+    svc.check({ symbol: 'X', assetClass: 'us_equity_small_mid', timestamp: 'now' });
+    expect(logger.calls[0]).toMatchObject({
+      qwId: 'QW_11',
+      decision: 'block',
+      reason: 'class_paused',
+      wouldHavePassedWithoutFlag: true,
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/quick-wins/__tests__/qw-17-repeat-symbol-cap.spec.ts
+++ b/apps/api/src/modules/lisa/quick-wins/__tests__/qw-17-repeat-symbol-cap.spec.ts
@@ -1,0 +1,82 @@
+import { ConfigService } from '@nestjs/config';
+import { Qw17RepeatSymbolCapService } from '../qw-17-repeat-symbol-cap.service';
+import type { QwDecisionLoggerService } from '../qw-decision-logger.service';
+import type { SupabaseService } from '../../../supabase/supabase.service';
+
+function makeConfig(map: Record<string, string>): ConfigService {
+  return { get: (k: string) => map[k] } as unknown as ConfigService;
+}
+function makeLogger(): QwDecisionLoggerService & { calls: unknown[] } {
+  const calls: unknown[] = [];
+  return { log: (e: unknown) => calls.push(e), calls } as unknown as QwDecisionLoggerService & {
+    calls: unknown[];
+  };
+}
+function makeSupabaseNoop(): SupabaseService {
+  return {
+    isReady: () => false,
+    getClient: () => {
+      throw new Error('not ready');
+    },
+  } as unknown as SupabaseService;
+}
+
+describe('Qw17RepeatSymbolCapService', () => {
+  it('us_equity_small_mid cap 1: 1st pass, 2nd block', async () => {
+    const svc = new Qw17RepeatSymbolCapService(makeConfig({}), makeSupabaseNoop(), makeLogger());
+    const sig = { symbol: 'X', assetClass: 'us_equity_small_mid', timestamp: '2026-05-20T15:00:00Z' };
+    expect((await svc.check(sig)).decision).toBe('pass');
+    expect((await svc.check(sig)).decision).toBe('block');
+  });
+
+  it('asia_equity cap 4: 4 pass, 5th block', async () => {
+    const svc = new Qw17RepeatSymbolCapService(makeConfig({}), makeSupabaseNoop(), makeLogger());
+    const sig = { symbol: '005930.KO', assetClass: 'asia_equity', timestamp: '2026-05-20T05:00:00Z' };
+    for (let i = 0; i < 4; i++) {
+      expect((await svc.check(sig)).decision).toBe('pass');
+    }
+    expect((await svc.check(sig)).decision).toBe('block');
+  });
+
+  it('unknown class → pass', async () => {
+    const svc = new Qw17RepeatSymbolCapService(makeConfig({}), makeSupabaseNoop(), makeLogger());
+    const r = await svc.check({
+      symbol: 'EURUSD',
+      assetClass: 'fx_major',
+      timestamp: '2026-05-20T10:00:00Z',
+    });
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('no_cap_for_class');
+  });
+
+  it('different symbols same class share separate counters', async () => {
+    const svc = new Qw17RepeatSymbolCapService(makeConfig({}), makeSupabaseNoop(), makeLogger());
+    expect(
+      (await svc.check({ symbol: 'A', assetClass: 'us_equity_small_mid', timestamp: '2026-05-20T15:00:00Z' }))
+        .decision,
+    ).toBe('pass');
+    expect(
+      (await svc.check({ symbol: 'B', assetClass: 'us_equity_small_mid', timestamp: '2026-05-20T15:00:00Z' }))
+        .decision,
+    ).toBe('pass');
+    expect(
+      (await svc.check({ symbol: 'A', assetClass: 'us_equity_small_mid', timestamp: '2026-05-20T15:00:00Z' }))
+        .decision,
+    ).toBe('block');
+  });
+
+  it('logs block with cap details', async () => {
+    const logger = makeLogger();
+    const svc = new Qw17RepeatSymbolCapService(makeConfig({}), makeSupabaseNoop(), logger);
+    const sig = { symbol: 'X', assetClass: 'us_equity_small_mid', timestamp: '2026-05-20T15:00:00Z' };
+    await svc.check(sig);
+    await svc.check(sig);
+    expect(logger.calls).toHaveLength(1);
+    expect(logger.calls[0]).toMatchObject({
+      qwId: 'QW_17',
+      decision: 'block',
+      reason: 'repeat_cap_reached',
+      wouldHavePassedWithoutFlag: true,
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/quick-wins/__tests__/qw-18-exchange-multiplier.spec.ts
+++ b/apps/api/src/modules/lisa/quick-wins/__tests__/qw-18-exchange-multiplier.spec.ts
@@ -1,0 +1,96 @@
+import { ConfigService } from '@nestjs/config';
+import { Qw18ExchangeMultiplierService } from '../qw-18-exchange-multiplier.service';
+import type { QwDecisionLoggerService } from '../qw-decision-logger.service';
+
+function makeConfig(map: Record<string, string>): ConfigService {
+  return { get: (k: string) => map[k] } as unknown as ConfigService;
+}
+function makeLogger(): QwDecisionLoggerService & { calls: unknown[] } {
+  const calls: unknown[] = [];
+  return { log: (e: unknown) => calls.push(e), calls } as unknown as QwDecisionLoggerService & {
+    calls: unknown[];
+  };
+}
+
+describe('Qw18ExchangeMultiplierService', () => {
+  it('passes non-asia classes', () => {
+    const svc = new Qw18ExchangeMultiplierService(makeConfig({}), makeLogger());
+    expect(svc.check({ symbol: 'AAPL', assetClass: 'us_equity_large', timestamp: 'now' }).decision).toBe(
+      'pass',
+    );
+  });
+
+  it('asia .SHE → modify ×1.5', () => {
+    const svc = new Qw18ExchangeMultiplierService(makeConfig({}), makeLogger());
+    const r = svc.check({
+      symbol: '600519.SHE',
+      assetClass: 'asia_equity',
+      timestamp: 'now',
+      score: 1.8,
+    });
+    expect(r.decision).toBe('modify');
+    expect(r.multiplier).toBe(1.5);
+    expect(r.exchange).toBe('.SHE');
+  });
+
+  it('asia .KQ with score >= 1.2 → modify ×0.7', () => {
+    const svc = new Qw18ExchangeMultiplierService(makeConfig({}), makeLogger());
+    const r = svc.check({
+      symbol: '059120.KQ',
+      assetClass: 'asia_equity',
+      timestamp: 'now',
+      score: 1.5,
+    });
+    expect(r.decision).toBe('modify');
+    expect(r.multiplier).toBe(0.7);
+  });
+
+  it('asia .KQ with score < 1.2 → block (Règle B)', () => {
+    const svc = new Qw18ExchangeMultiplierService(makeConfig({}), makeLogger());
+    const r = svc.check({
+      symbol: '059120.KQ',
+      assetClass: 'asia_equity',
+      timestamp: 'now',
+      score: 0.9,
+    });
+    expect(r.decision).toBe('block');
+    expect(r.reason).toBe('kq_score_below_min');
+  });
+
+  it('asia .KQ with null score → block (defensive)', () => {
+    const svc = new Qw18ExchangeMultiplierService(makeConfig({}), makeLogger());
+    const r = svc.check({
+      symbol: '059120.KQ',
+      assetClass: 'asia_equity',
+      timestamp: 'now',
+      score: null,
+    });
+    expect(r.decision).toBe('block');
+  });
+
+  it('asia .KO (no rule) → pass', () => {
+    const svc = new Qw18ExchangeMultiplierService(makeConfig({}), makeLogger());
+    const r = svc.check({
+      symbol: '005930.KO',
+      assetClass: 'asia_equity',
+      timestamp: 'now',
+      score: 2.0,
+    });
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('no_rule_for_suffix');
+  });
+
+  it('configurable QW_18_KQ_SCORE_MIN', () => {
+    const svc = new Qw18ExchangeMultiplierService(
+      makeConfig({ QW_18_KQ_SCORE_MIN: '2.0' }),
+      makeLogger(),
+    );
+    const r = svc.check({
+      symbol: '059120.KQ',
+      assetClass: 'asia_equity',
+      timestamp: 'now',
+      score: 1.5,
+    });
+    expect(r.decision).toBe('block');
+  });
+});

--- a/apps/api/src/modules/lisa/quick-wins/__tests__/qw-6-symbol-blacklist.spec.ts
+++ b/apps/api/src/modules/lisa/quick-wins/__tests__/qw-6-symbol-blacklist.spec.ts
@@ -1,0 +1,90 @@
+import { ConfigService } from '@nestjs/config';
+import { Qw6SymbolBlacklistService } from '../qw-6-symbol-blacklist.service';
+import type { QwDecisionLoggerService } from '../qw-decision-logger.service';
+
+function makeConfig(map: Record<string, string>): ConfigService {
+  return { get: (k: string) => map[k] } as unknown as ConfigService;
+}
+
+function makeLogger(): QwDecisionLoggerService & { calls: unknown[] } {
+  const calls: unknown[] = [];
+  return { log: (e: unknown) => calls.push(e), calls } as unknown as QwDecisionLoggerService & {
+    calls: unknown[];
+  };
+}
+
+describe('Qw6SymbolBlacklistService', () => {
+  describe('default blacklist (CGNX, PODD, ORA, QCOM, ST, PRU)', () => {
+    let svc: Qw6SymbolBlacklistService;
+    beforeEach(() => {
+      svc = new Qw6SymbolBlacklistService(makeConfig({}), makeLogger());
+    });
+
+    it.each(['CGNX', 'PODD', 'ORA', 'QCOM', 'ST', 'PRU'])('blocks %s', (sym) => {
+      const r = svc.check({ symbol: sym, assetClass: 'us_equity_large', timestamp: '2026-05-20T10:00:00Z' });
+      expect(r.decision).toBe('block');
+      expect(r.reason).toBe('blacklist_static');
+    });
+
+    it('blocks suffixed variants (CGNX.US → CGNX)', () => {
+      expect(
+        svc.check({ symbol: 'CGNX.US', assetClass: 'us_equity_large', timestamp: '2026-05-20T10:00:00Z' })
+          .decision,
+      ).toBe('block');
+    });
+
+    it('passes AAPL (not in list)', () => {
+      expect(
+        svc.check({ symbol: 'AAPL', assetClass: 'us_equity_large', timestamp: '2026-05-20T10:00:00Z' })
+          .decision,
+      ).toBe('pass');
+    });
+
+    it('is case-insensitive', () => {
+      expect(
+        svc.check({ symbol: 'cgnx', assetClass: 'us_equity_large', timestamp: '2026-05-20T10:00:00Z' })
+          .decision,
+      ).toBe('block');
+    });
+  });
+
+  describe('custom blacklist via env', () => {
+    it('overrides default', () => {
+      const svc = new Qw6SymbolBlacklistService(
+        makeConfig({ QW_6_SYMBOL_BLACKLIST: 'TSLA,NVDA' }),
+        makeLogger(),
+      );
+      expect(svc.check({ symbol: 'TSLA', assetClass: 'us_equity_large', timestamp: 'now' }).decision).toBe(
+        'block',
+      );
+      expect(svc.check({ symbol: 'CGNX', assetClass: 'us_equity_large', timestamp: 'now' }).decision).toBe(
+        'pass',
+      );
+    });
+
+    it('empty string disables', () => {
+      const svc = new Qw6SymbolBlacklistService(
+        makeConfig({ QW_6_SYMBOL_BLACKLIST: '' }),
+        makeLogger(),
+      );
+      expect(svc.check({ symbol: 'CGNX', assetClass: 'us_equity_large', timestamp: 'now' }).decision).toBe(
+        'pass',
+      );
+    });
+  });
+
+  describe('observability', () => {
+    it('logs on block with shadow flag', () => {
+      const logger = makeLogger();
+      const svc = new Qw6SymbolBlacklistService(makeConfig({}), logger);
+      svc.check({ symbol: 'CGNX', assetClass: 'us_equity_large', timestamp: '2026-05-20T10:00:00Z' });
+      expect(logger.calls).toHaveLength(1);
+      expect(logger.calls[0]).toMatchObject({
+        qwId: 'QW_6',
+        decision: 'block',
+        reason: 'blacklist_static',
+        wouldHavePassedWithoutFlag: true,
+      });
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/quick-wins/index.ts
+++ b/apps/api/src/modules/lisa/quick-wins/index.ts
@@ -1,0 +1,8 @@
+export { QuickWinsPipelineService } from './quick-wins-pipeline.service';
+export { QwDecisionLoggerService } from './qw-decision-logger.service';
+export { Qw1SessionFilterService } from './qw-1-session-filter.service';
+export { Qw6SymbolBlacklistService } from './qw-6-symbol-blacklist.service';
+export { Qw11AssetClassGateService } from './qw-11-asset-class-gate.service';
+export { Qw17RepeatSymbolCapService } from './qw-17-repeat-symbol-cap.service';
+export { Qw18ExchangeMultiplierService } from './qw-18-exchange-multiplier.service';
+export type { QwSignal, QwResult, QwTrace, QwDecision, QwId } from './types';

--- a/apps/api/src/modules/lisa/quick-wins/quick-wins-pipeline.service.ts
+++ b/apps/api/src/modules/lisa/quick-wins/quick-wins-pipeline.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Qw1SessionFilterService } from './qw-1-session-filter.service';
+import { Qw6SymbolBlacklistService } from './qw-6-symbol-blacklist.service';
+import { Qw11AssetClassGateService } from './qw-11-asset-class-gate.service';
+import { Qw17RepeatSymbolCapService } from './qw-17-repeat-symbol-cap.service';
+import { Qw18ExchangeMultiplierService } from './qw-18-exchange-multiplier.service';
+import type { QwId, QwResult, QwSignal, QwTrace } from './types';
+
+/**
+ * Phase 5 N1 PR-1 — orchestrateur Quick Wins.
+ *
+ * Cascade ordre strict : QW#1 → QW#6 → QW#11 → QW#17 → QW#18.
+ * Short-circuit dès qu'un QW renvoie 'block'.
+ * Master flag QUICK_WINS_PIPELINE_ENABLED (default 'false' tant que la draft PR
+ * n'est pas mergée). Mardi matin l'agent flip à true en même temps que le merge.
+ */
+@Injectable()
+export class QuickWinsPipelineService {
+  private readonly logger = new Logger(QuickWinsPipelineService.name);
+  private readonly masterEnabled: boolean;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly qw1: Qw1SessionFilterService,
+    private readonly qw6: Qw6SymbolBlacklistService,
+    private readonly qw11: Qw11AssetClassGateService,
+    private readonly qw17: Qw17RepeatSymbolCapService,
+    private readonly qw18: Qw18ExchangeMultiplierService,
+  ) {
+    this.masterEnabled = (this.config.get<string>('QUICK_WINS_PIPELINE_ENABLED') ?? 'false') === 'true';
+    if (this.masterEnabled) {
+      this.logger.log('Quick Wins pipeline ENABLED (master flag on)');
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.masterEnabled;
+  }
+
+  async evaluate(signal: QwSignal): Promise<QwResult> {
+    if (!this.masterEnabled) {
+      return { decision: 'pass', sizingMultiplier: 1.0, modifications: [], qwTrace: [] };
+    }
+
+    const trace: QwTrace[] = [];
+    let sizingMultiplier = 1.0;
+    const modifications: string[] = [];
+
+    const ordered = [
+      () => Promise.resolve(this.qw1.check(signal)),
+      () => Promise.resolve(this.qw6.check(signal)),
+      () => Promise.resolve(this.qw11.check(signal)),
+      () => this.qw17.check(signal),
+      () => Promise.resolve(this.qw18.check(signal)),
+    ];
+
+    for (const step of ordered) {
+      const result = await step();
+      trace.push(result);
+
+      if (result.decision === 'block') {
+        return {
+          decision: 'block',
+          blockedBy: result.qwId as QwId,
+          reason: result.reason,
+          qwTrace: trace,
+        };
+      }
+
+      if (result.decision === 'modify' && typeof result.multiplier === 'number') {
+        sizingMultiplier *= result.multiplier;
+        modifications.push(`${result.qwId} ${result.reason}`);
+      }
+    }
+
+    if (modifications.length > 0) {
+      return {
+        decision: 'modify',
+        sizingMultiplier,
+        modifications,
+        qwTrace: trace,
+      };
+    }
+
+    return { decision: 'pass', sizingMultiplier: 1.0, modifications: [], qwTrace: trace };
+  }
+}

--- a/apps/api/src/modules/lisa/quick-wins/qw-1-session-filter.service.ts
+++ b/apps/api/src/modules/lisa/quick-wins/qw-1-session-filter.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { QwDecisionLoggerService } from './qw-decision-logger.service';
+import type { QwSignal, QwTrace } from './types';
+
+/**
+ * QW#1 — Skip d'ouverture par classe sur fenêtre horaire UTC.
+ *
+ * Règle D (CLAUDE.md PR-1) : us_equity_large 14-16h UTC = skip absolu,
+ * même le vendredi. eu_equity 8h UTC = skip SAUF le vendredi (8h15
+ * vendredi reste autorisé — sizing boost à venir en PR-4).
+ */
+
+interface SessionRule {
+  assetClass: string;
+  skipHoursUtc: number[];
+  fridayException?: 'eu_friday_pass';
+}
+
+const SESSION_RULES: SessionRule[] = [
+  { assetClass: 'us_equity_large', skipHoursUtc: [14, 15] },
+  { assetClass: 'us_equity_small_mid', skipHoursUtc: [17] },
+  { assetClass: 'eu_equity', skipHoursUtc: [8], fridayException: 'eu_friday_pass' },
+  { assetClass: 'asia_equity', skipHoursUtc: [1, 2] },
+];
+
+@Injectable()
+export class Qw1SessionFilterService {
+  private readonly enabled: boolean;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly decisionLogger: QwDecisionLoggerService,
+  ) {
+    this.enabled = (this.config.get<string>('QW_1_SESSION_FILTER') ?? 'true') === 'true';
+  }
+
+  check(signal: QwSignal): QwTrace {
+    if (!this.enabled) {
+      return { qwId: 'QW_1', decision: 'pass', reason: 'flag_disabled' };
+    }
+
+    const date = new Date(signal.timestamp);
+    if (Number.isNaN(date.getTime())) {
+      return { qwId: 'QW_1', decision: 'pass', reason: 'invalid_timestamp' };
+    }
+
+    const hourUtc = date.getUTCHours();
+    const dowUtc = date.getUTCDay();
+    const rule = SESSION_RULES.find((r) => r.assetClass === signal.assetClass);
+
+    if (!rule) {
+      return { qwId: 'QW_1', decision: 'pass', reason: 'no_rule_for_class' };
+    }
+
+    if (!rule.skipHoursUtc.includes(hourUtc)) {
+      return { qwId: 'QW_1', decision: 'pass', reason: 'outside_skip_window' };
+    }
+
+    if (rule.fridayException === 'eu_friday_pass' && dowUtc === 5) {
+      return { qwId: 'QW_1', decision: 'pass', reason: 'eu_friday_exception' };
+    }
+
+    const reason = `session_skip_${rule.assetClass}_h${hourUtc}_utc`;
+    this.decisionLogger.log({
+      qwId: 'QW_1',
+      symbol: signal.symbol,
+      assetClass: signal.assetClass,
+      decision: 'block',
+      reason,
+      wouldHavePassedWithoutFlag: true,
+      details: { hourUtc, dowUtc, skipHoursUtc: rule.skipHoursUtc },
+    });
+
+    return { qwId: 'QW_1', decision: 'block', reason };
+  }
+}

--- a/apps/api/src/modules/lisa/quick-wins/qw-11-asset-class-gate.service.ts
+++ b/apps/api/src/modules/lisa/quick-wins/qw-11-asset-class-gate.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { QwDecisionLoggerService } from './qw-decision-logger.service';
+import type { QwSignal, QwTrace } from './types';
+
+/**
+ * QW#11 — Pause générique d'une asset class entière.
+ *
+ * Default : us_equity_small_mid (Kelly -39.7%, PnL -$12.25/j sur baseline 4j).
+ * Override : env PAUSED_ASSET_CLASSES=class1,class2,...
+ *
+ * Rollback : retirer la classe de la CSV, hot-reload non requis (les rows
+ * créés en pause expirent au prochain restart du service).
+ */
+@Injectable()
+export class Qw11AssetClassGateService {
+  private readonly pausedClasses: Set<string>;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly decisionLogger: QwDecisionLoggerService,
+  ) {
+    const raw = this.config.get<string>('PAUSED_ASSET_CLASSES') ?? 'us_equity_small_mid';
+    this.pausedClasses = new Set(
+      raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+  }
+
+  check(signal: QwSignal): QwTrace {
+    if (this.pausedClasses.size === 0) {
+      return { qwId: 'QW_11', decision: 'pass', reason: 'no_paused_classes' };
+    }
+
+    if (!this.pausedClasses.has(signal.assetClass)) {
+      return { qwId: 'QW_11', decision: 'pass', reason: 'class_not_paused' };
+    }
+
+    this.decisionLogger.log({
+      qwId: 'QW_11',
+      symbol: signal.symbol,
+      assetClass: signal.assetClass,
+      decision: 'block',
+      reason: 'class_paused',
+      wouldHavePassedWithoutFlag: true,
+      details: { pausedClasses: Array.from(this.pausedClasses) },
+    });
+
+    return { qwId: 'QW_11', decision: 'block', reason: 'class_paused' };
+  }
+}

--- a/apps/api/src/modules/lisa/quick-wins/qw-17-repeat-symbol-cap.service.ts
+++ b/apps/api/src/modules/lisa/quick-wins/qw-17-repeat-symbol-cap.service.ts
@@ -1,0 +1,135 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { QwDecisionLoggerService } from './qw-decision-logger.service';
+import type { QwSignal, QwTrace } from './types';
+
+/**
+ * QW#17 — Repeat-same-day cap par classe.
+ *
+ * Format env QW_17_REPEAT_CAPS=asia:4,us_sm:1,crypto:1,eu:2,us_large:2.
+ * Day boundary = 00:00 Europe/Paris (UTC+2 été, UTC+1 hiver — calcul dérivé).
+ *
+ * Cache in-memory + hydratation Supabase au premier check d'une journée
+ * (resilience restart Fly). Compteurs purgés des jours > 2 au passage.
+ */
+
+const SHORT_TO_LONG_CLASS: Record<string, string> = {
+  asia: 'asia_equity',
+  us_sm: 'us_equity_small_mid',
+  us_large: 'us_equity_large',
+  eu: 'eu_equity',
+  crypto: 'crypto_major',
+};
+
+@Injectable()
+export class Qw17RepeatSymbolCapService {
+  private readonly logger = new Logger(Qw17RepeatSymbolCapService.name);
+  private readonly rules = new Map<string, number>();
+  private readonly counters = new Map<string, Map<string, number>>();
+  private readonly hydrated = new Set<string>();
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+    private readonly decisionLogger: QwDecisionLoggerService,
+  ) {
+    const raw = this.config.get<string>('QW_17_REPEAT_CAPS') ?? 'asia:4,us_sm:1,crypto:1,eu:2,us_large:2';
+    raw.split(',').forEach((pair) => {
+      const [short, maxStr] = pair.split(':').map((s) => s.trim());
+      const fullClass = SHORT_TO_LONG_CLASS[short];
+      const max = Number.parseInt(maxStr, 10);
+      if (fullClass && Number.isFinite(max) && max > 0) {
+        this.rules.set(fullClass, max);
+      }
+    });
+  }
+
+  async check(signal: QwSignal): Promise<QwTrace> {
+    const cap = this.rules.get(signal.assetClass);
+    if (cap === undefined) {
+      return { qwId: 'QW_17', decision: 'pass', reason: 'no_cap_for_class' };
+    }
+
+    const dayKey = this.getParisDayKey(signal.timestamp);
+    if (!this.hydrated.has(dayKey)) {
+      await this.hydrateFromDb(dayKey);
+      this.purgeOldDays(dayKey);
+    }
+
+    const dayMap = this.counters.get(dayKey) ?? new Map<string, number>();
+    const symbolKey = `${signal.symbol.toUpperCase()}__${signal.assetClass}`;
+    const currentCount = dayMap.get(symbolKey) ?? 0;
+
+    if (currentCount >= cap) {
+      this.decisionLogger.log({
+        qwId: 'QW_17',
+        symbol: signal.symbol,
+        assetClass: signal.assetClass,
+        decision: 'block',
+        reason: 'repeat_cap_reached',
+        wouldHavePassedWithoutFlag: true,
+        details: { dayKey, currentCount, cap },
+      });
+      return { qwId: 'QW_17', decision: 'block', reason: 'repeat_cap_reached' };
+    }
+
+    dayMap.set(symbolKey, currentCount + 1);
+    this.counters.set(dayKey, dayMap);
+
+    return { qwId: 'QW_17', decision: 'pass', reason: `count_${currentCount + 1}_of_${cap}` };
+  }
+
+  /** Visible pour les tests : day key au sens Paris (UTC+1 hiver / UTC+2 été). */
+  getParisDayKey(timestamp: string): string {
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return 'invalid';
+    const parisStr = date.toLocaleString('en-CA', {
+      timeZone: 'Europe/Paris',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    return parisStr;
+  }
+
+  private async hydrateFromDb(dayKey: string): Promise<void> {
+    this.hydrated.add(dayKey);
+    if (!this.supabase.isReady()) return;
+
+    const dayStartUtc = new Date(`${dayKey}T00:00:00+02:00`).toISOString();
+    const dayEndUtc = new Date(`${dayKey}T23:59:59+02:00`).toISOString();
+
+    try {
+      const { data, error } = await this.supabase
+        .getClient()
+        .from('lisa_positions')
+        .select('symbol, asset_class')
+        .gte('entry_timestamp', dayStartUtc)
+        .lte('entry_timestamp', dayEndUtc);
+
+      if (error) {
+        this.logger.warn(`QW_17 hydrate failed for ${dayKey}: ${error.message}`);
+        return;
+      }
+
+      const dayMap = new Map<string, number>();
+      (data ?? []).forEach((row: { symbol: string; asset_class: string }) => {
+        const key = `${row.symbol.toUpperCase()}__${row.asset_class}`;
+        dayMap.set(key, (dayMap.get(key) ?? 0) + 1);
+      });
+      this.counters.set(dayKey, dayMap);
+    } catch (err) {
+      this.logger.warn(`QW_17 hydrate exception for ${dayKey}: ${(err as Error).message}`);
+    }
+  }
+
+  private purgeOldDays(currentDayKey: string): void {
+    for (const cached of this.counters.keys()) {
+      if (cached < currentDayKey && cached !== 'invalid') {
+        this.counters.delete(cached);
+        this.hydrated.delete(cached);
+      }
+    }
+  }
+}

--- a/apps/api/src/modules/lisa/quick-wins/qw-18-exchange-multiplier.service.ts
+++ b/apps/api/src/modules/lisa/quick-wins/qw-18-exchange-multiplier.service.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { QwDecisionLoggerService } from './qw-decision-logger.service';
+import type { QwSignal, QwTrace } from './types';
+
+/**
+ * QW#18 — Asia exchange multiplier + .KQ score gate.
+ *
+ * .SHE × 1.5 sizing boost (Shanghai/Shenzhen sont les plus persistents).
+ * .KQ × 0.7 sizing cut, ET skip si score < QW_18_KQ_SCORE_MIN (Règle B).
+ *
+ * S'applique uniquement à asset_class = 'asia_equity'.
+ */
+
+interface ExchangeRule {
+  suffix: string;
+  multiplier: number;
+  scoreMinForTrade: number | null;
+}
+
+@Injectable()
+export class Qw18ExchangeMultiplierService {
+  private readonly rules: ExchangeRule[];
+  private readonly kqScoreMin: number;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly decisionLogger: QwDecisionLoggerService,
+  ) {
+    this.kqScoreMin = Number.parseFloat(this.config.get<string>('QW_18_KQ_SCORE_MIN') ?? '1.2');
+
+    const raw = this.config.get<string>('QW_18_EXCHANGE_MULT') ?? '.SHE:1.5,.KQ:0.7';
+    this.rules = raw
+      .split(',')
+      .map((pair) => {
+        const [suffix, multStr] = pair.split(':').map((s) => s.trim());
+        const mult = Number.parseFloat(multStr);
+        if (!suffix || !Number.isFinite(mult)) return null;
+        return {
+          suffix,
+          multiplier: mult,
+          scoreMinForTrade: suffix === '.KQ' ? this.kqScoreMin : null,
+        } satisfies ExchangeRule;
+      })
+      .filter((r): r is ExchangeRule => r !== null);
+  }
+
+  check(signal: QwSignal): QwTrace {
+    if (signal.assetClass !== 'asia_equity') {
+      return { qwId: 'QW_18', decision: 'pass', reason: 'not_asia_class' };
+    }
+
+    const symbolUpper = signal.symbol.toUpperCase();
+    const rule = this.rules.find((r) => symbolUpper.endsWith(r.suffix.toUpperCase()));
+    if (!rule) {
+      return { qwId: 'QW_18', decision: 'pass', reason: 'no_rule_for_suffix' };
+    }
+
+    if (rule.scoreMinForTrade !== null) {
+      const score = signal.score ?? null;
+      if (score === null || score < rule.scoreMinForTrade) {
+        this.decisionLogger.log({
+          qwId: 'QW_18',
+          symbol: signal.symbol,
+          assetClass: signal.assetClass,
+          decision: 'block',
+          reason: 'kq_score_below_min',
+          wouldHavePassedWithoutFlag: true,
+          details: { score, kqScoreMin: rule.scoreMinForTrade, suffix: rule.suffix },
+        });
+        return { qwId: 'QW_18', decision: 'block', reason: 'kq_score_below_min' };
+      }
+    }
+
+    const reason = `exchange_mult_${rule.suffix}_x${rule.multiplier}`;
+    this.decisionLogger.log({
+      qwId: 'QW_18',
+      symbol: signal.symbol,
+      assetClass: signal.assetClass,
+      decision: 'modify',
+      reason,
+      wouldHavePassedWithoutFlag: true,
+      details: { suffix: rule.suffix, multiplier: rule.multiplier, score: signal.score ?? null },
+    });
+
+    return {
+      qwId: 'QW_18',
+      decision: 'modify',
+      reason,
+      multiplier: rule.multiplier,
+      exchange: rule.suffix,
+    };
+  }
+}

--- a/apps/api/src/modules/lisa/quick-wins/qw-6-symbol-blacklist.service.ts
+++ b/apps/api/src/modules/lisa/quick-wins/qw-6-symbol-blacklist.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { QwDecisionLoggerService } from './qw-decision-logger.service';
+import type { QwSignal, QwTrace } from './types';
+
+/**
+ * QW#6 — Blacklist statique de tickers (gaspilleurs confirmés).
+ *
+ * Default : CGNX, PODD, ORA, QCOM, ST, PRU (6 tickers identifiés sur
+ * baseline 14j PnL négatif sans signal de retournement).
+ * Override : env QW_6_SYMBOL_BLACKLIST=CSV.
+ *
+ * Note : ortho de TickerBlacklistService (qui gère les 404 EODHD).
+ * Ici on bloque l'ouverture, pas le fetch.
+ */
+@Injectable()
+export class Qw6SymbolBlacklistService {
+  private readonly blacklist: Set<string>;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly decisionLogger: QwDecisionLoggerService,
+  ) {
+    const raw = this.config.get<string>('QW_6_SYMBOL_BLACKLIST') ?? 'CGNX,PODD,ORA,QCOM,ST,PRU';
+    this.blacklist = new Set(
+      raw
+        .split(',')
+        .map((s) => s.trim().toUpperCase())
+        .filter(Boolean),
+    );
+  }
+
+  check(signal: QwSignal): QwTrace {
+    if (this.blacklist.size === 0) {
+      return { qwId: 'QW_6', decision: 'pass', reason: 'empty_blacklist' };
+    }
+
+    const baseSymbol = signal.symbol.split('.')[0].toUpperCase();
+    if (!this.blacklist.has(baseSymbol)) {
+      return { qwId: 'QW_6', decision: 'pass', reason: 'not_in_blacklist' };
+    }
+
+    this.decisionLogger.log({
+      qwId: 'QW_6',
+      symbol: signal.symbol,
+      assetClass: signal.assetClass,
+      decision: 'block',
+      reason: 'blacklist_static',
+      wouldHavePassedWithoutFlag: true,
+      details: { baseSymbol, blacklistSize: this.blacklist.size },
+    });
+
+    return { qwId: 'QW_6', decision: 'block', reason: 'blacklist_static' };
+  }
+}

--- a/apps/api/src/modules/lisa/quick-wins/qw-decision-logger.service.ts
+++ b/apps/api/src/modules/lisa/quick-wins/qw-decision-logger.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseService } from '../../supabase/supabase.service';
+import type { QwId, QwDecision } from './types';
+
+export interface QwLogEntry {
+  qwId: QwId;
+  symbol: string;
+  assetClass: string;
+  decision: QwDecision;
+  reason: string;
+  wouldHavePassedWithoutFlag: boolean;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Logger Règle E — append-only dans qw_decision_log.
+ * Fire-and-forget : une erreur d'insertion log un warn mais ne casse jamais
+ * le cycle scanner appelant.
+ */
+@Injectable()
+export class QwDecisionLoggerService {
+  private readonly logger = new Logger(QwDecisionLoggerService.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  log(entry: QwLogEntry): void {
+    if (!this.supabase.isReady()) return;
+    void this.supabase
+      .getClient()
+      .from('qw_decision_log')
+      .insert({
+        qw_id: entry.qwId,
+        symbol: entry.symbol,
+        asset_class: entry.assetClass,
+        decision: entry.decision,
+        reason: entry.reason,
+        would_have_passed_without_flag: entry.wouldHavePassedWithoutFlag,
+        details: entry.details ?? {},
+      })
+      .then(({ error }: { error: { message: string } | null }) => {
+        if (error) {
+          this.logger.warn(`qw_decision_log insert failed (${entry.qwId} ${entry.symbol}): ${error.message}`);
+        }
+      });
+  }
+}

--- a/apps/api/src/modules/lisa/quick-wins/types.ts
+++ b/apps/api/src/modules/lisa/quick-wins/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Phase 5 N1 PR-1 — Quick Wins pipeline shared types.
+ *
+ * Cascade ordre : QW#1 → QW#6 → QW#11 → QW#17 → QW#18.
+ * Chaque QW retourne un QwTrace. La pipeline aggrège en QwResult.
+ *
+ * Asset classes attendues (valeurs granulaires Lisa déjà en base) :
+ *   - 'crypto_major' / 'crypto_alt'
+ *   - 'us_equity_large' / 'us_equity_small_mid'
+ *   - 'eu_equity'
+ *   - 'asia_equity'
+ */
+
+export type QwId = 'QW_1' | 'QW_6' | 'QW_11' | 'QW_17' | 'QW_18';
+
+export type QwDecision = 'pass' | 'block' | 'modify';
+
+export interface QwSignal {
+  symbol: string;
+  assetClass: string;
+  /** ISO 8601 string. Si absent côté caller : new Date().toISOString(). */
+  timestamp: string;
+  /** Score composite (conviction / persistence / autre). null si non applicable. */
+  score?: number | null;
+}
+
+export interface QwTrace {
+  qwId: QwId;
+  decision: QwDecision;
+  reason: string;
+  /** Pour modify : multiplier appliqué au sizing (1.0 = neutre). */
+  multiplier?: number;
+  /** Pour modify (QW_18) : suffixe exchange détecté. */
+  exchange?: string;
+  /** Détail libre pour debug. */
+  details?: Record<string, unknown>;
+}
+
+export type QwResult =
+  | { decision: 'pass'; sizingMultiplier: 1.0; modifications: []; qwTrace: QwTrace[] }
+  | { decision: 'block'; blockedBy: QwId; reason: string; qwTrace: QwTrace[] }
+  | {
+      decision: 'modify';
+      sizingMultiplier: number;
+      modifications: string[];
+      qwTrace: QwTrace[];
+    };

--- a/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.r12-price-usd.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.r12-price-usd.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Bug #R12 — Test that EodhdIntradayService.logCall records `price_usd`.
+ *
+ * Pre-R12 prod state (16/05/2026) : 180 751 intraday calls / 14 jours, 0 %
+ * `price_usd` non-null. Cause : the `logCall` payload omitted `price_usd`
+ * AND the success log was emitted BEFORE the response was parsed.
+ *
+ * Fix verified ici :
+ *   - non-empty response → INSERT row with `price_usd` = dernière candle close
+ *   - empty response (HTTP 200, []) → row with `price_usd` = null, success=true
+ *   - HTTP 404 → row with `price_usd` = null, success=false
+ *   - ticks endpoint (`getCandlesViaTicks`) idem (dernière tick price)
+ */
+
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EodhdIntradayService } from '../eodhd-intraday.service';
+import { SupabaseService } from '../../../supabase/supabase.service';
+
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+function makeServiceWithCapture() {
+  const config = {
+    get: jest.fn((k: string) => (k === 'EODHD_API_KEY' ? 'test-key' : undefined)),
+  } as unknown as ConfigService;
+  const inserted: Array<Record<string, unknown>> = [];
+  const insertMock = jest.fn().mockImplementation((row: Record<string, unknown>) => {
+    inserted.push(row);
+    return Promise.resolve({ error: null });
+  });
+  const supabase = {
+    isReady: () => true,
+    getClient: () => ({ from: () => ({ insert: insertMock }) }),
+  } as unknown as SupabaseService;
+  return { svc: new EodhdIntradayService(config, supabase), inserted };
+}
+
+async function flushAsync() {
+  // fire-and-forget log uses Promise microtask — flush twice to be safe
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+describe('Bug #R12 — EodhdIntradayService logs price_usd', () => {
+  afterEach(() => {
+    delete (global as { fetch?: unknown }).fetch;
+  });
+
+  it('getCandles success → INSERT row carries price_usd = last close', async () => {
+    const { svc, inserted } = makeServiceWithCapture();
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { timestamp: 1_700_000_000, open: 100, high: 101, low: 99, close: 100.5, volume: 1000 },
+        { timestamp: 1_700_000_300, open: 100.5, high: 102, low: 100, close: 101.75, volume: 1500 },
+      ],
+      text: async () => '',
+    });
+
+    const res = await svc.getCandles('AAPL.US', '5m', 20);
+    await flushAsync();
+
+    expect(res).not.toBeNull();
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      called_by: 'intraday',
+      success: true,
+      status_code: 200,
+      price_usd: 101.75,
+    });
+  });
+
+  it('getCandles empty response → INSERT row with price_usd=null + success=true', async () => {
+    const { svc, inserted } = makeServiceWithCapture();
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [],
+      text: async () => '[]',
+    });
+
+    const res = await svc.getCandles('AAPL.US', '5m');
+    await flushAsync();
+
+    expect(res).toBeNull();
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      called_by: 'intraday',
+      success: true,
+      status_code: 200,
+      price_usd: null,
+    });
+  });
+
+  it('getCandles HTTP 404 → INSERT row with price_usd=null + success=false', async () => {
+    const { svc, inserted } = makeServiceWithCapture();
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => null,
+      text: async () => 'Not Found',
+    });
+
+    const res = await svc.getCandles('FAKE.US', '5m');
+    await flushAsync();
+
+    expect(res).toBeNull();
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      called_by: 'intraday',
+      success: false,
+      status_code: 404,
+      price_usd: null,
+    });
+  });
+
+  it('getCandlesViaTicks success → INSERT row carries price_usd = last tick price', async () => {
+    const { svc, inserted } = makeServiceWithCapture();
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { timestamp: 1_700_000_000_000, price: 100.5, volume: 100, seq: 1 },
+        { timestamp: 1_700_000_000_100, price: 101.25, volume: 200, seq: 2 },
+      ],
+      text: async () => '',
+    });
+
+    const fromTs = Math.floor(Date.now() / 1000) - 3600;
+    const toTs = Math.floor(Date.now() / 1000);
+    const res = await svc.getCandlesViaTicks('AAPL.US', '5m', 5, { fromTs, toTs });
+    await flushAsync();
+
+    expect(res).not.toBeNull();
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      called_by: 'intraday',
+      success: true,
+      status_code: 200,
+      price_usd: 101.25,
+    });
+  });
+
+  it('getCandles only-zero-close candles (e.g. Asia pre-market) → price_usd=null', async () => {
+    const { svc, inserted } = makeServiceWithCapture();
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { timestamp: 1_700_000_000, open: 0, high: 0, low: 0, close: 0, volume: 0 },
+      ],
+      text: async () => '',
+    });
+
+    const res = await svc.getCandles('AAPL.US', '5m');
+    await flushAsync();
+
+    // data[] non-empty so logCall fires, but all candles filtered → no last close
+    expect(res?.candles).toEqual([]);
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]).toMatchObject({
+      called_by: 'intraday',
+      success: true,
+      status_code: 200,
+      price_usd: null,
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -97,7 +97,7 @@ export class EodhdIntradayService {
     return k && k !== 'demo' ? k : null;
   }
 
-  private logCall(row: { ticker: string; success: boolean; statusCode?: number; latencyMs?: number; errorMessage?: string }): void {
+  private logCall(row: { ticker: string; success: boolean; statusCode?: number; latencyMs?: number; errorMessage?: string; priceUsd?: number | null }): void {
     (async () => {
       try {
         await this.supabase.getClient().from('eodhd_request_log').insert({
@@ -107,6 +107,9 @@ export class EodhdIntradayService {
           success: row.success,
           status_code: row.statusCode ?? null,
           latency_ms: row.latencyMs ?? null,
+          // Bug #R12 — record parsed price for prix-vs-PnL audits.
+          // Aligned with lisa.service.ts logger (live_price/market_snapshot/yahoo).
+          price_usd: row.priceUsd ?? null,
           called_by: 'intraday',
           error_message: row.errorMessage ?? null,
         });
@@ -299,10 +302,12 @@ export class EodhdIntradayService {
       }
 
       const data = await res.json() as Array<Record<string, unknown>>;
-      this.logCall({ ticker: eodhdTicker, success: true, statusCode: res.status, latencyMs });
 
       if (!Array.isArray(data) || data.length === 0) {
         this.logger.debug(`[eodhd] ${eodhdTicker} empty response (${latencyMs}ms)`);
+        // Bug #R12 — log empty response with success=true (HTTP 200, no payload)
+        // distinguishable from parsed-price rows by price_usd IS NULL.
+        this.logCall({ ticker: eodhdTicker, success: true, statusCode: res.status, latencyMs });
         return null;
       }
 
@@ -322,6 +327,17 @@ export class EodhdIntradayService {
       // les candles utiles au caller). Le serveur EODHD a déjà restreint via
       // les query params from/to.
       const candles = useRange ? allCandles : allCandles.slice(-count);
+
+      // Bug #R12 — log AFTER parse so price_usd carries the last close
+      // (debloque C45 mesure "réponse vide intraday non-404" + audit prix vs PnL).
+      const lastClose = candles.length > 0 ? candles[candles.length - 1].close : null;
+      this.logCall({
+        ticker: eodhdTicker,
+        success: true,
+        statusCode: res.status,
+        latencyMs,
+        priceUsd: lastClose != null && Number.isFinite(lastClose) && lastClose > 0 ? lastClose : null,
+      });
 
       // PR #285 — rawCount = nb candles AVANT filter close>0 ; requestedSymbol
       // = ticker effectivement envoyé dans l'URL EODHD (peut différer de
@@ -440,9 +456,11 @@ export class EodhdIntradayService {
         return null;
       }
       const data = (await res.json()) as Array<Record<string, unknown>>;
-      this.logCall({ ticker: normalized, success: true, statusCode: res.status, latencyMs });
-      if (!Array.isArray(data) || data.length === 0) return null;
-      return data
+      if (!Array.isArray(data) || data.length === 0) {
+        this.logCall({ ticker: normalized, success: true, statusCode: res.status, latencyMs });
+        return null;
+      }
+      const ticks = data
         .map<RawTick>((d) => {
           const tick: RawTick = {
             timestamp: typeof d.timestamp === 'number' ? d.timestamp : Number(d.timestamp ?? 0),
@@ -456,6 +474,16 @@ export class EodhdIntradayService {
           return tick;
         })
         .filter((t) => t.price > 0 && t.timestamp > 0);
+      // Bug #R12 — log AFTER parse so price_usd carries the last tick price.
+      const lastTickPrice = ticks.length > 0 ? ticks[ticks.length - 1].price : null;
+      this.logCall({
+        ticker: normalized,
+        success: true,
+        statusCode: res.status,
+        latencyMs,
+        priceUsd: lastTickPrice != null && Number.isFinite(lastTickPrice) && lastTickPrice > 0 ? lastTickPrice : null,
+      });
+      return ticks;
     } catch (e) {
       this.logger.debug(`[eodhd:ticks] ${normalized} fetch error: ${String(e).slice(0, 80)}`);
       return null;

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -43,6 +43,8 @@ import { TradeOutcomeRecorderService } from './trade-outcome-recorder.service';
 import { DailyProfitGovernor } from './daily-profit-governor.service';
 import { PatternAdoptionService } from '../../bot-lab/services/pattern-adoption.service';
 import { EodhdEnrichmentService } from './eodhd-enrichment.service';
+// Phase 5 N1 PR-1 — Quick Wins gate (sessions/blacklist/class-pause/repeat-cap/exchange-mult)
+import { QuickWinsPipelineService } from '../quick-wins';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types internes
@@ -180,6 +182,7 @@ export class MechanicalTradingService {
     private readonly dailyProfitGovernor: DailyProfitGovernor,
     private readonly patternAdoption: PatternAdoptionService,
     private readonly enrichment: EodhdEnrichmentService,
+    private readonly quickWins: QuickWinsPipelineService,
   ) {}
 
   /**
@@ -883,6 +886,28 @@ export class MechanicalTradingService {
       );
       if (alreadyOpen) continue;
 
+      // Phase 5 N1 PR-1 — Quick Wins gate (no-op si QUICK_WINS_PIPELINE_ENABLED=false).
+      // QW#1 sessions / #6 blacklist / #11 class-pause / #17 repeat-cap / #18 exchange-mult.
+      let qwSizingMultiplier = 1.0;
+      const qwResult = await this.quickWins.evaluate({
+        symbol: target.symbol,
+        assetClass: target.assetClass,
+        timestamp: new Date().toISOString(),
+        score: target.convictionScore,
+      });
+      if (qwResult.decision === 'block') {
+        this.logger.debug(
+          `[QW] skip ${target.symbol} — blocked by ${qwResult.blockedBy}: ${qwResult.reason}`,
+        );
+        continue;
+      }
+      if (qwResult.decision === 'modify') {
+        qwSizingMultiplier = qwResult.sizingMultiplier;
+        this.logger.debug(
+          `[QW] ${target.symbol} sizing ×${qwSizingMultiplier.toFixed(2)} (${qwResult.modifications.join(', ')})`,
+        );
+      }
+
       // Skip si le marché n'est pas ouvert — évite les ouvertures à prix
       // stale en afterhours/weekend/holiday qui gappent au réveil.
       const marketState = this.exchangeHours.getMarketState(target.symbol, target.assetClass);
@@ -947,7 +972,7 @@ export class MechanicalTradingService {
 
       // Taille de position (trajectoire + momentum)
       // En hyper_active, effectiveMaxPositionPct cape à 25 % (cf. ci-dessus).
-      const maxNotional = capitalUsd.mul(effectiveMaxPositionPct).div(100).mul(sizingMultiplier);
+      const maxNotional = capitalUsd.mul(effectiveMaxPositionPct).div(100).mul(sizingMultiplier).mul(qwSizingMultiplier);
       // Cap "first wave" : si on a déjà ouvert près de cycleNotionalCap
       // dans ce cycle, on réduit le notional restant pour ne pas dépasser.
       const remainingCycleBudget = cycleNotionalCap.minus(cycleNotionalUsed);

--- a/supabase/migrations/0140_qw_decision_log.sql
+++ b/supabase/migrations/0140_qw_decision_log.sql
@@ -1,0 +1,41 @@
+-- 0140 — Phase 5 N1 PR-1 : table d'observabilité des Quick Wins (Règle E)
+--
+-- Chaque QW (#1, #6, #11, #17, #18) écrit une ligne à chaque décision
+-- (pass / block / modify) pour permettre la mesure J+5 :
+--   - combien de signaux par QW
+--   - shadow impact (`would_have_passed_without_flag`) pour chiffrer le gate
+--   - audit a posteriori des blocages (debug régressions)
+--
+-- Pas de FK vers lisa_positions : un block ne crée pas de position, donc
+-- pas de position_id à référencer. Le couple (symbol, created_at) suffit
+-- pour rejoindre lisa_positions si le signal est passé.
+
+CREATE TABLE IF NOT EXISTS qw_decision_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  qw_id text NOT NULL,
+  symbol text NOT NULL,
+  asset_class text NOT NULL,
+  decision text NOT NULL CHECK (decision IN ('pass', 'block', 'modify')),
+  reason text NOT NULL,
+  would_have_passed_without_flag boolean NOT NULL DEFAULT false,
+  details jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_qw_decision_log_created_at
+  ON qw_decision_log (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_qw_decision_log_qw_id_created_at
+  ON qw_decision_log (qw_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_qw_decision_log_symbol_created_at
+  ON qw_decision_log (symbol, created_at DESC);
+
+COMMENT ON TABLE qw_decision_log IS
+  'Phase 5 N1 PR-1 — log append-only des décisions des Quick Wins (Règle E observabilité).';
+COMMENT ON COLUMN qw_decision_log.qw_id IS
+  'QW_1 | QW_6 | QW_11 | QW_17 | QW_18';
+COMMENT ON COLUMN qw_decision_log.decision IS
+  'pass : laisser passer ; block : empêcher ouverture ; modify : ajuster sizing';
+COMMENT ON COLUMN qw_decision_log.would_have_passed_without_flag IS
+  'True si le signal aurait été accepté sans ce QW — sert à chiffrer le shadow impact J+5.';


### PR DESCRIPTION
## Phase 5 N1 PR-1 — Quick Wins sessions + symbols + cleanup

**Statut** : draft. **Ne pas merger avant** validation R12 (PR #327) lundi 18/05 22h30 Paris.
Mergeable mardi 19/05 matin par l'agent (cf. calendar brief §7).

**Safety** : master flag `QUICK_WINS_PIPELINE_ENABLED=false` par défaut → pipeline no-op tant que désactivée → **aucun impact runtime au merge**. Le flip à `true` se fait via Fly secrets séparément.

---

### 1 · Ce qui est livré (5 QW + observability)

| QW | Service | Env flag par défaut | Décision |
|---|---|---|---|
| **#1** Session filter | `qw-1-session-filter.service.ts` | `QW_1_SESSION_FILTER=true` | block sur fenêtre UTC par classe |
| **#6** Symbol blacklist | `qw-6-symbol-blacklist.service.ts` | `QW_6_SYMBOL_BLACKLIST=CGNX,PODD,ORA,QCOM,ST,PRU` | block |
| **#11** Asset class gate | `qw-11-asset-class-gate.service.ts` | `PAUSED_ASSET_CLASSES=us_equity_small_mid` | block |
| **#17** Repeat-cap | `qw-17-repeat-symbol-cap.service.ts` | `QW_17_REPEAT_CAPS=asia:4,us_sm:1,crypto:1,eu:2,us_large:2` | block après N opens même jour Paris |
| **#18** Exchange mult | `qw-18-exchange-multiplier.service.ts` | `QW_18_EXCHANGE_MULT=.SHE:1.5,.KQ:0.7` + `QW_18_KQ_SCORE_MIN=1.2` | modify sizing (Règle B .KQ → block si score<min) |

**Cascade ordre strict** : QW#1 → QW#6 → QW#11 → QW#17 → QW#18. Short-circuit dès le premier `block`. Orchestrateur : `quick-wins-pipeline.service.ts`.

**Observabilité Règle E** : migration `0140_qw_decision_log.sql` (append-only, JSONB details, 3 index) + `QwDecisionLoggerService` fire-and-forget. Chaque QW logge `would_have_passed_without_flag` pour mesurer le shadow impact J+5.

---

### 2 · Intégration

`apps/api/src/modules/lisa/services/mechanical-trading.service.ts` — dans le loop `for (const target of directive.targetSymbols)`, juste **après** `if (alreadyOpen) continue;` (donc avant les coûteux fetchs market state / earnings / correlation) :

```ts
const qwResult = await this.quickWins.evaluate({
  symbol: target.symbol,
  assetClass: target.assetClass,
  timestamp: new Date().toISOString(),
  score: target.convictionScore,
});
if (qwResult.decision === 'block') continue;
let qwSizingMultiplier = qwResult.decision === 'modify' ? qwResult.sizingMultiplier : 1.0;
```

Le `qwSizingMultiplier` (per-iteration) est appliqué au `maxNotional` (et n'affecte pas le `sizingMultiplier` directive-wide).

---

### 3 · Déviations vs brief original (à valider)

| Brief | Réalité codebase | Décision |
|---|---|---|
| `apps/api/src/modules/scanner/quick-wins/` | Pas de module `scanner/` — Lisa utilise `gainers-scanner/` (coarse equity/crypto) et `lisa/services/mechanical-trading.service.ts` (granular us_equity_large, etc.) | **Path final : `apps/api/src/modules/lisa/quick-wins/`** — vit où il s'intègre |
| `apps/api/migrations/` | Migrations vivent dans `supabase/migrations/` avec numérotation séquentielle (0139 = dernière) | **`supabase/migrations/0140_qw_decision_log.sql`** |
| QW#22 migration cleanup `.NSE` + 30 gaspilleurs sur `tickers_universe` | Tables `tickers_universe` et `migrations_audit_log` **n'existent pas** dans le schéma actuel | **DEFERRED** — QW#6 couvre la partie blacklist d'ouverture ; pour les 404 EODHD, `TickerBlacklistService` (Bug #R10) gère déjà les .NSE morts au niveau fetch. Si besoin de purge plus large : ticket séparé après audit du schéma symboles réel. |
| `recordDecision()` / `applyCapitalRotation()` comme injection points | Ces méthodes n'existent pas — la création de position se fait via `.insert({...})` direct dans `mechanical-trading.service.ts:1218` | Intégration au loop `for (const target...)` avant les checks coûteux |
| Asset classes à dériver depuis symbole | Lisa **utilise déjà** `us_equity_large` / `us_equity_small_mid` / `eu_equity` / `asia_equity` / `crypto_major` directement dans `target.assetClass` et `lisa_positions.asset_class` | Pas de derivation layer — les valeurs sont déjà granulaires |

---

### 4 · Tests

```
$ npx jest --testPathPattern quick-wins
Test Suites: 6 passed, 6 total
Tests:       50 passed, 50 total
```

Couvre : cascade ordre, master flag disabled, Règle D (us_equity_large 14-16h UTC absolu Friday inclus), exception Friday eu_equity, Règle B (.KQ score gate), blacklist case-insensitive, repeat-cap par classe, hydratation Supabase noop quand non-ready, observability logging avec `would_have_passed_without_flag`.

```
$ npx tsc -b   # green
$ npx jest --testPathPattern mechanical-trading   # 22/22 pass (no regression)
```

Lint : seulement des warnings `consistent-type-imports` (cosmetic) — pattern existant ailleurs dans le codebase (1114 issues pré-existantes sur main). **0 erreur** introduite.

---

### 5 · Procédure d'activation mardi 19/05 (post-merge R12)

```bash
# 1. Apply migration
psql $SUPABASE_URL -f supabase/migrations/0140_qw_decision_log.sql

# 2. Set Fly secrets (effet < 30s après deploy)
flyctl secrets set --app smartvest \
  QUICK_WINS_PIPELINE_ENABLED=true \
  QW_1_SESSION_FILTER=true \
  QW_6_SYMBOL_BLACKLIST=CGNX,PODD,ORA,QCOM,ST,PRU \
  PAUSED_ASSET_CLASSES=us_equity_small_mid \
  QW_17_REPEAT_CAPS=asia:4,us_sm:1,crypto:1,eu:2,us_large:2 \
  QW_18_EXCHANGE_MULT=.SHE:1.5,.KQ:0.7 \
  QW_18_KQ_SCORE_MIN=1.2
```

### 6 · Rollback (en cas de PnL dégradation > 30% J+1)

```bash
flyctl secrets set --app smartvest QUICK_WINS_PIPELINE_ENABLED=false
# Effet < 30s, pipeline retourne `pass` avec trace vide → comportement baseline restauré
```

### 7 · Métriques de validation J+5

Query SQL dans le brief master §7 ("MÉTRIQUES VALIDATION J+5") — count par `qw_id` × `decision`, shadow impact, PnL/jour par classe vs baseline 4j (12-15 mai -$648/j brut).

---

### 8 · Checklist agent merge mardi

- [ ] R12 (PR #327) validée et mergée (prérequis CLAUDE.md)
- [ ] CI typecheck ✅
- [ ] CI Jest ✅
- [ ] Pas de conflit avec `main`
- [ ] Migration 0140 appliquée en Supabase prod
- [ ] Flip `gh pr ready` puis `gh pr merge --squash --delete-branch`
- [ ] Set `QUICK_WINS_PIPELINE_ENABLED=true` (et autres flags) sur Fly
- [ ] Verify `qw_decision_log` reçoit des inserts dans les 15 min
- [ ] Sauf imprévu : laisser tourner J+5 → query métriques 25/05 avant lancement PR-2

---

Refs : brief master prompt v2 §4 PR-1 (16/05), Règles A-E, calendar §7. Pas de QW#15/14a (réservés PR-4), pas de TP/SL touch (réservé PR-2 25/05).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_