### PR TITLE
feat(phase5-n2): Kelly fractional sizing per asset_class

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -86,6 +86,9 @@ import { AssetClassTpSlConfigService } from './services/asset-class-tpsl-config.
 // Phase 5 N1 PR-3+PR-4 — circuit breaker + sanity R5 hotfix
 import { LisaCircuitBreakerService } from './services/circuit-breaker.service';
 import { SanityR5Service } from './services/sanity-r5.service';
+// Phase 5 N2 — Kelly fractional sizing per asset_class
+import { AssetClassKellyConfigService } from './services/asset-class-kelly-config.service';
+import { KellyRecomputeService } from './services/kelly-recompute.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule, BotLabModule, GainersModule],
@@ -192,6 +195,9 @@ import { SanityR5Service } from './services/sanity-r5.service';
     Qw47LseSkipService,
     LisaCircuitBreakerService,
     SanityR5Service,
+    // Phase 5 N2 — Kelly fractional sizing (lecture cache + worker cron horaire)
+    AssetClassKellyConfigService,
+    KellyRecomputeService,
   ],
   exports: [
     LisaService,

--- a/apps/api/src/modules/lisa/services/__tests__/asset-class-kelly-config.service.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/asset-class-kelly-config.service.spec.ts
@@ -1,0 +1,140 @@
+import { AssetClassKellyConfigService } from '../asset-class-kelly-config.service';
+import type { SupabaseService } from '../../../supabase/supabase.service';
+
+interface RowShape {
+  asset_class: string;
+  notional_usd: number;
+  kelly_fraction: number;
+  sample_size: number;
+}
+
+function makeSupabaseStub(rows: RowShape[] | null, ready = true, error: { message: string } | null = null): SupabaseService {
+  return {
+    isReady: () => ready,
+    getClient: () => ({
+      from: (_t: string) => ({
+        select: (_cols: string) => Promise.resolve({ data: rows, error }),
+      }),
+    }),
+  } as unknown as SupabaseService;
+}
+
+const SEED: RowShape[] = [
+  { asset_class: 'us_equity_large', notional_usd: 1800, kelly_fraction: 0.12, sample_size: 46 },
+  { asset_class: 'eu_equity', notional_usd: 1575, kelly_fraction: 0, sample_size: 38 },
+  { asset_class: 'asia_equity', notional_usd: 2200, kelly_fraction: 0.18, sample_size: 80 },
+  { asset_class: 'us_equity_small_mid', notional_usd: 1500, kelly_fraction: 0.10, sample_size: 27 },
+];
+
+describe('AssetClassKellyConfigService', () => {
+  it('charge le cache au onModuleInit (4 lignes seed)', async () => {
+    const svc = new AssetClassKellyConfigService(makeSupabaseStub(SEED));
+    await svc.onModuleInit();
+    expect(svc.getCacheSnapshot()).toHaveLength(4);
+  });
+
+  it('getNotionalUsd retourne le notional pour classe activée (kelly>0, sample>=30)', async () => {
+    const svc = new AssetClassKellyConfigService(makeSupabaseStub(SEED));
+    await svc.onModuleInit();
+    expect(svc.getNotionalUsd('us_equity_large')).toBe(1800);
+    expect(svc.getNotionalUsd('asia_equity')).toBe(2200);
+  });
+
+  it('getNotionalUsd retourne null si kelly_fraction = 0 (edge négatif)', async () => {
+    const svc = new AssetClassKellyConfigService(makeSupabaseStub(SEED));
+    await svc.onModuleInit();
+    expect(svc.getNotionalUsd('eu_equity')).toBeNull();
+  });
+
+  it('getNotionalUsd retourne null si sample_size < 30', async () => {
+    const svc = new AssetClassKellyConfigService(makeSupabaseStub(SEED));
+    await svc.onModuleInit();
+    expect(svc.getNotionalUsd('us_equity_small_mid')).toBeNull();
+  });
+
+  it('getNotionalUsd retourne null pour classe absente du cache', async () => {
+    const svc = new AssetClassKellyConfigService(makeSupabaseStub(SEED));
+    await svc.onModuleInit();
+    expect(svc.getNotionalUsd('crypto_major')).toBeNull();
+    expect(svc.getNotionalUsd('fx_major')).toBeNull();
+  });
+
+  it('Supabase not ready → reload no-op, cache vide', async () => {
+    const svc = new AssetClassKellyConfigService(makeSupabaseStub(null, false));
+    await svc.onModuleInit();
+    expect(svc.getCacheSnapshot()).toHaveLength(0);
+    expect(svc.getNotionalUsd('us_equity_large')).toBeNull();
+  });
+
+  it('reload échec Supabase → cache précédent conservé (fail-open)', async () => {
+    const svc = new AssetClassKellyConfigService(makeSupabaseStub(SEED));
+    await svc.onModuleInit();
+    expect(svc.getNotionalUsd('us_equity_large')).toBe(1800);
+
+    Object.assign(svc as unknown as { supabase: SupabaseService }, {
+      supabase: makeSupabaseStub(null, true, { message: 'connection reset' }),
+    });
+    await svc.reload();
+
+    expect(svc.getNotionalUsd('us_equity_large')).toBe(1800); // toujours là
+  });
+
+  it('reload empty → cache précédent conservé', async () => {
+    const svc = new AssetClassKellyConfigService(makeSupabaseStub(SEED));
+    await svc.onModuleInit();
+    expect(svc.getCacheSnapshot()).toHaveLength(4);
+
+    Object.assign(svc as unknown as { supabase: SupabaseService }, {
+      supabase: makeSupabaseStub([], true),
+    });
+    await svc.reload();
+
+    expect(svc.getCacheSnapshot()).toHaveLength(4);
+  });
+
+  it('ignore les lignes avec valeurs non numériques (robustesse parse)', async () => {
+    const corrupted = {
+      asset_class: 'bad',
+      notional_usd: 'NaN' as unknown as number,
+      kelly_fraction: 0.10,
+      sample_size: 50,
+    };
+    const svc = new AssetClassKellyConfigService(
+      makeSupabaseStub([
+        { asset_class: 'us_equity_large', notional_usd: 1800, kelly_fraction: 0.12, sample_size: 46 },
+        corrupted,
+      ]),
+    );
+    await svc.onModuleInit();
+    expect(svc.getCacheSnapshot()).toHaveLength(1);
+    expect(svc.getNotionalUsd('bad')).toBeNull();
+  });
+
+  it('stale detection : trigger reload async, retour immédiat valeur cachée', async () => {
+    jest.useFakeTimers();
+    let callCount = 0;
+    const supabase = {
+      isReady: () => true,
+      getClient: () => ({
+        from: (_t: string) => ({
+          select: (_c: string) => {
+            callCount += 1;
+            return Promise.resolve({ data: SEED, error: null });
+          },
+        }),
+      }),
+    } as unknown as SupabaseService;
+
+    const svc = new AssetClassKellyConfigService(supabase);
+    await svc.onModuleInit();
+    expect(callCount).toBe(1);
+
+    jest.setSystemTime(Date.now() + 61_000); // > TTL 60s
+    expect(svc.getNotionalUsd('us_equity_large')).toBe(1800);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(callCount).toBe(2);
+
+    jest.useRealTimers();
+  });
+});

--- a/apps/api/src/modules/lisa/services/__tests__/kelly-recompute.service.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/kelly-recompute.service.spec.ts
@@ -1,0 +1,227 @@
+import { KellyRecomputeService } from '../kelly-recompute.service';
+import type { ConfigService } from '@nestjs/config';
+import type { SupabaseService } from '../../../supabase/supabase.service';
+import type { KellySizingService } from '../../../gainers-scanner/kelly/kelly-sizing.service';
+
+interface FetchRow {
+  status: string;
+  realized_pnl_pct: number | null;
+  exit_price: number | null;
+  entry_price: number | null;
+}
+
+function makeConfig(map: Record<string, string> = {}): ConfigService {
+  return { get: (k: string) => map[k] } as unknown as ConfigService;
+}
+
+function makeKellySizingMock(result: {
+  fractionSuggested: number | null;
+  fullKelly: number;
+  winRateLowerWilson: number;
+}): KellySizingService & { compute: jest.Mock } {
+  return {
+    compute: jest.fn().mockReturnValue({
+      ...result,
+      inputs: {},
+    }),
+  } as unknown as KellySizingService & { compute: jest.Mock };
+}
+
+/**
+ * Helper : crée un stub Supabase qui :
+ *  - retourne `fetchRows` sur le SELECT lisa_positions (toute la chaîne .from.select.eq.eq.like.gte.gt.limit)
+ *  - capture les payloads UPSERT sur asset_class_kelly_config
+ */
+function makeSupabaseStub(
+  fetchRows: FetchRow[],
+  options: { isReady?: boolean; selectError?: { message: string } | null; upsertError?: { message: string } | null } = {},
+): { service: SupabaseService; upserts: Array<Record<string, unknown>> } {
+  const upserts: Array<Record<string, unknown>> = [];
+  const selectChain: any = {
+    eq: () => selectChain,
+    like: () => selectChain,
+    gte: () => selectChain,
+    gt: () => selectChain,
+    limit: () => Promise.resolve({ data: fetchRows, error: options.selectError ?? null }),
+  };
+  const service = {
+    isReady: () => options.isReady ?? true,
+    getClient: () => ({
+      from: (_t: string) => ({
+        select: (_c: string) => selectChain,
+        upsert: (payload: Record<string, unknown>) => {
+          upserts.push(payload);
+          return Promise.resolve({ error: options.upsertError ?? null });
+        },
+      }),
+    }),
+  } as unknown as SupabaseService;
+  return { service, upserts };
+}
+
+function mkRow(status: string, pnlPct: number, entryPrice = 100, exitPrice = 102): FetchRow {
+  return { status, realized_pnl_pct: pnlPct, entry_price: entryPrice, exit_price: exitPrice };
+}
+
+describe('KellyRecomputeService', () => {
+  it('skip si n_closed < 30 (échantillon insuffisant)', async () => {
+    const rows: FetchRow[] = Array.from({ length: 10 }, () => mkRow('closed_target', 2.5));
+    const { service: supabase, upserts } = makeSupabaseStub(rows);
+    const sizing = makeKellySizingMock({ fractionSuggested: 0.1, fullKelly: 0.2, winRateLowerWilson: 0.5 });
+    const svc = new KellyRecomputeService(makeConfig(), supabase, sizing);
+
+    await svc.recomputeForClass('us_equity_large');
+
+    expect(sizing.compute).not.toHaveBeenCalled();
+    expect(upserts).toHaveLength(0);
+  });
+
+  it('edge négatif → upsert notional=1575 fraction=0 source=auto_recompute_no_edge', async () => {
+    const rows: FetchRow[] = [
+      ...Array.from({ length: 10 }, () => mkRow('closed_target', 2.5)),
+      ...Array.from({ length: 30 }, () => mkRow('closed_stop', -1.5)),
+    ];
+    const { service: supabase, upserts } = makeSupabaseStub(rows);
+    const sizing = makeKellySizingMock({
+      fractionSuggested: 0, // KellySizingService.compute renvoie 0 sur edge négatif
+      fullKelly: -0.45,
+      winRateLowerWilson: 0.12,
+    });
+    const svc = new KellyRecomputeService(makeConfig(), supabase, sizing);
+
+    await svc.recomputeForClass('us_equity_large');
+
+    expect(sizing.compute).toHaveBeenCalledTimes(1);
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]).toMatchObject({
+      asset_class: 'us_equity_large',
+      notional_usd: 1575,
+      kelly_fraction: 0,
+      source: 'auto_recompute_no_edge',
+      sample_size: 40,
+    });
+  });
+
+  it('edge positif → notional = fraction × capital, clampé [500, 3000]', async () => {
+    const rows: FetchRow[] = [
+      ...Array.from({ length: 25 }, () => mkRow('closed_target', 3.0)),
+      ...Array.from({ length: 15 }, () => mkRow('closed_stop', -1.0)),
+    ];
+    const { service: supabase, upserts } = makeSupabaseStub(rows);
+    // fraction 0.12 × capital 15750 = $1890 → dans la fenêtre [500, 3000]
+    const sizing = makeKellySizingMock({
+      fractionSuggested: 0.12,
+      fullKelly: 0.24,
+      winRateLowerWilson: 0.55,
+    });
+    const svc = new KellyRecomputeService(makeConfig(), supabase, sizing);
+
+    await svc.recomputeForClass('asia_equity');
+
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]).toMatchObject({
+      asset_class: 'asia_equity',
+      kelly_fraction: 0.12,
+      source: 'auto_recompute',
+    });
+    expect(Number(upserts[0].notional_usd)).toBeCloseTo(1890, 0);
+  });
+
+  it('clamp upper $3000 si fraction × capital trop élevé', async () => {
+    const rows: FetchRow[] = [
+      ...Array.from({ length: 25 }, () => mkRow('closed_target', 3.0)),
+      ...Array.from({ length: 15 }, () => mkRow('closed_stop', -1.0)),
+    ];
+    const { service: supabase, upserts } = makeSupabaseStub(rows);
+    // fraction 0.25 × 15750 = 3937.5 → clamp 3000
+    const sizing = makeKellySizingMock({
+      fractionSuggested: 0.25,
+      fullKelly: 0.5,
+      winRateLowerWilson: 0.7,
+    });
+    const svc = new KellyRecomputeService(makeConfig(), supabase, sizing);
+
+    await svc.recomputeForClass('asia_equity');
+
+    expect(upserts[0].notional_usd).toBe(3000);
+  });
+
+  it('clamp lower $500 si fraction × capital trop faible', async () => {
+    const rows: FetchRow[] = [
+      ...Array.from({ length: 25 }, () => mkRow('closed_target', 3.0)),
+      ...Array.from({ length: 15 }, () => mkRow('closed_stop', -1.0)),
+    ];
+    const { service: supabase, upserts } = makeSupabaseStub(rows);
+    // fraction 0.01 × 15750 = $157 → clamp 500
+    const sizing = makeKellySizingMock({
+      fractionSuggested: 0.01,
+      fullKelly: 0.02,
+      winRateLowerWilson: 0.45,
+    });
+    const svc = new KellyRecomputeService(makeConfig(), supabase, sizing);
+
+    await svc.recomputeForClass('asia_equity');
+
+    expect(upserts[0].notional_usd).toBe(500);
+  });
+
+  it('Supabase not ready → skip recomputeAll sans crash', async () => {
+    const { service: supabase, upserts } = makeSupabaseStub([], { isReady: false });
+    const sizing = makeKellySizingMock({ fractionSuggested: 0.1, fullKelly: 0.2, winRateLowerWilson: 0.5 });
+    const svc = new KellyRecomputeService(makeConfig(), supabase, sizing);
+
+    await svc.recomputeAll();
+
+    expect(sizing.compute).not.toHaveBeenCalled();
+    expect(upserts).toHaveLength(0);
+  });
+
+  it('select error → log warn, pas d upsert, pas de throw', async () => {
+    const { service: supabase, upserts } = makeSupabaseStub([], {
+      selectError: { message: 'connection lost' },
+    });
+    const sizing = makeKellySizingMock({ fractionSuggested: 0.1, fullKelly: 0.2, winRateLowerWilson: 0.5 });
+    const svc = new KellyRecomputeService(makeConfig(), supabase, sizing);
+
+    await svc.recomputeForClass('us_equity_large');
+
+    expect(sizing.compute).not.toHaveBeenCalled();
+    expect(upserts).toHaveLength(0);
+  });
+
+  it('payoff ratio non calculable (slAvg null) → skip', async () => {
+    // Que des closed_target, pas de closed_stop → slAvg null
+    const rows: FetchRow[] = Array.from({ length: 40 }, () => mkRow('closed_target', 2.5));
+    const { service: supabase, upserts } = makeSupabaseStub(rows);
+    const sizing = makeKellySizingMock({ fractionSuggested: 0.1, fullKelly: 0.2, winRateLowerWilson: 0.5 });
+    const svc = new KellyRecomputeService(makeConfig(), supabase, sizing);
+
+    await svc.recomputeForClass('us_equity_large');
+
+    expect(sizing.compute).not.toHaveBeenCalled();
+    expect(upserts).toHaveLength(0);
+  });
+
+  it('CAPITAL via env var KELLY_CAPITAL_ESTIME_USD prend le pas', async () => {
+    const rows: FetchRow[] = [
+      ...Array.from({ length: 25 }, () => mkRow('closed_target', 3.0)),
+      ...Array.from({ length: 15 }, () => mkRow('closed_stop', -1.0)),
+    ];
+    const { service: supabase, upserts } = makeSupabaseStub(rows);
+    const sizing = makeKellySizingMock({
+      fractionSuggested: 0.1,
+      fullKelly: 0.2,
+      winRateLowerWilson: 0.55,
+    });
+    // 0.1 × 20000 = $2000
+    const svc = new KellyRecomputeService(
+      makeConfig({ KELLY_CAPITAL_ESTIME_USD: '20000' }),
+      supabase,
+      sizing,
+    );
+
+    await svc.recomputeForClass('asia_equity');
+
+    expect(Number(upserts[0].notional_usd)).toBeCloseTo(2000, 0);
+  });
+});

--- a/apps/api/src/modules/lisa/services/asset-class-kelly-config.service.ts
+++ b/apps/api/src/modules/lisa/services/asset-class-kelly-config.service.ts
@@ -1,0 +1,115 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+/**
+ * Phase 5 N2 — lecture du notional Kelly par asset_class (`asset_class_kelly_config`).
+ *
+ * Pattern identique à AssetClassTpSlConfigService (PR #329) : cache in-memory,
+ * TTL 60 s, reload async non-bloquant sur cache stale, fail-open total.
+ *
+ * Activation conditionnelle : `getNotionalUsd(class)` retourne `null` si
+ *   - classe absente du cache OU
+ *   - `kelly_fraction <= 0` (edge négatif / pas d activation) OU
+ *   - `sample_size < 30` (échantillon insuffisant, ADR-007 §3.4)
+ *
+ * `null` = caller doit fallback au notional uniforme historique.
+ */
+
+export interface KellyConfigRow {
+  asset_class: string;
+  notional_usd: number;
+  kelly_fraction: number;
+  sample_size: number;
+}
+
+const MIN_SAMPLE_SIZE = 30;
+
+@Injectable()
+export class AssetClassKellyConfigService implements OnModuleInit {
+  private readonly logger = new Logger(AssetClassKellyConfigService.name);
+  private readonly cache = new Map<string, KellyConfigRow>();
+  private lastLoadAt: Date | null = null;
+  private readonly CACHE_TTL_MS = 60_000;
+  private inflightReload: Promise<void> | null = null;
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.reload();
+  }
+
+  /** Force reload synchrone. Visible pour tests + bootstrap. */
+  async reload(): Promise<void> {
+    if (!this.supabase.isReady()) {
+      this.logger.warn('[Kelly] Supabase not ready — config reload skipped');
+      return;
+    }
+    try {
+      const { data, error } = await this.supabase
+        .getClient()
+        .from('asset_class_kelly_config')
+        .select('asset_class, notional_usd, kelly_fraction, sample_size');
+      if (error) throw error;
+      if (!data || data.length === 0) {
+        this.logger.warn('[Kelly] asset_class_kelly_config returned empty — keeping previous cache');
+        this.lastLoadAt = new Date();
+        return;
+      }
+      this.cache.clear();
+      for (const row of data as Array<Record<string, unknown>>) {
+        const ac = String(row.asset_class);
+        const notional = Number(row.notional_usd);
+        const fraction = Number(row.kelly_fraction);
+        const sample = Number(row.sample_size);
+        if (!ac || !Number.isFinite(notional) || !Number.isFinite(fraction) || !Number.isFinite(sample)) continue;
+        this.cache.set(ac, {
+          asset_class: ac,
+          notional_usd: notional,
+          kelly_fraction: fraction,
+          sample_size: sample,
+        });
+      }
+      this.lastLoadAt = new Date();
+      this.logger.log(`[Kelly] config loaded: ${this.cache.size} classes`);
+    } catch (err) {
+      this.logger.error(
+        `[Kelly] config reload failed (${(err as Error).message}) — keeping previous cache (fail-open)`,
+      );
+    }
+  }
+
+  private isStale(): boolean {
+    if (!this.lastLoadAt) return true;
+    return Date.now() - this.lastLoadAt.getTime() > this.CACHE_TTL_MS;
+  }
+
+  private triggerStaleReload(): void {
+    if (this.inflightReload) return;
+    this.inflightReload = this.reload().finally(() => {
+      this.inflightReload = null;
+    });
+  }
+
+  /**
+   * Retourne le notional Kelly recommandé (USD) si la classe est activée :
+   *   - présente en cache ET
+   *   - `kelly_fraction > 0` (edge positif détecté) ET
+   *   - `sample_size >= 30` (échantillon suffisant).
+   *
+   * Retourne `null` sinon : le caller doit fallback au notional uniforme.
+   * Trigger reload async si cache stale (n attend pas le résultat).
+   */
+  getNotionalUsd(assetClass: string): number | null {
+    if (this.isStale()) this.triggerStaleReload();
+    const row = this.cache.get(assetClass);
+    if (!row) return null;
+    if (row.kelly_fraction <= 0) return null;
+    if (row.sample_size < MIN_SAMPLE_SIZE) return null;
+    return row.notional_usd;
+  }
+
+  /** Visible pour debug / admin endpoint éventuel. */
+  getCacheSnapshot(): KellyConfigRow[] {
+    return Array.from(this.cache.values());
+  }
+}

--- a/apps/api/src/modules/lisa/services/kelly-recompute.service.ts
+++ b/apps/api/src/modules/lisa/services/kelly-recompute.service.ts
@@ -1,0 +1,236 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Cron } from '@nestjs/schedule';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { KellySizingService } from '../../gainers-scanner/kelly/kelly-sizing.service';
+
+/**
+ * Phase 5 N2 — worker horaire qui recalcule la matrice Kelly par asset_class.
+ *
+ * Pour chaque classe :
+ *  1. Fetch stats 14j glissants depuis lisa_positions (n_closed, WR, payoff)
+ *  2. Filtre outliers R5 : realized_pnl_pct > -50 ET exit_price > entry × 0.5
+ *  3. Si n_closed < 30 → skip (échantillon insuffisant, ADR-007 §3.4)
+ *  4. Appel KellySizingService.compute() (Wilson95L + half-Kelly + clamp 0.25)
+ *  5. Conversion fraction → notional via CAPITAL_ESTIME_USD (clamp [500, 3000])
+ *  6. Upsert asset_class_kelly_config
+ *
+ * Si edge négatif (fullKelly ≤ 0) : upsert notional=1575 (fallback), fraction=0,
+ * source='auto_recompute_no_edge'. Le service consommateur lit la fraction et
+ * désactive l override → caller utilise le notional uniforme historique.
+ */
+
+const ASSET_CLASSES = [
+  'us_equity_large',
+  'us_equity_small_mid',
+  'eu_equity',
+  'asia_equity',
+  'crypto_major',
+] as const;
+
+const NOTIONAL_FALLBACK_USD = 1575;
+const NOTIONAL_MIN = 500;
+const NOTIONAL_MAX = 3000;
+
+// TODO Phase 5 N3 : récupérer le capital réel via portfolios.equity_usd au lieu
+// de la constante. Pour MVP, baseline = notional_avg actuel × max positions.
+const CAPITAL_ESTIME_USD = 15_750;
+const DEFAULT_PORTFOLIO_ID = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+interface ClassStats {
+  n_closed: number;
+  wr: number;
+  tp_avg_pct: number | null;
+  sl_avg_pct: number | null;
+}
+
+@Injectable()
+export class KellyRecomputeService {
+  private readonly logger = new Logger(KellyRecomputeService.name);
+  private readonly portfolioId: string;
+  private readonly capitalUsd: number;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+    private readonly kellySizing: KellySizingService,
+  ) {
+    this.portfolioId = this.config.get<string>('PORTFOLIO_ID') ?? DEFAULT_PORTFOLIO_ID;
+    const raw = this.config.get<string>('KELLY_CAPITAL_ESTIME_USD');
+    const parsed = raw != null ? Number.parseFloat(raw) : NaN;
+    this.capitalUsd = Number.isFinite(parsed) && parsed > 0 ? parsed : CAPITAL_ESTIME_USD;
+  }
+
+  @Cron('0 * * * *', { timeZone: 'UTC' })
+  async recomputeAll(): Promise<void> {
+    if (!this.supabase.isReady()) {
+      this.logger.warn('[Kelly] Supabase not ready — skip hourly recompute');
+      return;
+    }
+    this.logger.log(`[Kelly] hourly recompute start (portfolio=${this.portfolioId.slice(0, 8)} capital=$${this.capitalUsd})`);
+    for (const assetClass of ASSET_CLASSES) {
+      try {
+        await this.recomputeForClass(assetClass);
+      } catch (err) {
+        this.logger.warn(`[Kelly] recompute failed for ${assetClass}: ${(err as Error).message}`);
+      }
+    }
+    this.logger.log('[Kelly] hourly recompute done');
+  }
+
+  /** Visible pour tests + endpoint admin éventuel. */
+  async recomputeForClass(assetClass: string): Promise<void> {
+    const stats = await this.fetchClassStats(assetClass);
+    if (!stats) return; // erreur déjà loggée
+
+    if (stats.n_closed < 30) {
+      this.logger.log(
+        `[Kelly] ${assetClass} skip : n_closed=${stats.n_closed} < 30 (échantillon insuffisant)`,
+      );
+      return;
+    }
+
+    const payoffRatio = this.computePayoffRatio(stats.tp_avg_pct, stats.sl_avg_pct);
+    if (payoffRatio === null) {
+      this.logger.warn(
+        `[Kelly] ${assetClass} skip : payoff ratio non calculable (tp_avg=${stats.tp_avg_pct} sl_avg=${stats.sl_avg_pct})`,
+      );
+      return;
+    }
+
+    const result = this.kellySizing.compute({
+      winRate: stats.wr,
+      sampleSize: stats.n_closed,
+      payoffRatio,
+    });
+
+    // fractionSuggested null = sample insuffisant côté KellySizingService (ne devrait
+    // plus arriver vu notre garde n_closed>=30, mais on protège).
+    const fraction = result.fractionSuggested ?? 0;
+    const edgeNegative = result.fullKelly <= 0;
+
+    let notionalUsd: number;
+    let source: string;
+
+    if (edgeNegative || fraction === 0) {
+      notionalUsd = NOTIONAL_FALLBACK_USD;
+      source = 'auto_recompute_no_edge';
+    } else {
+      const raw = fraction * this.capitalUsd;
+      notionalUsd = Math.max(NOTIONAL_MIN, Math.min(NOTIONAL_MAX, raw));
+      source = 'auto_recompute';
+    }
+
+    await this.upsertConfig({
+      asset_class: assetClass,
+      notional_usd: notionalUsd,
+      kelly_fraction: edgeNegative ? 0 : fraction,
+      win_rate_observed: stats.wr,
+      win_rate_wilson_lower: result.winRateLowerWilson,
+      payoff_ratio: payoffRatio,
+      sample_size: stats.n_closed,
+      source,
+    });
+
+    this.logger.log(
+      `[Kelly] ${assetClass} fraction=${(fraction * 100).toFixed(2)}% notional=$${notionalUsd.toFixed(0)} n=${stats.n_closed} wr=${(stats.wr * 100).toFixed(1)}% wilson95L=${(result.winRateLowerWilson * 100).toFixed(2)}% payoff=${payoffRatio.toFixed(3)} source=${source}`,
+    );
+  }
+
+  /**
+   * Fetch les positions fermées 14j filtrées (outliers R5 exclus) puis aggrège
+   * côté JS (Supabase JS n a pas de SUM/AVG natif sans .rpc()).
+   */
+  private async fetchClassStats(assetClass: string): Promise<ClassStats | null> {
+    const sinceIso = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+    try {
+      const { data, error } = await this.supabase
+        .getClient()
+        .from('lisa_positions')
+        .select('status, realized_pnl_pct, exit_price, entry_price')
+        .eq('portfolio_id', this.portfolioId)
+        .eq('asset_class', assetClass)
+        .like('status', 'closed%')
+        .gte('created_at', sinceIso)
+        .gt('realized_pnl_pct', -50)
+        .limit(2000);
+
+      if (error) {
+        this.logger.warn(`[Kelly] ${assetClass} stats query failed: ${error.message}`);
+        return null;
+      }
+
+      const rows = (data ?? []) as Array<{
+        status: string;
+        realized_pnl_pct: number | null;
+        exit_price: number | null;
+        entry_price: number | null;
+      }>;
+
+      // Garde supplémentaire R5 : exit_price > entry × 0.5 (le filter -50 le couvre
+      // déjà mathématiquement, mais on garde la garde explicite pour audit).
+      const safe = rows.filter((r) => {
+        if (r.entry_price == null || r.exit_price == null) return true;
+        return r.exit_price > r.entry_price * 0.5;
+      });
+
+      const n_closed = safe.length;
+      if (n_closed === 0) {
+        return { n_closed: 0, wr: 0, tp_avg_pct: null, sl_avg_pct: null };
+      }
+
+      const tpRows = safe.filter((r) => r.status === 'closed_target');
+      const slRows = safe.filter((r) => r.status === 'closed_stop');
+      const wr = tpRows.length / n_closed;
+
+      const avg = (xs: Array<{ realized_pnl_pct: number | null }>): number | null => {
+        const vals = xs.map((r) => r.realized_pnl_pct).filter((v): v is number => Number.isFinite(v as number));
+        if (vals.length === 0) return null;
+        return vals.reduce((a, b) => a + b, 0) / vals.length;
+      };
+
+      return {
+        n_closed,
+        wr,
+        tp_avg_pct: avg(tpRows),
+        sl_avg_pct: avg(slRows),
+      };
+    } catch (err) {
+      this.logger.warn(`[Kelly] ${assetClass} stats exception: ${(err as Error).message}`);
+      return null;
+    }
+  }
+
+  private computePayoffRatio(tpAvgPct: number | null, slAvgPct: number | null): number | null {
+    if (tpAvgPct == null || slAvgPct == null) return null;
+    if (slAvgPct === 0) return null;
+    const ratio = Math.abs(tpAvgPct) / Math.abs(slAvgPct);
+    return Number.isFinite(ratio) && ratio > 0 ? ratio : null;
+  }
+
+  private async upsertConfig(payload: {
+    asset_class: string;
+    notional_usd: number;
+    kelly_fraction: number;
+    win_rate_observed: number;
+    win_rate_wilson_lower: number;
+    payoff_ratio: number;
+    sample_size: number;
+    source: string;
+  }): Promise<void> {
+    const { error } = await this.supabase
+      .getClient()
+      .from('asset_class_kelly_config')
+      .upsert(
+        {
+          ...payload,
+          computed_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'asset_class' },
+      );
+    if (error) {
+      this.logger.warn(`[Kelly] upsert failed for ${payload.asset_class}: ${error.message}`);
+    }
+  }
+}

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -52,6 +52,8 @@ import { resolveTpSlPcts } from './tpsl-resolver';
 import { LisaCircuitBreakerService } from './circuit-breaker.service';
 import { SanityR5Service } from './sanity-r5.service';
 import { Qw3WarmupExtendedService } from '../quick-wins/qw-3-warmup-extended.service';
+// Phase 5 N2 — Kelly fractional sizing per asset_class
+import { AssetClassKellyConfigService } from './asset-class-kelly-config.service';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types internes
@@ -194,6 +196,7 @@ export class MechanicalTradingService {
     private readonly circuitBreaker: LisaCircuitBreakerService,
     private readonly sanityR5: SanityR5Service,
     private readonly qw3Warmup: Qw3WarmupExtendedService,
+    private readonly assetClassKelly: AssetClassKellyConfigService,
   ) {}
 
   /**
@@ -984,7 +987,23 @@ export class MechanicalTradingService {
 
       // Taille de position (trajectoire + momentum)
       // En hyper_active, effectiveMaxPositionPct cape à 25 % (cf. ci-dessus).
-      const maxNotional = capitalUsd.mul(effectiveMaxPositionPct).div(100).mul(sizingMultiplier).mul(qwSizingMultiplier);
+      //
+      // Phase 5 N2 — Kelly fractional sizing override par asset_class :
+      // si la matrice Kelly retourne un notional pour cette classe (edge positif
+      // détecté, sample_size >= 30), on l utilise comme BASE en lieu et place du
+      // calcul capital × pct. Les multipliers QW#15 / QW#18 / directive sizing
+      // s appliquent ENSUITE en aval pour booster / couper sur cette base.
+      const kellyNotional = this.assetClassKelly.getNotionalUsd(target.assetClass);
+      const baseNotional = kellyNotional !== null
+        ? new Decimal(kellyNotional)
+        : capitalUsd.mul(effectiveMaxPositionPct).div(100);
+      if (kellyNotional !== null) {
+        const defaultBase = capitalUsd.mul(effectiveMaxPositionPct).div(100);
+        this.logger.log(
+          `[Kelly] ${target.symbol} (${target.assetClass}) base notional override: $${kellyNotional.toFixed(0)} (vs default $${defaultBase.toFixed(0)})`,
+        );
+      }
+      const maxNotional = baseNotional.mul(sizingMultiplier).mul(qwSizingMultiplier);
       // Cap "first wave" : si on a déjà ouvert près de cycleNotionalCap
       // dans ce cycle, on réduit le notional restant pour ne pas dépasser.
       const remainingCycleBudget = cycleNotionalCap.minus(cycleNotionalUsed);

--- a/supabase/migrations/0143_kelly_per_class_notional.sql
+++ b/supabase/migrations/0143_kelly_per_class_notional.sql
@@ -1,0 +1,64 @@
+-- 0143 — Phase 5 N2 : Kelly fractional sizing par asset_class
+--
+-- Stocke le notional recommandé par classe, calculé par KellyRecomputeService
+-- toutes les heures depuis les positions fermées 14j glissants.
+--
+-- - notional_usd : montant recommandé en USD (clamp [500, 3000])
+-- - kelly_fraction : fraction Kelly (half-Kelly + clamp 0.25, ADR-007 §3.2)
+-- - sample_size : trades fermés sur la fenêtre 14j (min 30 pour activer)
+-- - win_rate_wilson_lower : borne basse 95 % Wilson (conservateur)
+-- - source : 'seed_initial' / 'auto_recompute' / 'auto_recompute_no_edge'
+--
+-- Si kelly_fraction = 0 OU sample_size < 30 : le service consommateur fallback
+-- au notional uniforme historique (~$1575). Backward-compatible 100 %.
+
+CREATE TABLE IF NOT EXISTS asset_class_kelly_config (
+  asset_class TEXT PRIMARY KEY,
+  notional_usd NUMERIC NOT NULL CHECK (notional_usd >= 500 AND notional_usd <= 3000),
+  kelly_fraction NUMERIC NOT NULL CHECK (kelly_fraction >= 0 AND kelly_fraction <= 0.25),
+  win_rate_observed NUMERIC,
+  win_rate_wilson_lower NUMERIC,
+  payoff_ratio NUMERIC,
+  sample_size INTEGER,
+  computed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  source TEXT NOT NULL DEFAULT 'auto_recompute',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kelly_config_computed_at
+  ON asset_class_kelly_config(computed_at);
+
+-- Seeds par défaut : fallback $1575 toutes classes, kelly_fraction=0 (= override désactivé).
+-- Le service KellyRecomputeService remplacera ces seeds dès le premier run horaire
+-- (typiquement à la prochaine heure ronde post-deploy).
+INSERT INTO asset_class_kelly_config (asset_class, notional_usd, kelly_fraction, sample_size, source)
+VALUES
+  ('us_equity_large',      1575, 0, 0, 'seed_initial'),
+  ('us_equity_small_mid',  1575, 0, 0, 'seed_initial'),
+  ('eu_equity',            1575, 0, 0, 'seed_initial'),
+  ('asia_equity',          1575, 0, 0, 'seed_initial'),
+  ('crypto_major',         1575, 0, 0, 'seed_initial')
+ON CONFLICT (asset_class) DO NOTHING;
+
+-- RLS lecture autorisée pour tous (config publique non sensible), écritures
+-- restreintes au service_role via les UPSERT du worker NestJS.
+ALTER TABLE asset_class_kelly_config ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'asset_class_kelly_config' AND policyname = 'kelly_config_read_all'
+  ) THEN
+    CREATE POLICY "kelly_config_read_all" ON asset_class_kelly_config FOR SELECT USING (true);
+  END IF;
+END$$;
+
+COMMENT ON TABLE asset_class_kelly_config IS
+  'Phase 5 N2 — notional recommandé par Kelly fractionnel par asset_class. Recompute horaire.';
+COMMENT ON COLUMN asset_class_kelly_config.notional_usd IS
+  'Notional en USD à utiliser à l ouverture (clamp [500, 3000]).';
+COMMENT ON COLUMN asset_class_kelly_config.kelly_fraction IS
+  'Fraction Kelly (half-Kelly + clamp 0.25). 0 = override désactivé, fallback caller.';
+COMMENT ON COLUMN asset_class_kelly_config.sample_size IS
+  'Nombre de trades fermés sur la fenêtre 14j. Min 30 pour activer (ADR-007 §3.4).';


### PR DESCRIPTION
## Phase 5 N2 — Kelly fractional sizing par asset_class

Branche le `KellySizingService` (ADR-007 PR #207a, existant côté gainers-scanner) sur les positions LISA réelles via une matrice DB recomputée toutes les heures. **Pas de modif TP/SL** — uniquement notional.

### Livrables

| Fichier | Rôle |
|---|---|
| `supabase/migrations/0143_kelly_per_class_notional.sql` | Table `asset_class_kelly_config` + seeds $1575/classe + RLS read-only |
| `apps/api/src/modules/lisa/services/asset-class-kelly-config.service.ts` | Lecture cache TTL 60s, pattern identique `AssetClassTpSlConfigService` (PR #329), fail-open total |
| `apps/api/src/modules/lisa/services/kelly-recompute.service.ts` | Worker cron `@Cron('0 * * * *')` UTC : fetch 14j → filter R5 → KellySizing → upsert |
| `apps/api/src/modules/lisa/services/mechanical-trading.service.ts` | Override base notional dans le loop d'ouverture (avant multipliers QW) |
| `apps/api/src/modules/lisa/lisa.module.ts` | Register les 2 nouveaux services |
| `__tests__/asset-class-kelly-config.service.spec.ts` (10 cas) | Cache, TTL stale, fail-open, conditions d'activation |
| `__tests__/kelly-recompute.service.spec.ts` (9 cas) | n<30 skip, edge négatif, clamp [500, 3000], Supabase down |

### Logique d'activation

`getNotionalUsd(class)` retourne `null` si :
- classe absente du cache, OU
- `kelly_fraction <= 0` (edge négatif), OU
- `sample_size < 30` (échantillon insuffisant)

→ caller fallback transparent au calcul `capital × effectiveMaxPositionPct / 100`.

Quand activé : Kelly fixe la **base** notional. Les multipliers `directive.sizingMultiplier`, `qwSizingMultiplier` (QW#15 first-trade boost, QW#18 .SHE/.KQ exchange mult) s'appliquent **ensuite en aval** sur cette base.

### Baseline 14j (mesurée 16 mai 20h55 CEST, outlier R5 SEE.LSE exclu)

| Classe | n | WR obs | Wilson95L | payoff | fullKelly | Verdict |
|---|---:|---:|---:|---:|---:|---|
| eu_equity | 38 | 44.9% | 30.29% | 0.902 | -46.97% | EDGE NÉGATIF |
| us_equity_large | 46 | 19.2% | 10.38% | 0.976 | -81.43% | EDGE NÉGATIF |
| asia_equity | 80 | 18.0% | 11.11% | 1.417 | -51.61% | EDGE NÉGATIF |
| us_equity_small_mid | 27 | — | — | — | — | n<30 INSUFFICIENT |
| crypto_major | 9 | — | — | — | — | n<30 INSUFFICIENT |

**Verdict initial : NO_TRADE toutes classes** (`kelly_fraction=0`). Backward-compatible 100 %.

Le système s'auto-activera dès qu'un edge positif sera détecté (post 5j des 8 QW + Circuit Breaker mergés PR #331 si la cible +$441/jour se matérialise). Recompute horaire automatique, aucune action manuelle.

### Capital estimé

MVP : constante `CAPITAL_ESTIME_USD = 15_750` (= notional_avg historique × 10 positions max). Override via env `KELLY_CAPITAL_ESTIME_USD`. **TODO Phase 5 N3** : récupérer le réel depuis `portfolios.equity_usd`.

### Tests

```
$ npx jest --testPathPattern "kelly"
Test Suites: 3 passed, 3 total
Tests:       30 passed, 30 total

$ npx jest --testPathPattern "modules/lisa"   # full Lisa suite
Test Suites: 107 passed, 107 total
Tests:       1369 passed, 1369 total   (1350 avant + 19 Kelly)

$ npx tsc -b   # green
```

### Rollback

3 chemins :
1. `KellyRecomputeService` ne s'exécute pas (cron disabled / Supabase down) → cache vide → fallback transparent
2. `kelly_fraction=0` en DB pour toutes classes → fallback (état initial des seeds)
3. Revert la PR (table reste mais inutilisée)

### Procédure post-merge

```bash
# 1. Apply migration
psql $SUPABASE_URL -f supabase/migrations/0143_kelly_per_class_notional.sql

# 2. Le cron tournera à la prochaine heure ronde
# 3. Audit : SELECT * FROM asset_class_kelly_config ORDER BY computed_at DESC;
```

### Interdits respectés

- KellySizingService inchangé (ADR-007, intouchable)
- `asset_class_tpsl_config` (PR #329) inchangé
- Services QW (PR #331) inchangés
- Aucun hardcode notional dans le code (tout passe par DB)
- Pas d'emoji

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_