### PR TITLE
hotfix(qw45): forwardRef MechanicalTradingService injection (fix prod crash loop)

### DIFF
--- a/apps/api/src/modules/lisa/quick-wins/qw-45-force-close-us-large.service.ts
+++ b/apps/api/src/modules/lisa/quick-wins/qw-45-force-close-us-large.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cron } from '@nestjs/schedule';
 import { SupabaseService } from '../../supabase/supabase.service';
@@ -36,6 +36,13 @@ export class Qw45ForceCloseUsLargeService {
   constructor(
     private readonly config: ConfigService,
     private readonly supabase: SupabaseService,
+    // forwardRef pour casser le cycle DI : MechanicalTradingService transite par
+    // LisaService → ... → re-touche un provider du même module à l'init.
+    // Sans forwardRef, Nest reçoit undefined à l'index [2] et l'app crashe au boot
+    // (production crash loop observé sur PR #332). Le forwardRef diffère la
+    // résolution jusqu'au premier appel runtime, ce qui suffit (le cron @Cron
+    // ne tire forceClosePosition qu'à 19:45 UTC en Lun-Ven).
+    @Inject(forwardRef(() => MechanicalTradingService))
     private readonly mechanicalTrading: MechanicalTradingService,
   ) {
     this.enabled = (this.config.get<string>('QW45_FORCE_CLOSE_US_LARGE_ENABLED') ?? 'true') === 'true';


### PR DESCRIPTION
## URGENT — Production crash loop

App `smartvest` sur Fly est en crash-loop continu depuis le merge de PR #332. Logs Fly montrent :

```
[Nest] ERROR [ExceptionHandler] Nest can't resolve dependencies of the
Qw45ForceCloseUsLargeService (ConfigService, SupabaseService, ?).
Please make sure that the argument dependency at index [2] is available
in the LisaModule context.

INFO Main child exited normally with code: 1
machine has reached its max restart count of 10
```

Le service crashe à `NestFactory.create(AppModule)` → l'app n'écoute jamais sur 0.0.0.0:3001 → tous les requests vers `tcp/443` retournent `[PR01] no known healthy instances`.

## Cause

PR #332 a injecté `MechanicalTradingService` dans `Qw45ForceCloseUsLargeService` sans `forwardRef`. NestJS détecte un cycle DI transitif via `LisaModule` (`MechanicalTradingService` → `LisaService` → ...) au moment de l'init eager des providers.

Les specs Jest unitaires utilisent du `new Qw45ForceCloseUsLargeService(mockConfig, mockSupabase, mockMechanical)` manuel — le DI Nest n'est jamais exercé, donc le cycle est passé inaperçu côté CI.

## Fix

```ts
@Inject(forwardRef(() => MechanicalTradingService))
private readonly mechanicalTrading: MechanicalTradingService,
```

Pattern NestJS standard. Diffère la résolution au premier appel runtime (cron `@Cron('45 19 * * 1-5', UTC)`). Aucun impact fonctionnel — le service reste 100 % opérationnel.

## Vérification

```
$ npx tsc -b   # clean
$ npx jest --testPathPattern "qw-45"   # 6/6 pass (specs inchangés)
```

## Diff

1 fichier, 8 insertions, 1 deletion (juste l'import `forwardRef`/`Inject` + le décorateur sur le param constructor).

## Follow-up (séparé)

Ajouter un smoke test régression : `Test.createTestingModule({ imports: [LisaModule] }).compile()` qui aurait catché ce cycle en CI. Sera tracké en ticket séparé pour ne pas étendre le scope de ce hotfix urgent.

## Action mergeur

À merger **immédiatement** + déployer Fly pour restaurer le service. Pas de migration DB, rollback < 30s si problème post-deploy (`git revert` + redeploy).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_