### PR TITLE
feat(blacklist): PR #337 — étend DEAD_TICKERS_STATIC avec 14 tickers asia (gain ~7400 calls/j + arrêt hémorragie $119/j)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/ticker-blacklist.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/ticker-blacklist.spec.ts
@@ -52,6 +52,45 @@ describe('TickerBlacklistService', () => {
     });
   });
 
+  describe('PR #337 — asia empty-response + saigneur', () => {
+    it('blackliste 222420.KQ par défaut (saigneur -$3582/30j)', () => {
+      const svc = makeService();
+      expect(svc.isBlacklisted('222420.KQ')).toBe(true);
+    });
+
+    it('blackliste 000500.KO par défaut (empty response permanent)', () => {
+      const svc = makeService();
+      expect(svc.isBlacklisted('000500.KO')).toBe(true);
+    });
+
+    it.each([
+      '000500.KO', '003550.KO', '005070.KO', '005300.KO', '016360.KO',
+      '093370.KO', '039830.KQ', '045390.KQ', '047770.KQ', '059120.KQ',
+      '088800.KQ', '094360.KQ', '200710.KQ', '222420.KQ',
+    ])('blackliste %s (case-insensitive)', (ticker) => {
+      const svc = makeService();
+      expect(svc.isBlacklisted(ticker)).toBe(true);
+      expect(svc.isBlacklisted(ticker.toLowerCase())).toBe(true);
+    });
+
+    it('NE blackliste PAS 002900.KO (seul .KO rentable +$177/30j)', () => {
+      const svc = makeService();
+      expect(svc.isBlacklisted('002900.KO')).toBe(false);
+    });
+
+    it('NE blackliste PAS 005930.KO (Samsung, contrôle)', () => {
+      const svc = makeService();
+      expect(svc.isBlacklisted('005930.KO')).toBe(false);
+    });
+
+    it('respecte le flag GAINERS_NSE_BLACKLIST_ENABLED=false (rollback global asia + NSE)', () => {
+      const svc = makeService({ GAINERS_NSE_BLACKLIST_ENABLED: 'false' });
+      expect(svc.isBlacklisted('222420.KQ')).toBe(false);
+      expect(svc.isBlacklisted('BHEL.NSE')).toBe(false);
+      expect(svc.isBlacklisted('000500.KO')).toBe(false);
+    });
+  });
+
   describe('auto-blacklist on strikes', () => {
     it('3 strikes 404 in 24h → blacklisted', () => {
       const svc = makeService();
@@ -159,7 +198,7 @@ describe('TickerBlacklistService', () => {
       const t0 = Date.now();
       const stats = svc.getStats();
       expect(stats.staticEnabled).toBe(true);
-      expect(stats.staticSize).toBe(9);
+      expect(stats.staticSize).toBe(23); // PR #337 : 9 NSE + 13 asia empty + 1 saigneur
       expect(stats.dynamicCount).toBe(0);
 
       // Add a dynamic blacklist

--- a/apps/api/src/modules/lisa/services/ticker-blacklist.service.ts
+++ b/apps/api/src/modules/lisa/services/ticker-blacklist.service.ts
@@ -3,25 +3,31 @@ import { ConfigService } from '@nestjs/config';
 import { DEAD_NSE_TICKERS } from '@smartvest/ai-analyst';
 
 /**
- * Bug #R10 — Blacklist tickers EODHD morts (HTTP 404 persistant).
+ * Bug #R10 + PR #337 — Blacklist tickers EODHD confirmés inutiles.
  *
  * Deux niveaux :
- *   1. Statique : 9 tickers `.NSE` confirmés morts depuis ≥ 7 jours (mesure
- *      15/05/2026, ~81k calls EODHD gaspillés sur la fenêtre). Liste exportée
- *      par `@smartvest/ai-analyst` (DEAD_NSE_TICKERS).
+ *   1. Statique : 23 tickers (.NSE morts 404 + .KO/.KQ empty-response + saigneur).
+ *      Liste exportée par `@smartvest/ai-analyst` (DEAD_TICKERS_STATIC, alias
+ *      DEAD_NSE_TICKERS conservé pour backward-compat).
+ *      Mesure 17/05/2026 : ~143k calls EODHD gaspillés sur 7j + hémorragie -$119/j.
  *   2. Dynamique : compteur de strikes 404 par ticker sur fenêtre glissante 24h.
  *      Au-delà du seuil (`GAINERS_AUTO_BLACKLIST_404_STRIKES`, default 3) → ban
  *      pour `GAINERS_AUTO_BLACKLIST_TTL_HOURS` heures (default 24).
  *
- * Stockage MVP : in-memory Map. Phase MESURE active jusqu'au 17/05 — pas
- * d'ALTER TABLE Supabase ce sprint. La perte de l'état au restart Fly est
- * tolérable : la liste statique des 9 tickers évite les 9 leaks de référence,
- * et un strike-counter en mémoire reconverge en quelques cycles.
+ * Stockage MVP : in-memory Map pour la partie dynamique. Pas d'ALTER TABLE
+ * Supabase à ce sprint. La perte de l'état au restart Fly est tolérable :
+ * la liste statique couvre les leaks majeurs, et un strike-counter en mémoire
+ * reconverge en quelques cycles.
  *
  * Env vars :
- *   - GAINERS_NSE_BLACKLIST_ENABLED       (default true)
+ *   - GAINERS_NSE_BLACKLIST_ENABLED       (default true) — couvre TOUT le static
  *   - GAINERS_AUTO_BLACKLIST_404_STRIKES  (default 3)
  *   - GAINERS_AUTO_BLACKLIST_TTL_HOURS    (default 24)
+ *
+ * Note : `GAINERS_NSE_BLACKLIST_ENABLED=false` désactive AUSSI la blacklist asia
+ * (même flag par simplicité — flag par catégorie n'apporte rien tant qu'on ne
+ * fait pas de rollback partiel). Si rollback urgent sur asia uniquement, retirer
+ * les lignes asia du Set DEAD_TICKERS_STATIC et redeploy.
  *
  * Pour les tests : injection ConfigService partiel suffit, pas de DB.
  */

--- a/packages/ai-analyst/src/strategies/__tests__/session-filter.spec.ts
+++ b/packages/ai-analyst/src/strategies/__tests__/session-filter.spec.ts
@@ -93,16 +93,43 @@ describe('session-filter helpers', () => {
     });
   });
 
-  describe('DEAD_NSE_TICKERS', () => {
-    it('contains exactly 9 tickers (R10 confirmed dead set)', () => {
-      expect(DEAD_NSE_TICKERS.size).toBe(9);
+  describe('DEAD_NSE_TICKERS (alias) + DEAD_TICKERS_STATIC', () => {
+    it('total = 23 tickers (9 NSE legacy + 13 asia empty + 1 saigneur)', () => {
+      expect(DEAD_NSE_TICKERS.size).toBe(23);
     });
 
     it.each([
       'BHEL.NSE', 'CESC.NSE', 'GHCL.NSE', 'HEG.NSE', 'IGPL.NSE',
       'NESCO.NSE', 'NITCO.NSE', 'NOCIL.NSE', 'SOTL.NSE',
-    ])('contains %s', (ticker) => {
+    ])('contains legacy .NSE %s', (ticker) => {
       expect(DEAD_NSE_TICKERS.has(ticker)).toBe(true);
+    });
+
+    it.each([
+      '000500.KO', '003550.KO', '005070.KO', '005300.KO', '016360.KO',
+      '093370.KO', '039830.KQ', '045390.KQ', '047770.KQ', '059120.KQ',
+      '088800.KQ', '094360.KQ', '200710.KQ',
+    ])('contains asia empty-response %s (PR #337)', (ticker) => {
+      expect(DEAD_NSE_TICKERS.has(ticker)).toBe(true);
+    });
+
+    it('contient le saigneur 222420.KQ (PR #337)', () => {
+      expect(DEAD_NSE_TICKERS.has('222420.KQ')).toBe(true);
+    });
+
+    it('NE contient PAS 002900.KO (seul .KO rentable +$177/30j)', () => {
+      expect(DEAD_NSE_TICKERS.has('002900.KO')).toBe(false);
+    });
+
+    it('NE contient PAS 005930.KO (Samsung, contrôle)', () => {
+      expect(DEAD_NSE_TICKERS.has('005930.KO')).toBe(false);
+    });
+
+    it('alias DEAD_NSE_TICKERS pointe vers DEAD_TICKERS_STATIC (backward-compat)', () => {
+      // Vérification de l'alias deprecated : même référence d'objet
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { DEAD_TICKERS_STATIC } = require('../session-filter');
+      expect(DEAD_NSE_TICKERS).toBe(DEAD_TICKERS_STATIC);
     });
   });
 });
@@ -110,13 +137,15 @@ describe('session-filter helpers', () => {
 describe('filterTickersForFetch — R9/R10 spec cases', () => {
   it('Asia closed at 11:40 UTC → 0 fetch for .KQ/.KO/.SHE (US still pre-RTH)', () => {
     const r = filterTickersForFetch(
-      ['002371.SHE', '000500.KO', '045390.KQ', 'AAPL', 'BTCUSDT'],
+      // PR #337 : `005930.KO` (Samsung) + `002900.KO` (seul rentable) hors static
+      // blacklist, donc bien droppés en session_closed et non en nse_blacklisted.
+      ['002371.SHE', '005930.KO', '002900.KO', 'AAPL', 'BTCUSDT'],
       { now: utcOn(11, 40) },
     );
     // 11:40 UTC : Asia fermé (after 08:00), US pre-RTH (14:30 only), seul crypto ouvert
     expect(r.kept).toEqual(['BTCUSDT']);
     expect(r.droppedSessionClosed.asia).toEqual([
-      '002371.SHE', '000500.KO', '045390.KQ',
+      '002371.SHE', '005930.KO', '002900.KO',
     ]);
     expect(r.droppedSessionClosed.us).toEqual(['AAPL']);
   });
@@ -170,9 +199,12 @@ describe('filterTickersForFetch — R9/R10 spec cases', () => {
   });
 
   it('R9 prod scenario reproduction : 11:40 UTC, mix universe', () => {
-    // Reproduit la séquence prod 15/05/2025 11:40 UTC (Asia closed, US pre-RTH, EU open)
+    // Reproduit la séquence prod 15/05/2025 11:40 UTC (Asia closed, US pre-RTH, EU open).
+    // PR #337 : substitution des tickers asia par des entrées hors static blacklist
+    // (`005930.KO` Samsung, `002900.KO` rentable) — sinon ils tombent en
+    // droppedNseBlacklist au lieu de droppedSessionClosed.asia.
     const symbols = [
-      '002371.SHE', '000500.KO', '045390.KQ', // 3 Asia → drop
+      '002371.SHE', '005930.KO', '002900.KO', // 3 Asia → drop
       'MC.PA', 'BMW.DE',                        // 2 EU → keep (open)
       'AAPL',                                   // US closed pre-RTH → drop
       'BTCUSDT', 'ETHUSDT',                     // 2 crypto → keep
@@ -252,7 +284,10 @@ describe('filterTickersForFetch — R9/R10 spec cases', () => {
 describe('formatFilterLog', () => {
   it('formats counts with multiplier (R9 example : 17 Asia × 1 = 17 saved)', () => {
     const symbols = [
-      '002371.SHE', '000500.KO', '045390.KQ',
+      // PR #337 : `000500.KO` et `045390.KQ` désormais dans static blacklist —
+      // substitution par des tickers hors blacklist pour que le comptage reste
+      // `3 asia` et non `1 asia, 2 nse_blacklisted`.
+      '002371.SHE', '005930.KO', '002900.KO',
       'AAPL',
     ];
     const r = filterTickersForFetch(symbols, { now: new Date(Date.UTC(2025, 4, 12, 11, 40)) });

--- a/packages/ai-analyst/src/strategies/session-filter.ts
+++ b/packages/ai-analyst/src/strategies/session-filter.ts
@@ -75,12 +75,19 @@ export function marketForSymbol(symbol: string): MarketSessionClass | null {
 }
 
 /**
- * Bug #R10 — Blacklist statique de tickers .NSE morts confirmés HTTP 404
- * depuis 7+ jours (mesure 15/05/2026, ~81 000 calls EODHD gaspillés sur cette
- * fenêtre seule). Ces tickers ne reviennent pas — soit délistés EODHD, soit
- * symbol convention NSE différente. À retirer si EODHD republie la data.
+ * Bug #R10 + PR #337 — Blacklist statique de tickers EODHD confirmés inutiles :
+ *   1. .NSE morts (HTTP 404 persistant ≥ 7j, mesure 15/05/2026, ~81k calls/7j gaspillés)
+ *   2. Asia empty-response permanents (HTTP 200 + body vide, ~62k calls/7j gaspillés,
+ *      0 prix jamais retourné sur 7j, 0 accept sur 30j) — mesure 17/05/2026
+ *   3. Saigneur asia (222420.KQ : 102 SL / 0 TP sur 30j, PnL -$3582 = -$119/j) —
+ *      blacklist proactive pour arrêt hémorragie immédiat
+ *
+ * À retirer si EODHD republie la data ou si un ticker prouve de la valeur via
+ * audit manuel. Le `002900.KO` reste autorisé (seul .KO/.KQ rentable mesuré
+ * sur 30j : +$177.51 / 33 % WR).
  */
-export const DEAD_NSE_TICKERS: ReadonlySet<string> = new Set<string>([
+export const DEAD_TICKERS_STATIC: ReadonlySet<string> = new Set<string>([
+  // --- .NSE morts (R10 original, 9 tickers) ---
   'BHEL.NSE',
   'CESC.NSE',
   'GHCL.NSE',
@@ -90,7 +97,33 @@ export const DEAD_NSE_TICKERS: ReadonlySet<string> = new Set<string>([
   'NITCO.NSE',
   'NOCIL.NSE',
   'SOTL.NSE',
+
+  // --- Asia empty-response permanents (PR #337, 13 tickers) ---
+  // Mesure 17/05/2026 : 4000-4750 calls/7j chacun, 100 % empty, 0 accept sur 30j.
+  '000500.KO',
+  '003550.KO',
+  '005070.KO',
+  '005300.KO',
+  '016360.KO',
+  '093370.KO',
+  '039830.KQ',
+  '045390.KQ',
+  '047770.KQ',
+  '059120.KQ',
+  '088800.KQ',
+  '094360.KQ',
+  '200710.KQ',
+
+  // --- Asia saigneur (PR #337, 1 ticker) ---
+  // 222420.KQ : 102 SL / 0 TP sur 30j, PnL -$3582 (-$119/j). Arrêt hémorragie.
+  '222420.KQ',
 ]);
+
+/**
+ * @deprecated Utiliser `DEAD_TICKERS_STATIC`. Alias gardé pour backward-compat
+ *   avec les callers existants (TickerBlacklistService, tests).
+ */
+export const DEAD_NSE_TICKERS: ReadonlySet<string> = DEAD_TICKERS_STATIC;
 
 export interface FilterOptions {
   now: Date;


### PR DESCRIPTION
## Contexte
Logs Fly 17/05 dimanche matin → 27 empty response / 65 min sur 15 tickers asia (.KO/.KQ). Investigation EODHD directe + SQL `eodhd_request_log` 7j + `lisa_positions` 30j révèle :
- **13 tickers asia** : ~62k calls/7j, 100 % HTTP 200 + `price_usd=NULL`, **0 prix jamais retourné sur 7j, 0 accept sur 30j malgré 0-150 signaux** → gaspillage pur, aucune opportunité ratée
- **1 saigneur** `222420.KQ` : 102 SL / 0 TP sur 30j, **0 % WR**, PnL -$3582 (-$119/j) → hémorragie active
- **1 conservé** `002900.KO` : +$177/30j, 33 % WR → exclu du blacklist (seul .KO/.KQ rentable mesuré)

## Gain attendu
- Quota EODHD : **-7400 calls/jour** (~7.4 % quota)
- PnL : **+$119/jour mesurable** (pertes 222420.KQ évitées)
- Risque opportunité ratée : nul (preuves SQL 30j)

## Modifications

| Fichier | Rôle |
|---|---|
| `packages/ai-analyst/src/strategies/session-filter.ts` | Renomme `DEAD_NSE_TICKERS` → `DEAD_TICKERS_STATIC` (+ alias deprecated pour backward-compat). 9 NSE + 13 asia + 1 saigneur = **23 entrées** |
| `apps/api/src/modules/lisa/services/ticker-blacklist.service.ts` | JSDoc seulement (portée élargie + note rollback) |
| `__tests__/session-filter.spec.ts` | Mise à jour `size=23` + 6 specs PR #337 + fixtures asia déjà blacklistés substitués |
| `__tests__/ticker-blacklist.spec.ts` | Mise à jour `staticSize=23` + 5 specs PR #337 |

Aucune modif Supabase, Fly, Vercel. Aucun nouvel import. Backward-compat 100 % via `export const DEAD_NSE_TICKERS = DEAD_TICKERS_STATIC`.

## Tests

```
$ npm test --workspace=@smartvest/ai-analyst
Test Suites: 26 passed
Tests:       471 passed (454 avant + 17 nouveaux PR #337)

$ npx jest --testPathPattern "modules/lisa" --forceExit
Test Suites: 109 passed
Tests:       1426 passed (1407 avant + 19 nouveaux PR #337)

$ npx tsc -b  # clean
```

## Rollback

```bash
flyctl secrets set GAINERS_NSE_BLACKLIST_ENABLED=false -a smartvest
```

Désactive l'intégralité du static (asia + NSE). Pour rollback partiel asia uniquement : retirer les lignes asia du Set `DEAD_TICKERS_STATIC` et redeploy (le flag NSE/asia est unifié par simplicité).

## Validation post-merge (J+1)

Cron de contrôle automatique programmé lundi 18 mai 22h45 Paris pour mesurer :
- pct calls 200 OK avec `price > 0` sur les autres asia (anti-régression)
- décompte signaux asia accept sur 24h (anti-opportunité ratée)
- PnL asia jour vs baseline 30j

Si anti-régression détectée → revert via flag immédiat ou retrait sélectif du Set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_