### PR TITLE
feat(ui): adaptive params dashboard - TP/SL matrix + QW activity + circuit breaker (Phase 5 N1+N2)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Body, Controller, Get, Headers, HttpCode, Param, Post, Query } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Get, Headers, HttpCode, Param, Patch, Post, Query } from '@nestjs/common';
 import { extractUserId } from '../../common/extract-user-id';
 import { LisaService } from './services/lisa.service';
 import { DecisionLogService } from './services/decision-log.service';
@@ -8,6 +8,10 @@ import { NewsRankerService } from './services/news-ranker.service';
 import { EodhdEnrichmentService } from './services/eodhd-enrichment.service';
 import { NewsAggregatorService } from './services/news-aggregator.service';
 import { SupabaseService } from '../supabase/supabase.service';
+// PR #338 — UI Phase 5 N1+N2 (matrice TP/SL, QW activity, risk state)
+import { AssetClassTpslService } from './services/asset-class-tpsl.service';
+import { QuickWinsStatsService } from './services/quick-wins-stats.service';
+import { RiskStateService } from './services/risk-state.service';
 import { DailySessionService } from './services/daily-session.service';
 import { ProfitSweepService } from './services/profit-sweep.service';
 import { MacroModeService, type MacroMode } from './services/macro-mode.service';
@@ -50,7 +54,52 @@ export class LisaController {
     private readonly gainersUserShadow: GainersUserShadowService,
     private readonly gainersAutoRelax: GainersAutoRelaxService,
     private readonly postSlBackfill: PostSlBackfillService,
+    private readonly assetClassTpsl: AssetClassTpslService,
+    private readonly qwStats: QuickWinsStatsService,
+    private readonly riskState: RiskStateService,
   ) {}
+
+  // ─────────────────────────────────────────────────────────────────
+  // PR #338 — UI Phase 5 N1+N2 endpoints
+  // ─────────────────────────────────────────────────────────────────
+
+  @Get('asset-class-tpsl')
+  listAssetClassTpsl(@Headers() headers: Record<string, string>) {
+    extractUserId(headers);
+    return this.assetClassTpsl.list();
+  }
+
+  @Patch('asset-class-tpsl/:assetClass')
+  updateAssetClassTpsl(
+    @Headers() headers: Record<string, string>,
+    @Param('assetClass') assetClass: string,
+    @Body() body: Record<string, unknown>,
+  ) {
+    extractUserId(headers);
+    return this.assetClassTpsl.update(assetClass, body);
+  }
+
+  @Get('quick-wins/stats')
+  qwStats24h(@Headers() headers: Record<string, string>) {
+    extractUserId(headers);
+    return this.qwStats.stats24h();
+  }
+
+  @Get('quick-wins/recent')
+  qwRecent(@Headers() headers: Record<string, string>, @Query('limit') limit?: string) {
+    extractUserId(headers);
+    const parsed = parseInt(limit ?? '50', 10);
+    return this.qwStats.recent(Number.isFinite(parsed) ? parsed : 50);
+  }
+
+  @Get('risk-state/:portfolioId')
+  getRiskState(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+  ) {
+    extractUserId(headers);
+    return this.riskState.portfolioRiskState(portfolioId);
+  }
 
   // ─────────────────────────────────────────────────────────────────
   // MACRO MODE — INVESTMENT vs HARVEST

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -84,6 +84,10 @@ import {
 } from './quick-wins';
 // Phase 5 N1 PR-2 — matrice TP/SL par asset_class
 import { AssetClassTpSlConfigService } from './services/asset-class-tpsl-config.service';
+// PR #338 — UI Phase 5 N1+N2
+import { AssetClassTpslService } from './services/asset-class-tpsl.service';
+import { QuickWinsStatsService } from './services/quick-wins-stats.service';
+import { RiskStateService } from './services/risk-state.service';
 // Phase 5 N1 PR-3+PR-4 — circuit breaker + sanity R5 hotfix
 import { LisaCircuitBreakerService } from './services/circuit-breaker.service';
 import { SanityR5Service } from './services/sanity-r5.service';
@@ -186,6 +190,10 @@ import { KellyRecomputeService } from './services/kelly-recompute.service';
     QuickWinsPipelineService,
     // Phase 5 N1 PR-2 — matrice TP/SL DB-driven (read-only, cache 60s, fail-open)
     AssetClassTpSlConfigService,
+    // PR #338 — UI Phase 5 N1+N2 (lecture/écriture matrice TP/SL, agrégation QW stats, état de risque)
+    AssetClassTpslService,
+    QuickWinsStatsService,
+    RiskStateService,
     // Phase 5 N1 PR-3+PR-4 — nouveaux QWs + circuit breaker + sanity R5
     Qw3WarmupExtendedService,
     Qw4RegimeFilterService,

--- a/apps/api/src/modules/lisa/services/__tests__/asset-class-tpsl.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/asset-class-tpsl.spec.ts
@@ -1,0 +1,112 @@
+import { BadRequestException } from '@nestjs/common';
+import { AssetClassTpslService } from '../asset-class-tpsl.service';
+import type { SupabaseService } from '../../../supabase/supabase.service';
+
+interface ChainStub {
+  rows?: Array<Record<string, unknown>> | null;
+  selectError?: { message: string } | null;
+  updateRow?: Record<string, unknown> | null;
+  updateError?: { message: string } | null;
+}
+
+function makeSupabase(stub: ChainStub): SupabaseService {
+  return {
+    isReady: () => true,
+    getClient: () => ({
+      from: () => ({
+        // list path : .select(...).order(...)
+        select: (_cols: string, _opts?: unknown) => ({
+          order: () => Promise.resolve({ data: stub.rows ?? null, error: stub.selectError ?? null }),
+          eq: () => ({
+            select: () => ({
+              single: () =>
+                Promise.resolve({ data: stub.updateRow ?? null, error: stub.updateError ?? null }),
+            }),
+          }),
+        }),
+        // update path : .update(payload).eq(...).select().single()
+        update: () => ({
+          eq: () => ({
+            select: () => ({
+              single: () =>
+                Promise.resolve({ data: stub.updateRow ?? null, error: stub.updateError ?? null }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  } as unknown as SupabaseService;
+}
+
+describe('AssetClassTpslService', () => {
+  describe('list()', () => {
+    it('retourne le tableau ordonné par asset_class', async () => {
+      const rows = [
+        { asset_class: 'asia_equity', tp_pct: 0.03, sl_pct: -0.013 },
+        { asset_class: 'eu_equity', tp_pct: 0.025, sl_pct: -0.018 },
+      ];
+      const svc = new AssetClassTpslService(makeSupabase({ rows }));
+      const result = await svc.list();
+      expect(result).toHaveLength(2);
+      expect(result[0].asset_class).toBe('asia_equity');
+    });
+  });
+
+  describe('update() — clamps', () => {
+    it('rejette tp_pct=0.15 (hors range)', async () => {
+      const svc = new AssetClassTpslService(makeSupabase({}));
+      await expect(
+        svc.update('us_equity_large', { tp_pct: 0.15 }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejette sl_pct=0.01 (positif)', async () => {
+      const svc = new AssetClassTpslService(makeSupabase({}));
+      await expect(
+        svc.update('us_equity_large', { sl_pct: 0.01 }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejette score_min_floor=10 (hors range)', async () => {
+      const svc = new AssetClassTpslService(makeSupabase({}));
+      await expect(
+        svc.update('us_equity_large', { score_min_floor: 10 }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejette warmup_min_override=200 (hors range)', async () => {
+      const svc = new AssetClassTpslService(makeSupabase({}));
+      await expect(
+        svc.update('us_equity_large', { warmup_min_override: 200 }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejette asset_class inconnue', async () => {
+      const svc = new AssetClassTpslService(makeSupabase({}));
+      await expect(
+        svc.update('fx_major', { tp_pct: 0.02 }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('accepte patch valide et retourne row updated', async () => {
+      const updated = {
+        asset_class: 'us_equity_large',
+        tp_pct: 0.028,
+        sl_pct: -0.014,
+        warmup_min_override: 30,
+        regime_filter_enabled: false,
+        score_min_floor: 0.85,
+        path_eff_floor: 0.6,
+        notes: 'test',
+        updated_at: new Date().toISOString(),
+      };
+      const svc = new AssetClassTpslService(makeSupabase({ updateRow: updated }));
+      const result = await svc.update('us_equity_large', {
+        tp_pct: 0.028,
+        sl_pct: -0.014,
+      });
+      expect(result.tp_pct).toBe(0.028);
+      expect(result.asset_class).toBe('us_equity_large');
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/__tests__/quick-wins-stats.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/quick-wins-stats.spec.ts
@@ -1,0 +1,99 @@
+import { QuickWinsStatsService } from '../quick-wins-stats.service';
+import type { SupabaseService } from '../../../supabase/supabase.service';
+
+interface Stub {
+  statsRows?: Array<Record<string, unknown>> | null;
+  recentRows?: Array<Record<string, unknown>> | null;
+  recentLimitCaptured?: { last: number | null };
+}
+
+function makeSupabase(stub: Stub): SupabaseService {
+  return {
+    isReady: () => true,
+    getClient: () => ({
+      from: () => ({
+        select: () => ({
+          gte: () => ({
+            limit: () => Promise.resolve({ data: stub.statsRows ?? null, error: null }),
+          }),
+          order: () => ({
+            limit: (n: number) => {
+              if (stub.recentLimitCaptured) stub.recentLimitCaptured.last = n;
+              return Promise.resolve({ data: stub.recentRows ?? null, error: null });
+            },
+          }),
+        }),
+      }),
+    }),
+  } as unknown as SupabaseService;
+}
+
+describe('QuickWinsStatsService', () => {
+  describe('stats24h()', () => {
+    it('aggrège correctement les décisions par qw_id', async () => {
+      const rows = [
+        { qw_id: 'QW_1', decision: 'pass', would_have_passed_without_flag: false },
+        { qw_id: 'QW_1', decision: 'block', would_have_passed_without_flag: true },
+        { qw_id: 'QW_1', decision: 'block', would_have_passed_without_flag: true },
+        { qw_id: 'QW_18', decision: 'modify', would_have_passed_without_flag: true },
+      ];
+      const svc = new QuickWinsStatsService(makeSupabase({ statsRows: rows }));
+      const result = await svc.stats24h();
+      expect(result).toHaveLength(2);
+
+      const qw1 = result.find((r) => r.qw_id === 'QW_1')!;
+      expect(qw1.total).toBe(3);
+      expect(qw1.pass).toBe(1);
+      expect(qw1.block).toBe(2);
+      expect(qw1.modify).toBe(0);
+      expect(qw1.shadow_would_have_passed).toBe(2);
+    });
+
+    it('calcule pct_block avec 1 décimale (block/total × 100)', async () => {
+      const rows = [
+        { qw_id: 'QW_46', decision: 'block', would_have_passed_without_flag: true },
+        { qw_id: 'QW_46', decision: 'block', would_have_passed_without_flag: true },
+        { qw_id: 'QW_46', decision: 'pass', would_have_passed_without_flag: false },
+      ];
+      const svc = new QuickWinsStatsService(makeSupabase({ statsRows: rows }));
+      const result = await svc.stats24h();
+      const qw46 = result.find((r) => r.qw_id === 'QW_46')!;
+      expect(qw46.pct_block).toBe(66.7); // 2/3 = 0.6667 → 66.7
+    });
+
+    it('retourne tableau vide si table vide', async () => {
+      const svc = new QuickWinsStatsService(makeSupabase({ statsRows: [] }));
+      const result = await svc.stats24h();
+      expect(result).toEqual([]);
+    });
+
+    it('résultat trié par qw_id ascendant', async () => {
+      const rows = [
+        { qw_id: 'QW_46', decision: 'pass', would_have_passed_without_flag: false },
+        { qw_id: 'QW_1', decision: 'pass', would_have_passed_without_flag: false },
+        { qw_id: 'QW_18', decision: 'modify', would_have_passed_without_flag: true },
+      ];
+      const svc = new QuickWinsStatsService(makeSupabase({ statsRows: rows }));
+      const result = await svc.stats24h();
+      expect(result.map((r) => r.qw_id)).toEqual(['QW_1', 'QW_18', 'QW_46']);
+    });
+  });
+
+  describe('recent()', () => {
+    it('clamp limit à [1, 200]', async () => {
+      const captured = { last: null as number | null };
+      const svc = new QuickWinsStatsService(
+        makeSupabase({ recentRows: [], recentLimitCaptured: captured }),
+      );
+
+      await svc.recent(500);
+      expect(captured.last).toBe(200);
+
+      await svc.recent(-5);
+      expect(captured.last).toBe(1);
+
+      await svc.recent(75);
+      expect(captured.last).toBe(75);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/__tests__/risk-state.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/risk-state.spec.ts
@@ -1,0 +1,130 @@
+import { ConfigService } from '@nestjs/config';
+import { RiskStateService } from '../risk-state.service';
+import type { SupabaseService } from '../../../supabase/supabase.service';
+
+interface Stub {
+  cbRow?: Record<string, unknown> | null;
+  cbError?: { message: string } | null;
+  recentRows?: Array<Record<string, unknown>> | null;
+  count24h?: number | null;
+}
+
+function makeSupabase(stub: Stub): SupabaseService {
+  return {
+    isReady: () => true,
+    getClient: () => ({
+      from: (table: string) => {
+        if (table === 'lisa_circuit_breaker_state') {
+          return {
+            select: () => ({
+              eq: () => ({
+                order: () => ({
+                  limit: () => ({
+                    maybeSingle: () =>
+                      Promise.resolve({ data: stub.cbRow ?? null, error: stub.cbError ?? null }),
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+        // lisa_sanity_rejections : 2 modes (recent + count head)
+        return {
+          select: (_cols: string, opts?: { count?: string; head?: boolean }) => {
+            if (opts?.head) {
+              return {
+                gte: () => Promise.resolve({ count: stub.count24h ?? 0, error: null }),
+              };
+            }
+            return {
+              order: () => ({
+                limit: () => Promise.resolve({ data: stub.recentRows ?? [], error: null }),
+              }),
+            };
+          },
+        };
+      },
+    }),
+  } as unknown as SupabaseService;
+}
+
+function makeConfig(env: Record<string, string>): ConfigService {
+  return { get: (k: string) => env[k] } as unknown as ConfigService;
+}
+
+const PF = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+describe('RiskStateService', () => {
+  it('is_tripped=false si aucune ligne circuit_breaker', async () => {
+    const svc = new RiskStateService(makeSupabase({ cbRow: null }), makeConfig({}));
+    const r = await svc.portfolioRiskState(PF);
+    expect(r.circuit_breaker.is_tripped).toBe(false);
+    expect(r.circuit_breaker.triggered_at).toBeNull();
+  });
+
+  it('is_tripped=true si dernière ligne a resolved_at=null', async () => {
+    const svc = new RiskStateService(
+      makeSupabase({
+        cbRow: {
+          id: 'cb-1',
+          triggered_at: '2026-05-17T10:00:00Z',
+          reason: 'daily_drawdown_400',
+          pnl_at_trigger: -425,
+          positions_open_at_trigger: 3,
+          resolved_at: null,
+          notes: null,
+        },
+      }),
+      makeConfig({}),
+    );
+    const r = await svc.portfolioRiskState(PF);
+    expect(r.circuit_breaker.is_tripped).toBe(true);
+    expect(r.circuit_breaker.pnl_at_trigger).toBe(-425);
+  });
+
+  it('is_tripped=false si dernière ligne a resolved_at non-null', async () => {
+    const svc = new RiskStateService(
+      makeSupabase({
+        cbRow: {
+          id: 'cb-1',
+          triggered_at: '2026-05-16T10:00:00Z',
+          reason: 'daily_drawdown_400',
+          resolved_at: '2026-05-16T22:00:00Z',
+        },
+      }),
+      makeConfig({}),
+    );
+    const r = await svc.portfolioRiskState(PF);
+    expect(r.circuit_breaker.is_tripped).toBe(false);
+  });
+
+  it('feature_flags reflète QUICK_WINS_PIPELINE_ENABLED', async () => {
+    const svcOn = new RiskStateService(
+      makeSupabase({}),
+      makeConfig({ QUICK_WINS_PIPELINE_ENABLED: 'true' }),
+    );
+    const rOn = await svcOn.portfolioRiskState(PF);
+    expect(rOn.feature_flags.quick_wins_pipeline_enabled).toBe(true);
+
+    const svcOff = new RiskStateService(makeSupabase({}), makeConfig({}));
+    const rOff = await svcOff.portfolioRiskState(PF);
+    expect(rOff.feature_flags.quick_wins_pipeline_enabled).toBe(false);
+  });
+
+  it('feature_flags : gainers_nse_blacklist_enabled true par défaut, false seulement si explicit', async () => {
+    const def = new RiskStateService(makeSupabase({}), makeConfig({}));
+    expect((await def.portfolioRiskState(PF)).feature_flags.gainers_nse_blacklist_enabled).toBe(true);
+
+    const off = new RiskStateService(
+      makeSupabase({}),
+      makeConfig({ GAINERS_NSE_BLACKLIST_ENABLED: 'false' }),
+    );
+    expect((await off.portfolioRiskState(PF)).feature_flags.gainers_nse_blacklist_enabled).toBe(false);
+  });
+
+  it('count_24h reflète le count Supabase', async () => {
+    const svc = new RiskStateService(makeSupabase({ count24h: 3 }), makeConfig({}));
+    const r = await svc.portfolioRiskState(PF);
+    expect(r.sanity_rejections.count_24h).toBe(3);
+  });
+});

--- a/apps/api/src/modules/lisa/services/asset-class-tpsl.service.ts
+++ b/apps/api/src/modules/lisa/services/asset-class-tpsl.service.ts
@@ -1,0 +1,96 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+export interface AssetClassTpslRow {
+  asset_class: string;
+  tp_pct: number;
+  sl_pct: number;
+  warmup_min_override: number | null;
+  regime_filter_enabled: boolean;
+  score_min_floor: number | null;
+  path_eff_floor: number | null;
+  notes: string | null;
+  updated_at: string;
+}
+
+/**
+ * PR #338 — service de lecture/écriture pour la matrice TP/SL par asset_class
+ * (table `asset_class_tpsl_config`, migrations 0141 + 0142).
+ *
+ * Lecture : list ordonnée pour le panel UI parameters.
+ * Écriture : update partiel avec whitelist colonnes + clamps stricts cohérents
+ * avec les CHECK constraints SQL.
+ */
+@Injectable()
+export class AssetClassTpslService {
+  private static readonly ALLOWED_CLASSES = [
+    'us_equity_large',
+    'us_equity_small_mid',
+    'eu_equity',
+    'asia_equity',
+    'crypto_major',
+  ];
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  static isAllowedClass(assetClass: string): boolean {
+    return AssetClassTpslService.ALLOWED_CLASSES.includes(assetClass);
+  }
+
+  async list(): Promise<AssetClassTpslRow[]> {
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('asset_class_tpsl_config')
+      .select('asset_class, tp_pct, sl_pct, warmup_min_override, regime_filter_enabled, score_min_floor, path_eff_floor, notes, updated_at')
+      .order('asset_class');
+    if (error) throw new BadRequestException(error.message);
+    return (data ?? []) as AssetClassTpslRow[];
+  }
+
+  async update(assetClass: string, patch: Record<string, unknown>): Promise<AssetClassTpslRow> {
+    if (!AssetClassTpslService.isAllowedClass(assetClass)) {
+      throw new BadRequestException(`asset_class inconnu : ${assetClass}`);
+    }
+
+    const allowed = [
+      'tp_pct',
+      'sl_pct',
+      'warmup_min_override',
+      'regime_filter_enabled',
+      'score_min_floor',
+      'path_eff_floor',
+      'notes',
+    ] as const;
+
+    const payload: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    for (const k of allowed) {
+      if (patch[k] !== undefined) payload[k] = patch[k];
+    }
+
+    if (typeof payload.tp_pct === 'number' && (payload.tp_pct <= 0 || payload.tp_pct > 0.1)) {
+      throw new BadRequestException('tp_pct doit être dans (0, 0.10]');
+    }
+    if (typeof payload.sl_pct === 'number' && (payload.sl_pct >= 0 || payload.sl_pct < -0.05)) {
+      throw new BadRequestException('sl_pct doit être dans [-0.05, 0)');
+    }
+    if (typeof payload.score_min_floor === 'number' && (payload.score_min_floor < 0 || payload.score_min_floor > 5)) {
+      throw new BadRequestException('score_min_floor doit être dans [0, 5]');
+    }
+    if (typeof payload.path_eff_floor === 'number' && (payload.path_eff_floor < 0 || payload.path_eff_floor > 1)) {
+      throw new BadRequestException('path_eff_floor doit être dans [0, 1]');
+    }
+    if (typeof payload.warmup_min_override === 'number' && (payload.warmup_min_override < 0 || payload.warmup_min_override > 120)) {
+      throw new BadRequestException('warmup_min_override doit être dans [0, 120] minutes');
+    }
+
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('asset_class_tpsl_config')
+      .update(payload)
+      .eq('asset_class', assetClass)
+      .select()
+      .single();
+    if (error) throw new BadRequestException(error.message);
+    return data as AssetClassTpslRow;
+  }
+}

--- a/apps/api/src/modules/lisa/services/quick-wins-stats.service.ts
+++ b/apps/api/src/modules/lisa/services/quick-wins-stats.service.ts
@@ -1,0 +1,93 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+export interface QwStatsRow {
+  qw_id: string;
+  total: number;
+  pass: number;
+  block: number;
+  modify: number;
+  shadow_would_have_passed: number;
+  pct_block: number;
+  pct_modify: number;
+}
+
+export interface QwRecentEntry {
+  id: string;
+  created_at: string;
+  qw_id: string;
+  symbol: string;
+  asset_class: string;
+  decision: string;
+  reason: string;
+  would_have_passed_without_flag: boolean;
+}
+
+/**
+ * PR #338 — agrégation des décisions Quick Wins (table `qw_decision_log`,
+ * migration 0140) pour le dashboard UI activity.
+ *
+ * stats24h : agrégation par qw_id sur la fenêtre 24h glissante.
+ * recent   : N dernières décisions (clamp [1, 200]).
+ */
+@Injectable()
+export class QuickWinsStatsService {
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async stats24h(): Promise<QwStatsRow[]> {
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('qw_decision_log')
+      .select('qw_id, decision, would_have_passed_without_flag')
+      .gte('created_at', since)
+      .limit(50_000);
+    if (error) throw new BadRequestException(error.message);
+
+    const rows = (data ?? []) as Array<{
+      qw_id: string;
+      decision: string;
+      would_have_passed_without_flag: boolean;
+    }>;
+
+    const byQw = new Map<string, QwStatsRow>();
+    for (const r of rows) {
+      const cur = byQw.get(r.qw_id) ?? {
+        qw_id: r.qw_id,
+        total: 0,
+        pass: 0,
+        block: 0,
+        modify: 0,
+        shadow_would_have_passed: 0,
+        pct_block: 0,
+        pct_modify: 0,
+      };
+      cur.total += 1;
+      if (r.decision === 'pass') cur.pass += 1;
+      else if (r.decision === 'block') cur.block += 1;
+      else if (r.decision === 'modify') cur.modify += 1;
+      if (r.would_have_passed_without_flag) cur.shadow_would_have_passed += 1;
+      byQw.set(r.qw_id, cur);
+    }
+
+    return Array.from(byQw.values())
+      .map((r) => ({
+        ...r,
+        pct_block: r.total > 0 ? Math.round((r.block / r.total) * 1000) / 10 : 0,
+        pct_modify: r.total > 0 ? Math.round((r.modify / r.total) * 1000) / 10 : 0,
+      }))
+      .sort((a, b) => a.qw_id.localeCompare(b.qw_id));
+  }
+
+  async recent(limit = 50): Promise<QwRecentEntry[]> {
+    const clamped = Math.min(Math.max(Number.isFinite(limit) ? limit : 50, 1), 200);
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('qw_decision_log')
+      .select('id, created_at, qw_id, symbol, asset_class, decision, reason, would_have_passed_without_flag')
+      .order('created_at', { ascending: false })
+      .limit(clamped);
+    if (error) throw new BadRequestException(error.message);
+    return (data ?? []) as QwRecentEntry[];
+  }
+}

--- a/apps/api/src/modules/lisa/services/risk-state.service.ts
+++ b/apps/api/src/modules/lisa/services/risk-state.service.ts
@@ -1,0 +1,114 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+export interface SanityRow {
+  id: string;
+  symbol: string;
+  asset_class: string | null;
+  raw_exit_price: number | null;
+  raw_pnl_pct: number | null;
+  raison: string;
+  rejected_at: string;
+}
+
+export interface RiskStateResponse {
+  circuit_breaker: {
+    is_tripped: boolean;
+    triggered_at: string | null;
+    reason: string | null;
+    pnl_at_trigger: number | null;
+    positions_open_at_trigger: number | null;
+    resolved_at: string | null;
+    notes: string | null;
+  };
+  sanity_rejections: {
+    count_24h: number;
+    recent: SanityRow[];
+  };
+  feature_flags: {
+    quick_wins_pipeline_enabled: boolean;
+    gainers_nse_blacklist_enabled: boolean;
+  };
+}
+
+/**
+ * PR #338 — aggrégation état de risque d'un portfolio pour le bandeau UI :
+ *   - circuit breaker actif si dernière ligne `lisa_circuit_breaker_state`
+ *     a `resolved_at IS NULL`
+ *   - sanity rejections (count 24h + 20 dernières) depuis `lisa_sanity_rejections`
+ *   - lecture read-only des flags feature côté ConfigService
+ *
+ * Toutes les requêtes Supabase sont concurrentes via `Promise.all`.
+ */
+@Injectable()
+export class RiskStateService {
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly config: ConfigService,
+  ) {}
+
+  async portfolioRiskState(portfolioId: string): Promise<RiskStateResponse> {
+    if (!portfolioId) {
+      throw new BadRequestException('portfolioId requis');
+    }
+
+    const sinceIso = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const [cbResult, recentResult, count24hResult] = await Promise.all([
+      this.supabase
+        .getClient()
+        .from('lisa_circuit_breaker_state')
+        .select('id, triggered_at, reason, pnl_at_trigger, positions_open_at_trigger, resolved_at, notes')
+        .eq('portfolio_id', portfolioId)
+        .order('triggered_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      this.supabase
+        .getClient()
+        .from('lisa_sanity_rejections')
+        .select('id, symbol, asset_class, raw_exit_price, raw_pnl_pct, raison, rejected_at')
+        .order('rejected_at', { ascending: false })
+        .limit(20),
+      this.supabase
+        .getClient()
+        .from('lisa_sanity_rejections')
+        .select('id', { count: 'exact', head: true })
+        .gte('rejected_at', sinceIso),
+    ]);
+
+    if (cbResult.error) throw new BadRequestException(cbResult.error.message);
+    if (recentResult.error) throw new BadRequestException(recentResult.error.message);
+    if (count24hResult.error) throw new BadRequestException(count24hResult.error.message);
+
+    const cbRow = cbResult.data as {
+      id: string;
+      triggered_at: string | null;
+      reason: string | null;
+      pnl_at_trigger: number | null;
+      positions_open_at_trigger: number | null;
+      resolved_at: string | null;
+      notes: string | null;
+    } | null;
+    const isTripped = Boolean(cbRow && !cbRow.resolved_at);
+
+    return {
+      circuit_breaker: {
+        is_tripped: isTripped,
+        triggered_at: cbRow?.triggered_at ?? null,
+        reason: cbRow?.reason ?? null,
+        pnl_at_trigger: cbRow?.pnl_at_trigger ?? null,
+        positions_open_at_trigger: cbRow?.positions_open_at_trigger ?? null,
+        resolved_at: cbRow?.resolved_at ?? null,
+        notes: cbRow?.notes ?? null,
+      },
+      sanity_rejections: {
+        count_24h: count24hResult.count ?? 0,
+        recent: (recentResult.data ?? []) as SanityRow[],
+      },
+      feature_flags: {
+        quick_wins_pipeline_enabled: (this.config.get<string>('QUICK_WINS_PIPELINE_ENABLED') ?? 'false') === 'true',
+        gainers_nse_blacklist_enabled: (this.config.get<string>('GAINERS_NSE_BLACKLIST_ENABLED') ?? 'true') !== 'false',
+      },
+    };
+  }
+}

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -36,6 +36,7 @@ import { LiveTradingStatusPanel } from '@/components/lisa/live-trading-status-pa
 import { LiveTradingWizard } from '@/components/lisa/live-trading-wizard';
 import { useOperatingMode } from '@/hooks/use-operating-mode';
 import { AutopilotBudgetBadge } from '@/components/lisa/autopilot-budget-badge';
+import { RiskStateBanner } from '@/components/lisa/risk-state-banner';
 import { LisaDecisionLog } from '@/components/lisa/decision-log';
 import { MechanicalAgentCard } from '@/components/lisa/mechanical-agent-card';
 import { OptionPositionsCard } from '@/components/lisa/option-positions-card';
@@ -577,6 +578,9 @@ export default function LisaPage() {
           <AutopilotBudgetBadge portfolioId={selectedPortfolioId} />
         </div>
       )}
+
+      {/* PR #338 — bandeau état de risque (circuit breaker + sanity rejections + flags Fly) */}
+      {selectedPortfolioId && <RiskStateBanner portfolioId={selectedPortfolioId} />}
 
       {/* Phase G LIVE — Status panel (auto-shown si LIVE flags activés) */}
       <LiveTradingStatusPanel />

--- a/apps/web/src/app/lisa/parameters/page.tsx
+++ b/apps/web/src/app/lisa/parameters/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePortfolios } from '@/hooks/use-portfolio';
+import { RiskStateBanner } from '@/components/lisa/risk-state-banner';
+import { AssetClassTpslMatrix } from '@/components/lisa/asset-class-tpsl-matrix';
+import { QuickWinsActivityPanel } from '@/components/lisa/quick-wins-activity-panel';
+
+/**
+ * PR #338 — page Paramètres adaptatifs (Phase 5 N1+N2).
+ *
+ * Regroupe :
+ *   1. Bandeau état de risque (circuit breaker + sanity rejections + flags)
+ *   2. Matrice TP/SL par asset_class (édition)
+ *   3. Dashboard activité Quick Wins (24h stats + 50 dernières décisions)
+ */
+export default function LisaParametersPage() {
+  const portfoliosQuery = usePortfolios();
+  const simulationPortfolios = (portfoliosQuery.data ?? []).filter(
+    (p) => (p as { is_simulation?: boolean }).is_simulation,
+  );
+
+  const [selectedPortfolioId, setSelectedPortfolioId] = useState<string | null>(
+    simulationPortfolios[0]?.id ?? null,
+  );
+
+  useEffect(() => {
+    if (!selectedPortfolioId && simulationPortfolios.length > 0) {
+      setSelectedPortfolioId(simulationPortfolios[0].id);
+    }
+  }, [simulationPortfolios, selectedPortfolioId]);
+
+  return (
+    <div className="container mx-auto py-8 space-y-8 max-w-6xl px-4">
+      <header>
+        <h1 className="text-3xl font-bold">Paramètres adaptatifs SmartVest</h1>
+        <p className="text-muted-foreground mt-2">
+          Configuration runtime des paramètres adaptatifs par classe d&apos;actif, monitoring des
+          Quick Wins, et état du circuit breaker. Tous les changements sont appliqués immédiatement
+          au prochain cycle scanner.
+        </p>
+      </header>
+
+      {simulationPortfolios.length > 1 && (
+        <div className="rounded-lg border bg-card p-3">
+          <label className="text-sm font-medium block mb-2">Portefeuille de simulation</label>
+          <select
+            value={selectedPortfolioId ?? ''}
+            onChange={(e) => setSelectedPortfolioId(e.target.value)}
+            className="w-full rounded border bg-background px-3 py-2 text-sm"
+          >
+            {simulationPortfolios.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name ?? p.id}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-3">État de risque</h2>
+        <RiskStateBanner portfolioId={selectedPortfolioId} />
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-2">Matrice TP/SL par classe d&apos;actif</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          Override des paramètres TP/SL globaux. Les valeurs ici écrasent les défauts gainers pour
+          les 5 classes seedées (asset_class_tpsl_config). TP et SL sont affichés en pourcentage
+          humain (la DB stocke en décimal).
+        </p>
+        <AssetClassTpslMatrix />
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-2">Activité Quick Wins (24 h)</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          Décisions pass/block/modify des Quick Wins pipeline. Le master flag
+          QUICK_WINS_PIPELINE_ENABLED contrôle l&apos;ensemble côté Fly. Une QW listée
+          &laquo; Inactif &raquo; n&apos;a produit aucune décision sur 24 h (flag désactivé ou
+          conditions non rencontrées).
+        </p>
+        <QuickWinsActivityPanel />
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/lisa/asset-class-tpsl-matrix.tsx
+++ b/apps/web/src/components/lisa/asset-class-tpsl-matrix.tsx
@@ -1,0 +1,285 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CheckCircle2, RotateCcw } from 'lucide-react';
+import {
+  useAssetClassTpsl,
+  useUpdateAssetClassTpsl,
+  type AssetClassTpslRow,
+} from '@/hooks/use-asset-class-tpsl';
+
+/**
+ * PR #338 — matrice TP/SL par asset_class (5 classes seedées par migrations 0141/0142).
+ *
+ * La DB stocke en décimal (0.030 = 3 %). L'UI affiche en pourcentage humain (× 100)
+ * pour TP/SL et applique la conversion inverse au save. Les autres colonnes
+ * (warmup_min_override, score_min_floor, path_eff_floor) sont déjà en unités humaines.
+ */
+
+const SEED_BASELINE = '2026-05-16T00:00:00Z'; // mig 0141 + 0142 appliquées le 16 mai
+
+const COLUMNS = [
+  { key: 'asset_class' as const, label: 'Classe' },
+  { key: 'tp_pct' as const, label: 'TP (%)' },
+  { key: 'sl_pct' as const, label: 'SL (%)' },
+  { key: 'warmup_min_override' as const, label: 'Warmup (min)' },
+  { key: 'score_min_floor' as const, label: 'Score floor' },
+  { key: 'path_eff_floor' as const, label: 'Path eff floor' },
+  { key: 'regime_filter_enabled' as const, label: 'Régime' },
+];
+
+function fmtClass(c: string): string {
+  return c
+    .split('_')
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join(' ');
+}
+
+interface Draft {
+  tp_pct: string;
+  sl_pct: string;
+  warmup_min_override: string;
+  score_min_floor: string;
+  path_eff_floor: string;
+  regime_filter_enabled: boolean;
+}
+
+function toDraft(row: AssetClassTpslRow): Draft {
+  return {
+    tp_pct: (row.tp_pct * 100).toFixed(3),
+    sl_pct: (row.sl_pct * 100).toFixed(3),
+    warmup_min_override: row.warmup_min_override?.toString() ?? '',
+    score_min_floor: row.score_min_floor?.toString() ?? '',
+    path_eff_floor: row.path_eff_floor?.toString() ?? '',
+    regime_filter_enabled: row.regime_filter_enabled,
+  };
+}
+
+export function AssetClassTpslMatrix() {
+  const q = useAssetClassTpsl();
+  const update = useUpdateAssetClassTpsl();
+  const [drafts, setDrafts] = useState<Record<string, Draft>>({});
+  const [savedAt, setSavedAt] = useState<Record<string, number>>({});
+  const [errorMsg, setErrorMsg] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (q.data) {
+      const next: Record<string, Draft> = {};
+      for (const row of q.data) next[row.asset_class] = toDraft(row);
+      setDrafts(next);
+    }
+  }, [q.data]);
+
+  if (q.isLoading) {
+    return <div className="text-sm text-muted-foreground italic">Chargement de la matrice…</div>;
+  }
+  if (q.isError) {
+    return <div className="text-sm text-red-600">Erreur de chargement : {String(q.error)}</div>;
+  }
+
+  const rows = q.data ?? [];
+
+  const handleSave = async (row: AssetClassTpslRow) => {
+    const d = drafts[row.asset_class];
+    if (!d) return;
+    setErrorMsg((m) => ({ ...m, [row.asset_class]: '' }));
+
+    const tpDec = Number.parseFloat(d.tp_pct) / 100;
+    const slDec = Number.parseFloat(d.sl_pct) / 100;
+    const warmup = d.warmup_min_override.trim() === '' ? null : Number.parseInt(d.warmup_min_override, 10);
+    const score = d.score_min_floor.trim() === '' ? null : Number.parseFloat(d.score_min_floor);
+    const pathEff = d.path_eff_floor.trim() === '' ? null : Number.parseFloat(d.path_eff_floor);
+
+    try {
+      await update.mutateAsync({
+        assetClass: row.asset_class,
+        patch: {
+          tp_pct: tpDec,
+          sl_pct: slDec,
+          warmup_min_override: warmup,
+          score_min_floor: score,
+          path_eff_floor: pathEff,
+          regime_filter_enabled: d.regime_filter_enabled,
+        },
+      });
+      setSavedAt((m) => ({ ...m, [row.asset_class]: Date.now() }));
+      setTimeout(() => {
+        setSavedAt((m) => {
+          const copy = { ...m };
+          delete copy[row.asset_class];
+          return copy;
+        });
+      }, 3000);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setErrorMsg((m) => ({ ...m, [row.asset_class]: msg }));
+    }
+  };
+
+  const handleReset = (row: AssetClassTpslRow) => {
+    setDrafts((d) => ({ ...d, [row.asset_class]: toDraft(row) }));
+    setErrorMsg((m) => ({ ...m, [row.asset_class]: '' }));
+  };
+
+  const seedBaselineMs = new Date(SEED_BASELINE).getTime();
+
+  return (
+    <div className="rounded-lg border bg-card overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50 border-b">
+            <tr>
+              {COLUMNS.map((c) => (
+                <th key={c.key} className="px-3 py-2 text-left font-medium">
+                  {c.label}
+                </th>
+              ))}
+              <th className="px-3 py-2 text-right font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const d = drafts[row.asset_class];
+              if (!d) return null;
+              const wasOverridden = new Date(row.updated_at).getTime() > seedBaselineMs;
+              const isSaved = savedAt[row.asset_class];
+              const err = errorMsg[row.asset_class];
+
+              return (
+                <tr key={row.asset_class} className="border-b last:border-b-0">
+                  <td className="px-3 py-2 font-medium">
+                    <div className="flex flex-col">
+                      <span>{fmtClass(row.asset_class)}</span>
+                      {wasOverridden && (
+                        <span className="text-xs text-amber-600 dark:text-amber-500">
+                          Override actif depuis {new Date(row.updated_at).toLocaleDateString('fr-FR')}
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0.01"
+                      max="10"
+                      value={d.tp_pct}
+                      onChange={(e) =>
+                        setDrafts((m) => ({ ...m, [row.asset_class]: { ...d, tp_pct: e.target.value } }))
+                      }
+                      className="w-20 rounded border bg-background px-2 py-1 text-right"
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="-5"
+                      max="-0.01"
+                      value={d.sl_pct}
+                      onChange={(e) =>
+                        setDrafts((m) => ({ ...m, [row.asset_class]: { ...d, sl_pct: e.target.value } }))
+                      }
+                      className="w-20 rounded border bg-background px-2 py-1 text-right"
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      type="number"
+                      step="1"
+                      min="0"
+                      max="120"
+                      placeholder="—"
+                      value={d.warmup_min_override}
+                      onChange={(e) =>
+                        setDrafts((m) => ({
+                          ...m,
+                          [row.asset_class]: { ...d, warmup_min_override: e.target.value },
+                        }))
+                      }
+                      className="w-20 rounded border bg-background px-2 py-1 text-right"
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      max="5"
+                      placeholder="—"
+                      value={d.score_min_floor}
+                      onChange={(e) =>
+                        setDrafts((m) => ({
+                          ...m,
+                          [row.asset_class]: { ...d, score_min_floor: e.target.value },
+                        }))
+                      }
+                      className="w-20 rounded border bg-background px-2 py-1 text-right"
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      type="number"
+                      step="0.05"
+                      min="0"
+                      max="1"
+                      placeholder="—"
+                      value={d.path_eff_floor}
+                      onChange={(e) =>
+                        setDrafts((m) => ({
+                          ...m,
+                          [row.asset_class]: { ...d, path_eff_floor: e.target.value },
+                        }))
+                      }
+                      className="w-20 rounded border bg-background px-2 py-1 text-right"
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      type="checkbox"
+                      checked={d.regime_filter_enabled}
+                      onChange={(e) =>
+                        setDrafts((m) => ({
+                          ...m,
+                          [row.asset_class]: { ...d, regime_filter_enabled: e.target.checked },
+                        }))
+                      }
+                      className="h-4 w-4"
+                    />
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    <div className="flex justify-end gap-2 items-center">
+                      {isSaved && (
+                        <CheckCircle2 className="h-4 w-4 text-emerald-600" aria-label="Sauvegardé" />
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => handleReset(row)}
+                        title="Réinitialiser à la valeur DB courante"
+                        className="rounded border px-2 py-1 hover:bg-muted/50"
+                      >
+                        <RotateCcw className="h-3 w-3" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleSave(row)}
+                        disabled={update.isPending}
+                        className="rounded bg-primary text-primary-foreground px-3 py-1 text-xs disabled:opacity-50"
+                      >
+                        {update.isPending ? '…' : 'Sauvegarder'}
+                      </button>
+                    </div>
+                    {err && <div className="text-xs text-red-600 mt-1">{err}</div>}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <div className="p-3 text-xs text-muted-foreground bg-muted/30 border-t">
+        Modifications appliquées immédiatement au prochain cycle scanner. TP/SL affichés en pourcentage humain (×100 vs stockage décimal en DB).
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/lisa/gainers-config-panel.tsx
+++ b/apps/web/src/components/lisa/gainers-config-panel.tsx
@@ -257,9 +257,12 @@ export function GainersConfigPanel({ portfolioId }: Props) {
       <section className="space-y-3">
         <div className="text-xs uppercase tracking-wider text-foreground font-semibold">
           2. Take-profit / Stop-loss
+          <span className="ml-2 normal-case text-[10px] font-normal text-amber-400">
+            Override matrice par classe actif (5 classes seedées)
+          </span>
         </div>
         <div className="grid grid-cols-2 gap-3">
-          <Field label="Take-profit défaut (%)" hint="(0, 50]">
+          <Field label="Take-profit défaut (%)" hint="(0, 50] — override matrice TP/SL prend le pas par classe">
             <input
               type="number"
               min={0.1}
@@ -270,7 +273,7 @@ export function GainersConfigPanel({ portfolioId }: Props) {
               className="h-8 w-full rounded-md border bg-background px-2 text-xs"
             />
           </Field>
-          <Field label="Stop-loss défaut (%)" hint="(0, 20]">
+          <Field label="Stop-loss défaut (%)" hint="(0, 20] — override matrice TP/SL prend le pas par classe">
             <input
               type="number"
               min={0.1}
@@ -282,6 +285,12 @@ export function GainersConfigPanel({ portfolioId }: Props) {
             />
           </Field>
         </div>
+        <a
+          href="/lisa/parameters"
+          className="inline-block text-xs text-blue-400 hover:text-blue-300 hover:underline"
+        >
+          Configurer TP/SL par classe d&apos;actif →
+        </a>
       </section>
 
       {/* 3. Cooldown */}

--- a/apps/web/src/components/lisa/quick-wins-activity-panel.tsx
+++ b/apps/web/src/components/lisa/quick-wins-activity-panel.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useQuickWinsRecent, useQuickWinsStats } from '@/hooks/use-quick-wins-stats';
+
+/**
+ * PR #338 — dashboard activité des Quick Wins (table qw_decision_log, migration 0140).
+ *
+ * Section 1 : stats agrégées 24h par qw_id (total / pass / block / modify / pct_block / shadow).
+ * Section 2 : 50 dernières décisions individuelles (table déroulante).
+ *
+ * Les QW attendus pour le pipeline complet :
+ *   QW_1 / QW_4 / QW_6 / QW_9 / QW_11 / QW_15 / QW_17 / QW_18 / QW_27 / QW_46 / QW_47
+ *   + CIRCUIT_BREAKER pré-cascade
+ * Si une QW n'a aucune ligne 24h, on l'affiche en gris "Inactif" (drapeau désactivé
+ * ou aucune décision dans la fenêtre).
+ */
+
+const EXPECTED_QWS = [
+  'CIRCUIT_BREAKER',
+  'QW_1',
+  'QW_4',
+  'QW_6',
+  'QW_9',
+  'QW_11',
+  'QW_14A',
+  'QW_15',
+  'QW_17',
+  'QW_18',
+  'QW_27',
+  'QW_46',
+  'QW_47',
+];
+
+function fmtRelative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)} min`;
+  if (ms < 86_400_000) return `${Math.round(ms / 3_600_000)} h`;
+  return `${Math.round(ms / 86_400_000)} j`;
+}
+
+function decisionBadge(d: string): string {
+  if (d === 'block') return 'bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-400 border-red-500';
+  if (d === 'modify') return 'bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-500 border-amber-500';
+  return 'bg-emerald-50 dark:bg-emerald-950/20 text-emerald-700 dark:text-emerald-400 border-emerald-500';
+}
+
+export function QuickWinsActivityPanel() {
+  const statsQ = useQuickWinsStats();
+  const recentQ = useQuickWinsRecent(50);
+
+  const stats = statsQ.data ?? [];
+  const recent = recentQ.data ?? [];
+
+  const byQw = new Map(stats.map((s) => [s.qw_id, s]));
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border bg-card overflow-hidden">
+        <div className="bg-muted/50 border-b px-3 py-2 text-sm font-medium">
+          Stats 24h par Quick Win
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/30 border-b">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium">QW ID</th>
+                <th className="px-3 py-2 text-right font-medium">Total</th>
+                <th className="px-3 py-2 text-right font-medium">Pass</th>
+                <th className="px-3 py-2 text-right font-medium">Block</th>
+                <th className="px-3 py-2 text-right font-medium">Modify</th>
+                <th className="px-3 py-2 text-right font-medium">% Block</th>
+                <th className="px-3 py-2 text-right font-medium">Shadow (auraient passé)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {EXPECTED_QWS.map((qwId) => {
+                const row = byQw.get(qwId);
+                if (!row) {
+                  return (
+                    <tr key={qwId} className="border-b last:border-b-0 text-muted-foreground italic">
+                      <td className="px-3 py-2 font-mono text-xs">{qwId}</td>
+                      <td colSpan={6} className="px-3 py-2 text-xs">
+                        Inactif (aucune décision 24h)
+                      </td>
+                    </tr>
+                  );
+                }
+                return (
+                  <tr key={qwId} className="border-b last:border-b-0">
+                    <td className="px-3 py-2 font-mono text-xs">{qwId}</td>
+                    <td className="px-3 py-2 text-right">{row.total}</td>
+                    <td className="px-3 py-2 text-right text-emerald-700 dark:text-emerald-400">
+                      {row.pass}
+                    </td>
+                    <td className="px-3 py-2 text-right text-red-700 dark:text-red-400">{row.block}</td>
+                    <td className="px-3 py-2 text-right text-amber-700 dark:text-amber-500">
+                      {row.modify}
+                    </td>
+                    <td className="px-3 py-2 text-right">{row.pct_block.toFixed(1)} %</td>
+                    <td className="px-3 py-2 text-right text-muted-foreground">
+                      {row.shadow_would_have_passed}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        {statsQ.isError && (
+          <div className="px-3 py-2 text-xs text-red-600 border-t bg-red-50 dark:bg-red-950/20">
+            Erreur de chargement stats : {String(statsQ.error)}
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-lg border bg-card overflow-hidden">
+        <div className="bg-muted/50 border-b px-3 py-2 text-sm font-medium">
+          50 dernières décisions
+        </div>
+        <div className="overflow-y-auto max-h-96">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/30 border-b sticky top-0">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium">Date</th>
+                <th className="px-3 py-2 text-left font-medium">QW</th>
+                <th className="px-3 py-2 text-left font-medium">Symbole</th>
+                <th className="px-3 py-2 text-left font-medium">Classe</th>
+                <th className="px-3 py-2 text-left font-medium">Décision</th>
+                <th className="px-3 py-2 text-left font-medium">Raison</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recent.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-3 py-4 text-center text-muted-foreground text-xs italic">
+                    Aucune décision récente.
+                  </td>
+                </tr>
+              )}
+              {recent.map((row) => (
+                <tr key={row.id} className="border-b last:border-b-0">
+                  <td className="px-3 py-2 text-xs text-muted-foreground">
+                    {fmtRelative(row.created_at)}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-xs">{row.qw_id}</td>
+                  <td className="px-3 py-2 font-mono text-xs">{row.symbol}</td>
+                  <td className="px-3 py-2 text-xs text-muted-foreground">{row.asset_class}</td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`inline-block rounded border px-2 py-0.5 text-xs ${decisionBadge(row.decision)}`}
+                    >
+                      {row.decision}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-xs">{row.reason}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {recentQ.isError && (
+          <div className="px-3 py-2 text-xs text-red-600 border-t bg-red-50 dark:bg-red-950/20">
+            Erreur de chargement décisions : {String(recentQ.error)}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/lisa/risk-state-banner.tsx
+++ b/apps/web/src/components/lisa/risk-state-banner.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState } from 'react';
+import { AlertTriangle, ChevronDown, ChevronUp, ShieldAlert } from 'lucide-react';
+import { useRiskState, type SanityRow } from '@/hooks/use-risk-state';
+
+/**
+ * PR #338 — bandeau état de risque pour la page /lisa et /lisa/parameters.
+ *
+ * - bandeau rouge sticky si circuit breaker actif (lisa_circuit_breaker_state)
+ * - bandeau orange si sanity rejections sur 24h (lisa_sanity_rejections)
+ * - badges feature flags Fly (read-only) avec tooltip toggle CLI
+ *
+ * Polling 30s côté hook. Composant rend null si aucune donnée (pas de bandeau bruyant).
+ */
+
+function fmtRelative(iso: string | null): string {
+  if (!iso) return '';
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return `il y a ${Math.round(ms / 1000)} s`;
+  if (ms < 3_600_000) return `il y a ${Math.round(ms / 60_000)} min`;
+  if (ms < 86_400_000) return `il y a ${Math.round(ms / 3_600_000)} h`;
+  return `il y a ${Math.round(ms / 86_400_000)} j`;
+}
+
+export function RiskStateBanner({ portfolioId }: { portfolioId: string | null }) {
+  const [showDetails, setShowDetails] = useState(false);
+  const q = useRiskState(portfolioId);
+
+  if (!portfolioId || !q.data) return null;
+
+  const { circuit_breaker: cb, sanity_rejections: sanity, feature_flags: flags } = q.data;
+  const hasAnyAlert = cb.is_tripped || sanity.count_24h > 0;
+
+  return (
+    <div className="space-y-2">
+      {cb.is_tripped && (
+        <div className="rounded-lg border-2 border-red-500 bg-red-50 dark:bg-red-950/30 p-4">
+          <div className="flex items-start gap-3">
+            <ShieldAlert className="h-5 w-5 text-red-600 flex-shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <div className="font-semibold text-red-700 dark:text-red-400">
+                Circuit breaker déclenché : {cb.reason ?? 'raison inconnue'}
+              </div>
+              <div className="text-sm text-red-700/80 dark:text-red-400/80 mt-1">
+                Déclenchement {fmtRelative(cb.triggered_at)} ·
+                {cb.pnl_at_trigger != null && ` PnL ${cb.pnl_at_trigger.toFixed(2)} USD · `}
+                {cb.positions_open_at_trigger != null &&
+                  `${cb.positions_open_at_trigger} positions ouvertes au moment du trip`}
+              </div>
+              {cb.notes && (
+                <div className="text-xs text-red-700/70 dark:text-red-400/70 mt-1 italic">{cb.notes}</div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {sanity.count_24h > 0 && (
+        <div className="rounded-lg border border-amber-500 bg-amber-50 dark:bg-amber-950/30 p-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5" />
+              <div className="flex-1">
+                <div className="font-medium text-amber-700 dark:text-amber-500">
+                  {sanity.count_24h} anomalie{sanity.count_24h > 1 ? 's' : ''} prix bloquée
+                  {sanity.count_24h > 1 ? 's' : ''} sur 24 h (R5 sanity)
+                </div>
+                <div className="text-sm text-amber-700/80 dark:text-amber-500/80 mt-1">
+                  Ces fermetures de positions ont été refusées car le prix d'exit était aberrant
+                  (exit_price ≤ 0 ou ratio &lt; 50 % entry ou pnl_pct &lt; -50 %).
+                </div>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowDetails((v) => !v)}
+              className="text-xs text-amber-700 dark:text-amber-400 hover:underline flex items-center gap-1"
+            >
+              {showDetails ? 'Masquer' : 'Voir détails'}
+              {showDetails ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            </button>
+          </div>
+          {showDetails && sanity.recent.length > 0 && (
+            <div className="mt-3 overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead className="border-b border-amber-200 dark:border-amber-900">
+                  <tr>
+                    <th className="px-2 py-1 text-left">Symbole</th>
+                    <th className="px-2 py-1 text-left">Classe</th>
+                    <th className="px-2 py-1 text-right">Exit price</th>
+                    <th className="px-2 py-1 text-right">PnL %</th>
+                    <th className="px-2 py-1 text-left">Raison</th>
+                    <th className="px-2 py-1 text-left">Rejeté</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sanity.recent.map((r: SanityRow) => (
+                    <tr key={r.id} className="border-b border-amber-100 dark:border-amber-900/50">
+                      <td className="px-2 py-1 font-mono">{r.symbol}</td>
+                      <td className="px-2 py-1 text-muted-foreground">{r.asset_class ?? '—'}</td>
+                      <td className="px-2 py-1 text-right">
+                        {r.raw_exit_price != null ? r.raw_exit_price.toFixed(4) : '—'}
+                      </td>
+                      <td className="px-2 py-1 text-right">
+                        {r.raw_pnl_pct != null ? `${r.raw_pnl_pct.toFixed(2)} %` : '—'}
+                      </td>
+                      <td className="px-2 py-1">{r.raison}</td>
+                      <td className="px-2 py-1 text-muted-foreground">{fmtRelative(r.rejected_at)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2 text-xs items-center">
+        <span className="text-muted-foreground">Flags Fly (read-only) :</span>
+        <FlagBadge
+          label="QUICK_WINS_PIPELINE_ENABLED"
+          enabled={flags.quick_wins_pipeline_enabled}
+        />
+        <FlagBadge
+          label="GAINERS_NSE_BLACKLIST_ENABLED"
+          enabled={flags.gainers_nse_blacklist_enabled}
+        />
+      </div>
+
+      {!hasAnyAlert && (
+        <div className="text-xs text-muted-foreground italic">
+          Aucune alerte de risque active. Circuit breaker resté inactif, aucune anomalie prix sur 24 h.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FlagBadge({ label, enabled }: { label: string; enabled: boolean }) {
+  const color = enabled
+    ? 'border-emerald-500 bg-emerald-50 dark:bg-emerald-950/20 text-emerald-700 dark:text-emerald-400'
+    : 'border-zinc-400 bg-zinc-50 dark:bg-zinc-900 text-zinc-600 dark:text-zinc-400';
+  return (
+    <span
+      className={`inline-block rounded border px-2 py-0.5 font-mono ${color}`}
+      title={`Toggle via : flyctl secrets set ${label}=${enabled ? 'false' : 'true'} -a smartvest`}
+    >
+      {label} : {enabled ? 'ON' : 'OFF'}
+    </span>
+  );
+}

--- a/apps/web/src/hooks/use-asset-class-tpsl.ts
+++ b/apps/web/src/hooks/use-asset-class-tpsl.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+/**
+ * PR #338 — accès lecture/écriture à la matrice TP/SL par asset_class
+ * (table `asset_class_tpsl_config`, migrations 0141 + 0142).
+ */
+export interface AssetClassTpslRow {
+  asset_class: string;
+  tp_pct: number;
+  sl_pct: number;
+  warmup_min_override: number | null;
+  regime_filter_enabled: boolean;
+  score_min_floor: number | null;
+  path_eff_floor: number | null;
+  notes: string | null;
+  updated_at: string;
+}
+
+export function useAssetClassTpsl() {
+  return useQuery({
+    queryKey: ['asset-class-tpsl'],
+    queryFn: () => apiFetch<AssetClassTpslRow[]>('/lisa/asset-class-tpsl'),
+    refetchInterval: 60_000,
+  });
+}
+
+export function useUpdateAssetClassTpsl() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ assetClass, patch }: { assetClass: string; patch: Partial<AssetClassTpslRow> }) =>
+      apiFetch<AssetClassTpslRow>(`/lisa/asset-class-tpsl/${assetClass}`, {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['asset-class-tpsl'] });
+    },
+  });
+}

--- a/apps/web/src/hooks/use-quick-wins-stats.ts
+++ b/apps/web/src/hooks/use-quick-wins-stats.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+/**
+ * PR #338 — agrégation Quick Wins activity sur 24h glissantes
+ * (table `qw_decision_log`, migration 0140).
+ */
+export interface QwStatsRow {
+  qw_id: string;
+  total: number;
+  pass: number;
+  block: number;
+  modify: number;
+  shadow_would_have_passed: number;
+  pct_block: number;
+  pct_modify: number;
+}
+
+export interface QwRecentEntry {
+  id: string;
+  created_at: string;
+  qw_id: string;
+  symbol: string;
+  asset_class: string;
+  decision: string;
+  reason: string;
+  would_have_passed_without_flag: boolean;
+}
+
+export function useQuickWinsStats() {
+  return useQuery({
+    queryKey: ['quick-wins-stats'],
+    queryFn: () => apiFetch<QwStatsRow[]>('/lisa/quick-wins/stats'),
+    refetchInterval: 60_000,
+  });
+}
+
+export function useQuickWinsRecent(limit = 50) {
+  return useQuery({
+    queryKey: ['quick-wins-recent', limit],
+    queryFn: () => apiFetch<QwRecentEntry[]>(`/lisa/quick-wins/recent?limit=${limit}`),
+    refetchInterval: 30_000,
+  });
+}

--- a/apps/web/src/hooks/use-risk-state.ts
+++ b/apps/web/src/hooks/use-risk-state.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+/**
+ * PR #338 — état de risque d'un portfolio :
+ *   - circuit breaker (lisa_circuit_breaker_state, migration 0142)
+ *   - sanity rejections (lisa_sanity_rejections, migration 0142)
+ *   - feature flags Fly (read-only ConfigService côté backend)
+ */
+export interface SanityRow {
+  id: string;
+  symbol: string;
+  asset_class: string | null;
+  raw_exit_price: number | null;
+  raw_pnl_pct: number | null;
+  raison: string;
+  rejected_at: string;
+}
+
+export interface RiskStateResponse {
+  circuit_breaker: {
+    is_tripped: boolean;
+    triggered_at: string | null;
+    reason: string | null;
+    pnl_at_trigger: number | null;
+    positions_open_at_trigger: number | null;
+    resolved_at: string | null;
+    notes: string | null;
+  };
+  sanity_rejections: {
+    count_24h: number;
+    recent: SanityRow[];
+  };
+  feature_flags: {
+    quick_wins_pipeline_enabled: boolean;
+    gainers_nse_blacklist_enabled: boolean;
+  };
+}
+
+export function useRiskState(portfolioId: string | null) {
+  return useQuery({
+    queryKey: ['risk-state', portfolioId],
+    queryFn: () => apiFetch<RiskStateResponse>(`/lisa/risk-state/${portfolioId}`),
+    enabled: !!portfolioId,
+    refetchInterval: 30_000,
+  });
+}


### PR DESCRIPTION
## Objectif

Combler le décalage entre le backend Phase 5 N1+N2 (migrations 0140-0143 + Quick Wins pipeline + Circuit Breaker + Sanity rejections) et l'UI Next.js qui ne reflétait plus la réalité runtime.

## Chantiers couverts

### A — Matrice TP/SL par classe (critique)
- `AssetClassTpslService` (list + update avec whitelist colonnes + clamps SQL-cohérents)
- 2 endpoints `GET/PATCH /lisa/asset-class-tpsl[/:class]`
- Hook `useAssetClassTpsl` + composant `AssetClassTpslMatrix` (édition inline, conversion décimal/% , indicateur override actif)
- Badge "Override matrice par classe actif" + lien `→` dans `gainers-config-panel.tsx`

### B — Dashboard Quick Wins activity
- `QuickWinsStatsService` (agrégation 24h + recent 50, clamp [1, 200])
- 2 endpoints `GET /lisa/quick-wins/stats` + `/lisa/quick-wins/recent`
- Composant `QuickWinsActivityPanel` (tableau stats par QW + table 50 dernières décisions avec badges colorés)

### C — Bandeau Circuit Breaker + Sanity + flags
- `RiskStateService` (CB + sanity 24h + feature flags, lecture concurrente `Promise.all`)
- Endpoint `GET /lisa/risk-state/:portfolioId`
- Composant `RiskStateBanner` intégré dans `/lisa` (après `KillSwitchBanner`) et `/lisa/parameters`

### Page dédiée
- Nouvelle route `/lisa/parameters` (3 sections empilées + sélecteur portefeuille)

## Tables consommées (toutes existantes, aucune migration)
- `asset_class_tpsl_config` (mig 0141 + ALTER 0142)
- `qw_decision_log` (mig 0140)
- `lisa_circuit_breaker_state` (mig 0142)
- `lisa_sanity_rejections` (mig 0142)

## Flags lus (read-only ConfigService)
- `QUICK_WINS_PIPELINE_ENABLED` (default false)
- `GAINERS_NSE_BLACKLIST_ENABLED` (default true)

## Tests

```
$ npx tsc -b   # workspace clean
$ npx jest --testPathPattern "asset-class-tpsl.spec|quick-wins-stats.spec|risk-state.spec"
Test Suites: 3 passed, 3 total
Tests:       18 passed

$ npx jest --testPathPattern "modules/lisa" --forceExit
Test Suites: 112 passed
Tests:       1444 passed (1426 avant + 18 PR #338)
```

## Diff
17 fichiers, 1549 insertions, 3 deletions :
- Backend (8 fichiers) : 3 services + 3 specs + controller + module
- Frontend (7 fichiers) : 3 hooks + 3 composants + 1 page
- Modifs minimes (2 fichiers) : badge + lien dans `gainers-config-panel.tsx`, `RiskStateBanner` dans `lisa/page.tsx`

## Backward compatibility
Panel `gainers-config-panel.tsx` reste 100 % fonctionnel. Seuls changements visuels : badge "Override matrice actif" et lien vers `/lisa/parameters`. Aucune écriture côté front ne change le comportement runtime existant.

## Sécurité
- `extractUserId(headers)` sur tous les endpoints (pattern existant)
- PATCH whitelist colonnes (`asset_class` PK + `updated_at` non patchables)
- Clamps backend cohérents avec CHECK SQL
- Aucun token Fly/Supabase exposé côté front

## Rollback
Revert commit. Les 4 tables backend restent intactes, runtime continue de lire les seeds 0141/0142 comme avant. Aucune migration à dérouler.

## Notes
- Aucune nouvelle dépendance npm
- Format français pour tous les libellés UI, aucun emoji
- Le brief utilisait `this.supabase.client` — j'ai corrigé en `this.supabase.getClient()` (API réelle du `SupabaseService`)
- Le brief référençait `use-operating-mode.ts` comme pattern hook — j'ai mirroré `use-autopilot-cost-status.ts` (pattern équivalent identifié dans le repo)
- Lien sidebar `/lisa/parameters` non ajouté (la sidebar/nav existante n'a pas été localisée ; ajout possible en follow-up). Accès actuel : via le lien depuis `gainers-config-panel.tsx` ou navigation directe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_