### PR TITLE
feat(eodhd): PR #339 — weekend/session filter sur getCandles (gain ~440k API calls/mois)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/eodhd-intraday-range.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/eodhd-intraday-range.spec.ts
@@ -22,6 +22,7 @@ const mockApiCostTracker = {
 const mockConfig = {
   get: jest.fn((key: string) => {
     if (key === 'EODHD_API_KEY') return 'test-api-key';
+    if (key === 'EODHD_WEEKEND_FILTER_ENABLED') return 'false';
     return undefined;
   }),
 } as unknown as { get: jest.Mock };

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.r9-r10-prefilter.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.r9-r10-prefilter.spec.ts
@@ -38,6 +38,7 @@ function makeConfig(env: Record<string, string> = {}): ConfigService {
     get: (key: string) => {
       if (key === 'SCAN_INTERVAL_MINUTES') return '15';
       if (key === 'EODHD_API_KEY') return 'test-key';
+      if (key === 'EODHD_WEEKEND_FILTER_ENABLED') return env[key] ?? 'false';
       return env[key];
     },
   } as unknown as ConfigService;

--- a/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.p19o.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.p19o.spec.ts
@@ -19,7 +19,7 @@ jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
 jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
 jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
 
-function makeService(envMap: Record<string, string | undefined> = { EODHD_API_KEY: 'test-key' }) {
+function makeService(envMap: Record<string, string | undefined> = { EODHD_API_KEY: 'test-key', EODHD_WEEKEND_FILTER_ENABLED: 'false' }) {
   const config = { get: jest.fn((k: string) => envMap[k]) } as unknown as ConfigService;
   const supabase = {
     isReady: () => true,

--- a/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.p19r.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.p19r.spec.ts
@@ -22,7 +22,7 @@ jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
 jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
 jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
 
-function makeService(envMap: Record<string, string | undefined> = { EODHD_API_KEY: 'test-key' }) {
+function makeService(envMap: Record<string, string | undefined> = { EODHD_API_KEY: 'test-key', EODHD_WEEKEND_FILTER_ENABLED: 'false' }) {
   const config = { get: jest.fn((k: string) => envMap[k]) } as unknown as ConfigService;
   const supabase = {
     isReady: () => true,

--- a/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.pr339-weekend-filter.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.pr339-weekend-filter.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * PR #339 — Weekend / session-closed filter sur EodhdIntradayService.getCandles.
+ *
+ * Avant ce fix : 5242 calls intraday asia en 12h weekend (samedi 21h UTC →
+ * dimanche 06h UTC), 100 % empty_real, ~26k API calls EODHD gaspillés.
+ *
+ * Le pré-filtre `filterTickersForFetch` existant n'est appliqué que par
+ * `top-gainers-scanner`. 6 autres callers (shadow-signals, multi-tf,
+ * lisa.service, etc.) bypassent ce filtre. Le fix à la couche basse
+ * (getCandles) les protège tous d'un coup.
+ *
+ * Comportement attendu :
+ *   - .KO / .KQ (asia) un weekend → skip silencieux, fetch jamais appelé
+ *   - .US un weekend → skip silencieux
+ *   - .CC crypto un weekend → fetch normal (24/7)
+ *   - kill-switch EODHD_WEEKEND_FILTER_ENABLED=false → fetch normal
+ */
+
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EodhdIntradayService } from '../eodhd-intraday.service';
+import { SupabaseService } from '../../../supabase/supabase.service';
+
+// Silence boot logs.
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+function makeService(env: Record<string, string> = {}): EodhdIntradayService {
+  const config = {
+    get: jest.fn((k: string) => env[k]),
+  } as unknown as ConfigService;
+  const supabase = {
+    isReady: () => true,
+    getClient: () => ({ from: () => ({ insert: jest.fn().mockResolvedValue({ error: null }) }) }),
+  } as unknown as SupabaseService;
+  return new EodhdIntradayService(config, supabase);
+}
+
+describe('PR #339 — weekend / session filter early-return', () => {
+  afterEach(() => {
+    delete (global as { fetch?: unknown }).fetch;
+    jest.useRealTimers();
+  });
+
+  it('skip fetch un dimanche pour ticker .KO (asia closed weekend)', async () => {
+    // Dimanche 17 mai 2026 06:00 UTC (Korea fermé)
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-17T06:00:00Z'));
+    const fetchSpy = jest.fn();
+    (global as { fetch?: unknown }).fetch = fetchSpy;
+
+    const service = makeService({ EODHD_API_KEY: 'real-key' });
+    const result = await service.getCandles('005930.KO', '5m', 20);
+
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('skip fetch un samedi pour ticker .US (us closed weekend)', async () => {
+    // Samedi 16 mai 2026 18:00 UTC (US fermé)
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-16T18:00:00Z'));
+    const fetchSpy = jest.fn();
+    (global as { fetch?: unknown }).fetch = fetchSpy;
+
+    const service = makeService({ EODHD_API_KEY: 'real-key' });
+    const result = await service.getCandles('AAPL.US', '5m', 20);
+
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('skip fetch un samedi pour ticker .KQ (kosdaq closed weekend)', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-16T03:00:00Z'));
+    const fetchSpy = jest.fn();
+    (global as { fetch?: unknown }).fetch = fetchSpy;
+
+    const service = makeService({ EODHD_API_KEY: 'real-key' });
+    const result = await service.getCandles('222420.KQ', '5m', 20);
+
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('autorise fetch crypto le weekend (24/7)', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-17T06:00:00Z')); // dimanche
+    const fetchSpy = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { timestamp: 1715900000, open: 70000, high: 70100, low: 69900, close: 70050, volume: 100 },
+      ],
+    });
+    (global as { fetch?: unknown }).fetch = fetchSpy;
+
+    const service = makeService({ EODHD_API_KEY: 'real-key' });
+    const result = await service.getCandles('BTC-USD.CC', '5m', 20);
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(result).not.toBeNull();
+  });
+
+  it('respecte EODHD_WEEKEND_FILTER_ENABLED=false (kill-switch)', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-17T06:00:00Z')); // dimanche
+    const fetchSpy = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [],
+    });
+    (global as { fetch?: unknown }).fetch = fetchSpy;
+
+    const service = makeService({
+      EODHD_API_KEY: 'real-key',
+      EODHD_WEEKEND_FILTER_ENABLED: 'false',
+    });
+    await service.getCandles('005930.KO', '5m', 20);
+
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it('autorise fetch un mardi pour ticker .KO en pleine session', async () => {
+    // Mardi 19 mai 2026 02:00 UTC = 11:00 KST (KOSPI 09:00-15:30 KST)
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-19T02:00:00Z'));
+    const fetchSpy = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [],
+    });
+    (global as { fetch?: unknown }).fetch = fetchSpy;
+
+    const service = makeService({ EODHD_API_KEY: 'real-key' });
+    await service.getCandles('005930.KO', '5m', 20);
+
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.r12-price-usd.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/eodhd-intraday.r12-price-usd.spec.ts
@@ -23,7 +23,11 @@ jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
 
 function makeServiceWithCapture() {
   const config = {
-    get: jest.fn((k: string) => (k === 'EODHD_API_KEY' ? 'test-key' : undefined)),
+    get: jest.fn((k: string) => {
+      if (k === 'EODHD_API_KEY') return 'test-key';
+      if (k === 'EODHD_WEEKEND_FILTER_ENABLED') return 'false';
+      return undefined;
+    }),
   } as unknown as ConfigService;
   const inserted: Array<Record<string, unknown>> = [];
   const insertMock = jest.fn().mockImplementation((row: Record<string, unknown>) => {

--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { TickerBlacklistService } from './ticker-blacklist.service';
+// PR #339 — Weekend / session-closed filter sur getCandles (couche basse).
+import { isMarketOpenForClass, marketForSymbol } from '@smartvest/ai-analyst';
 
 /**
  * EodhdIntradayService — récupère les bougies intraday OHLCV depuis EODHD
@@ -65,6 +67,8 @@ export interface RawTick {
 @Injectable()
 export class EodhdIntradayService {
   private readonly logger = new Logger(EodhdIntradayService.name);
+  /** PR #339 — Weekend / session-closed filter (default ON, kill-switch via env). */
+  private readonly weekendFilterEnabled: boolean;
   private cache = new Map<string, CandleSeries>();
 
   constructor(
@@ -90,6 +94,12 @@ export class EodhdIntradayService {
       const tail = k.length >= 4 ? k.slice(-4) : '****';
       this.logger.log(`[eodhd] provider initialized, key=***${tail} (length=${k.length})`);
     }
+
+    // PR #339 — Weekend filter sur getCandles (kill-switch via env, default ON).
+    // Si EODHD_WEEKEND_FILTER_ENABLED=false → désactive le filtre, retour comportement legacy.
+    const weekendFlag = this.config.get<string>('EODHD_WEEKEND_FILTER_ENABLED');
+    this.weekendFilterEnabled = weekendFlag !== 'false';
+    this.logger.log(`[eodhd] weekend filter ${this.weekendFilterEnabled ? 'ENABLED' : 'DISABLED'}`);
   }
 
   private apiKey(): string | null {
@@ -237,6 +247,27 @@ export class EodhdIntradayService {
     if (this.blacklist?.isBlacklisted(eodhdTicker)) {
       this.logger.debug(`[eodhd] ${eodhdTicker} skipped (blacklist)`);
       return null;
+    }
+
+    // PR #339 — Skip fetch si session/weekend fermé pour la classe marché du ticker.
+    // Source bug 17/05/2026 : 5242 calls intraday asia en 12h weekend (100 % empty,
+    // 26k API calls EODHD gaspillés). Protège TOUS les callers (multi-tf,
+    // shadow-signals, lisa.service, etc.) d un coup à la couche basse.
+    //
+    // Crypto exempté (24/7). Unknown market = passe (conservateur, on ne casse
+    // rien pour forex/commodities/indices futurs).
+    if (this.weekendFilterEnabled) {
+      const cls = marketForSymbol(eodhdTicker);
+      if (cls && cls !== 'crypto' && !isMarketOpenForClass(cls, new Date())) {
+        this.logger.debug(`[eodhd] ${eodhdTicker} skipped (session closed for ${cls})`);
+        this.logCall({
+          ticker: eodhdTicker,
+          success: false,
+          statusCode: 0,
+          errorMessage: 'SKIP_SESSION_CLOSED',
+        });
+        return null;
+      }
     }
 
     // PR #284 — Mode range explicite : skip cache (range-specific), guard


### PR DESCRIPTION
Ajoute un early-return dans `EodhdIntradayService.getCandles()` qui skip le fetch HTTP quand la classe marché du ticker est fermée (weekend ou hors horaires session). Crypto exempté (24/7).

## Diagnostic 17/05/2026

| Métrique | Valeur |
|---|---|
| Calls intraday 12h weekend (sam 21h → dim 06h UTC) | **5242** |
| Empty_real (status 200 + price_usd NULL) | **100 %** |
| Classes concernées | **100 % asia** (24 tickers uniques .KO/.KQ) |
| Multi intraday EODHD | ×5 API calls/HTTP → **26 210 API calls gaspillés en 12h** |
| Quota EODHD à 06h UTC dimanche | **72.99 %** (alerte cron 355833de) |

**Cause racine** : `filterTickersForFetch` (qui filtre déjà les marchés fermés) n'est appliqué que par `top-gainers-scanner`. 6 autres callers (shadow-signals, multi-tf, lisa.service, etc.) bypassent ce pré-filtre et frappent direct EODHD. Fix à la couche basse → protège tous les callers d'un coup.

## Implémentation

- Import `{ isMarketOpenForClass, marketForSymbol }` depuis `@smartvest/ai-analyst`
- Flag env `EODHD_WEEKEND_FILTER_ENABLED` (default `true`, kill-switch sur `false`)
- Early-return après check blacklist :
  ```ts
  if (this.weekendFilterEnabled) {
    const cls = marketForSymbol(eodhdTicker);
    if (cls && cls !== 'crypto' && !isMarketOpenForClass(cls, new Date())) {
      this.logCall({ ..., errorMessage: 'SKIP_SESSION_CLOSED' });
      return null;
    }
  }
  ```
- Crypto exempté (24/7), unknown market = passe (conservateur)
- `logCall` avec `errorMessage='SKIP_SESSION_CLOSED'` pour mesurer le gain post-deploy via SQL

## Gain estimé

| Fenêtre | API calls économisés |
|---|---|
| Weekend asia 12h | -26k |
| Weekend complet (50h) | -110k |
| **Mensuel (4 weekends)** | **-440k** |

≈ 15 % de la marge quota mensuelle libérée.

## Tests Jest

6 nouveaux specs (`eodhd-intraday.pr339-weekend-filter.spec.ts`) :
- Dimanche .KO → skip silencieux (fetch jamais appelé)
- Samedi .US → skip silencieux
- Samedi .KQ → skip silencieux
- Crypto .CC dimanche → fetch normal (24/7)
- Kill-switch `EODHD_WEEKEND_FILTER_ENABLED=false` → fetch passe
- Mardi session pleine .KO → fetch passe

**Full repo : 2100/2100 verts** (+ 471 ai-analyst).

5 specs eodhd-intraday existants ont reçu `EODHD_WEEKEND_FILTER_ENABLED: 'false'` dans leur config mock car ils utilisaient `new Date()` réel (dimanche au moment de l'écriture) et frappaient désormais le filtre. Flag false dans les fixtures préserve le comportement pre-PR #339 sans réécrire les assertions.

## Diff

7 fichiers, 175 insertions, 3 deletions :
- `eodhd-intraday.service.ts` — 31 lignes (import + flag constructor + early-return)
- `eodhd-intraday.pr339-weekend-filter.spec.ts` — 135 lignes (nouveau spec)
- 5 specs existants — 1-6 lignes chacun (config mock kill-switch)

Aucune migration SQL, aucune nouvelle dépendance npm.

## Kill-switch

```bash
flyctl secrets set EODHD_WEEKEND_FILTER_ENABLED=false --app smartvest
```

→ rollback sans revert git.

## Validation post-merge T+24h (dimanche 24 mai)

```sql
SELECT date_trunc('hour', timestamp) AS h,
       COUNT(*) AS calls,
       COUNT(*) FILTER (WHERE error_message='SKIP_SESSION_CLOSED') AS skipped
FROM eodhd_request_log
WHERE called_by='intraday' AND timestamp >= NOW() - INTERVAL '12 hours'
GROUP BY h ORDER BY h DESC;
```

Attendu : `calls ~ skipped` pendant les heures weekend asia (skip enregistré, 0 fetch HTTP réel), drop drastique du quota EODHD apiRequests journalier.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_