### PR TITLE
feat(lisa): PR #341 weekend filter in fetchCascade for macro indicators

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/lisa-service.pr341-macro-weekend-cascade.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/lisa-service.pr341-macro-weekend-cascade.spec.ts
@@ -1,0 +1,169 @@
+import { LisaService } from '../lisa.service';
+
+/**
+ * PR #341 — tests pour `isCascadeFullyClosed`, helper utilisé par
+ * `fetchCascade` pour short-circuit silencieux quand TOUS les tickers ciblent
+ * des marchés fermés.
+ *
+ * Pattern identique à market-snapshot-refactor.spec : Object.create LisaService
+ * sans appeler le constructor (les méthodes testées sont pure logique).
+ */
+
+function makeBareLisaService(): LisaService {
+  return Object.create(LisaService.prototype) as LisaService;
+}
+
+describe('LisaService.isCascadeFullyClosed — PR #341 macro weekend filter', () => {
+  const service = makeBareLisaService();
+
+  describe('cascade fully closed → true', () => {
+    it('SPY.US samedi → true (us equity fermé weekend)', () => {
+      const sat = new Date('2026-05-16T15:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [{ ticker: 'SPY.US', quality: 'live' }],
+        sat,
+      );
+      expect(closed).toBe(true);
+    });
+
+    it('EURUSD.FOREX dimanche 21h UTC → true (forex pas encore réouvert)', () => {
+      const sun = new Date('2026-05-17T21:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [{ ticker: 'EURUSD.FOREX', quality: 'live' }],
+        sun,
+      );
+      expect(closed).toBe(true);
+    });
+
+    it('cascade gold avec XAUUSD.FOREX + GLD.US tous fermés samedi → true', () => {
+      const sat = new Date('2026-05-16T10:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [
+          { ticker: 'XAUUSD.FOREX', quality: 'live' },
+          { ticker: 'GLD.US', multiplier: 10, quality: 'proxy' },
+        ],
+        sat,
+      );
+      expect(closed).toBe(true);
+    });
+
+    it('cascade brent (USO.US) samedi → true', () => {
+      const sat = new Date('2026-05-16T10:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [{ ticker: 'USO.US', multiplier: 1.05, quality: 'proxy' }],
+        sat,
+      );
+      expect(closed).toBe(true);
+    });
+  });
+
+  describe('cascade traversée normale → false', () => {
+    it('EURUSD.FOREX dimanche 23h UTC → false (forex ouvert)', () => {
+      const sun = new Date('2026-05-17T23:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [{ ticker: 'EURUSD.FOREX', quality: 'live' }],
+        sun,
+      );
+      expect(closed).toBe(false);
+    });
+
+    it('SPY.US lundi 14h UTC → false (us equity ouvert)', () => {
+      const mon = new Date('2026-05-18T14:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [{ ticker: 'SPY.US', quality: 'live' }],
+        mon,
+      );
+      expect(closed).toBe(false);
+    });
+  });
+
+  describe('exemptions (source ou ticker spécial) → false même weekend', () => {
+    it('^VIX samedi → false (Yahoo indices toujours servis)', () => {
+      const sat = new Date('2026-05-16T03:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [{ ticker: '^VIX', source: 'yahoo', quality: 'live' }],
+        sat,
+      );
+      expect(closed).toBe(false);
+    });
+
+    it('^TNX samedi → false (Yahoo indice rates 24/7)', () => {
+      const sat = new Date('2026-05-16T03:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [{ ticker: '^TNX', source: 'yahoo', quality: 'live' }],
+        sat,
+      );
+      expect(closed).toBe(false);
+    });
+
+    it('DX-Y.NYB samedi → false (Yahoo dollar index exempt)', () => {
+      const sat = new Date('2026-05-16T03:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [{ ticker: 'DX-Y.NYB', source: 'yahoo', quality: 'live' }],
+        sat,
+      );
+      expect(closed).toBe(false);
+    });
+
+    it('DGS10 samedi → false (source FRED toujours considérée open)', () => {
+      const sat = new Date('2026-05-16T15:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [{ ticker: 'DGS10', source: 'fred', quality: 'live' }],
+        sat,
+      );
+      expect(closed).toBe(false);
+    });
+
+    it('BTC-USD.CC dimanche → false (crypto 24/7)', () => {
+      const sun = new Date('2026-05-17T03:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [{ ticker: 'BTC-USD.CC', quality: 'live' }],
+        sun,
+      );
+      expect(closed).toBe(false);
+    });
+
+    it('cascade us10y mixte (TNX yahoo + TNX.INDX eodhd + DGS10 fred) samedi → false', () => {
+      const sat = new Date('2026-05-16T15:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [
+          { ticker: '^TNX', source: 'yahoo', quality: 'live' },
+          { ticker: 'TNX.INDX', source: 'eodhd', quality: 'live' },
+          { ticker: 'DGS10', source: 'fred', quality: 'live' },
+        ],
+        sat,
+      );
+      expect(closed).toBe(false);
+    });
+
+    it('cascade dxy mixte avec UUP.US fallback samedi → false (DX-Y.NYB exempt)', () => {
+      const sat = new Date('2026-05-16T15:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [
+          { ticker: 'DX-Y.NYB', source: 'yahoo', quality: 'live' },
+          { ticker: 'DXY.INDX', source: 'eodhd', quality: 'live' },
+          { ticker: 'UUP.US', source: 'eodhd', multiplier: 4.1, quality: 'proxy' },
+        ],
+        sat,
+      );
+      expect(closed).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('attempts vide → false (rien à filtrer, pas de short-circuit)', () => {
+      const sat = new Date('2026-05-16T15:00:00Z');
+      const closed = service.isCascadeFullyClosed([], sat);
+      expect(closed).toBe(false);
+    });
+
+    it('source eodhd implicite (par défaut) sur SPY.US samedi → true', () => {
+      const sat = new Date('2026-05-16T15:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [{ ticker: 'SPY.US', quality: 'live' }], // pas de `source`, default eodhd
+        sat,
+      );
+      expect(closed).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -3042,6 +3042,31 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
   }
 
   /**
+   * PR #341 — détermine si TOUS les `attempts` d'une cascade ciblent des
+   * marchés fermés (.US/.FOREX/.COMM hors session). Si oui, le caller skip
+   * silencieusement les calls HTTP.
+   *
+   * Exemptions : FRED (EOD officiel servi 24/7), Yahoo indices (^VIX, ^TNX,
+   * ^IRX), DX-Y.NYB, crypto (.CC) — ces sources renvoient un last-close
+   * acceptable même hors session.
+   *
+   * Visible (public) pour tests unitaires Jest.
+   */
+  isCascadeFullyClosed(
+    attempts: Array<{ ticker: string; source?: 'eodhd' | 'yahoo' | 'stooq' | 'fred' }>,
+    now: Date = new Date(),
+  ): boolean {
+    if (attempts.length === 0) return false;
+    return attempts.every((a) => {
+      const src = a.source ?? 'eodhd';
+      if (src === 'fred') return false;
+      if (a.ticker.startsWith('^') || a.ticker === 'DX-Y.NYB') return false;
+      if (a.ticker.endsWith('.CC')) return false;
+      return !this.isMacroTickerMarketOpen(a.ticker, now);
+    });
+  }
+
+  /**
    * Refactor market_snapshot tâche C (17/05) — fetch dédié crypto via
    * endpoint live (/api/real-time) avec timeout long (5s) et SANS retry.
    *
@@ -3326,6 +3351,38 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         quality: 'live' | 'proxy';
       }>,
     ): Promise<number | null> => {
+      // PR #341 — early-return silencieux si TOUS les tickers de la cascade
+      // ciblent des marchés fermés (.US/.FOREX/.COMM hors session). Évite 9
+      // ERROR logs/heure le weekend sur cron market_snapshot (silver, gold,
+      // lqd, hyg, usdjpy, eurusd, qqq, spy, brent) en short-circuitant avant
+      // tout call HTTP qui retournerait null de toute façon.
+      //
+      // Exemptions :
+      //   - source 'fred' : sert l'EOD officiel même le weekend
+      //   - ticker '^...' ou 'DX-Y.NYB' (Yahoo) : last-close servi 24/7
+      //   - ticker '.CC' (crypto) : 24/7
+      //
+      // Kill-switch : LISA_MACRO_WEEKEND_FILTER_ENABLED=false (default ON).
+      const macroWeekendFilterEnabled =
+        process.env.LISA_MACRO_WEEKEND_FILTER_ENABLED !== 'false';
+      if (macroWeekendFilterEnabled && this.isCascadeFullyClosed(attempts)) {
+        const cached = this.lastKnownMacroValues.get(indicator);
+        if (cached && Date.now() - cached.timestamp < this.LAST_KNOWN_TTL_MS) {
+          dataQuality.stale.push(
+            `${indicator}(last_known_age=${Math.round((Date.now() - cached.timestamp) / 60_000)}min, weekend_skip)`,
+          );
+          this.logger.debug(
+            `[macro] ${indicator} weekend skip — serving last-known $${cached.value.toFixed(2)} (age ${Math.round((Date.now() - cached.timestamp) / 60_000)}min)`,
+          );
+          return cached.value;
+        }
+        dataQuality.fallback.push(indicator);
+        this.logger.debug(
+          `[macro] ${indicator} weekend skip — all sources closed, falling through to hardcoded default (silent)`,
+        );
+        return null;
+      }
+
       for (const a of attempts) {
         const source = a.source ?? 'eodhd';
         let v: number | null = null;

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -3053,7 +3053,12 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
    * Visible (public) pour tests unitaires Jest.
    */
   isCascadeFullyClosed(
-    attempts: Array<{ ticker: string; source?: 'eodhd' | 'yahoo' | 'stooq' | 'fred' }>,
+    attempts: Array<{
+      ticker: string;
+      source?: 'eodhd' | 'yahoo' | 'stooq' | 'fred';
+      multiplier?: number;
+      quality?: 'live' | 'proxy';
+    }>,
     now: Date = new Date(),
   ): boolean {
     if (attempts.length === 0) return false;


### PR DESCRIPTION
## Contexte

Le refactor `market_snapshot` du 17 mai (tâche B) avait introduit `isMacroTickerMarketOpen()` pour skipper silencieusement les calls EODHD sur tickers `.US`/`.FOREX`/`.COMM` weekend. Mais le filter ne couvrait que `fetchNum` (EODHD), pas les autres sources Yahoo / Stooq.

Résultat observé dimanche 17 mai 09h UTC dans les logs Fly : **9 ERROR `LisaService`** à 09:00:00 pile, indicators **silver, gold, lqd, hyg, usdjpy, eurusd, qqq, spy, brent**.

Cause : cascade traverse toutes les sources (yahoo, stooq, fred), toutes retournent null le weekend → fallback hardcoded + ERROR log.

## Fix

Early-return silencieux dans `fetchCascade` si **tous** les `attempts` ciblent des tickers fermés.

**Exemptions** :
- source `'fred'` : EOD officiel servi 24/7
- ticker `^...` (Yahoo indices) ou `DX-Y.NYB` : last-close servi 24/7
- ticker `.CC` : crypto 24/7

**Fallback chain quand cascade fully closed** :
1. last-known cache (<24h) → return cached, log DEBUG
2. pas de cache → return null + DEBUG silencieux, caller tombe sur fallback hardcoded
3. Cascade NOT fully closed → boucle for classique (comportement inchangé, ERROR log conservé en cas d'incident en pleine session)

Le helper `isCascadeFullyClosed(attempts, now)` extrait comme méthode publique pour tests unitaires (le closure local `fetchCascade` à `fetchMarketSnapshot` n'est pas testable directement).

## Mesure

| Avant | Après |
|---|---|
| 9 ERROR/h × 12h weekend = 108 logs/weekend | 0 ERROR pour ces 9 indicators |
| Bruit log + ~108 batches d'attempts HTTP yahoo/stooq inutiles | Short-circuit avant tout HTTP |

## Kill-switch

```bash
flyctl secrets set LISA_MACRO_WEEKEND_FILTER_ENABLED=false --app smartvest
```

Pattern identique à `MARKET_SNAPSHOT_WEEKEND_SKIP_ENABLED` (refactor tâche B 17/05).

## Tests Jest

15 specs dans `lisa-service.pr341-macro-weekend-cascade.spec.ts` :

- **4 cascades fully closed** : SPY samedi, EURUSD dimanche 21h, gold mixte (XAUUSD.FOREX + GLD.US), brent USO
- **2 traversées normales** : EURUSD dimanche 23h (forex ouvert), SPY lundi 14h
- **8 exemptions** : ^VIX, ^TNX, DX-Y.NYB samedi, DGS10 FRED, BTC-USD.CC, cascade us10y mixte, cascade dxy avec UUP fallback
- **1 edge case** : attempts vide → false

**Full api regression : 2115/2115 verts** (vs 2100 avant = +15 nouveaux specs).

## Diff

2 fichiers, 226 insertions :
- `lisa.service.ts` — 57 lignes (méthode `isCascadeFullyClosed` + early-return dans `fetchCascade`)
- `__tests__/lisa-service.pr341-macro-weekend-cascade.spec.ts` — 169 lignes (nouveau)

Aucune migration DB, aucune nouvelle dépendance, aucune modif d'`isMacroTickerMarketOpen` ou des autres méthodes (`fetchNum`, `fetchYahoo`, `fetchStooq`, `fetchFred`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_