### PR TITLE
feat(lisa): add Binance WS health snapshot every 5min (option C observability)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -220,3 +220,8 @@ QUICK_WINS_TWELVEDATA_SUPERTREND_US_LARGE=false
 # Filtre RSI overbought (>75) sur scanner crypto (10 paires hardcoded)
 # Coût estimé : ~150 appels/jour avec scanner crypto en mode actif
 QUICK_WINS_TWELVEDATA_RSI_CRYPTO=false
+
+# PR #343 — Binance WS observability snapshot (cron 5 min)
+# true (default) : log JSON [binance-ws-health] toutes les 5 min (grep VictoriaLogs)
+# false          : désactivation totale sans toucher au code (rollback à chaud Fly)
+BINANCE_WS_HEALTH_LOG_ENABLED=true

--- a/apps/api/src/modules/lisa/services/__tests__/realtime-price.pr343-ws-observability.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/realtime-price.pr343-ws-observability.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * PR #343 — observability Binance WS, snapshot 5 min (Option C).
+ *
+ * Tests les helpers purs (`mapWsState`, `computeSilentFailureSuspected`,
+ * `getOpenCryptoPositionsCount`) + le cron `logBinanceWsHealthSnapshot`
+ * en vérifiant la structure JSON loguée, le reset du compteur, le flag
+ * d activation, et le comportement fail-open Supabase.
+ */
+
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { RealtimePriceService } from '../realtime-price.service';
+import { SupabaseService } from '../../../supabase/supabase.service';
+
+const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+function makeConfig(env: Record<string, string> = {}): ConfigService {
+  return { get: (k: string) => env[k] } as unknown as ConfigService;
+}
+
+interface SupabaseStub {
+  count?: number | null;
+  error?: { message: string } | null;
+  ready?: boolean;
+}
+
+function makeSupabase(stub: SupabaseStub = {}): SupabaseService {
+  return {
+    isReady: () => stub.ready ?? true,
+    getClient: () => ({
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            in: () => ({
+              eq: () => Promise.resolve({ count: stub.count ?? 0, error: stub.error ?? null }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  } as unknown as SupabaseService;
+}
+
+function makeService(
+  env: Record<string, string> = {},
+  supabase: SupabaseService = makeSupabase(),
+): RealtimePriceService {
+  return new RealtimePriceService(supabase, makeConfig(env));
+}
+
+describe('RealtimePriceService — PR #343 observability', () => {
+  beforeEach(() => {
+    logSpy.mockClear();
+    warnSpy.mockClear();
+  });
+
+  describe('mapWsState', () => {
+    const svc = makeService();
+    it.each<[number | undefined | null, string]>([
+      [0, 'CONNECTING'],
+      [1, 'OPEN'],
+      [2, 'CLOSING'],
+      [3, 'CLOSED'],
+      [undefined, 'NOT_INITIALIZED'],
+      [null, 'NOT_INITIALIZED'],
+      [99, 'UNKNOWN'],
+    ])('readyState=%s → %s', (state, expected) => {
+      expect(svc.mapWsState(state ?? undefined)).toBe(expected);
+    });
+  });
+
+  describe('computeSilentFailureSuspected', () => {
+    it('OPEN + symbols>0 + msg=0 → true', () => {
+      expect(RealtimePriceService.computeSilentFailureSuspected('OPEN', 3, 0)).toBe(true);
+    });
+    it('OPEN + symbols>0 + msg>0 → false', () => {
+      expect(RealtimePriceService.computeSilentFailureSuspected('OPEN', 3, 42)).toBe(false);
+    });
+    it('CLOSED → false (peu importe le reste)', () => {
+      expect(RealtimePriceService.computeSilentFailureSuspected('CLOSED', 3, 0)).toBe(false);
+    });
+    it('symbols=0 → false (0 position crypto ouverte = WS volontairement fermé)', () => {
+      expect(RealtimePriceService.computeSilentFailureSuspected('OPEN', 0, 0)).toBe(false);
+    });
+    it('NOT_INITIALIZED → false', () => {
+      expect(RealtimePriceService.computeSilentFailureSuspected('NOT_INITIALIZED', 5, 0)).toBe(false);
+    });
+  });
+
+  describe('getOpenCryptoPositionsCount', () => {
+    it('succès → retourne le count', async () => {
+      const svc = makeService({}, makeSupabase({ count: 2 }));
+      expect(await svc.getOpenCryptoPositionsCount()).toBe(2);
+    });
+
+    it('Supabase not ready → null', async () => {
+      const svc = makeService({}, makeSupabase({ ready: false }));
+      expect(await svc.getOpenCryptoPositionsCount()).toBeNull();
+    });
+
+    it('Supabase error → null + warn log', async () => {
+      const svc = makeService({}, makeSupabase({ error: { message: 'connection reset' } }));
+      const result = await svc.getOpenCryptoPositionsCount();
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('crypto positions query failed'));
+    });
+
+    it('count null Supabase → 0 (default conservateur)', async () => {
+      const svc = makeService({}, makeSupabase({ count: null }));
+      expect(await svc.getOpenCryptoPositionsCount()).toBe(0);
+    });
+  });
+
+  describe('logBinanceWsHealthSnapshot — JSON structuré', () => {
+    it('flag BINANCE_WS_HEALTH_LOG_ENABLED=false → early-return, aucun log', async () => {
+      const svc = makeService({ BINANCE_WS_HEALTH_LOG_ENABLED: 'false' });
+      await svc.logBinanceWsHealthSnapshot();
+      const calls = logSpy.mock.calls.filter((c) => String(c[0]).includes('[binance-ws-health]'));
+      expect(calls).toHaveLength(0);
+    });
+
+    it('flag absent (default true) → log JSON produit', async () => {
+      const svc = makeService();
+      await svc.logBinanceWsHealthSnapshot();
+      const calls = logSpy.mock.calls.filter((c) => String(c[0]).includes('[binance-ws-health]'));
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    it('structure JSON complète et types corrects (WS non initialisé)', async () => {
+      const svc = makeService({}, makeSupabase({ count: 0 }));
+      await svc.logBinanceWsHealthSnapshot();
+      const call = logSpy.mock.calls.find((c) => String(c[0]).includes('[binance-ws-health]'));
+      expect(call).toBeDefined();
+      const jsonPart = String(call![0]).replace('[binance-ws-health] ', '');
+      const parsed = JSON.parse(jsonPart);
+      expect(parsed).toMatchObject({
+        event: 'binance_ws_health',
+        ws_state: 'NOT_INITIALIZED',
+        symbols_subscribed_count: 0,
+        symbols_subscribed: [],
+        msg_count_last_5min: 0,
+        last_msg_age_seconds: null,
+        open_crypto_positions: 0,
+        silent_failure_suspected: false,
+      });
+      expect(typeof parsed.ts_utc).toBe('string');
+      expect(parsed.ts_utc).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('reset compteur 5min après snapshot', async () => {
+      const svc = makeService();
+      // Inject un compteur non-zéro via reflection.
+      (svc as unknown as { msgCounter5min: number }).msgCounter5min = 17;
+      await svc.logBinanceWsHealthSnapshot();
+      expect((svc as unknown as { msgCounter5min: number }).msgCounter5min).toBe(0);
+    });
+
+    it('silent failure → warn additionnel', async () => {
+      const svc = makeService();
+      const internals = svc as unknown as {
+        ws: { readyState: number };
+        subscribedStreams: Set<string>;
+        msgCounter5min: number;
+      };
+      internals.ws = { readyState: 1 }; // OPEN
+      internals.subscribedStreams = new Set(['BTCUSDT', 'ETHUSDT']);
+      internals.msgCounter5min = 0;
+
+      await svc.logBinanceWsHealthSnapshot();
+
+      const warn = warnSpy.mock.calls.find((c) =>
+        String(c[0]).includes('SILENT FAILURE SUSPECTED'),
+      );
+      expect(warn).toBeDefined();
+    });
+
+    it('msg_count > 0 → pas de warn silent failure', async () => {
+      const svc = makeService();
+      const internals = svc as unknown as {
+        ws: { readyState: number };
+        subscribedStreams: Set<string>;
+        msgCounter5min: number;
+        lastMsgTs: number | null;
+      };
+      internals.ws = { readyState: 1 };
+      internals.subscribedStreams = new Set(['BTCUSDT']);
+      internals.msgCounter5min = 42;
+      internals.lastMsgTs = Date.now() - 1000;
+
+      await svc.logBinanceWsHealthSnapshot();
+
+      const warn = warnSpy.mock.calls.find((c) =>
+        String(c[0]).includes('SILENT FAILURE SUSPECTED'),
+      );
+      expect(warn).toBeUndefined();
+    });
+
+    it('last_msg_age_seconds calculé quand lastMsgTs présent', async () => {
+      const svc = makeService();
+      const internals = svc as unknown as { lastMsgTs: number | null };
+      internals.lastMsgTs = Date.now() - 30_000; // 30 s ago
+
+      await svc.logBinanceWsHealthSnapshot();
+      const call = logSpy.mock.calls.find((c) => String(c[0]).includes('[binance-ws-health]'));
+      const jsonPart = String(call![0]).replace('[binance-ws-health] ', '');
+      const parsed = JSON.parse(jsonPart);
+      expect(parsed.last_msg_age_seconds).toBeGreaterThan(25);
+      expect(parsed.last_msg_age_seconds).toBeLessThan(35);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/realtime-price.service.ts
+++ b/apps/api/src/modules/lisa/services/realtime-price.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Cron } from '@nestjs/schedule';
 import WebSocket from 'ws';
 import { SupabaseService } from '../../supabase/supabase.service';
 
@@ -35,6 +36,11 @@ export class RealtimePriceService implements OnModuleDestroy {
   private subscribedStreams = new Set<string>();
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // PR #343 — observability WS Binance (Option C, snapshot 5 min).
+  // Compteurs alimentés par le handler `message` ; reset après chaque snapshot.
+  private msgCounter5min = 0;
+  private lastMsgTs: number | null = null;
 
   /** Cache de prix : ticker uppercase → { price, source, asOf } */
   private cache = new Map<string, { price: string; source: 'binance_ws' | 'eodhd'; asOf: string }>();
@@ -203,6 +209,10 @@ export class RealtimePriceService implements OnModuleDestroy {
       });
 
       this.ws.on('message', (data: WebSocket.RawData) => {
+        // PR #343 — comptage messages pour snapshot santé (cron 5 min).
+        // Tout message reçu compte, même un parse-error (preuve d activité réseau).
+        this.msgCounter5min += 1;
+        this.lastMsgTs = Date.now();
         try {
           const raw = data.toString('utf8');
           const msg = JSON.parse(raw);
@@ -397,5 +407,101 @@ export class RealtimePriceService implements OnModuleDestroy {
       callsLastMinute,
       rateLimitPerMinute: EODHD_RATE_LIMIT_PER_MINUTE,
     };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // PR #343 — Observability snapshot Binance WS (Option C, sans changer le
+  // comportement runtime). Logue toutes les 5 min un JSON structuré pour
+  // permettre grep VictoriaLogs + alerting silent-failure futur.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** Map WebSocket readyState → label lisible. Visible pour tests. */
+  mapWsState(readyState: number | undefined | null): string {
+    if (readyState === undefined || readyState === null) return 'NOT_INITIALIZED';
+    const states = ['CONNECTING', 'OPEN', 'CLOSING', 'CLOSED'];
+    return states[readyState] ?? 'UNKNOWN';
+  }
+
+  /**
+   * Détecte une "silent failure" : WS rapporte OPEN mais aucun message
+   * reçu sur les 5 dernières minutes alors que des symboles sont abonnés.
+   * Visible pour tests unitaires.
+   */
+  static computeSilentFailureSuspected(
+    wsState: string,
+    symbolsSubscribedCount: number,
+    msgCount5min: number,
+  ): boolean {
+    return wsState === 'OPEN' && symbolsSubscribedCount > 0 && msgCount5min === 0;
+  }
+
+  /**
+   * Compte les positions crypto ouvertes du portfolio principal.
+   * Lecture-seule Supabase. Fail-open : retourne null si erreur (pas de crash cron).
+   */
+  async getOpenCryptoPositionsCount(): Promise<number | null> {
+    if (!this.supabase.isReady()) return null;
+    const portfolioId =
+      this.config.get<string>('PORTFOLIO_ID') ?? '58439d86-3f20-4a60-82a4-307f3f252bc2';
+    try {
+      const { count, error } = await this.supabase
+        .getClient()
+        .from('lisa_positions')
+        .select('id', { count: 'exact', head: true })
+        .eq('portfolio_id', portfolioId)
+        .in('asset_class', ['crypto_major', 'crypto_alt'])
+        .eq('status', 'open');
+      if (error) {
+        this.logger.warn(`[binance-ws-health] crypto positions query failed: ${error.message}`);
+        return null;
+      }
+      return count ?? 0;
+    } catch (err) {
+      this.logger.warn(`[binance-ws-health] crypto positions exception: ${(err as Error).message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Cron 5 min : snapshot santé Binance WS en JSON structuré.
+   * Désactivable via `BINANCE_WS_HEALTH_LOG_ENABLED=false` (default true).
+   */
+  @Cron('*/5 * * * *', { name: 'binance-ws-health-snapshot' })
+  async logBinanceWsHealthSnapshot(): Promise<void> {
+    const flag = this.config.get<string>('BINANCE_WS_HEALTH_LOG_ENABLED') ?? 'true';
+    if (flag !== 'true') return;
+
+    const now = Date.now();
+    const wsState = this.mapWsState(this.ws?.readyState);
+    const symbolsSubscribed = Array.from(this.subscribedStreams);
+    const lastMsgAgeSeconds = this.lastMsgTs ? (now - this.lastMsgTs) / 1000 : null;
+    const openCryptoPositions = await this.getOpenCryptoPositionsCount();
+    const silentFailureSuspected = RealtimePriceService.computeSilentFailureSuspected(
+      wsState,
+      symbolsSubscribed.length,
+      this.msgCounter5min,
+    );
+
+    const snapshot = {
+      event: 'binance_ws_health',
+      ts_utc: new Date(now).toISOString(),
+      ws_state: wsState,
+      symbols_subscribed_count: symbolsSubscribed.length,
+      symbols_subscribed: symbolsSubscribed,
+      msg_count_last_5min: this.msgCounter5min,
+      last_msg_age_seconds: lastMsgAgeSeconds,
+      open_crypto_positions: openCryptoPositions,
+      silent_failure_suspected: silentFailureSuspected,
+    };
+
+    this.logger.log(`[binance-ws-health] ${JSON.stringify(snapshot)}`);
+    if (silentFailureSuspected) {
+      this.logger.warn(
+        `[binance-ws-health] SILENT FAILURE SUSPECTED: ws=OPEN, ${symbolsSubscribed.length} symbols, 0 msg in 5min`,
+      );
+    }
+
+    // Reset compteur fenêtre 5 min.
+    this.msgCounter5min = 0;
   }
 }


### PR DESCRIPTION
## Objectif

Observabilité **pure** du WebSocket Binance sans changer le comportement runtime (Option C retenue par l'utilisateur). Snapshot JSON structuré toutes les 5 min permet le diagnostic future + alerting silent-failure.

## Contexte

L'audit du 17 mai a montré que le silence apparent du WS Binance n'était PAS un bug : 0 position crypto ouverte = WS volontairement fermé par `realtime-price.service.ts`. Mais ce comportement devient invisible quand on essaie de diagnostiquer un vrai problème futur (silent failure, throttling, réseau down).

## Livré

- `@Cron('*/5 * * * *')` `logBinanceWsHealthSnapshot` dans `RealtimePriceService`
- Compteurs `msgCounter5min` + `lastMsgTs` alimentés par le handler `message` existant. Reset du compteur après chaque snapshot.
- `mapWsState(readyState)` → `CONNECTING` / `OPEN` / `CLOSING` / `CLOSED` / `NOT_INITIALIZED` / `UNKNOWN`
- `computeSilentFailureSuspected(state, count, msg)` : `true` ssi (OPEN AND symbols>0 AND msg=0). Visible (static) pour tests.
- `getOpenCryptoPositionsCount()` : `SELECT COUNT lisa_positions WHERE asset_class IN (crypto_major, crypto_alt) AND status='open'`. **Fail-open total** (null si Supabase down, jamais throw).
- Snapshot JSON :
  ```json
  {
    "event": "binance_ws_health",
    "ts_utc": "...",
    "ws_state": "OPEN|CLOSED|NOT_INITIALIZED|...",
    "symbols_subscribed_count": 0,
    "symbols_subscribed": [],
    "msg_count_last_5min": 0,
    "last_msg_age_seconds": null,
    "open_crypto_positions": 0,
    "silent_failure_suspected": false
  }
  ```
- Si `silent_failure_suspected=true` → **warn additionnel** pour alerting
- Flag `BINANCE_WS_HEALTH_LOG_ENABLED=true` par défaut, désactivable à chaud via Fly secret sans toucher au code

## Aucun changement de comportement WebSocket

Le compteur `msgCounter5min` est incrémenté dans le handler `message` existant (1 instruction par message). Coût négligeable. Aucune modification du flow `open`/`close`/`error`/`reconnect`.

## Tests Jest

```
$ npx jest --testPathPattern "pr343"
Test Suites: 1 passed
Tests:       23 passed

$ npm test --workspace=@smartvest/api
Tests:       2151 passed + 2 todo (vs 2128 avant)
```

23 specs couvrant :
- `mapWsState` : 7 cas (readyState 0-3, undefined, null, 99)
- `computeSilentFailureSuspected` : 5 cas (OPEN+msg=0/msg>0, CLOSED, symbols=0, NOT_INITIALIZED)
- `getOpenCryptoPositionsCount` : 4 cas (succès, Supabase not ready, error, count null)
- `logBinanceWsHealthSnapshot` : 7 cas (flag false early-return, flag true log, JSON complet, reset compteur, silent failure warn, msg>0 pas de warn, age calculé)

## Diff

3 fichiers, 324 insertions :
- `realtime-price.service.ts` — 106 lignes (3 helpers + cron + 2 compteurs)
- `realtime-price.pr343-ws-observability.spec.ts` — 213 lignes (nouveau)
- `.env.example` — 5 lignes (doc flag)

## Activation post-merge

Aucune action utilisateur — flag est **ON par défaut**. Désactivation à chaud :

```bash
flyctl secrets set BINANCE_WS_HEALTH_LOG_ENABLED=false -a smartvest
```

## Cas d'usage attendus

1. **Diagnostic futur** "scanner crypto ne tourne plus" → historique 5 min précis pour identifier l'instant où le WS a basculé
2. **Cron alerting silent-failure** (grep `silent_failure_suspected:true` >= 2 occurrences consécutives → notification user)
3. **Audit weekend** : 0 position crypto → `ws_state=NOT_INITIALIZED` ou `CLOSED` attendu, confirme que c'est volontaire et non un bug

## Performance

Cron 5 min + 1 SELECT COUNT par tick → coût négligeable. Aucun impact perf observable.

## Checklist 7 critères acceptation

- [x] Lint propre (suit conventions repo)
- [x] Tous tests Jest passent (2151/2151)
- [x] Compilation réussie (`tsc -b` clean)
- [x] Logs JSON grepables : `grep '\[binance-ws-health\]'`
- [x] Aucun impact perf (cron 5 min + 1 SELECT COUNT)
- [x] Documentation `.env.example` à jour
- [x] Flag default `true`, désactivable à chaud via Fly secret

**Aucun changement de comportement WS, observabilité pure.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_