### PR TITLE
feat(eodhd): PR #344 P1 — instrumentation screener (gap 78 % quota)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -18,6 +18,8 @@ import { ExchangeHoursService } from './services/exchange-hours.service';
 import { BinanceMarketService } from './services/binance-market.service';
 import { EodhdMacroService } from './services/eodhd-macro.service';
 import { EodhdScreenerService } from './services/eodhd-screener.service';
+// PR #344 P1 — logger EODHD partagé (instrumentation quota)
+import { EodhdLoggerService } from './services/eodhd-logger.service';
 import { EodhdInsiderService } from './services/eodhd-insider.service';
 import { EodhdOptionsService } from './services/eodhd-options.service';
 import { BinanceLiquidationsService } from './services/binance-liquidations.service';
@@ -114,6 +116,8 @@ import { TwelveDataService } from './services/twelve-data.service';
     BinanceMarketService,
     EodhdMacroService,
     EodhdScreenerService,
+    // PR #344 P1 — logger EODHD partagé (instrumentation quota)
+    EodhdLoggerService,
     EodhdInsiderService,
     EodhdOptionsService,
     BinanceLiquidationsService,

--- a/apps/api/src/modules/lisa/services/__tests__/eodhd-logger.service.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/eodhd-logger.service.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * PR #344 P1 — tests EodhdLoggerService.
+ *
+ * Couvre :
+ *   - log() insert succès dans eodhd_request_log avec tous les champs
+ *   - log() insert path d'erreur (extras propagés)
+ *   - log() supabase not ready → no-op silencieux
+ *   - log() error Supabase → warn local, jamais throw
+ *   - estimateCredits() barème par endpoint
+ */
+
+import { Logger } from '@nestjs/common';
+import { EodhdLoggerService } from '../eodhd-logger.service';
+import type { SupabaseService } from '../../../supabase/supabase.service';
+
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+interface InsertCapture {
+  payloads: Array<Record<string, unknown>>;
+}
+
+function makeSupabase(opts: {
+  ready?: boolean;
+  error?: { message: string } | null;
+  capture?: InsertCapture;
+} = {}): SupabaseService {
+  return {
+    isReady: () => opts.ready ?? true,
+    getClient: () => ({
+      from: () => ({
+        insert: (payload: Record<string, unknown>) => {
+          if (opts.capture) opts.capture.payloads.push(payload);
+          return Promise.resolve({ error: opts.error ?? null });
+        },
+      }),
+    }),
+  } as unknown as SupabaseService;
+}
+
+async function flush(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+describe('EodhdLoggerService — PR #344 P1', () => {
+  beforeEach(() => {
+    warnSpy.mockClear();
+  });
+
+  describe('log() — succès path', () => {
+    it('insert dans eodhd_request_log avec tous les champs', async () => {
+      const capture: InsertCapture = { payloads: [] };
+      const svc = new EodhdLoggerService(makeSupabase({ capture }));
+      svc.log({
+        ticker: 'gainers_screener_US',
+        eodhdTicker: 'gainers_screener_US',
+        source: 'eodhd',
+        success: true,
+        statusCode: 200,
+        latencyMs: 234,
+        calledBy: 'gainers_screener',
+        endpoint: 'screener',
+        extras: { n_symbols_returned: 42, credits_estimes: 47, exchange: 'US' },
+      });
+      await flush();
+      expect(capture.payloads).toHaveLength(1);
+      expect(capture.payloads[0]).toMatchObject({
+        ticker: 'gainers_screener_US',
+        called_by: 'gainers_screener',
+        endpoint: 'screener',
+        success: true,
+        status_code: 200,
+        latency_ms: 234,
+      });
+      expect((capture.payloads[0].extras as Record<string, unknown>).credits_estimes).toBe(47);
+    });
+  });
+
+  describe('log() — error path', () => {
+    it('insert success=false + errorMessage + extras', async () => {
+      const capture: InsertCapture = { payloads: [] };
+      const svc = new EodhdLoggerService(makeSupabase({ capture }));
+      svc.log({
+        ticker: 'screener_oversold_quality',
+        source: 'eodhd',
+        success: false,
+        statusCode: 422,
+        latencyMs: 123,
+        calledBy: 'screener',
+        endpoint: 'screener',
+        extras: { preset: 'oversold_quality', credits_estimes: 5 },
+        errorMessage: 'HTTP_422 · filter unsupported',
+      });
+      await flush();
+      expect(capture.payloads).toHaveLength(1);
+      expect(capture.payloads[0]).toMatchObject({
+        success: false,
+        status_code: 422,
+        error_message: 'HTTP_422 · filter unsupported',
+        called_by: 'screener',
+        endpoint: 'screener',
+      });
+    });
+  });
+
+  describe('log() — fail-open', () => {
+    it('Supabase not ready → no-op silencieux (pas d insert)', async () => {
+      const capture: InsertCapture = { payloads: [] };
+      const svc = new EodhdLoggerService(makeSupabase({ ready: false, capture }));
+      svc.log({ ticker: 'AAPL.US', success: true, calledBy: 'screener' });
+      await flush();
+      expect(capture.payloads).toHaveLength(0);
+    });
+
+    it('Supabase erreur insert → warn local, pas de throw', async () => {
+      const capture: InsertCapture = { payloads: [] };
+      const svc = new EodhdLoggerService(
+        makeSupabase({ error: { message: 'connection reset' }, capture }),
+      );
+      svc.log({ ticker: 'AAPL.US', success: true, calledBy: 'screener' });
+      await flush();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('connection reset'));
+    });
+  });
+
+  describe('estimateCredits — barème par endpoint', () => {
+    it.each<[string, Record<string, unknown> | undefined, number]>([
+      ['screener', { n_symbols_returned: 42 }, 47], // 5 + 42
+      ['screener', { n_symbols_returned: 0 }, 5], // 5 + 0
+      ['screener', undefined, 5], // 5 + 0 (default)
+      ['intraday', undefined, 5],
+      ['technical', undefined, 5],
+      ['insider', undefined, 10],
+      ['options', undefined, 10],
+      ['real-time', undefined, 1],
+      ['eod', undefined, 1],
+      ['exchange-hours', undefined, 1],
+      ['unknown_endpoint', undefined, 1], // default conservateur
+    ])('endpoint=%s extras=%o → %d credits', (endpoint, extras, expected) => {
+      expect(EodhdLoggerService.estimateCredits(endpoint, extras)).toBe(expected);
+    });
+
+    it('extras.n_symbols_returned NaN → 5 + 0', () => {
+      expect(
+        EodhdLoggerService.estimateCredits('screener', { n_symbols_returned: 'invalid' }),
+      ).toBe(5);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/__tests__/eodhd-screener.pr344.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/eodhd-screener.pr344.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * PR #344 P1 — tests EodhdScreenerService instrumentation.
+ *
+ * Vérifie que EodhdScreenerService.runScan() délègue au EodhdLoggerService
+ * partagé avec endpoint='screener' + extras (preset, n_symbols_returned,
+ * credits_estimes). Success + error paths.
+ */
+
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EodhdScreenerService } from '../eodhd-screener.service';
+import { EodhdLoggerService } from '../eodhd-logger.service';
+import type { SupabaseService } from '../../../supabase/supabase.service';
+
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+function makeLogger(): EodhdLoggerService & { calls: Array<Record<string, unknown>> } {
+  const calls: Array<Record<string, unknown>> = [];
+  const stub = {
+    log: (entry: Record<string, unknown>) => calls.push(entry),
+    calls,
+  };
+  return stub as unknown as EodhdLoggerService & { calls: Array<Record<string, unknown>> };
+}
+
+function makeService(loggerStub: EodhdLoggerService): EodhdScreenerService {
+  const config = {
+    get: jest.fn((k: string) => (k === 'EODHD_API_KEY' ? 'test-key' : undefined)),
+  } as unknown as ConfigService;
+  const supabase = {
+    isReady: () => true,
+    getClient: () => ({ from: () => ({ insert: jest.fn().mockResolvedValue({ error: null }) }) }),
+  } as unknown as SupabaseService;
+  return new EodhdScreenerService(config, supabase, loggerStub);
+}
+
+describe('EodhdScreenerService — PR #344 P1 instrumentation', () => {
+  afterEach(() => {
+    delete (global as { fetch?: unknown }).fetch;
+  });
+
+  it('runScan success → log avec endpoint=screener + extras.preset + n_symbols_returned + credits_estimes', async () => {
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: Array.from({ length: 10 }, (_, i) => ({
+          code: `TEST${i}`,
+          exchange: 'US',
+          name: `Test ${i}`,
+          market_capitalization: 50_000_000_000,
+        })),
+      }),
+    });
+
+    const logger = makeLogger();
+    const svc = makeService(logger);
+    const results = await svc.runScan('oversold_quality', 10);
+
+    expect(results).toHaveLength(10);
+    const calls = (logger as unknown as { calls: Array<Record<string, unknown>> }).calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      calledBy: 'screener',
+      endpoint: 'screener',
+      success: true,
+      statusCode: 200,
+    });
+    const extras = calls[0].extras as Record<string, unknown>;
+    expect(extras.preset).toBe('oversold_quality');
+    expect(extras.n_symbols_returned).toBe(10);
+    expect(extras.credits_estimes).toBe(15); // 5 + 10
+  });
+
+  it('runScan HTTP 422 → log success=false + statusCode=422 + errorMessage', async () => {
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: async () => '{"errors": "filter unsupported"}',
+    });
+
+    const logger = makeLogger();
+    const svc = makeService(logger);
+    const results = await svc.runScan('momentum_mid_cap', 5);
+
+    expect(results).toHaveLength(0);
+    const calls = (logger as unknown as { calls: Array<Record<string, unknown>> }).calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      calledBy: 'screener',
+      endpoint: 'screener',
+      success: false,
+      statusCode: 422,
+    });
+    expect(String(calls[0].errorMessage)).toContain('HTTP_422');
+  });
+
+  it('runScan fetch exception → log success=false + errorMessage', async () => {
+    (global as { fetch?: unknown }).fetch = jest.fn().mockRejectedValue(new Error('network down'));
+
+    const logger = makeLogger();
+    const svc = makeService(logger);
+    const results = await svc.runScan('volume_anomaly', 5);
+
+    expect(results).toHaveLength(0);
+    const calls = (logger as unknown as { calls: Array<Record<string, unknown>> }).calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      calledBy: 'screener',
+      endpoint: 'screener',
+      success: false,
+    });
+    expect(String(calls[0].errorMessage)).toContain('network down');
+  });
+});

--- a/apps/api/src/modules/lisa/services/eodhd-logger.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-logger.service.ts
@@ -1,0 +1,106 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+/**
+ * PR #344 P1 — service partagé de log des appels EODHD.
+ *
+ * Extrait de `LisaService.logEodhdCall` (private) pour permettre l'instrumentation
+ * 100 % des appels EODHD (gap 78 % du quota actuellement invisible).
+ *
+ * Fire-and-forget : aucune erreur d'insert ne remonte au caller (warn log seulement).
+ *
+ * Champs étendus PR #344 vs version legacy :
+ *   - endpoint : URL relative EODHD ('screener', 'eod', 'real-time', etc.) — sépare
+ *     l'attribution par endpoint vs called_by (qui identifie le consumer).
+ *   - extras : JSONB libre pour métadonnées (n_symbols_returned, credits_estimes,
+ *     cache_hit, page/offset, ...).
+ *
+ * Le contrat reste compatible avec `LisaService.logEodhdCall` legacy : tous les
+ * champs hors `ticker`/`success`/`calledBy` sont optionnels. Les call sites existants
+ * peuvent être migrés progressivement sans refacto big-bang.
+ */
+
+export interface EodhdLogEntry {
+  ticker: string;
+  eodhdTicker?: string | null;
+  source?: 'eodhd' | 'fallback' | 'supabase_quotes' | 'yahoo' | 'stooq' | 'fred';
+  success: boolean;
+  statusCode?: number | null | undefined;
+  latencyMs?: number | undefined;
+  priceUsd?: number | null | undefined;
+  /** Identifiant du consumer ('live_price', 'market_snapshot', 'screener', etc.). */
+  calledBy: string;
+  /** PR #344 — endpoint EODHD relatif ('screener', 'eod', 'real-time', ...). */
+  endpoint?: string | undefined;
+  /** PR #344 — métadonnées libres (n_symbols_returned, credits_estimes, ...). */
+  extras?: Record<string, unknown> | undefined;
+  errorMessage?: string | undefined;
+}
+
+@Injectable()
+export class EodhdLoggerService {
+  private readonly logger = new Logger(EodhdLoggerService.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  /**
+   * Insert append-only dans `eodhd_request_log`. Fire-and-forget : ne throw jamais,
+   * warn local si Supabase rejette.
+   */
+  log(entry: EodhdLogEntry): void {
+    if (!this.supabase.isReady()) return;
+    void (async () => {
+      try {
+        const { error } = await this.supabase
+          .getClient()
+          .from('eodhd_request_log')
+          .insert({
+            ticker: entry.ticker,
+            eodhd_ticker: entry.eodhdTicker ?? null,
+            source: entry.source ?? 'eodhd',
+            success: entry.success,
+            status_code: entry.statusCode ?? null,
+            latency_ms: entry.latencyMs ?? null,
+            price_usd: entry.priceUsd ?? null,
+            called_by: entry.calledBy,
+            endpoint: entry.endpoint ?? null,
+            extras: entry.extras ?? null,
+            error_message: entry.errorMessage ?? null,
+          });
+        if (error) {
+          this.logger.warn(`eodhd_request_log insert failed: ${error.message}`);
+        }
+      } catch (err) {
+        this.logger.warn(`eodhd_request_log insert exception: ${(err as Error).message}`);
+      }
+    })();
+  }
+
+  /**
+   * Helper pour estimer les crédits EODHD consommés par appel, selon les barèmes
+   * documentés. Utilisé pour peupler `extras.credits_estimes` sur l'audit post-deploy.
+   *
+   * Référence : vendor/eodhd-claude-skills/skills/eodhd-api/references/general/pricing-and-plans.md
+   */
+  static estimateCredits(endpoint: string, extras?: Record<string, unknown>): number {
+    switch (endpoint) {
+      case 'screener': {
+        const n = Number(extras?.n_symbols_returned ?? 0);
+        return 5 + (Number.isFinite(n) ? n : 0);
+      }
+      case 'intraday':
+        return 5;
+      case 'technical':
+        return 5;
+      case 'insider':
+      case 'options':
+        return 10;
+      case 'real-time':
+      case 'eod':
+      case 'exchange-hours':
+        return 1;
+      default:
+        return 1;
+    }
+  }
+}

--- a/apps/api/src/modules/lisa/services/eodhd-screener.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-screener.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
+import { EodhdLoggerService } from './eodhd-logger.service';
 
 /**
  * EodhdScreenerService — wrap /api/screener pour que Lisa découvre
@@ -80,6 +81,7 @@ export class EodhdScreenerService {
   constructor(
     private readonly config: ConfigService,
     private readonly supabase: SupabaseService,
+    private readonly eodhdLogger: EodhdLoggerService,
   ) {}
 
   private apiKey(): string | null {
@@ -87,21 +89,38 @@ export class EodhdScreenerService {
     return k && k !== 'demo' ? k : null;
   }
 
-  private logCall(row: { ticker: string; success: boolean; statusCode?: number; latencyMs?: number; errorMessage?: string }): void {
-    (async () => {
-      try {
-        await this.supabase.getClient().from('eodhd_request_log').insert({
-          ticker: row.ticker,
-          eodhd_ticker: row.ticker,
-          source: 'eodhd',
-          success: row.success,
-          status_code: row.statusCode ?? null,
-          latency_ms: row.latencyMs ?? null,
-          called_by: 'screener',
-          error_message: row.errorMessage ?? null,
-        });
-      } catch { /* swallow */ }
-    })();
+  /**
+   * PR #344 — délégué au service partagé EodhdLoggerService. Inclut désormais
+   * `endpoint='screener'` + `extras` (preset, n_symbols_returned, credits_estimes,
+   * exchange) pour l'audit quota EODHD.
+   */
+  private logCall(row: {
+    ticker: string;
+    success: boolean;
+    statusCode?: number;
+    latencyMs?: number;
+    errorMessage?: string;
+    nSymbolsReturned?: number;
+    preset?: string;
+  }): void {
+    const extras: Record<string, unknown> = {};
+    if (row.preset != null) extras.preset = row.preset;
+    if (row.nSymbolsReturned != null) extras.n_symbols_returned = row.nSymbolsReturned;
+    extras.credits_estimes = EodhdLoggerService.estimateCredits('screener', {
+      n_symbols_returned: row.nSymbolsReturned ?? 0,
+    });
+    this.eodhdLogger.log({
+      ticker: row.ticker,
+      eodhdTicker: row.ticker,
+      source: 'eodhd',
+      success: row.success,
+      statusCode: row.statusCode,
+      latencyMs: row.latencyMs,
+      calledBy: 'screener',
+      endpoint: 'screener',
+      extras,
+      errorMessage: row.errorMessage,
+    });
   }
 
   async runScan(preset: ScreenerPreset, limit = 10): Promise<ScreenerResult[]> {
@@ -131,12 +150,21 @@ export class EodhdScreenerService {
           statusCode: res.status,
           latencyMs,
           errorMessage: `HTTP_${res.status} · ${bodySnippet || 'no body'}`,
+          preset,
         });
         return [];
       }
       const body = await res.json() as Record<string, unknown>;
       const data = (body.data ?? body) as Array<Record<string, unknown>>;
-      this.logCall({ ticker: `screener_${preset}`, success: true, statusCode: res.status, latencyMs });
+      const nSymbolsReturned = Array.isArray(data) ? data.length : 0;
+      this.logCall({
+        ticker: `screener_${preset}`,
+        success: true,
+        statusCode: res.status,
+        latencyMs,
+        preset,
+        nSymbolsReturned,
+      });
 
       if (!Array.isArray(data)) return [];
       const results: ScreenerResult[] = data.slice(0, limit).map((r) => ({
@@ -157,7 +185,7 @@ export class EodhdScreenerService {
       return results;
     } catch (e) {
       this.logger.warn(`Screener ${preset} failed: ${String(e).slice(0, 80)}`);
-      this.logCall({ ticker: `screener_${preset}`, success: false, latencyMs: Date.now() - tStart, errorMessage: String(e).slice(0, 200) });
+      this.logCall({ ticker: `screener_${preset}`, success: false, latencyMs: Date.now() - tStart, errorMessage: String(e).slice(0, 200), preset });
       return [];
     }
   }

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -20,8 +20,10 @@
  *   - Multi-currency portfolio (paperBroker actuel = USD only)
  */
 
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
+// PR #344 P1 — logger EODHD partagé pour instrumenter les screener calls
+import { EodhdLoggerService } from './eodhd-logger.service';
 import { CronJob } from 'cron';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
@@ -531,6 +533,11 @@ export class TopGainersScannerService implements OnModuleInit {
      * (toujours bénéfique), pas d'auto-blacklist dynamique.
      */
     private readonly tickerBlacklist?: TickerBlacklistService,
+    /**
+     * PR #344 P1 — logger EODHD partagé. Optional pour préserver compat tests
+     * existants qui instancient le scanner avec un sous-ensemble de dépendances.
+     */
+    @Optional() private readonly eodhdLogger?: EodhdLoggerService,
   ) {}
 
   /**
@@ -1280,8 +1287,10 @@ export class TopGainersScannerService implements OnModuleInit {
     const filters = encodeURIComponent(JSON.stringify(filtersList));
     const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}&limit=100&offset=0&fmt=json`;
     this.logger.debug(`[top-gainers] EODHD screener exchange=${exUpper} filters=${filtersList.length}`);
+    const tStart = Date.now();
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+      const latencyMs = Date.now() - tStart;
       if (!res.ok) {
         // P18c — log le body pour diagnostic (422 = champ filter invalide,
         // 401 = token expiré, 403 = plan insuffisant). Tronqué à 200 char.
@@ -1289,6 +1298,23 @@ export class TopGainersScannerService implements OnModuleInit {
         this.logger.warn(
           `[top-gainers] eodhd ${exUpper} HTTP ${res.status} — body: ${body.slice(0, 200)}`,
         );
+        // PR #344 P1 — instrumentation log EODHD screener (error path).
+        this.eodhdLogger?.log({
+          ticker: `gainers_screener_${exUpper}`,
+          eodhdTicker: `gainers_screener_${exUpper}`,
+          source: 'eodhd',
+          success: false,
+          statusCode: res.status,
+          latencyMs,
+          calledBy: 'gainers_screener',
+          endpoint: 'screener',
+          extras: {
+            exchange: exUpper,
+            filters_count: filtersList.length,
+            credits_estimes: 5, // base only, pas de symboles retournés
+          },
+          errorMessage: `HTTP_${res.status} · ${body.slice(0, 200)}`,
+        });
         return [];
       }
       const json = await res.json() as { data?: EodhdScreenerRow[] } | EodhdScreenerRow[];
@@ -1301,9 +1327,46 @@ export class TopGainersScannerService implements OnModuleInit {
       if (!isUs) {
         mapped = mapped.filter((c) => (c.changePct ?? 0) > 3);
       }
+      // PR #344 P1 — instrumentation log EODHD screener (success path).
+      // Coût EODHD réel = 5 (base call) + N symboles retournés (cf. pricing-and-plans.md).
+      this.eodhdLogger?.log({
+        ticker: `gainers_screener_${exUpper}`,
+        eodhdTicker: `gainers_screener_${exUpper}`,
+        source: 'eodhd',
+        success: true,
+        statusCode: res.status,
+        latencyMs,
+        calledBy: 'gainers_screener',
+        endpoint: 'screener',
+        extras: {
+          exchange: exUpper,
+          filters_count: filtersList.length,
+          n_symbols_returned: rows.length,
+          n_symbols_mapped: mapped.length,
+          credits_estimes: EodhdLoggerService.estimateCredits('screener', {
+            n_symbols_returned: rows.length,
+          }),
+        },
+      });
       return mapped;
     } catch (e) {
       this.logger.debug(`[top-gainers] eodhd ${exUpper} fetch error: ${String(e).slice(0, 120)}`);
+      // PR #344 P1 — instrumentation log EODHD screener (exception path).
+      this.eodhdLogger?.log({
+        ticker: `gainers_screener_${exUpper}`,
+        eodhdTicker: `gainers_screener_${exUpper}`,
+        source: 'eodhd',
+        success: false,
+        latencyMs: Date.now() - tStart,
+        calledBy: 'gainers_screener',
+        endpoint: 'screener',
+        extras: {
+          exchange: exUpper,
+          filters_count: filtersList.length,
+          credits_estimes: 0, // exception → call probablement non-débité
+        },
+        errorMessage: String(e).slice(0, 200),
+      });
       return [];
     }
   }

--- a/supabase/migrations/0145_eodhd_endpoint_extras.sql
+++ b/supabase/migrations/0145_eodhd_endpoint_extras.sql
@@ -1,0 +1,24 @@
+-- 0145 — PR #344 P1 : enrichit eodhd_request_log avec endpoint + extras (JSONB)
+--
+-- Préparation pour l'instrumentation 100 % des appels EODHD (gap 78 % du
+-- quota actuellement invisible dans le log). P1 = screener uniquement
+-- (probable gros consommateur d'après l'audit 17/05).
+--
+-- - endpoint : 'screener', 'eod', 'real-time', 'intraday', 'technical', etc.
+--   Sépare l'attribution par endpoint indépendamment du called_by (qui est
+--   l'identifiant du consumer).
+-- - extras   : JSONB libre pour métadonnées spécifiques (n_symbols_returned
+--   sur screener pour estimer les crédits réels = 5 + N, page/offset, cache_hit,
+--   credits_estimes par appel, etc.).
+
+ALTER TABLE eodhd_request_log
+  ADD COLUMN IF NOT EXISTS endpoint TEXT,
+  ADD COLUMN IF NOT EXISTS extras JSONB;
+
+COMMENT ON COLUMN eodhd_request_log.endpoint IS
+  'PR #344 — URL endpoint EODHD relatif (screener, eod, real-time, technical, etc.).';
+COMMENT ON COLUMN eodhd_request_log.extras IS
+  'PR #344 — métadonnées libres JSONB (n_symbols_returned, credits_estimes, cache_hit, page, ...).';
+
+CREATE INDEX IF NOT EXISTS idx_eodhd_req_log_endpoint
+  ON eodhd_request_log(endpoint, timestamp DESC);


### PR DESCRIPTION
## Scope révisé — P1 only (screener)

Décision utilisateur après audit complexité du brief original (14 services × instrumentation = 8-12h, risque régression élevé). Scope réduit à **screener uniquement** — statistiquement le plus probable gros consommateur du gap 78 % observé le 17/05.

## Audit 17/05 12h43 UTC

| Métrique | Valeur |
|---|---|
| Quota EODHD réel (`/api/user`) | 74 009 / 100 000 crédits |
| Loggés en DB (4 callers) | 16 017 |
| **Gap non expliqué** | **57 992 (78 %)** |
| Ratio empirique | 21.58× par HTTP loggé |

**Hypothèse P1** : screener `TopGainersScannerService` (9 calls/cycle × 5 + N symboles) explique l'essentiel du gap.

## Livré

| Fichier | Rôle |
|---|---|
| `supabase/migrations/0145_eodhd_endpoint_extras.sql` | ALTER TABLE ADD COLUMN endpoint TEXT + extras JSONB + index |
| `apps/api/src/modules/lisa/services/eodhd-logger.service.ts` | **Nouveau** : service DI-able partagé, signature étendue, helper `estimateCredits()` |
| `apps/api/src/modules/lisa/services/eodhd-screener.service.ts` | Inject + délègue `logCall` au service partagé avec endpoint+extras |
| `apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts` | **3 sites** `fetchEodhdScreener` désormais loggés (success/HTTP error/exception) — c'était le gap principal |
| `apps/api/src/modules/lisa/lisa.module.ts` | Register `EodhdLoggerService` |
| `__tests__/eodhd-logger.service.spec.ts` | 11 specs (succès, error, fail-open, estimateCredits barème) |
| `__tests__/eodhd-screener.pr344.spec.ts` | 3 specs (success path, HTTP 422, exception path) |

## Pattern d'instrumentation

```ts
this.eodhdLogger?.log({
  ticker: `gainers_screener_${exUpper}`,
  source: 'eodhd',
  success: true,
  statusCode: res.status,
  latencyMs,
  calledBy: 'gainers_screener',
  endpoint: 'screener',
  extras: {
    exchange: exUpper,
    n_symbols_returned: rows.length,
    credits_estimes: EodhdLoggerService.estimateCredits('screener', {
      n_symbols_returned: rows.length,
    }),
  },
});
```

Le `?.` permet d'injecter `@Optional` dans `TopGainersScannerService` — préserve la compat des tests existants qui instancient le scanner avec un sous-ensemble de dépendances.

## Tests

```
$ npx jest --testPathPattern "eodhd-logger|eodhd-screener.pr344"
Test Suites: 2 passed
Tests:       19 passed

$ npm test --workspace=@smartvest/api
Tests:       2185 passed + 2 todo (vs 2151 avant)
```

## Diff

7 fichiers, 511 insertions, 18 deletions :
- 1 nouvelle migration (24 lignes)
- 1 nouveau service (106 lignes)
- 2 services existants instrumentés (eodhd-screener +62/-18, top-gainers-scanner +65)
- 2 nouveaux spec files (268 lignes)
- 1 module wiring (4 lignes)

`LisaService.logEodhdCall` existant (15+ call sites) **inchangé** — pas de big-bang refacto. Le nouveau service partagé prépare le terrain pour les futures instrumentations sans gros refacto.

## HORS SCOPE de ce PR (deferred conditionnellement)

- P2 (eod : volume-baseline, correlation, rebound, ohlcv-cache)
- P3 (insider, options, technical)
- P4 (calendar, macro-indicator, exchange-hours, enrichment-events)
- P5 (intraday real-time fallback)
- Refacto `LisaService.logEodhdCall` vers `EodhdLoggerService` (sans risque, à faire après validation)

## Validation post-deploy T+24h

```sql
SELECT called_by, endpoint, COUNT(*) AS http_calls,
       SUM((extras->>'credits_estimes')::int) AS credits_estimes
FROM eodhd_request_log
WHERE timestamp >= NOW() - INTERVAL '24 hours'
GROUP BY called_by, endpoint
ORDER BY credits_estimes DESC;
```

**Cible** : `credits_estimes` cumul `gainers_screener` >= 30 % d'`apiRequests` EODHD réels.

**Si < 30 %** → hypothèse P1 explique-tout invalidée, **PR #346 nécessaire** pour P2-P5 (pattern et infrastructure prêts dans cette PR).

## Aucun changement de comportement métier

Pure instrumentation. Le seul effet runtime nouveau : 9 inserts Supabase de plus par cycle scanner (fire-and-forget, log warn sur erreur, jamais throw). Coût négligeable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_