### PR TITLE
feat(scanner): PR #345 — wire TwelveData Supertrend US + RSI crypto filters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -213,13 +213,19 @@ MARKET_SNAPSHOT_CRYPTO_VIA_LIVE_PRICE=true
 # (zéro impact runtime). Activation consumer via les 2 flags ci-dessous.
 TWELVEDATA_API_KEY=
 
-# Filtre Supertrend 30min sur signaux us_equity_large (REJECT si direction=down)
-# Coût estimé : ~50 appels/jour avec volume actuel us_large
-QUICK_WINS_TWELVEDATA_SUPERTREND_US_LARGE=false
+# ─── PR #345 — TwelveData filtres scanner (wiring effectif) ──────────────────
+# Renomme les flags POC PR #342 (QUICK_WINS_TWELVEDATA_*) qui n'étaient pas wirés.
+# Ces nouveaux noms (TWELVEDATA_FILTER_*) sont lus par TopGainersScannerService
+# entre le check path_eff et l'accept (cf. line ~2218). Default OFF, activation
+# progressive en 2 phases (Supertrend US d'abord 48h, puis RSI crypto).
 
-# Filtre RSI overbought (>75) sur scanner crypto (10 paires hardcoded)
-# Coût estimé : ~150 appels/jour avec scanner crypto en mode actif
-QUICK_WINS_TWELVEDATA_RSI_CRYPTO=false
+# Filtre Supertrend 30min sur us_equity_large + us_equity_small_mid
+# REJECT si direction='down'. Coût estimé : ~10-30 appels/jour
+TWELVEDATA_FILTER_US_SUPERTREND_ENABLED=false
+
+# Filtre RSI 5min overbought (>75) sur crypto_major (10 paires Binance mappées
+# vers Coinbase Pro via binanceToTwelveDataCrypto). Coût estimé : ~5-15 appels/jour
+TWELVEDATA_FILTER_CRYPTO_RSI_ENABLED=false
 
 # PR #343 — Binance WS observability snapshot (cron 5 min)
 # true (default) : log JSON [binance-ws-health] toutes les 5 min (grep VictoriaLogs)

--- a/apps/api/src/modules/lisa/quick-wins/types.ts
+++ b/apps/api/src/modules/lisa/quick-wins/types.ts
@@ -30,7 +30,9 @@ export type QwId =
   | 'QW_45'
   | 'QW_46'
   | 'QW_47'
-  | 'CIRCUIT_BREAKER';
+  | 'CIRCUIT_BREAKER'
+  | 'TD_SUPERTREND_US'   // PR #345 — filtre TwelveData Supertrend US equity
+  | 'TD_RSI_CRYPTO';     // PR #345 — filtre TwelveData RSI crypto overbought
 
 export type QwDecision = 'pass' | 'block' | 'modify';
 

--- a/apps/api/src/modules/lisa/services/__tests__/twelve-data-scanner-filters.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/twelve-data-scanner-filters.spec.ts
@@ -1,0 +1,263 @@
+/**
+ * PR #345 — tests pour evaluateTwelveDataFilters (helper pur).
+ *
+ * Couvre :
+ *   - Supertrend US : flag OFF → no call, flag ON + down → reject, ON + up → accept
+ *   - RSI crypto    : flag OFF → no call, flag ON + RSI 82 → reject, ON + RSI 50 → accept
+ *   - TwelveData null (rate limit / clé absente) → fail-open accept
+ *   - asset_class non éligible → bypass
+ *   - symbole crypto non mappable → bypass
+ *   - flags croisés (US flag ON sur crypto signal → bypass)
+ */
+
+import { evaluateTwelveDataFilters } from '../twelve-data-scanner-filters';
+import { TwelveDataService } from '../twelve-data.service';
+
+interface MockCounters {
+  supertrendCalls: number;
+  rsiCalls: number;
+  lastRsiArgs: unknown[] | null;
+}
+
+function makeTwelveDataMock(overrides: {
+  supertrend?: Awaited<ReturnType<TwelveDataService['getSupertrendSignal']>>;
+  rsi?: Awaited<ReturnType<TwelveDataService['getRsi']>>;
+}): { service: TwelveDataService; counters: MockCounters } {
+  const counters: MockCounters = { supertrendCalls: 0, rsiCalls: 0, lastRsiArgs: null };
+  const service = {
+    getSupertrendSignal: (..._args: unknown[]) => {
+      counters.supertrendCalls += 1;
+      return Promise.resolve(overrides.supertrend ?? null);
+    },
+    getRsi: (...args: unknown[]) => {
+      counters.rsiCalls += 1;
+      counters.lastRsiArgs = args;
+      return Promise.resolve(overrides.rsi ?? null);
+    },
+    constructor: TwelveDataService,
+  } as unknown as TwelveDataService;
+  return { service, counters };
+}
+
+describe('evaluateTwelveDataFilters — PR #345', () => {
+  describe('Filtre Supertrend US (flag OFF)', () => {
+    it('flag OFF → no call TwelveData même si signal US', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 180, direction: 'down', timestamp: '2026-05-17 14:00' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'AAPL',
+        assetClass: 'us_equity_large',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(0);
+    });
+  });
+
+  describe('Filtre Supertrend US (flag ON)', () => {
+    it('us_equity_large + direction=down → reject_supertrend_down', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 180.5, direction: 'down', timestamp: '2026-05-17 14:00' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'AAPL',
+        assetClass: 'us_equity_large',
+        supertrendEnabled: true,
+        cryptoRsiEnabled: false,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('reject_supertrend_down');
+      if (r.decision === 'reject_supertrend_down') {
+        expect(r.reason).toContain('direction=down');
+        expect(r.reason).toContain('180.5');
+      }
+      expect(counters.supertrendCalls).toBe(1);
+    });
+
+    it('us_equity_small_mid + direction=down → reject (les 2 classes US couvertes)', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 50, direction: 'down', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'SMALLCO',
+        assetClass: 'us_equity_small_mid',
+        supertrendEnabled: true,
+        cryptoRsiEnabled: false,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('reject_supertrend_down');
+    });
+
+    it('direction=up → accept', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 180, direction: 'up', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'AAPL',
+        assetClass: 'us_equity_large',
+        supertrendEnabled: true,
+        cryptoRsiEnabled: false,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+    });
+
+    it('TwelveData retourne null (rate limit / clé absente) → fail-open accept', async () => {
+      const { service: td, counters } = makeTwelveDataMock({ supertrend: null });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'AAPL',
+        assetClass: 'us_equity_large',
+        supertrendEnabled: true,
+        cryptoRsiEnabled: false,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(1); // appel tenté
+    });
+
+    it('asset_class eu_equity → bypass (filtre US seulement)', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 50, direction: 'down', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'NESN.SW',
+        assetClass: 'eu_equity',
+        supertrendEnabled: true,
+        cryptoRsiEnabled: false,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(0); // pas d'appel pour EU
+    });
+
+    it('asset_class crypto_major + supertrend flag ON → bypass (filtre US only)', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 50, direction: 'down', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        supertrendEnabled: true,
+        cryptoRsiEnabled: false,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(0);
+    });
+  });
+
+  describe('Filtre RSI crypto (flag ON)', () => {
+    it('RSI > 75 → reject_rsi_overbought + symbol mappé BTCUSDT → BTC/USD', async () => {
+      const { service: td, counters } = makeTwelveDataMock({ rsi: { value: 82.34, timestamp: 'now' } });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('reject_rsi_overbought');
+      if (r.decision === 'reject_rsi_overbought') {
+        expect(r.reason).toContain('RSI 82.34');
+        expect(r.reason).toContain('> 75');
+      }
+      expect(counters.rsiCalls).toBe(1);
+      expect(counters.lastRsiArgs?.[0]).toBe('BTC/USD');
+    });
+
+    it('RSI = 50 (neutre) → accept', async () => {
+      const { service: td, counters } = makeTwelveDataMock({ rsi: { value: 50, timestamp: 'now' } });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'ETHUSDT',
+        assetClass: 'crypto_major',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+    });
+
+    it('RSI = 75 exact → accept (seuil strict >)', async () => {
+      const { service: td, counters } = makeTwelveDataMock({ rsi: { value: 75, timestamp: 'now' } });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+    });
+
+    it('symbole non mappable Binance → bypass, accept', async () => {
+      const { service: td, counters } = makeTwelveDataMock({ rsi: { value: 90, timestamp: 'now' } });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'INVALID_NOT_A_PAIR',
+        assetClass: 'crypto_major',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.rsiCalls).toBe(0);
+    });
+
+    it('TwelveData null (rate limit) → fail-open accept', async () => {
+      const { service: td, counters } = makeTwelveDataMock({ rsi: null });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+    });
+
+    it('asset_class us_equity_large + RSI flag ON → bypass (filtre crypto only)', async () => {
+      const { service: td, counters } = makeTwelveDataMock({ rsi: { value: 90, timestamp: 'now' } });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'AAPL',
+        assetClass: 'us_equity_large',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.rsiCalls).toBe(0);
+    });
+  });
+
+  describe('Filtres simultanés (les deux ON)', () => {
+    it('us_equity_large + supertrend down → reject (RSI non appelé même si flag ON)', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 100, direction: 'down', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'AAPL',
+        assetClass: 'us_equity_large',
+        supertrendEnabled: true,
+        cryptoRsiEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('reject_supertrend_down');
+      expect(counters.rsiCalls).toBe(0); // pas appelé sur asset_class US
+    });
+
+    it('crypto_major + RSI 80 → reject (Supertrend non appelé même si flag ON)', async () => {
+      const { service: td, counters } = makeTwelveDataMock({ rsi: { value: 80, timestamp: 'now' } });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'BTCUSDT',
+        assetClass: 'crypto_major',
+        supertrendEnabled: true,
+        cryptoRsiEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('reject_rsi_overbought');
+      expect(counters.supertrendCalls).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -36,6 +36,8 @@ export type ShadowDecision =
   | 'reject_no_tf_data'
   | 'reject_earnings_imminent'  // PR Phase 1 — earnings dans la fenêtre filter
   | 'reject_opening_buffer'     // PR Phase 1 — premières N min après open
+  | 'reject_supertrend_down'    // PR #345 — TwelveData Supertrend 30m direction=down (us_equity)
+  | 'reject_rsi_overbought'     // PR #345 — TwelveData RSI 5m > 75 (crypto_major)
   | 'reject_other';
 
 export interface RecordDecisionInput {

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -24,6 +24,10 @@ import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 // PR #344 P1 — logger EODHD partagé pour instrumenter les screener calls
 import { EodhdLoggerService } from './eodhd-logger.service';
+// PR #345 — filtres TwelveData (Supertrend US + RSI crypto)
+import { TwelveDataService } from './twelve-data.service';
+import { evaluateTwelveDataFilters } from './twelve-data-scanner-filters';
+import { QwDecisionLoggerService } from '../quick-wins/qw-decision-logger.service';
 import { CronJob } from 'cron';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
@@ -538,6 +542,12 @@ export class TopGainersScannerService implements OnModuleInit {
      * existants qui instancient le scanner avec un sous-ensemble de dépendances.
      */
     @Optional() private readonly eodhdLogger?: EodhdLoggerService,
+    /**
+     * PR #345 — TwelveData service pour filtres Supertrend US + RSI crypto.
+     * Optional : si non injecté OU flags OFF, filtres no-op (signal passe normalement).
+     */
+    @Optional() private readonly twelveData?: TwelveDataService,
+    @Optional() private readonly qwLogger?: QwDecisionLoggerService,
   ) {}
 
   /**
@@ -2211,6 +2221,39 @@ export class TopGainersScannerService implements OnModuleInit {
           recordShadowDecision(cand, 'reject_path_eff', persistence);
           continue;
         }
+        // PR #345 — Filtres TwelveData (Supertrend US + RSI crypto). No-op si
+        // flags OFF ou service non injecté. Fail-open total (null TD = pass).
+        if (this.twelveData) {
+          const supertrendEnabled =
+            (this.config.get<string>('TWELVEDATA_FILTER_US_SUPERTREND_ENABLED') ?? 'false') === 'true';
+          const cryptoRsiEnabled =
+            (this.config.get<string>('TWELVEDATA_FILTER_CRYPTO_RSI_ENABLED') ?? 'false') === 'true';
+          if (supertrendEnabled || cryptoRsiEnabled) {
+            const tdFilter = await evaluateTwelveDataFilters({
+              symbol: cand.symbol,
+              assetClass: cand.assetClass,
+              supertrendEnabled,
+              cryptoRsiEnabled,
+              twelveData: this.twelveData,
+            });
+            if (tdFilter.decision !== 'accept') {
+              this.logger.log(
+                `[top-gainers] ${cand.symbol} TwelveData filter ${tdFilter.decision}: ${tdFilter.reason}`,
+              );
+              this.qwLogger?.log({
+                qwId: tdFilter.decision === 'reject_supertrend_down' ? 'TD_SUPERTREND_US' : 'TD_RSI_CRYPTO',
+                symbol: cand.symbol,
+                assetClass: cand.assetClass,
+                decision: 'block',
+                reason: tdFilter.reason,
+                wouldHavePassedWithoutFlag: true,
+              });
+              recordShadowDecision(cand, tdFilter.decision, persistence);
+              continue;
+            }
+          }
+        }
+
         this.logger.log(
           `[top-gainers] ${cand.symbol} persistence=${persistence.persistenceCount} score=${persistence.persistenceScore.toFixed(2)} pathEff=${persistence.pathQuality?.overallEfficiency?.toFixed(2) ?? 'n/a'} (${persistence.pathQuality?.overallSmoothness ?? 'n/a'}) → OPEN`,
         );

--- a/apps/api/src/modules/lisa/services/twelve-data-scanner-filters.ts
+++ b/apps/api/src/modules/lisa/services/twelve-data-scanner-filters.ts
@@ -1,0 +1,91 @@
+/**
+ * PR #345 — helpers purs pour les filtres TwelveData branchés sur le scanner gainers.
+ *
+ * Logique extraite en module pour tester unitairement sans booter le scanner
+ * (TopGainersScannerService = 2700 LOC, dépendances DI lourdes).
+ *
+ * Filtres :
+ *   1. Supertrend US equity 30m   : reject si direction='down' (us_equity_large/small_mid)
+ *   2. RSI crypto 5m surachat     : reject si value > 75 (crypto_major)
+ *
+ * Le filtre ne court PAS si :
+ *   - le flag d'env est désactivé (default OFF)
+ *   - asset_class ne correspond pas
+ *   - TwelveData retourne null (fail-open : signal passe)
+ *   - le symbole n'est pas mappable (crypto seulement)
+ */
+
+import type { TwelveDataService } from './twelve-data.service';
+
+export type ScannerFilterDecision =
+  | { decision: 'accept' }
+  | { decision: 'reject_supertrend_down'; reason: string }
+  | { decision: 'reject_rsi_overbought'; reason: string };
+
+const US_CLASSES = new Set(['us_equity_large', 'us_equity_small_mid']);
+const CRYPTO_CLASSES = new Set(['crypto_major']);
+const RSI_OVERBOUGHT_THRESHOLD = 75;
+
+export interface FilterContext {
+  symbol: string;
+  assetClass: string;
+  supertrendEnabled: boolean;
+  cryptoRsiEnabled: boolean;
+  twelveData: TwelveDataService;
+}
+
+/**
+ * Applique les filtres TwelveData dans l'ordre :
+ *   1. Supertrend US (si flag ON + asset_class US)
+ *   2. RSI crypto (si flag ON + asset_class crypto)
+ *
+ * Retourne `{ decision: 'accept' }` si tous les filtres passent (ou sont OFF).
+ * Sinon, le 1er filtre qui bloque renvoie son decision + reason.
+ *
+ * Fail-open : tout retour `null` de TwelveData (clé absente, rate limit, etc.)
+ * est traité comme "info indisponible → on laisse passer".
+ */
+export async function evaluateTwelveDataFilters(
+  ctx: FilterContext,
+): Promise<ScannerFilterDecision> {
+  // Filtre 1 — Supertrend US 30m
+  if (ctx.supertrendEnabled && US_CLASSES.has(ctx.assetClass)) {
+    const st = await ctx.twelveData.getSupertrendSignal(ctx.symbol, '30min', 10, 3, 'scanner_us_supertrend');
+    if (st !== null && st.direction === 'down') {
+      return {
+        decision: 'reject_supertrend_down',
+        reason: `supertrend direction=down at ${st.timestamp} value=${st.value.toFixed(4)}`,
+      };
+    }
+  }
+
+  // Filtre 2 — RSI crypto 5m overbought
+  if (ctx.cryptoRsiEnabled && CRYPTO_CLASSES.has(ctx.assetClass)) {
+    const tdSymbol = TwelveDataServiceStaticMapper(ctx.symbol, ctx.twelveData);
+    if (tdSymbol !== null) {
+      const rsi = await ctx.twelveData.getRsi(tdSymbol, '5min', 14, 'scanner_crypto_rsi');
+      if (rsi !== null && rsi.value > RSI_OVERBOUGHT_THRESHOLD) {
+        return {
+          decision: 'reject_rsi_overbought',
+          reason: `RSI ${rsi.value.toFixed(2)} > ${RSI_OVERBOUGHT_THRESHOLD} (overbought) at ${rsi.timestamp}`,
+        };
+      }
+    }
+  }
+
+  return { decision: 'accept' };
+}
+
+/**
+ * Helper pour appeler le mapper static depuis le service injecté (le TypeScript
+ * d'instance ne voit pas les méthodes static — on accède via la classe).
+ */
+function TwelveDataServiceStaticMapper(symbol: string, instance: TwelveDataService): string | null {
+  const ctor = instance.constructor as unknown as {
+    binanceToTwelveDataCrypto?: (pair: string) => string | null;
+  };
+  if (typeof ctor.binanceToTwelveDataCrypto === 'function') {
+    return ctor.binanceToTwelveDataCrypto(symbol);
+  }
+  return null;
+}

--- a/supabase/migrations/0146_shadow_signals_decision_constraint.sql
+++ b/supabase/migrations/0146_shadow_signals_decision_constraint.sql
@@ -1,0 +1,43 @@
+-- 0146 — PR #345 : étend la CHECK constraint sur gainers_user_shadow_signals.decision
+--
+-- Migration originale 0134 avait une CHECK list fermée de 9 valeurs. Depuis
+-- plusieurs migrations le scanner s'est mis à insérer des valeurs hors liste
+-- (reject_earnings_imminent, reject_opening_buffer) qui étaient silencieusement
+-- rejetées par la contrainte (les inserts shadow signals étant fire-and-forget,
+-- nulle alerte n'a remonté).
+--
+-- Cette migration :
+--   1. Réinstaure la CHECK avec une liste élargie pour les 2 valeurs déjà émises
+--      par le code (réparation silencieuse — les futurs inserts succeederont).
+--   2. Ajoute les 2 nouvelles valeurs PR #345 (filtres TwelveData) :
+--        - reject_supertrend_down : Supertrend 30m direction=down (us_equity)
+--        - reject_rsi_overbought  : RSI 5m > 75 (crypto_major)
+--
+-- Idempotent : DROP IF EXISTS + ADD.
+
+ALTER TABLE public.gainers_user_shadow_signals
+  DROP CONSTRAINT IF EXISTS gainers_user_shadow_signals_decision_check;
+
+ALTER TABLE public.gainers_user_shadow_signals
+  ADD CONSTRAINT gainers_user_shadow_signals_decision_check
+  CHECK (decision IN (
+    'accept',
+    'reject_path_eff',
+    'reject_persistence',
+    'reject_cooldown',
+    'reject_post_sl_cooldown',
+    'reject_p_win',
+    'reject_budget_cap',
+    'reject_no_tf_data',
+    'reject_other',
+    -- Valeurs déjà émises par le scanner (insert silencieusement rejeté avant 0146)
+    'reject_earnings_imminent',
+    'reject_opening_buffer',
+    -- PR #345 — filtres TwelveData
+    'reject_supertrend_down',
+    'reject_rsi_overbought'
+  ));
+
+COMMENT ON CONSTRAINT gainers_user_shadow_signals_decision_check
+  ON public.gainers_user_shadow_signals IS
+  'PR #345 — étend la liste pour 4 valeurs (2 réparation silent failure + 2 nouvelles filtres TwelveData).';


### PR DESCRIPTION
## Objectif

Branche les 2 filtres TwelveData (PR #342 POC du service) sur le scanner gainers entre le check `path_eff` et l'`accept`. **Default OFF**, fail-open total.

## Architecture

- Helper pur `evaluateTwelveDataFilters` extrait dans `twelve-data-scanner-filters.ts` pour testabilité (closure scanner = 2700 LOC, dépendances DI lourdes, refacto invasif évité)
- `TwelveDataService` + `QwDecisionLoggerService` injectés `@Optional` dans `TopGainersScannerService` (préserve compat tests existants)
- Filtre court **uniquement** si proposedDecision='accept' (économie crédits TD)
- Logs `qw_decision_log` avec `qw_id='TD_SUPERTREND_US'` / `'TD_RSI_CRYPTO'` + `recordShadowDecision` avec les 2 nouvelles valeurs

## Hooks

| Filtre | Asset class | Endpoint | Reject si |
|---|---|---|---|
| Supertrend 30m | `us_equity_large` + `us_equity_small_mid` | `/supertrend` | `direction === 'down'` |
| RSI 5m | `crypto_major` | `/rsi` (BTCUSDT → BTC/USD) | `value > 75` |

## Flags (default OFF)

```bash
TWELVEDATA_FILTER_US_SUPERTREND_ENABLED=false
TWELVEDATA_FILTER_CRYPTO_RSI_ENABLED=false
```

Naming retenu vs PR #342 dead flags (`QUICK_WINS_TWELVEDATA_*` jamais wirés).

## Migration 0146

Étend la CHECK constraint sur `gainers_user_shadow_signals.decision` pour 4 valeurs hors liste :
- 2 **réparation silent failure** : `reject_earnings_imminent` + `reject_opening_buffer` (déjà émis par le scanner depuis PR Phase 1 mais silencieusement rejetés par la CHECK 0134 — les inserts shadow étaient fire-and-forget, nulle alerte n'a remonté)
- 2 **nouvelles PR #345** : `reject_supertrend_down` + `reject_rsi_overbought`

## Types étendus

| Fichier | Ajout |
|---|---|
| `gainers-user-shadow.service.ts` | `ShadowDecision` += `reject_supertrend_down` + `reject_rsi_overbought` |
| `quick-wins/types.ts` | `QwId` += `TD_SUPERTREND_US` + `TD_RSI_CRYPTO` |

## Tests

```
$ npx jest --testPathPattern "twelve-data-scanner-filters"
Test Suites: 1 passed
Tests:       15 passed

$ npm test --workspace=@smartvest/api
Tests:       2200 passed + 2 todo (vs 2185 avant)
```

15 specs couvrent : Supertrend OFF/ON×{down,up,null}, EU bypass, crypto bypass, RSI ON+82/50/75-exact, symbole non mappable, null fail-open, US bypass, filtres simultanés (1er bloquant court).

## Plan d'activation progressif

**Phase 1** — poser la clé (utilisateur) :
```bash
flyctl secrets set TWELVEDATA_API_KEY=xxxxxxxx -a smartvest
```
Vérifier logs : `[twelvedata] provider initialized, key=***xxxx`.

**Phase 2** — Supertrend US uniquement (48h mesure) :
```bash
flyctl secrets set TWELVEDATA_FILTER_US_SUPERTREND_ENABLED=true -a smartvest
```
- Volume bloqué : `SELECT COUNT(*) FROM qw_decision_log WHERE qw_id='TD_SUPERTREND_US' AND created_at >= NOW() - INTERVAL '24 hours'`
- PnL US vs baseline 7j

**Phase 3** — ajouter RSI crypto (après Phase 2 validée) :
```bash
flyctl secrets set TWELVEDATA_FILTER_CRYPTO_RSI_ENABLED=true -a smartvest
```

**Phase 4** — décision Pro 79$ si gain cumulé > +$100/jour et besoin couverture eu/asia.

## Coût TwelveData

Plan Basic gratuit (8 crédits/min, 800/jour) :
- Supertrend US : 1 crédit/call × ~10-30 accept/jour = **10-30 crédits/jour**
- RSI crypto : 1 crédit/call × ~5-15 accept/jour = **5-15 crédits/jour**
- **Total : ~15-45 crédits/jour** sur 800 quota = **2-6 %**

Rate-limit minute (cap interne 7/min) respecté grâce au `CreditTracker` PR #342.

## Diff

7 fichiers, 458 insertions, 8 deletions :
- 1 helper pur nouveau (91 lignes)
- 1 spec nouvelle (263 lignes)
- 1 migration (43 lignes)
- 3 services existants étendus (top-gainers-scanner +43, types +2, gainers-user-shadow +2)
- `.env.example` documenté

## Aucun changement de comportement si flags OFF

Avec `TWELVEDATA_FILTER_*=false` (default) ou `TwelveDataService` non injecté ou clé absente → tous les filtres no-op, signal passe normalement. Validation : Phase 1 valide la clé avant Phase 2 active les filtres.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_