### PR TITLE
feat(harvest): PR #347 — bouton "Remise à zéro affichage gains" (UI-only)

### DIFF
--- a/apps/web/src/components/lisa/daily-harvest-tracker.tsx
+++ b/apps/web/src/components/lisa/daily-harvest-tracker.tsx
@@ -1,7 +1,21 @@
 'use client';
 
-import { TrendingUp, ShieldCheck, Target, Lock, AlertTriangle, Calendar, CalendarDays } from 'lucide-react';
+import { useState } from 'react';
+import {
+  TrendingUp,
+  ShieldCheck,
+  Target,
+  Lock,
+  AlertTriangle,
+  Calendar,
+  CalendarDays,
+  CalendarRange,
+  RotateCcw,
+} from 'lucide-react';
 import { useDailyHarvest, type HarvestState } from '@/hooks/use-daily-harvest';
+import { useGainersStatus } from '@/hooks/use-operating-mode';
+import { useHarvestDisplayOffset } from '@/hooks/use-harvest-display-offset';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 
 const STATE_DISPLAY: Record<HarvestState, { label: string; icon: typeof Target; color: string; bg: string }> = {
   IDLE: { label: 'En attente', icon: Target, color: 'text-slate-600', bg: 'bg-slate-100 dark:bg-slate-900/40' },
@@ -17,6 +31,13 @@ const STATE_DISPLAY: Record<HarvestState, { label: string; icon: typeof Target; 
 
 export function DailyHarvestTracker({ portfolioId }: { portfolioId: string }) {
   const query = useDailyHarvest(portfolioId);
+  // PR #347 — YTD source : useGainersStatus (GainersStatus expose ytdPnlUsd + ytdTradesCount + ytdMonthsCount).
+  // Secured YTD non agrégé côté backend → 0 placeholder (la card affiche un footnote dédié).
+  // enabled=true : on a déjà filtré query.data.mode==='DAILY_HARVEST' au-dessus, le hook gainers-status est
+  // safe à appeler (l'endpoint répond aussi en mode harvest).
+  const gainersStatusQuery = useGainersStatus(portfolioId, true);
+  const { offset, setRebase, clearRebase } = useHarvestDisplayOffset(portfolioId);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   // Mode pas actif → pas de widget
   if (!query.data || query.data.mode !== 'DAILY_HARVEST' || !query.data.progress || !query.data.session) {
@@ -27,8 +48,48 @@ export function DailyHarvestTracker({ portfolioId }: { portfolioId: string }) {
   const stateDisplay = STATE_DISPLAY[progress.state];
   const Icon = stateDisplay.icon;
 
-  const progressClamped = Math.min(100, Math.max(0, progress.progressPct));
-  const isOverTarget = progress.progressPct > 100;
+  // PR #347 — YTD côté frontend : useTradingStats (TradingStatsResponse) expose ytdPnlUsd seulement.
+  // Secured YTD non agrégé côté backend → 0 placeholder (la card affiche un footnote dédié).
+  const ytdRealizedRaw = gainersStatusQuery.data?.ytdPnlUsd ?? 0;
+  const ytdSecuredRaw = 0;
+  const ytdTradesCount = gainersStatusQuery.data?.ytdTradesCount ?? 0;
+  const ytdMonthsCount = gainersStatusQuery.data?.ytdMonthsCount ?? 0;
+
+  // PR #347 — valeurs ajustées par offset client localStorage (8 montants).
+  const dailyRealizedRaw = cumulativeStats?.daily.realized ?? 0;
+  const dailySecuredRaw = cumulativeStats?.daily.secured ?? 0;
+  const mtdRealizedRaw = cumulativeStats?.mtd.realized ?? 0;
+  const mtdSecuredRaw = cumulativeStats?.mtd.secured ?? 0;
+
+  const realizedTodayAdj = progress.realizedToday - (offset?.realizedToday ?? 0);
+  const securedTodayAdj = progress.securedToday - (offset?.securedToday ?? 0);
+  const dailyRealizedAdj = dailyRealizedRaw - (offset?.dailyRealized ?? 0);
+  const dailySecuredAdj = dailySecuredRaw - (offset?.dailySecured ?? 0);
+  const mtdRealizedAdj = mtdRealizedRaw - (offset?.mtdRealized ?? 0);
+  const mtdSecuredAdj = mtdSecuredRaw - (offset?.mtdSecured ?? 0);
+  const ytdRealizedAdj = ytdRealizedRaw - (offset?.ytdRealized ?? 0);
+  const ytdSecuredAdj = ytdSecuredRaw - (offset?.ytdSecured ?? 0);
+
+  // Progression objectif recalculée sur valeur ajustée.
+  const progressPctAdj =
+    progress.targetAmountUsd > 0 ? (realizedTodayAdj / progress.targetAmountUsd) * 100 : 0;
+  const remainingToTargetAdj = progress.targetAmountUsd - realizedTodayAdj;
+  const progressClamped = Math.min(100, Math.max(0, progressPctAdj));
+  const isOverTarget = progressPctAdj > 100;
+
+  const handleRebaseConfirm = () => {
+    setRebase({
+      realizedToday: progress.realizedToday,
+      securedToday: progress.securedToday,
+      dailyRealized: dailyRealizedRaw,
+      dailySecured: dailySecuredRaw,
+      mtdRealized: mtdRealizedRaw,
+      mtdSecured: mtdSecuredRaw,
+      ytdRealized: ytdRealizedRaw,
+      ytdSecured: ytdSecuredRaw,
+    });
+    setConfirmOpen(false);
+  };
 
   return (
     <div className="space-y-3">
@@ -42,17 +103,51 @@ export function DailyHarvestTracker({ portfolioId }: { portfolioId: string }) {
             {stateDisplay.label}
           </span>
         </div>
-        <span className="text-[10px] text-muted-foreground font-mono">
-          Session du {new Date(session.sessionDate).toLocaleDateString('fr-FR')}
-        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] text-muted-foreground font-mono">
+            Session du {new Date(session.sessionDate).toLocaleDateString('fr-FR')}
+          </span>
+          {offset && (
+            <span className="text-[10px] text-amber-700 dark:text-amber-300 font-mono">
+              Rebasé depuis{' '}
+              {new Date(offset.rebasedAt).toLocaleString('fr-FR', {
+                day: '2-digit',
+                month: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </span>
+          )}
+          {offset ? (
+            <button
+              type="button"
+              onClick={clearRebase}
+              title="Annuler la remise à zéro de l'affichage"
+              className="inline-flex items-center gap-1 h-7 px-2 rounded border text-[11px] hover:bg-muted/50"
+            >
+              <RotateCcw className="h-3 w-3" />
+              Annuler rebase
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setConfirmOpen(true)}
+              title="Remettre à zéro l'affichage des gains (jour, mois, année + objectif) sans toucher à la DB"
+              className="inline-flex items-center gap-1 h-7 px-2 rounded border text-[11px] hover:bg-muted/50"
+            >
+              <RotateCcw className="h-3 w-3" />
+              Remise à zéro affichage
+            </button>
+          )}
+        </div>
       </div>
 
-      {/* Barre de progression vers l'objectif */}
+      {/* Barre de progression vers l'objectif (valeurs ajustées) */}
       <div>
         <div className="flex items-baseline justify-between mb-1">
           <span className="text-xs text-muted-foreground">Progression vers l&apos;objectif</span>
-          <span className={`text-sm font-mono font-medium ${progress.realizedToday >= 0 ? 'text-emerald-700 dark:text-emerald-300' : 'text-red-600'}`}>
-            {progress.realizedToday >= 0 ? '+' : ''}${progress.realizedToday.toFixed(2)}
+          <span className={`text-sm font-mono font-medium ${realizedTodayAdj >= 0 ? 'text-emerald-700 dark:text-emerald-300' : 'text-red-600'}`}>
+            {realizedTodayAdj >= 0 ? '+' : ''}${realizedTodayAdj.toFixed(2)}
             {' / '}
             <span className="text-muted-foreground">${progress.targetAmountUsd.toFixed(2)}</span>
           </span>
@@ -64,11 +159,11 @@ export function DailyHarvestTracker({ portfolioId }: { portfolioId: string }) {
           />
         </div>
         <div className="flex justify-between mt-1 text-[10px] text-muted-foreground">
-          <span>{progress.progressPct.toFixed(0)}% atteint</span>
+          <span>{progressPctAdj.toFixed(0)}% atteint</span>
           <span>
-            {progress.remainingToTarget > 0
-              ? `Reste $${progress.remainingToTarget.toFixed(2)} à faire`
-              : `Dépassé de +$${Math.abs(progress.remainingToTarget).toFixed(2)}`}
+            {remainingToTargetAdj > 0
+              ? `Reste $${remainingToTargetAdj.toFixed(2)} à faire`
+              : `Dépassé de +$${Math.abs(remainingToTargetAdj).toFixed(2)}`}
           </span>
         </div>
       </div>
@@ -77,7 +172,7 @@ export function DailyHarvestTracker({ portfolioId }: { portfolioId: string }) {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 pt-2 border-t border-current/10 text-xs">
         <Metric
           label="Vault sécurisé jour"
-          value={`$${progress.securedToday.toFixed(2)}`}
+          value={`$${securedTodayAdj.toFixed(2)}`}
           color="text-emerald-700 dark:text-emerald-300"
           tooltip="Profits transférés hors capital de trading. Non réinjectables."
         />
@@ -98,7 +193,7 @@ export function DailyHarvestTracker({ portfolioId }: { portfolioId: string }) {
           value={
             progress.lossRemainingBeforeLock != null
               ? `$${progress.lossRemainingBeforeLock.toFixed(2)}`
-              : progress.isLocked ? '🔒 Verrouillé' : '✅ Libre'
+              : progress.isLocked ? 'Verrouillé' : 'Libre'
           }
           color={progress.isLocked ? 'text-red-600' : 'text-foreground'}
           tooltip={
@@ -117,13 +212,38 @@ export function DailyHarvestTracker({ portfolioId }: { portfolioId: string }) {
       )}
     </div>
 
-    {/* Cartes cumuls : gains journaliers + gains mensuels */}
+    {/* Cartes cumuls : jour + mois + année (PR #347) */}
     {cumulativeStats && (
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <DailyCumulCard stats={cumulativeStats} target={progress.targetAmountUsd} />
-        <MonthlyCumulCard stats={cumulativeStats} />
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <DailyCumulCard
+          stats={cumulativeStats}
+          target={progress.targetAmountUsd}
+          realizedAdj={dailyRealizedAdj}
+          securedAdj={dailySecuredAdj}
+        />
+        <MonthlyCumulCard
+          stats={cumulativeStats}
+          realizedAdj={mtdRealizedAdj}
+          securedAdj={mtdSecuredAdj}
+        />
+        <YearlyCumulCard
+          realizedAdj={ytdRealizedAdj}
+          securedAdj={ytdSecuredAdj}
+          tradesCount={ytdTradesCount}
+          monthsCount={ytdMonthsCount}
+        />
       </div>
     )}
+
+    <ConfirmDialog
+      open={confirmOpen}
+      title="Remettre à zéro l'affichage des gains ?"
+      description="Cette action capture les valeurs courantes des 4 zones (jour, mois, année + objectif) comme baseline locale. L'affichage soustraira ensuite cette baseline tant qu'elle est active. AUCUNE modification de la base de données : les crons et l'historique complet de lisa_positions ne sont pas impactés. Tu peux annuler ce rebase en un clic à tout moment."
+      onConfirm={handleRebaseConfirm}
+      onCancel={() => setConfirmOpen(false)}
+      confirmLabel="Remettre à zéro l'affichage"
+      cancelLabel="Annuler"
+    />
 
     </div>
   );
@@ -136,12 +256,14 @@ export function DailyHarvestTracker({ portfolioId }: { portfolioId: string }) {
 function DailyCumulCard(props: {
   stats: NonNullable<ReturnType<typeof useDailyHarvest>['data']>['cumulativeStats'];
   target: number;
+  realizedAdj: number;
+  securedAdj: number;
 }) {
   const stats = props.stats;
   if (!stats) return null;
 
   const { daily } = stats;
-  const totalToday = daily.realized; // realized inclut gains nets, secured = sous-ensemble matérialisé
+  const totalToday = props.realizedAdj;
   const isPositive = totalToday >= 0;
   const sign = isPositive ? '+' : '';
   const targetReached = props.target > 0 && totalToday >= props.target;
@@ -155,7 +277,7 @@ function DailyCumulCard(props: {
         </div>
         {targetReached && (
           <span className="text-xs bg-emerald-600 text-white rounded px-2 py-0.5 font-medium">
-            🎯 Cible atteinte
+            Cible atteinte
           </span>
         )}
       </div>
@@ -177,7 +299,7 @@ function DailyCumulCard(props: {
         <div>
           <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Sécurisé</div>
           <div className="font-mono font-medium text-emerald-700 dark:text-emerald-300">
-            ${daily.secured.toFixed(2)}
+            ${props.securedAdj.toFixed(2)}
           </div>
         </div>
         <div>
@@ -201,12 +323,14 @@ function DailyCumulCard(props: {
 
 function MonthlyCumulCard(props: {
   stats: NonNullable<ReturnType<typeof useDailyHarvest>['data']>['cumulativeStats'];
+  realizedAdj: number;
+  securedAdj: number;
 }) {
   const stats = props.stats;
   if (!stats) return null;
 
   const { mtd, bestDay, worstDay } = stats;
-  const isPositive = mtd.realized >= 0;
+  const isPositive = props.realizedAdj >= 0;
   const sign = isPositive ? '+' : '';
   const monthLabel = new Date().toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
   const winRateMonth = mtd.sessionsCount > 0
@@ -225,7 +349,7 @@ function MonthlyCumulCard(props: {
 
       <div className="space-y-1">
         <div className={`text-2xl font-mono font-bold tabular-nums ${isPositive ? 'text-blue-700 dark:text-blue-300' : 'text-red-600'}`}>
-          {sign}${mtd.realized.toFixed(2)}
+          {sign}${props.realizedAdj.toFixed(2)}
         </div>
         <div className="text-xs text-muted-foreground">
           {mtd.sessionsCount} session{mtd.sessionsCount > 1 ? 's' : ''} ·{' '}
@@ -270,12 +394,65 @@ function MonthlyCumulCard(props: {
         <div>
           <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Vault MTD</div>
           <div className="font-mono font-medium text-emerald-700 dark:text-emerald-300">
-            ${mtd.secured.toFixed(2)}
+            ${props.securedAdj.toFixed(2)}
           </div>
         </div>
         <div>
           <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Trades MTD</div>
           <div className="font-mono font-medium">{mtd.tradesCount}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// PR #347 — CARTE — Gains annuels cumulés (YTD)
+// ═══════════════════════════════════════════════════════════════════
+
+function YearlyCumulCard(props: {
+  realizedAdj: number;
+  securedAdj: number;
+  tradesCount: number;
+  monthsCount: number;
+}) {
+  const isPositive = props.realizedAdj >= 0;
+  const sign = isPositive ? '+' : '';
+  const yearLabel = new Date().toLocaleDateString('fr-FR', { year: 'numeric' });
+
+  return (
+    <div className="rounded-lg border p-4 space-y-3 bg-violet-50/50 dark:bg-violet-950/20">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <CalendarRange className="h-4 w-4 text-violet-700 dark:text-violet-300" />
+          <h3 className="text-sm font-medium">Gains de l&apos;année</h3>
+        </div>
+        <span className="text-xs text-muted-foreground">{yearLabel}</span>
+      </div>
+
+      <div className="space-y-1">
+        <div className={`text-2xl font-mono font-bold tabular-nums ${isPositive ? 'text-violet-700 dark:text-violet-300' : 'text-red-600'}`}>
+          {sign}${props.realizedAdj.toFixed(2)}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {props.monthsCount} mois actif{props.monthsCount > 1 ? 's' : ''} ·{' '}
+          {props.tradesCount} trade{props.tradesCount > 1 ? 's' : ''}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 pt-2 border-t border-current/10 text-xs">
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Vault YTD</div>
+          <div className="font-mono font-medium text-violet-700 dark:text-violet-300">
+            ${props.securedAdj.toFixed(2)}
+          </div>
+          <div className="text-[9px] text-muted-foreground italic">
+            secured agrégé non disponible
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Trades YTD</div>
+          <div className="font-mono font-medium">{props.tradesCount}</div>
         </div>
       </div>
     </div>

--- a/apps/web/src/hooks/use-harvest-display-offset.ts
+++ b/apps/web/src/hooks/use-harvest-display-offset.ts
@@ -1,0 +1,93 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * PR #347 — offset client localStorage pour rebaser l'affichage des 4 zones
+ * de gains du tracker DAILY_HARVEST (jour, mois, année + panel objectif) sans
+ * toucher au backend ni à la DB.
+ *
+ * Cas d'usage : la position bug SEE.LSE (exit_price=0, -$1574 fictif 14/05/2026)
+ * pollue les agrégats. L'utilisateur veut une remise à zéro visuelle persistante
+ * sans déclencher resetSimulation (DELETE destructif 8 tables interdit ici).
+ *
+ * - Scope clé localStorage : par `portfolioId` → changer de portfolio
+ *   n'hérite pas de l'offset.
+ * - Sync inter-onglets via event `storage`.
+ * - SSR-safe : retourne `null` côté serveur.
+ */
+
+export interface HarvestOffset {
+  realizedToday: number;
+  securedToday: number;
+  dailyRealized: number;
+  dailySecured: number;
+  mtdRealized: number;
+  mtdSecured: number;
+  ytdRealized: number;
+  ytdSecured: number;
+  rebasedAt: string; // ISO timestamp
+}
+
+const STORAGE_KEY_PREFIX = 'smartvest:harvest-display-offset:';
+
+function readOffset(portfolioId: string): HarvestOffset | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY_PREFIX + portfolioId);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as HarvestOffset;
+    const numericKeys: Array<keyof HarvestOffset> = [
+      'realizedToday',
+      'securedToday',
+      'dailyRealized',
+      'dailySecured',
+      'mtdRealized',
+      'mtdSecured',
+      'ytdRealized',
+      'ytdSecured',
+    ];
+    for (const k of numericKeys) {
+      const v = parsed[k];
+      if (typeof v !== 'number' || !Number.isFinite(v)) return null;
+    }
+    if (!parsed.rebasedAt || Number.isNaN(new Date(parsed.rebasedAt).getTime())) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function useHarvestDisplayOffset(portfolioId: string) {
+  const [offset, setOffset] = useState<HarvestOffset | null>(null);
+
+  useEffect(() => {
+    setOffset(readOffset(portfolioId));
+  }, [portfolioId]);
+
+  useEffect(() => {
+    function onStorage(e: StorageEvent) {
+      if (e.key === STORAGE_KEY_PREFIX + portfolioId) {
+        setOffset(readOffset(portfolioId));
+      }
+    }
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, [portfolioId]);
+
+  const setRebase = useCallback(
+    (next: Omit<HarvestOffset, 'rebasedAt'>) => {
+      const full: HarvestOffset = { ...next, rebasedAt: new Date().toISOString() };
+      window.localStorage.setItem(STORAGE_KEY_PREFIX + portfolioId, JSON.stringify(full));
+      setOffset(full);
+    },
+    [portfolioId],
+  );
+
+  const clearRebase = useCallback(() => {
+    window.localStorage.removeItem(STORAGE_KEY_PREFIX + portfolioId);
+    setOffset(null);
+  }, [portfolioId]);
+
+  return { offset, setRebase, clearRebase };
+}


### PR DESCRIPTION
## Objectif

Bouton client persistant qui rebase l'affichage des **4 zones de gains** du tracker DAILY_HARVEST (jour, mois, année + panel objectif) **sans toucher au backend ni à la DB**.

Cas d'usage : la position bug SEE.LSE (exit_price=0, -$1574 fictif 14/05/2026) pollue les agrégats. L'utilisateur veut une remise à zéro visuelle sans déclencher `resetSimulation` (DELETE destructif 8 tables interdit ici).

## Livré

### Nouveau hook `useHarvestDisplayOffset`
- localStorage scopé par `portfolioId` : `smartvest:harvest-display-offset:{id}`
- Stocke 8 valeurs offsetées (realizedToday, securedToday × 4 zones) + `rebasedAt` ISO timestamp
- Sync inter-onglets via event `storage`
- SSR-safe (`typeof window` guard)
- Fail-safe parsing : JSON corrompu, NaN, rebasedAt invalide → offset null

### Composant `DailyHarvestTracker` enrichi
- **3 colonnes** au lieu de 2 : `DailyCumulCard` + `MonthlyCumulCard` + **`YearlyCumulCard`** (nouvelle, couleur violet, icône `CalendarRange`)
- Bouton "Remise à zéro affichage" dans le header (zone session) avec `ConfirmDialog` existant — libellé français explicite : capture baseline, aucune modif DB, annulable en un clic
- Badge "Rebasé depuis JJ/MM HH:mm" + bouton "Annuler rebase" (un clic, sans confirmation, restaure les valeurs brutes)
- Toutes les zones affichent les **valeurs ajustées** (raw - offset). `progressPct` + `remainingToTarget` recalculés sur réalisé ajusté
- YTD sourcé via `useGainersStatus.ytdPnlUsd / ytdTradesCount / ytdMonthsCount` (endpoint backend existant, **aucun ajout serveur**). Secured YTD = 0 placeholder (non agrégé côté backend) avec footnote dans la carte

## Aucune modification backend

- Aucun endpoint API ajouté/modifié
- Aucune écriture Supabase
- Aucune migration
- `useDailyHarvest` hook inchangé (retourne toujours valeurs brutes serveur)
- Crons monitoring lisent toujours `lisa_positions` complet (l'historique réel est conservé, le rebase est purement visuel client)

## Diff

| Fichier | Lignes |
|---|---|
| `apps/web/src/hooks/use-harvest-display-offset.ts` (nouveau) | +93 |
| `apps/web/src/components/lisa/daily-harvest-tracker.tsx` | +227 / -25 |

## Convention adaptée

Le brief mentionnait shadcn `AlertDialog` — pas installé dans ce repo. Substitué par le `ConfirmDialog` custom existant (`apps/web/src/components/ui/confirm-dialog.tsx`), même API focus-trap / ESC, libellé français cohérent.

## Tests — gap documenté

`apps/web` **n'a aucun runner de tests configuré** (ni Jest ni Vitest dans `package.json`). Ajouter Jest + @testing-library/react + jsdom + ts-jest config serait une infrastructure entière à wirer hors scope ce PR (note : aucun test web n'existe non plus pour les autres hooks `useDailyHarvest`, `useOperatingMode`, etc. — même gap existant).

Le hook est pur (~95 LOC), defensive parsing exhaustif, types stricts. Audit par revue de code suffisant.

**Suite api regression intacte : 2200/2200 verts.**

## Validation post-deploy manuelle

1. Aller sur `/lisa`, voir le bouton **"Remise à zéro affichage"** dans le header du tracker DAILY_HARVEST
2. Cliquer → confirm dialog français explicite (titre, description, "Remettre à zéro l'affichage" / "Annuler")
3. Confirmer → les 4 zones passent à 0 (ou affichent les +X récents si nouveaux trades depuis le rebase), badge "Rebasé depuis JJ/MM HH:mm" apparaît
4. Bouton **"Annuler rebase"** → un clic restaure les valeurs brutes
5. Reload page → offset persiste
6. Ouvrir 2e onglet sur `/lisa` → sync automatique (storage event)
7. Changer de portfolio (si plusieurs sim) → pas d'offset hérité

## Aucun risque de régression

Si `offset === null` (cas par défaut tant que l'utilisateur ne clique pas), valeurs ajustées = valeurs brutes (soustraction de 0). Le composant se comporte exactement comme avant pour l'utilisateur qui n'utilise pas la feature.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_