### PR TITLE
fix(top-gainers-log): populate detected_asset_class for filtered candidates

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -3212,9 +3212,14 @@ export class TopGainersScannerService implements OnModuleInit {
     // Sample 10 filtered candidates pour audit
     const filtered = allCandidates.filter((c) => !topSet.has(c.symbol)).slice(0, 10);
     for (const c of filtered) {
+      // PR #350 — fix log detected_asset_class : utiliser la classe portée par
+      // le candidat (parser EODHD/Binance) avec fallback sur detectAssetClass.
+      // Avant : `market` hardcodé 'us_equity_small_mid' + `detected_asset_class`
+      // absent → 70% des rows filtered en NULL/faux sur 14j.
+      const assetClass = c.assetClass ?? detectAssetClass(c.symbol, c.exchange ?? 'unknown', c.marketCap);
       rows.push({
         symbol: c.symbol,
-        market: 'us_equity_small_mid', // best-effort, asset class non recalculée pour log
+        market: assetClass,
         exchange: c.exchange ?? 'unknown',
         close_price: String(c.close),
         high_price: String(c.high),
@@ -3224,6 +3229,7 @@ export class TopGainersScannerService implements OnModuleInit {
         market_cap_usd: String(c.marketCap),
         score: '0',
         decision: 'filtered',
+        detected_asset_class: assetClass,
       });
     }
     if (rows.length === 0) {


### PR DESCRIPTION
## Contexte

Bug d'observabilité prouvé sur 14j glissants : **96 293 lignes (70%)** de `top_gainers_log` ont `detected_asset_class = NULL` et `market = 'us_equity_small_mid'` hardcodé, même pour des tickers BINANCE / `.KO` / `.LSE` / `.XETRA` / `.PA` / `.SW` / `.SHG` / `.KQ` / `.AU`.

## Cause racine

`apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts:persistLog()`

- Boucle `top` (l. 3196-3211) : ✅ écrit correctement `market: t.assetClass` + `detected_asset_class: t.assetClass`
- Boucle `filtered` (l. 3214-3228) : ❌ hardcodait `market: 'us_equity_small_mid'` et omettait `detected_asset_class` → NULL en DB

## Fix (chirurgical, 2 lignes)

```ts
const assetClass = c.assetClass ?? detectAssetClass(c.symbol, c.exchange ?? 'unknown', c.marketCap);
rows.push({
  ...,
  market: assetClass,                 // fix #1
  ...,
  detected_asset_class: assetClass,   // fix #2
});
```

`c.assetClass` est déjà porté par le candidat depuis :
- `mapEodhdRow` ligne 1431 (`detectAssetClass(symbol, exchange, marketCap)`)
- Binance fetch ligne 1330

Fallback `detectAssetClass(...)` couvre le cas `undefined`.

## Validation post-merge (SQL T+2h)

```sql
SELECT decision, detected_asset_class, COUNT(*) AS n
FROM top_gainers_log
WHERE captured_at >= NOW() - INTERVAL '2 hours'
GROUP BY decision, detected_asset_class
ORDER BY decision, n DESC;
```

Attendu : `decision='filtered'` avec `detected_asset_class IS NOT NULL` ≥ 95% des lignes, distribution cohérente :
- `crypto_major` sur BINANCE
- `asia_equity` sur `.KO`, `.KQ`, `.SHG`, `.AU`
- `eu_equity` sur `.LSE`, `.XETRA`, `.PA`, `.SW`

## Hors-scope

- Pas de modif de `detectAssetClass()` ni `selectTopGainers()`
- Boucle `top` non touchée (déjà correcte)
- Pas de migration (colonne déjà nullable)
- Pas de backfill historique des 96 293 lignes existantes

## Pourquoi maintenant

Prérequis observabilité de PR #351 (scoring continu) : sans ce fix, le backtest de PR #351 sur logs récents serait pollué par 70% de rows mal classées.

## QA

- `npx tsc --noEmit` (apps/api) ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_