### PR TITLE
feat(mechanical-trading): gate isInExchangeSession before INSERT lisa_positions

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/mechanical-trading-session-gate.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/mechanical-trading-session-gate.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * PR #349 — Gate isInExchangeSession dans mechanical-trading.
+ *
+ * Preuve empirique 14j : 10 entrées pré-marché .SHG/.SHE → 8 SL / 1 TP /
+ * 1 inval = -$289.47 net. Le gate amont getMarketState() avait un trou
+ * pour asia ; ce PR ajoute un 2e gate au plus près de l'INSERT
+ * lisa_positions, contre la source de vérité EXCHANGE_SESSIONS.
+ *
+ * Ce spec teste le helper isInExchangeSession isolément — la garantie
+ * que mechanical-trading.service.ts l'appelle juste avant l'INSERT
+ * est couverte par le test d'intégration mécanique (autre spec).
+ */
+
+import { isInExchangeSession } from '../exchange-sessions.helper';
+
+describe('Session gate before INSERT lisa_positions — PR #349', () => {
+  describe('Shanghai pre-market (bug 14j)', () => {
+    // 00:17 UTC = 08:17 Shanghai (1h13 avant l'ouverture officielle 09:30 SH).
+    // Pattern observé sur 10 entrées : gap baissier au open → SL fake.
+    const preMarketSH = new Date('2026-05-18T00:17:00Z');
+
+    it('blocks .SHG before official open 09:30 Shanghai', () => {
+      expect(isInExchangeSession('601100.SHG', preMarketSH)).toBe(false);
+    });
+
+    it('blocks .SHE before official open 09:30 Shanghai', () => {
+      expect(isInExchangeSession('300024.SHE', preMarketSH)).toBe(false);
+    });
+  });
+
+  describe('Shanghai during session', () => {
+    // 02:00 UTC = 10:00 Shanghai = en pleine session 09:30-15:00.
+    const duringSH = new Date('2026-05-18T02:00:00Z');
+
+    it('allows .SHG during 09:30-15:00 Shanghai', () => {
+      expect(isInExchangeSession('601100.SHG', duringSH)).toBe(true);
+    });
+
+    it('allows .SHE during 09:30-15:00 Shanghai', () => {
+      expect(isInExchangeSession('300024.SHE', duringSH)).toBe(true);
+    });
+  });
+
+  describe('Other exchanges pre-market protection', () => {
+    // 23:30 UTC dimanche = 08:30 Tokyo / Seoul lundi (avant ouverture).
+    const preMarketTokyoSeoul = new Date('2026-05-17T23:30:00Z');
+
+    it('blocks .T before Tokyo open 09:00', () => {
+      expect(isInExchangeSession('7203.T', preMarketTokyoSeoul)).toBe(false);
+    });
+
+    it('blocks .KO before Seoul open 09:00', () => {
+      expect(isInExchangeSession('005930.KO', preMarketTokyoSeoul)).toBe(false);
+    });
+  });
+
+  describe('Crypto always-on bypass', () => {
+    // 03:00 UTC : équities asia/EU/US toutes fermées, crypto doit passer.
+    const anyTime = new Date('2026-05-18T03:00:00Z');
+
+    it('allows .CC anytime (always-on)', () => {
+      expect(isInExchangeSession('BTCUSD.CC', anyTime)).toBe(true);
+    });
+
+    it('allows .FOREX anytime (always-on)', () => {
+      expect(isInExchangeSession('EURUSD.FOREX', anyTime)).toBe(true);
+    });
+  });
+
+  describe('US during session', () => {
+    // 18:00 UTC = 14:00 New York = en pleine session 09:30-16:00.
+    // Note : EODHD convention = ticker.US, ex AAPL.US (cf. ensureExchangeSuffix
+    // dans top-gainers-scanner.service.ts ligne 1399). Un AAPL nu retournerait
+    // false (helper conservateur), mais c'est un cas qui ne survient pas dans
+    // le flow mécanique car le scanner appose toujours le suffixe.
+    const duringUS = new Date('2026-05-18T18:00:00Z');
+
+    it('allows .US during session', () => {
+      expect(isInExchangeSession('AAPL.US', duringUS)).toBe(true);
+    });
+  });
+
+  describe('Weekend protection', () => {
+    // Samedi 17 mai 2026 14:00 UTC : aucune équity ouverte.
+    const saturday = new Date('2026-05-16T14:00:00Z');
+
+    it('blocks .US on Saturday even in normal hours window', () => {
+      expect(isInExchangeSession('AAPL.US', saturday)).toBe(false);
+    });
+
+    it('blocks .SHG on Saturday', () => {
+      expect(isInExchangeSession('601100.SHG', saturday)).toBe(false);
+    });
+
+    it('still allows .CC on Saturday (crypto 24/7)', () => {
+      expect(isInExchangeSession('BTCUSD.CC', saturday)).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -43,6 +43,7 @@ import { TradeOutcomeRecorderService } from './trade-outcome-recorder.service';
 import { DailyProfitGovernor } from './daily-profit-governor.service';
 import { PatternAdoptionService } from '../../bot-lab/services/pattern-adoption.service';
 import { EodhdEnrichmentService } from './eodhd-enrichment.service';
+import { isInExchangeSession } from './exchange-sessions.helper';
 // Phase 5 N1 PR-1 — Quick Wins gate (sessions/blacklist/class-pause/repeat-cap/exchange-mult)
 import { QuickWinsPipelineService } from '../quick-wins';
 // Phase 5 N1 PR-2 — matrice TP/SL par asset_class
@@ -1258,6 +1259,34 @@ export class MechanicalTradingService {
           }).catch(() => null);
           continue; // skip cette ouverture, passe au prochain target
         }
+      }
+
+      // PR #349 — Gate session exchange (defense en profondeur).
+      // Preuve empirique 14j : 10 entrées pré-marché Shanghai/Shenzhen
+      // (.SHG/.SHE) → 8 SL / 1 TP / 1 inval = -$289.47 net. Le gate amont
+      // getMarketState() ligne 928 a un trou pour asia. On verrouille ici
+      // contre EXCHANGE_SESSIONS (source de vérité EODHD, DST-safe).
+      // Crypto/forex/commodities passent via ALWAYS_ON_SUFFIXES.
+      const nowDate = new Date();
+      if (!isInExchangeSession(target.symbol, nowDate)) {
+        this.logger.warn(
+          `[MÉCANIQUE] Skip ${target.symbol} (${target.assetClass}) — off_exchange_session @ ${nowDate.toISOString()}`,
+        );
+        await this.decisionLog.append({
+          portfolioId,
+          kind: 'mechanical_skip',
+          summary: `[MÉCANIQUE] Skip ${target.symbol} — off_exchange_session`,
+          rationale: `Gate isInExchangeSession bloque ouverture pré/post-marché contre EXCHANGE_SESSIONS (source EODHD). asset_class=${target.assetClass} now=${nowDate.toISOString()}`,
+          payload: {
+            symbol: target.symbol,
+            assetClass: target.assetClass,
+            reason: 'off_exchange_session',
+            timestampUtc: nowDate.toISOString(),
+            directiveId: directive.id,
+          },
+          triggeredBy: 'mechanical_cron',
+        }).catch(() => null);
+        continue; // passe au prochain target
       }
 
       const positionId = randomUUID();


### PR DESCRIPTION
## Contexte (preuve empirique 14j)

Le pipeline mécanique ouvre des positions **avant l'ouverture officielle** des bourses Shanghai/Shenzhen :

| Suffix | Total 14j | Pré-session | SL | TP | Inval | Net PnL |
|---|---:|---:|---:|---:|---:|---:|
| .SHE | 22 | 7 | 5 | 1 | 1 | -$155.50 |
| .SHG | 5 | 3 | 3 | 0 | 0 | -$133.97 |

**10 entrées pré-marché Shanghai/Shenzhen → 8 SL / 1 TP / 1 inval = -$289.47 net.**

Pattern : entries à 08:17 SH (= 00:17 UTC), soit 1h13 avant l'open officiel 09:30 SH. Prix EODHD = close veille (stale) → gap baissier à l'open matérialise instantanément un SL fictif.

Post-fermeture : 39 trades 14j, 0 SL, 38 invalidations à coût quasi-nul → le filtre invalidation existant fonctionne pour post-close. **Bug strictement pré-ouverture asia.**

## Cause racine

- Config session DST-safe existe déjà : `EXCHANGE_SESSIONS` (18 bourses) + helper `isInExchangeSession()`
- Shadow simulator l'utilise correctement (`gainers-user-shadow.service.ts` l. 864)
- Le gate existant `getMarketState()` (l. 928) a un trou pour asia
- L'INSERT `lisa_positions` (l. 1267) n'avait aucun second gate

## Fix (défense en profondeur)

Ajout d'un 2e gate au plus près de l'INSERT, contre la source de vérité `EXCHANGE_SESSIONS` (IANA TZ + `Intl.DateTimeFormat` → DST natif).

```ts
const nowDate = new Date();
if (!isInExchangeSession(target.symbol, nowDate)) {
  this.logger.warn(`[MÉCANIQUE] Skip ${target.symbol} (...) — off_exchange_session @ ${nowDate.toISOString()}`);
  await this.decisionLog.append({
    portfolioId,
    kind: 'mechanical_skip',
    ...
  }).catch(() => null);
  continue;
}
```

**Note**: le brief recommandait `INSERT lisa_mechanical_cycle_summary`, mais cette table est un agrégat par cycle (colonnes `opens_count` / `closes_*_count` etc. — pas `event_type`/`symbol`/`asset_class`/`details`). J'ai donc utilisé `decisionLog.append({ kind: 'mechanical_skip', ... })` — kind déjà autorisé par le CHECK constraint depuis migration 0119, schéma compatible. Pas de migration nécessaire.

Crypto / forex / commodities / indices passent via `ALWAYS_ON_SUFFIXES` (.CC, .FOREX, .COMM, .INDX) — non impactés.

## Tests (12 cas, tous verts)

- Shanghai pré-marché (bug 14j) : .SHG/.SHE bloqués
- Shanghai durant session : .SHG/.SHE autorisés
- Tokyo / Seoul pré-marché : .T/.KO bloqués
- Crypto / forex always-on : .CC/.FOREX autorisés à toute heure
- US durant session : .US autorisé
- Weekend : équities bloquées, crypto OK

## Hors-scope

- Pas de modif `qw-1-session-filter` (défense en profondeur amont préservée)
- Pas de modif `getMarketState()` (bug asia non investigué, gate 2 le couvre)
- Pas de modif `gainers-user-shadow` (déjà correct)
- Pas de migration DB
- Pas de backfill historique

## QA

- `npx tsc --noEmit` (apps/api) ✅
- `npx jest mechanical-trading-session-gate` → 12 passed ✅

Gain attendu : +$10-30/j (économies sur tentatives pré-marché asia récurrentes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_