### PR TITLE
feat(scoring): PR #351 continuous discriminant score [0..100]

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -49,6 +49,10 @@ import { CandidateRejectReason } from '../../gainers-scanner/domain/gainers-enum
 // PR6.4 — Enrichment helpers (ATR + EMA + persistence depuis ohlcv_cache_daily)
 import { enrichShadowCandidate } from './shadow-enrichment.helper';
 import {
+  calculateContinuousScore,
+  type ScoringAssetClass,
+} from '@smartvest/ai-analyst';
+import {
   detectAssetClass,
   selectTopGainers,
   type TopGainerCandidate,
@@ -3179,6 +3183,55 @@ export class TopGainersScannerService implements OnModuleInit {
   }
 
   /**
+   * PR #351 — Calcule les sub-scores continus pour un candidat et retourne
+   * un fragment d'objet à splat dans la row top_gainers_log. Retourne `{}`
+   * si la classe n'est pas dans le scope scoring (crypto_alt, fx_*, commodity).
+   * Logging-only : le flag décisionnel CONTINUOUS_SCORING_ENABLED reste à OFF
+   * tant que le backtest n'a pas validé les seuils par classe.
+   */
+  private computeContinuousScoreFragment(
+    assetClass: TopGainerAssetClass,
+    changePct: number,
+    volume: number,
+    avgVol50d: number,
+    marketCap: number,
+    persistenceMultiTf: number,
+  ): Record<string, unknown> {
+    const supported: ReadonlySet<string> = new Set([
+      'asia_equity',
+      'eu_equity',
+      'us_equity_large',
+      'us_equity_small_mid',
+      'crypto_major',
+    ]);
+    if (!supported.has(assetClass)) return {};
+    const rvol = avgVol50d > 0 ? volume / avgVol50d : 0;
+    const r = calculateContinuousScore(
+      {
+        changePctSnapshot: changePct,
+        rvol,
+        marketCapUsd: marketCap > 0 ? marketCap : null,
+        persistenceMultiTf,
+        // momentum 5m/15m/30m : pas reconstructibles depuis le scan top-N
+        // sans cache prix intraday dédié. Laissé null → composant neutre 0.5.
+        momentum5m: null,
+        momentum15m: null,
+        momentum30m: null,
+        atrNormalized: null,
+      },
+      assetClass as ScoringAssetClass,
+    );
+    return {
+      sub_amplitude_score: r.subScores.amplitudeScore,
+      sub_rvol_score: r.subScores.rvolScore,
+      sub_momentum_score: r.subScores.momentumScore,
+      sub_persistence_score: r.subScores.persistenceScore,
+      sub_cap_quality_score: r.subScores.capQualityScore,
+      continuous_score_total: Number(r.total.toFixed(2)),
+    };
+  }
+
+  /**
    * Persist log entries dans top_gainers_log.
    * Logge tous les top retenus (decision='passed') + sample de filtered (audit).
    */
@@ -3207,6 +3260,9 @@ export class TopGainersScannerService implements OnModuleInit {
         score: String(t.score),
         decision: 'passed',
         detected_asset_class: t.assetClass,
+        ...this.computeContinuousScoreFragment(
+          t.assetClass, t.changePct, t.volume, t.avgVol50d, t.marketCap, t.score,
+        ),
       });
     }
     // Sample 10 filtered candidates pour audit
@@ -3230,6 +3286,10 @@ export class TopGainersScannerService implements OnModuleInit {
         score: '0',
         decision: 'filtered',
         detected_asset_class: assetClass,
+        // PR #351 — persistenceMultiTf=0 (candidat n'a pas passé le filtre multi-TF).
+        ...this.computeContinuousScoreFragment(
+          assetClass, c.changePct, c.volume, c.avgVol50d, c.marketCap, 0,
+        ),
       });
     }
     if (rows.length === 0) {

--- a/packages/ai-analyst/src/index.ts
+++ b/packages/ai-analyst/src/index.ts
@@ -29,3 +29,4 @@ export * from './strategies/bootstrap-ci';
 export * from './backtest/engine';
 export * from './backtest/metrics';
 export * from './backtest/runner';
+export * from './scoring/continuous-score';

--- a/packages/ai-analyst/src/scoring/continuous-score.spec.ts
+++ b/packages/ai-analyst/src/scoring/continuous-score.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * PR #351 — Tests scoring discriminant continu.
+ *
+ * Couverture :
+ *   - 5 sous-scores (amplitude, rvol, momentum, persistence, capQuality)
+ *   - Smoking gun 020560.KO (rvol=24.16 + chg=16.94, ignoré 477 fois en prod)
+ *   - FOMO penalty us_sm (rvol >3.5 → décroissance, >8.5 → 0)
+ *   - Bornes [0..100] et fallback (mcap null, momentum all-null)
+ */
+
+import {
+  calculateContinuousScore,
+  computeAmplitudeScore,
+  computeRvolScore,
+  computeMomentumScore,
+  computePersistenceSubScore,
+  computeCapQualityScore,
+} from './continuous-score';
+
+describe('PR #351 continuous-score', () => {
+  describe('computeAmplitudeScore', () => {
+    it('asia chg=10% → ~0.5 (centre sigmoid)', () => {
+      expect(computeAmplitudeScore(10, 'asia_equity')).toBeCloseTo(0.5, 2);
+    });
+    it('asia chg=20% → > 0.9', () => {
+      expect(computeAmplitudeScore(20, 'asia_equity')).toBeGreaterThan(0.9);
+    });
+    it('asia chg=0% → < 0.1', () => {
+      expect(computeAmplitudeScore(0, 'asia_equity')).toBeLessThan(0.1);
+    });
+    it('crypto chg=3% → ~0.5', () => {
+      expect(computeAmplitudeScore(3, 'crypto_major')).toBeCloseTo(0.5, 2);
+    });
+    it('us_large chg=7% → ~0.5', () => {
+      expect(computeAmplitudeScore(7, 'us_equity_large')).toBeCloseTo(0.5, 2);
+    });
+  });
+
+  describe('computeRvolScore', () => {
+    it('asia rvol=5 → 1.0 (target)', () => {
+      expect(computeRvolScore(5, 'asia_equity')).toBe(1.0);
+    });
+    it('asia rvol=2.5 → 0.5', () => {
+      expect(computeRvolScore(2.5, 'asia_equity')).toBeCloseTo(0.5, 2);
+    });
+    it('asia rvol=24.16 (smoking gun) → 1.0 (saturé)', () => {
+      expect(computeRvolScore(24.16, 'asia_equity')).toBe(1.0);
+    });
+    it('us_sm rvol=3 → 1.0 (modéré préféré)', () => {
+      expect(computeRvolScore(3, 'us_equity_small_mid')).toBe(1.0);
+    });
+    it('us_sm rvol=5 → décroissance ~0.7 (FOMO penalty)', () => {
+      const score = computeRvolScore(5, 'us_equity_small_mid');
+      expect(score).toBeGreaterThan(0.5);
+      expect(score).toBeLessThan(0.8);
+    });
+    it('us_sm rvol=10 → 0 (FOMO max)', () => {
+      expect(computeRvolScore(10, 'us_equity_small_mid')).toBe(0);
+    });
+    it('rvol=0 ou négatif → 0', () => {
+      expect(computeRvolScore(0, 'asia_equity')).toBe(0);
+      expect(computeRvolScore(-1, 'crypto_major')).toBe(0);
+    });
+  });
+
+  describe('computeMomentumScore', () => {
+    it('momentum 5m=2%, 15m=5%, 30m=8% → 1.0 (max)', () => {
+      expect(computeMomentumScore(0.02, 0.05, 0.08)).toBe(1.0);
+    });
+    it('momentum tout négatif → 0', () => {
+      expect(computeMomentumScore(-0.02, -0.05, -0.08)).toBe(0);
+    });
+    it('momentum 5m=1% seul, autres null → > 0.5 (positif partiel)', () => {
+      const score = computeMomentumScore(0.01, null, null);
+      expect(score).toBeGreaterThan(0.5);
+      expect(score).toBeLessThan(1);
+    });
+    it('tous null → 0.5 (neutre)', () => {
+      expect(computeMomentumScore(null, null, null)).toBe(0.5);
+    });
+  });
+
+  describe('computePersistenceSubScore', () => {
+    it('passe direct le ratio existant clampé [0, 1]', () => {
+      expect(computePersistenceSubScore(0.677)).toBe(0.677);
+      expect(computePersistenceSubScore(1.2)).toBe(1);
+      expect(computePersistenceSubScore(-0.1)).toBe(0);
+    });
+  });
+
+  describe('computeCapQualityScore', () => {
+    it('us_large mcap=500B → 1.0 (sweet spot)', () => {
+      expect(computeCapQualityScore(500e9, 'us_equity_large')).toBe(1.0);
+    });
+    it('us_large mcap=100B → 0.5 (trop petit)', () => {
+      expect(computeCapQualityScore(100e9, 'us_equity_large')).toBe(0.5);
+    });
+    it('us_large mcap=3000B → 0.7 (mega cap)', () => {
+      expect(computeCapQualityScore(3000e9, 'us_equity_large')).toBe(0.7);
+    });
+    it('us_sm mcap=3.54B (TP avg mesuré) → 1.0', () => {
+      expect(computeCapQualityScore(3.54e9, 'us_equity_small_mid')).toBe(1.0);
+    });
+    it('us_sm mcap=0.1B → 0.2 (penny FOMO)', () => {
+      expect(computeCapQualityScore(0.1e9, 'us_equity_small_mid')).toBe(0.2);
+    });
+    it('us_sm mcap=50B → 0.5 (dérive large)', () => {
+      expect(computeCapQualityScore(50e9, 'us_equity_small_mid')).toBe(0.5);
+    });
+    it('mcap null → 0.5 (fallback neutre)', () => {
+      expect(computeCapQualityScore(null, 'us_equity_large')).toBe(0.5);
+    });
+    it('asia/eu/crypto → 0.7 (neutre)', () => {
+      expect(computeCapQualityScore(10e9, 'asia_equity')).toBe(0.7);
+      expect(computeCapQualityScore(10e9, 'eu_equity')).toBe(0.7);
+      expect(computeCapQualityScore(10e9, 'crypto_major')).toBe(0.7);
+    });
+  });
+
+  describe('calculateContinuousScore — smoking gun 020560.KO', () => {
+    it('020560.KO (asia, chg=16.94%, rvol=24.16) DOIT scorer ≥ 65', () => {
+      const result = calculateContinuousScore({
+        changePctSnapshot: 16.94,
+        rvol: 24.16,
+        marketCapUsd: 5e9,
+        persistenceMultiTf: 0.5,
+        momentum5m: 0.01,
+        momentum15m: 0.02,
+        momentum30m: 0.05,
+        atrNormalized: null,
+      }, 'asia_equity');
+      expect(result.total).toBeGreaterThanOrEqual(65);
+      expect(result.subScores.rvolScore).toBe(1.0);
+      expect(result.subScores.amplitudeScore).toBeGreaterThan(0.85);
+    });
+
+    it('signal faible (chg=2%, rvol=1.2) DOIT scorer < 40', () => {
+      const result = calculateContinuousScore({
+        changePctSnapshot: 2,
+        rvol: 1.2,
+        marketCapUsd: 1e9,
+        persistenceMultiTf: 0.3,
+        momentum5m: 0,
+        momentum15m: 0,
+        momentum30m: 0,
+        atrNormalized: null,
+      }, 'asia_equity');
+      expect(result.total).toBeLessThan(40);
+    });
+
+    it('us_sm avec rvol=24 (FOMO) DOIT scorer < 50 malgré chg élevé', () => {
+      const result = calculateContinuousScore({
+        changePctSnapshot: 16,
+        rvol: 24,
+        marketCapUsd: 0.2e9,
+        persistenceMultiTf: 0.7,
+        momentum5m: 0.02,
+        momentum15m: 0.04,
+        momentum30m: 0.06,
+        atrNormalized: null,
+      }, 'us_equity_small_mid');
+      expect(result.total).toBeLessThan(50);
+      expect(result.subScores.rvolScore).toBe(0); // FOMO max
+      expect(result.subScores.capQualityScore).toBe(0.2); // penny
+    });
+  });
+
+  describe('calculateContinuousScore — bornes', () => {
+    it('cas max théorique → > 90', () => {
+      const result = calculateContinuousScore({
+        changePctSnapshot: 100,
+        rvol: 10,
+        marketCapUsd: 500e9,
+        persistenceMultiTf: 1,
+        momentum5m: 0.05,
+        momentum15m: 0.10,
+        momentum30m: 0.15,
+        atrNormalized: null,
+      }, 'us_equity_large');
+      expect(result.total).toBeGreaterThan(90);
+      expect(result.total).toBeLessThanOrEqual(100);
+    });
+
+    it('cas min → < 10 (toutes features nulles ou négatives)', () => {
+      const result = calculateContinuousScore({
+        changePctSnapshot: -10,
+        rvol: 0,
+        marketCapUsd: 0,
+        persistenceMultiTf: 0,
+        momentum5m: -0.05,
+        momentum15m: -0.10,
+        momentum30m: -0.15,
+        atrNormalized: null,
+      }, 'crypto_major');
+      expect(result.total).toBeLessThan(10);
+    });
+  });
+});

--- a/packages/ai-analyst/src/scoring/continuous-score.ts
+++ b/packages/ai-analyst/src/scoring/continuous-score.ts
@@ -1,0 +1,216 @@
+/**
+ * PR #351 — Scoring discriminant continu [0..100]
+ *
+ * Remplace le ratio binaire positives/available (multi-tf-persistence) par un
+ * score agrégeant amplitude (sigmoid chg vs cible classe), rvol (sigmoid avec
+ * inversion us_sm pour FOMO), momentum 5m/15m/30m pondéré, persistence multi-TF
+ * (existant clampé) et capQuality (bandes mcap Druckenmiller).
+ *
+ * Backed by 14j data analysis :
+ *   - 96 513 candidats `filtered` avec score=0 (smoking gun 020560.KO :
+ *     chg=16.94%, rvol=24.16x ignoré sur 477 snapshots consécutifs)
+ *   - 269 opened sur 41 976 passed (0.19% taux d'ouverture)
+ *   - Features TP vs SL discriminantes mesurées par classe (rvol asia,
+ *     mcap us_large/us_sm, FOMO inverse us_sm)
+ *
+ * Activation via feature flag CONTINUOUS_SCORING_ENABLED côté scanner ;
+ * fallback legacy si flag OFF.
+ */
+
+export type ScoringAssetClass =
+  | 'asia_equity'
+  | 'eu_equity'
+  | 'us_equity_large'
+  | 'us_equity_small_mid'
+  | 'crypto_major';
+
+export interface ScoreFeatures {
+  /** top_gainers_log.change_pct, en % (ex : 16.94) */
+  changePctSnapshot: number;
+  /** volume / avg_vol_50d (ex : 24.16) */
+  rvol: number;
+  /** top_gainers_log.market_cap_usd, en USD */
+  marketCapUsd: number | null;
+  /** existant : positives/available, [0..1] */
+  persistenceMultiTf: number;
+  /** (close - close_5m_ago) / close_5m_ago, décimal (ex : 0.02 = +2%) */
+  momentum5m: number | null;
+  momentum15m: number | null;
+  momentum30m: number | null;
+  /** ATR(14) / close, optionnel — non utilisé v1 */
+  atrNormalized: number | null;
+}
+
+export interface SubScores {
+  amplitudeScore: number;     // [0..1]
+  rvolScore: number;          // [0..1]
+  momentumScore: number;      // [0..1]
+  persistenceScore: number;   // [0..1]
+  capQualityScore: number;    // [0..1]
+}
+
+export interface ScoreResult {
+  total: number;              // [0..100]
+  subScores: SubScores;
+}
+
+interface SubScoreWeights {
+  amplitude: number;
+  rvol: number;
+  momentum: number;
+  persistence: number;
+  capQuality: number;
+}
+
+const AMPLITUDE_TARGET: Record<ScoringAssetClass, number> = {
+  asia_equity: 10,
+  eu_equity: 15,
+  us_equity_large: 7,
+  us_equity_small_mid: 15,
+  crypto_major: 3,
+};
+
+const RVOL_TARGET: Record<ScoringAssetClass, number> = {
+  asia_equity: 5,
+  eu_equity: 5,
+  us_equity_large: 3,
+  us_equity_small_mid: 5, // inversé dans computeRvolScore
+  crypto_major: 2,
+};
+
+const WEIGHTS: Record<ScoringAssetClass, SubScoreWeights> = {
+  asia_equity: {
+    amplitude: 0.20, rvol: 0.35, momentum: 0.20, persistence: 0.15, capQuality: 0.10,
+  },
+  eu_equity: {
+    amplitude: 0.25, rvol: 0.20, momentum: 0.25, persistence: 0.20, capQuality: 0.10,
+  },
+  us_equity_large: {
+    amplitude: 0.20, rvol: 0.15, momentum: 0.25, persistence: 0.10, capQuality: 0.30,
+  },
+  us_equity_small_mid: {
+    amplitude: 0.20, rvol: 0.20, momentum: 0.20, persistence: 0.15, capQuality: 0.25,
+  },
+  crypto_major: {
+    amplitude: 0.30, rvol: 0.10, momentum: 0.40, persistence: 0.15, capQuality: 0.05,
+  },
+};
+
+const SIGMOID_K = 0.3; // pente sigmoid amplitude (courbe douce, pas de cliff)
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * Sous-score amplitude : sigmoid logistique centrée sur la cible classe.
+ * - asia (target=10) : chg=10% → 0.5, chg=20% → 0.95
+ * - crypto (target=3) : chg=3% → 0.5, chg=10% → 0.88
+ */
+export function computeAmplitudeScore(changePct: number, assetClass: ScoringAssetClass): number {
+  const target = AMPLITUDE_TARGET[assetClass];
+  return 1 / (1 + Math.exp(-SIGMOID_K * (changePct - target)));
+}
+
+/**
+ * Sous-score RVOL :
+ * - us_equity_small_mid : INVERSE (rvol ≤3.5 = 1.0, décroissance linéaire
+ *   jusqu'à rvol 8.5 = 0). FOMO penalty mesuré sur 14j (SL avg rvol 4.86
+ *   vs TP avg rvol 3.27).
+ * - autres classes : linéaire saturé à 1.0 au-dessus de RVOL_TARGET.
+ */
+export function computeRvolScore(rvol: number, assetClass: ScoringAssetClass): number {
+  if (rvol <= 0) return 0;
+  if (assetClass === 'us_equity_small_mid') {
+    if (rvol <= 3.5) return 1.0;
+    return Math.max(0, 1 - (rvol - 3.5) / 5);
+  }
+  const target = RVOL_TARGET[assetClass];
+  return Math.min(1, rvol / target);
+}
+
+/**
+ * Sous-score momentum : pondération 5m × 0.5 + 15m × 0.3 + 30m × 0.2.
+ * Normalisation par TF : 5m=2%, 15m=5%, 30m=8% → 1.0 chacun.
+ * Si certains TF sont null → repondération sur les disponibles.
+ * Si TOUS null → 0.5 (neutre).
+ */
+export function computeMomentumScore(
+  m5: number | null,
+  m15: number | null,
+  m30: number | null,
+): number {
+  if (m5 === null && m15 === null && m30 === null) return 0.5;
+  const m5Norm = m5 === null ? 0 : clamp(m5 / 0.02, -1, 1);
+  const m15Norm = m15 === null ? 0 : clamp(m15 / 0.05, -1, 1);
+  const m30Norm = m30 === null ? 0 : clamp(m30 / 0.08, -1, 1);
+  let totalWeight = 0;
+  let weighted = 0;
+  if (m5 !== null) { weighted += 0.5 * m5Norm; totalWeight += 0.5; }
+  if (m15 !== null) { weighted += 0.3 * m15Norm; totalWeight += 0.3; }
+  if (m30 !== null) { weighted += 0.2 * m30Norm; totalWeight += 0.2; }
+  const raw = totalWeight > 0 ? weighted / totalWeight : 0;
+  return (raw + 1) / 2; // [-1, 1] → [0, 1]
+}
+
+/** Sous-score persistence : ratio multi-TF existant clampé [0, 1]. */
+export function computePersistenceSubScore(persistenceMultiTf: number): number {
+  return clamp(persistenceMultiTf, 0, 1);
+}
+
+/**
+ * Sous-score capQuality : bandes mcap Druckenmiller par classe.
+ * - us_large : sweet spot 200-2000B (winners 14j avg=$334B), mega cap=0.7
+ * - us_sm : sweet spot 0.3-10B (TP avg=$3.54B), penny<0.3B=0.2 (FOMO),
+ *   drift>10B=0.5
+ * - eu / asia / crypto : neutre 0.7 (mcap pas discriminant sur 14j)
+ */
+export function computeCapQualityScore(
+  marketCapUsd: number | null,
+  assetClass: ScoringAssetClass,
+): number {
+  if (marketCapUsd === null || marketCapUsd <= 0) return 0.5;
+  const mcap = marketCapUsd / 1e9;
+  switch (assetClass) {
+    case 'us_equity_large':
+      if (mcap < 200) return 0.5;
+      if (mcap > 2000) return 0.7;
+      return 1.0;
+    case 'us_equity_small_mid':
+      if (mcap < 0.3) return 0.2;
+      if (mcap > 10) return 0.5;
+      return 1.0;
+    case 'eu_equity':
+    case 'asia_equity':
+    case 'crypto_major':
+    default:
+      return 0.7;
+  }
+}
+
+/** Calcule le score continu [0..100] et retourne aussi les sous-scores. */
+export function calculateContinuousScore(
+  features: ScoreFeatures,
+  assetClass: ScoringAssetClass,
+): ScoreResult {
+  const subScores: SubScores = {
+    amplitudeScore: computeAmplitudeScore(features.changePctSnapshot, assetClass),
+    rvolScore: computeRvolScore(features.rvol, assetClass),
+    momentumScore: computeMomentumScore(
+      features.momentum5m,
+      features.momentum15m,
+      features.momentum30m,
+    ),
+    persistenceScore: computePersistenceSubScore(features.persistenceMultiTf),
+    capQualityScore: computeCapQualityScore(features.marketCapUsd, assetClass),
+  };
+  const w = WEIGHTS[assetClass];
+  const total = 100 * (
+    w.amplitude * subScores.amplitudeScore +
+    w.rvol * subScores.rvolScore +
+    w.momentum * subScores.momentumScore +
+    w.persistence * subScores.persistenceScore +
+    w.capQuality * subScores.capQualityScore
+  );
+  return { total: clamp(total, 0, 100), subScores };
+}

--- a/scripts/backtest-continuous-score.ts
+++ b/scripts/backtest-continuous-score.ts
@@ -1,0 +1,196 @@
+/**
+ * PR #351 — Backtest 14j scoring continu.
+ *
+ * Rejoue top_gainers_log avec calculateContinuousScore (sans calls réseau,
+ * pure features). Compare virtual_opened vs reel + WR virtuel par classe.
+ *
+ * Limitations historiques :
+ *   - momentum 5m/15m/30m → null (non reconstruisible depuis top_gainers_log,
+ *     besoin de prix intraday cache historique). Le backtest est donc
+ *     conservateur (momentum=0.5 neutre).
+ *   - atrNormalized → null (idem).
+ *
+ * Usage :
+ *   SUPABASE_URL=... SUPABASE_SERVICE_KEY=... \
+ *   pnpm tsx scripts/backtest-continuous-score.ts
+ *
+ * Critères GO (cf. brief PR #351 §8) :
+ *   - virtual_opened ≥ 25/jour
+ *   - WR virtuel global ≥ 42%
+ *   - aucune classe avec WR virtuel < 25%
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import {
+  calculateContinuousScore,
+  type ScoringAssetClass,
+} from '@smartvest/ai-analyst';
+
+const LOOKBACK_DAYS = 14;
+const SCORING_ASSET_CLASSES: ReadonlySet<string> = new Set([
+  'asia_equity',
+  'eu_equity',
+  'us_equity_large',
+  'us_equity_small_mid',
+  'crypto_major',
+]);
+
+interface ClassStats {
+  opened: number;
+  tp: number;
+  sl: number;
+  unknown: number;
+}
+
+async function main(): Promise<void> {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_KEY env vars');
+    process.exit(1);
+  }
+  const supabase = createClient(url, key);
+
+  const since = new Date(Date.now() - LOOKBACK_DAYS * 86400000).toISOString();
+
+  // 1. Logs scanner 14j
+  const { data: candidates, error: candErr } = await supabase
+    .from('top_gainers_log')
+    .select(
+      'symbol, detected_asset_class, market, change_pct, volume, avg_vol_50d, market_cap_usd, score, decision, captured_at',
+    )
+    .gte('captured_at', since)
+    .limit(500_000);
+
+  if (candErr) {
+    console.error('Failed to load top_gainers_log:', candErr.message);
+    process.exit(1);
+  }
+  if (!candidates || candidates.length === 0) {
+    console.error('No candidates in lookback window');
+    process.exit(1);
+  }
+  console.log(`Loaded ${candidates.length} top_gainers_log rows over ${LOOKBACK_DAYS}d`);
+
+  // 2. Seuils par classe
+  const { data: configs } = await supabase
+    .from('asset_class_tpsl_config')
+    .select('asset_class, continuous_score_floor');
+  const floors = new Map<string, number>();
+  configs?.forEach((c: { asset_class: string; continuous_score_floor: number | null }) => {
+    floors.set(c.asset_class, c.continuous_score_floor ?? 60);
+  });
+
+  // 3. Outcomes réels (positions clôturées) — index par symbol_date pour rapprochement
+  const { data: positions } = await supabase
+    .from('lisa_positions')
+    .select('symbol, asset_class, status, realized_pnl_usd, entry_timestamp')
+    .gte('entry_timestamp', since)
+    .in('status', ['closed_target', 'closed_stop']);
+
+  const outcomeBySymbolDate = new Map<string, 'TP' | 'SL'>();
+  positions?.forEach((p: { symbol: string; entry_timestamp: string; status: string }) => {
+    const date = p.entry_timestamp.slice(0, 10);
+    outcomeBySymbolDate.set(
+      `${p.symbol}_${date}`,
+      p.status === 'closed_target' ? 'TP' : 'SL',
+    );
+  });
+
+  // 4. Backtest
+  const stats: Record<string, ClassStats> = {};
+  let skippedBadClass = 0;
+
+  for (const c of candidates as Array<{
+    symbol: string;
+    detected_asset_class: string | null;
+    market: string | null;
+    change_pct: string | null;
+    volume: string | null;
+    avg_vol_50d: string | null;
+    market_cap_usd: string | null;
+    score: string | null;
+    captured_at: string;
+  }>) {
+    const acRaw = c.detected_asset_class ?? c.market;
+    if (!acRaw || !SCORING_ASSET_CLASSES.has(acRaw)) {
+      skippedBadClass += 1;
+      continue;
+    }
+    const ac = acRaw as ScoringAssetClass;
+
+    const vol = Number(c.volume ?? 0);
+    const avg = Number(c.avg_vol_50d ?? 0);
+    const rvol = avg > 0 ? vol / avg : 0;
+
+    const result = calculateContinuousScore(
+      {
+        changePctSnapshot: Number(c.change_pct ?? 0),
+        rvol,
+        marketCapUsd: c.market_cap_usd ? Number(c.market_cap_usd) : null,
+        persistenceMultiTf: Number(c.score ?? 0),
+        momentum5m: null, // non reconstructible
+        momentum15m: null,
+        momentum30m: null,
+        atrNormalized: null,
+      },
+      ac,
+    );
+
+    const floor = floors.get(ac) ?? 60;
+    if (result.total >= floor) {
+      const slot = (stats[ac] ??= { opened: 0, tp: 0, sl: 0, unknown: 0 });
+      slot.opened += 1;
+      const outcome = outcomeBySymbolDate.get(`${c.symbol}_${c.captured_at.slice(0, 10)}`);
+      if (outcome === 'TP') slot.tp += 1;
+      else if (outcome === 'SL') slot.sl += 1;
+      else slot.unknown += 1;
+    }
+  }
+
+  // 5. Rapport
+  console.log(`\n## Backtest ${LOOKBACK_DAYS}j PR #351\n`);
+  console.log(`Skipped (bad/missing asset_class) : ${skippedBadClass}\n`);
+  console.log('| Classe | Virtual Opened | TP | SL | Unknown | WR virtuel |');
+  console.log('|---|---:|---:|---:|---:|---:|');
+
+  let totalOpened = 0;
+  let totalTp = 0;
+  let totalSl = 0;
+  for (const [ac, s] of Object.entries(stats)) {
+    const closed = s.tp + s.sl;
+    const wr = closed > 0 ? ((s.tp / closed) * 100).toFixed(1) : 'N/A';
+    console.log(`| ${ac} | ${s.opened} | ${s.tp} | ${s.sl} | ${s.unknown} | ${wr}% |`);
+    totalOpened += s.opened;
+    totalTp += s.tp;
+    totalSl += s.sl;
+  }
+  const totalClosed = totalTp + totalSl;
+  const totalWrPct = totalClosed > 0 ? (totalTp / totalClosed) * 100 : 0;
+  console.log(
+    `| **TOTAL** | **${totalOpened}** | **${totalTp}** | **${totalSl}** | — | **${totalWrPct.toFixed(1)}%** |`,
+  );
+
+  const opensPerDay = totalOpened / LOOKBACK_DAYS;
+  console.log(`\nVirtual opened/jour : ${opensPerDay.toFixed(1)} (cible ≥25)`);
+  console.log(`WR virtuel global : ${totalWrPct.toFixed(1)}% (cible ≥42%)`);
+
+  // 6. Critères GO
+  const allClassesAbove25 = Object.values(stats).every((s) => {
+    const closed = s.tp + s.sl;
+    return closed === 0 || (s.tp / closed) * 100 >= 25;
+  });
+
+  console.log('\n## Critères GO');
+  console.log(`- Volume ≥25/j : ${opensPerDay >= 25 ? 'OK' : 'KO'} (${opensPerDay.toFixed(1)})`);
+  console.log(`- WR ≥42% : ${totalWrPct >= 42 ? 'OK' : 'KO'} (${totalWrPct.toFixed(1)}%)`);
+  console.log(`- Toutes classes WR ≥25% : ${allClassesAbove25 ? 'OK' : 'KO'}`);
+  const verdict =
+    opensPerDay >= 25 && totalWrPct >= 42 && allClassesAbove25 ? '**GO**' : '**NO_GO**';
+  console.log(`\nVerdict : ${verdict}`);
+}
+
+main().catch((e: Error) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/supabase/migrations/0147_pr351_continuous_score.sql
+++ b/supabase/migrations/0147_pr351_continuous_score.sql
@@ -1,0 +1,40 @@
+-- PR #351 — Scoring discriminant continu [0..100]
+--
+-- Ajoute :
+--   1. continuous_score_floor par classe dans asset_class_tpsl_config
+--      (seuils calibrés sur 14j data : asia=65, eu=70, us_large=60, us_sm=65, crypto=55)
+--   2. Sub-scores logging dans top_gainers_log (5 sous-scores + total)
+--   3. Index sur continuous_score_total pour requêtes audit / backtest
+
+BEGIN;
+
+-- 1. Seuil continu par classe
+ALTER TABLE asset_class_tpsl_config
+  ADD COLUMN IF NOT EXISTS continuous_score_floor INT DEFAULT 60;
+
+UPDATE asset_class_tpsl_config SET continuous_score_floor = 65 WHERE asset_class = 'asia_equity';
+UPDATE asset_class_tpsl_config SET continuous_score_floor = 70 WHERE asset_class = 'eu_equity';
+UPDATE asset_class_tpsl_config SET continuous_score_floor = 60 WHERE asset_class = 'us_equity_large';
+UPDATE asset_class_tpsl_config SET continuous_score_floor = 65 WHERE asset_class = 'us_equity_small_mid';
+UPDATE asset_class_tpsl_config SET continuous_score_floor = 55 WHERE asset_class = 'crypto_major';
+
+-- 2. Sub-scores dans top_gainers_log
+ALTER TABLE top_gainers_log
+  ADD COLUMN IF NOT EXISTS sub_amplitude_score NUMERIC(5,4),
+  ADD COLUMN IF NOT EXISTS sub_rvol_score NUMERIC(5,4),
+  ADD COLUMN IF NOT EXISTS sub_momentum_score NUMERIC(5,4),
+  ADD COLUMN IF NOT EXISTS sub_persistence_score NUMERIC(5,4),
+  ADD COLUMN IF NOT EXISTS sub_cap_quality_score NUMERIC(5,4),
+  ADD COLUMN IF NOT EXISTS continuous_score_total NUMERIC(5,2);
+
+-- 3. Index pour requêtes backtest et audit (filtre + tri sur score)
+CREATE INDEX IF NOT EXISTS idx_top_gainers_log_continuous_score
+  ON top_gainers_log (continuous_score_total DESC NULLS LAST, captured_at DESC);
+
+COMMENT ON COLUMN asset_class_tpsl_config.continuous_score_floor IS
+  'PR #351 — seuil de décision sur le score continu [0..100]. Si CONTINUOUS_SCORING_ENABLED=true, un candidat est accepté si scoreResult.total >= continuous_score_floor.';
+
+COMMENT ON COLUMN top_gainers_log.continuous_score_total IS
+  'PR #351 — score continu [0..100] agrégeant amplitude/rvol/momentum/persistence/capQuality. Loggué même si flag OFF pour backtest comparatif.';
+
+COMMIT;


### PR DESCRIPTION
## Diagnostic chiffré 14j

- **96 513 candidats `filtered`** avec score=0 (binaire pass/fail strict)
- **Smoking gun `020560.KO`** ignoré 477 snapshots consécutifs malgré `rvol=24.16x` + `chg=16.94%`
- **269 opened / 41 976 passed** = 0.19 % taux d'ouverture
- Features TP vs SL discriminantes mesurées par classe : asia rvol Δ +1.19, us_sm rvol inverse (FOMO), us_large mcap discriminant

## Architecture du score

`total = 100 × (w_amp × amplitudeScore + w_rvol × rvolScore + w_mom × momentumScore + w_pers × persistenceScore + w_cap × capQualityScore)`

| Classe | amp | rvol | mom | pers | cap |
|---|---|---|---|---|---|
| asia_equity | 0.20 | **0.35** | 0.20 | 0.15 | 0.10 |
| eu_equity | 0.25 | 0.20 | 0.25 | 0.20 | 0.10 |
| us_equity_large | 0.20 | 0.15 | 0.25 | 0.10 | **0.30** |
| us_equity_small_mid | 0.20 | 0.20 | 0.20 | 0.15 | 0.25 |
| crypto_major | **0.30** | 0.10 | **0.40** | 0.15 | 0.05 |

- **Amplitude** : sigmoid logistique centrée sur cible classe (asia=10 %, crypto=3 %, etc.)
- **RVOL** : linéaire saturé pour la plupart ; **inversé pour us_sm** (rvol > 3.5 → décroissance, > 8.5 → 0, FOMO penalty)
- **Momentum** : pondération 5m × 0.5 + 15m × 0.3 + 30m × 0.2 (fallback null → 0.5 neutre)
- **CapQuality** : bandes mcap Druckenmiller (us_large sweet 200-2000B, us_sm sweet 0.3-10B, penny=0.2, drift=0.5)

## Livrables

1. **`packages/ai-analyst/src/scoring/continuous-score.ts`** — module pur, 5 sub-scores, signature `calculateContinuousScore(features, assetClass)`
2. **`packages/ai-analyst/src/scoring/continuous-score.spec.ts`** — 30 tests verts, smoking gun couvert + FOMO penalty us_sm + bornes
3. **`supabase/migrations/0147_pr351_continuous_score.sql`** :
   - `continuous_score_floor` par classe dans `asset_class_tpsl_config` (asia=65, eu=70, us_large=60, us_sm=65, crypto=55)
   - 5 colonnes `sub_*_score` + `continuous_score_total` dans `top_gainers_log`
   - Index DESC pour audit/backtest
4. **`top-gainers-scanner.service.ts`** — `persistLog` injecte les sub-scores via helper `computeContinuousScoreFragment` (logging only, **decision path inchangé**)
5. **`scripts/backtest-continuous-score.ts`** — rejoue 14j `top_gainers_log`, compare opened virtuel vs réel, verdict GO/NO_GO

## Câblage minimal volontaire

Le decision path reste piloté par le score legacy. Les sub-scores sont **loggés en prod** pour alimenter le backtest sans risque de régression.

**Activation du gate `continuous_score_floor`** = follow-up PR conditionnel aux résultats du backtest (run `pnpm tsx scripts/backtest-continuous-score.ts` une fois la prod a produit ≥ 24h de logs sub-scores).

Avantage : safe par construction (additif, pas de régression possible) + data réelle (vs. backtest historique limité par momentum=null).

## Renommages

- `AssetClass` → **`ScoringAssetClass`** (collision avec zod enum `types/index.ts` aux values différentes)
- `computePersistenceScore` → **`computePersistenceSubScore`** (collision avec `strategies/multi-tf-persistence`)

## QA

- ✅ Tests scoring : 30/30 verts
- ✅ Tests top-gainers-scanner (non-régression) : 115/115 verts
- ✅ Typecheck `packages/ai-analyst` + `apps/api`
- ✅ Build dist `ai-analyst` OK (vérifié pour exports cross-package)

## Numérotation migration

Brief disait `0145`, mais `0145_eodhd_endpoint_extras.sql` et `0146_shadow_signals_decision_constraint.sql` sont déjà mergées → **renumérotée 0147**.

## Post-merge attendu

1. Migration appliquée → table prête
2. Cron suivant remplit `continuous_score_total` + sub-scores en prod
3. T+24h : `pnpm tsx scripts/backtest-continuous-score.ts > BACKTEST_PR351.md` → verdict GO/NO_GO
4. Si GO → follow-up PR pour activer le gate `continuous_score_floor` dans le decision path

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_