### PR TITLE
feat(intraday-router): PR #352 — TwelveData Pro intraday router + scanner universe 3000 + A/B flag

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p18e.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p18e.spec.ts
@@ -57,7 +57,15 @@ const mockIntradayCache = {
 const mockConfig = { get: jest.fn().mockReturnValue(undefined) } as any;
 
 function makeService(): MultiTimeframePersistenceService {
-  return new MultiTimeframePersistenceService(mockBinance, mockEodhd, mockYahoo, mockIntradayCache, mockConfig, { getStatus: () => ({ throttle: { multitfPaused: false } }) } as any);
+  // PR #352 — IntradayProviderRouter ajouté au constructor. Mock passthrough
+  // EODHD (préserve les fixtures p18e).
+  const mockRouter = {
+    getCandles: (ticker: string, interval: '1m' | '5m' | '1h', count: number) =>
+      mockEodhd.getCandles(ticker, interval, count).then((r: unknown) =>
+        r ? { ...(r as Record<string, unknown>), provider: 'eodhd' } : null,
+      ),
+  } as any;
+  return new MultiTimeframePersistenceService(mockBinance, mockEodhd, mockYahoo, mockIntradayCache, mockConfig, { getStatus: () => ({ throttle: { multitfPaused: false } }) } as any, mockRouter);
 }
 
 // ── 1. Aggregated log — single line for N misses ─────────────────────────────

--- a/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p19i.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/multi-tf-persistence.p19i.spec.ts
@@ -34,7 +34,15 @@ beforeEach(() => {
 const mockConfig = { get: jest.fn().mockReturnValue(undefined) } as any;
 
 function makeService() {
-  return new MultiTimeframePersistenceService(mockBinance, mockEodhd, mockYahoo, mockCache, mockConfig, { getStatus: () => ({ throttle: { multitfPaused: false } }) } as any);
+  // PR #352 — IntradayProviderRouter ajouté au constructor. Mock passthrough
+  // EODHD pour préserver les fixtures p19i.
+  const mockRouter = {
+    getCandles: (ticker: string, interval: '1m' | '5m' | '1h', count: number) =>
+      mockEodhd.getCandles(ticker, interval, count).then((r: unknown) =>
+        r ? { ...(r as Record<string, unknown>), provider: 'eodhd' } : null,
+      ),
+  } as any;
+  return new MultiTimeframePersistenceService(mockBinance, mockEodhd, mockYahoo, mockCache, mockConfig, { getStatus: () => ({ throttle: { multitfPaused: false } }) } as any, mockRouter);
 }
 
 function fakeYahooCandles(n = 13) {

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -98,6 +98,8 @@ import { AssetClassKellyConfigService } from './services/asset-class-kelly-confi
 import { KellyRecomputeService } from './services/kelly-recompute.service';
 // PR #342 POC — TwelveData service (lecture seule, indicateurs Supertrend/RSI/ATR)
 import { TwelveDataService } from './services/twelve-data.service';
+// PR #352 — Router intraday TD-first avec fallback EODHD (flag-gated)
+import { IntradayProviderRouter } from './services/intraday-provider-router.service';
 
 @Module({
   imports: [SupabaseModule, PerformanceModule, BotLabModule, GainersModule],
@@ -216,6 +218,8 @@ import { TwelveDataService } from './services/twelve-data.service';
     KellyRecomputeService,
     // PR #342 POC — TwelveData (flags consumer OFF par défaut, aucun impact runtime)
     TwelveDataService,
+    // PR #352 — Router intraday TD-first (flag OFF par défaut → passthrough EODHD)
+    IntradayProviderRouter,
   ],
   exports: [
     LisaService,

--- a/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
@@ -1,0 +1,392 @@
+/**
+ * PR #352 — Tests IntradayProviderRouter.
+ *
+ * Couverture :
+ *   - Flag OFF → 100% EODHD (passthrough)
+ *   - Flag ON + ratio 1.0 → 100% TD (mock TD success)
+ *   - Flag ON + ratio 0.0 → 100% EODHD
+ *   - Flag ON + ratio 0.5 → ~50/50 (statistique sur 100 symbols)
+ *   - TD null → fallback EODHD obligatoire
+ *   - TD success → EODHD jamais appelé
+ *   - Symbol asia (.KO) → routed EODHD direct (unmappable)
+ *   - Symbol US → routed TD si flag ON
+ *   - Hash déterministe : shouldRouteToTd retourne toujours pareil
+ *   - Sans TwelveDataService injecté → 100% EODHD
+ */
+
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { IntradayProviderRouter } from '../intraday-provider-router.service';
+import { TwelveDataService } from '../twelve-data.service';
+import { EodhdIntradayService } from '../eodhd-intraday.service';
+
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+
+function makeConfig(env: Record<string, string>): ConfigService {
+  return { get: jest.fn((k: string) => env[k]) } as unknown as ConfigService;
+}
+
+function makeEodhdMock(opts?: {
+  quote?: { price: number; changePct: number; timestamp: number } | null;
+  candles?: { ticker: string; interval: '1m' | '5m' | '1h'; candles: Array<{ timestamp: number; open: number; high: number; low: number; close: number; volume: number }>; asOf: number; rawCount?: number } | null;
+}): {
+  service: EodhdIntradayService;
+  quoteCalls: number;
+  candlesCalls: number;
+} {
+  const counters = { quoteCalls: 0, candlesCalls: 0 };
+  const service = {
+    getQuote: (_t: string) => {
+      counters.quoteCalls += 1;
+      return Promise.resolve(opts?.quote ?? null);
+    },
+    getCandles: (_t: string, _i: '1m' | '5m' | '1h', _c: number) => {
+      counters.candlesCalls += 1;
+      return Promise.resolve(opts?.candles ?? null);
+    },
+  } as unknown as EodhdIntradayService;
+  return {
+    service,
+    get quoteCalls() {
+      return counters.quoteCalls;
+    },
+    get candlesCalls() {
+      return counters.candlesCalls;
+    },
+  };
+}
+
+function makeTdMock(opts?: {
+  quote?: { price: number; changePct: number; timestamp: number } | null;
+  candles?: { symbol: string; interval: string; candles: Array<{ timestamp: number; open: number; high: number; low: number; close: number; volume: number }>; asOf: number } | null;
+}): {
+  service: TwelveDataService;
+  quoteCalls: number;
+  candlesCalls: number;
+} {
+  const counters = { quoteCalls: 0, candlesCalls: 0 };
+  const service = {
+    getQuote: (_s: string, _by?: string) => {
+      counters.quoteCalls += 1;
+      return Promise.resolve(opts?.quote ?? null);
+    },
+    getCandles: (_s: string, _i: string, _o?: number, _by?: string) => {
+      counters.candlesCalls += 1;
+      return Promise.resolve(opts?.candles ?? null);
+    },
+  } as unknown as TwelveDataService;
+  return {
+    service,
+    get quoteCalls() {
+      return counters.quoteCalls;
+    },
+    get candlesCalls() {
+      return counters.candlesCalls;
+    },
+  };
+}
+
+const TD_OK_QUOTE = { price: 180.5, changePct: 1.2, timestamp: 1747353600000 };
+const EODHD_OK_QUOTE = { price: 180.4, changePct: 1.1, timestamp: 1747353500000 };
+const TD_OK_CANDLES = {
+  symbol: 'AAPL',
+  interval: '1min',
+  candles: [
+    { timestamp: 1747353600, open: 1, high: 1, low: 1, close: 180.5, volume: 100 },
+  ],
+  asOf: 1747353600000,
+};
+const EODHD_OK_CANDLES = {
+  ticker: 'AAPL.US',
+  interval: '1m' as const,
+  candles: [
+    { timestamp: 1747353500, open: 1, high: 1, low: 1, close: 180.4, volume: 100 },
+  ],
+  asOf: 1747353500000,
+};
+
+describe('IntradayProviderRouter — PR #352', () => {
+  describe('flag OFF → 100% EODHD', () => {
+    it('getQuote utilise EODHD, jamais TD', async () => {
+      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      const td = makeTdMock({ quote: TD_OK_QUOTE });
+      const router = new IntradayProviderRouter(
+        makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'false' }),
+        eodhd.service,
+        td.service,
+      );
+      const r = await router.getQuote('AAPL.US');
+      expect(r).not.toBeNull();
+      expect(r!.provider).toBe('eodhd');
+      expect(r!.price).toBe(EODHD_OK_QUOTE.price);
+      expect(eodhd.quoteCalls).toBe(1);
+      expect(td.quoteCalls).toBe(0);
+    });
+
+    it('getCandles utilise EODHD, jamais TD', async () => {
+      const eodhd = makeEodhdMock({ candles: EODHD_OK_CANDLES });
+      const td = makeTdMock({ candles: TD_OK_CANDLES });
+      const router = new IntradayProviderRouter(
+        makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'false' }),
+        eodhd.service,
+        td.service,
+      );
+      const r = await router.getCandles('AAPL.US', '1m', 20);
+      expect(r).not.toBeNull();
+      expect(r!.provider).toBe('eodhd');
+      expect(eodhd.candlesCalls).toBe(1);
+      expect(td.candlesCalls).toBe(0);
+    });
+  });
+
+  describe('flag ON + ratio 1.0 → 100% TD', () => {
+    it('getQuote utilise TD, EODHD jamais appelé', async () => {
+      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      const td = makeTdMock({ quote: TD_OK_QUOTE });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      const r = await router.getQuote('AAPL.US');
+      expect(r!.provider).toBe('td');
+      expect(r!.price).toBe(TD_OK_QUOTE.price);
+      expect(td.quoteCalls).toBe(1);
+      expect(eodhd.quoteCalls).toBe(0);
+    });
+
+    it('getCandles 1m utilise TD avec interval mappé 1min', async () => {
+      const eodhd = makeEodhdMock({ candles: EODHD_OK_CANDLES });
+      const td = makeTdMock({ candles: TD_OK_CANDLES });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      const r = await router.getCandles('AAPL.US', '1m', 20);
+      expect(r!.provider).toBe('td');
+      expect(r!.candles).toHaveLength(1);
+      expect(r!.candles[0].close).toBe(180.5);
+      expect(td.candlesCalls).toBe(1);
+      expect(eodhd.candlesCalls).toBe(0);
+    });
+  });
+
+  describe('flag ON + ratio 0.0 → 100% EODHD', () => {
+    it('getQuote utilise EODHD, TD jamais appelé', async () => {
+      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      const td = makeTdMock({ quote: TD_OK_QUOTE });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '0.0',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      await router.getQuote('AAPL.US');
+      expect(eodhd.quoteCalls).toBe(1);
+      expect(td.quoteCalls).toBe(0);
+    });
+  });
+
+  describe('flag ON + ratio 0.5 → ~50/50 split déterministe', () => {
+    it('100 symbols différents → entre 30 et 70 routés TD', async () => {
+      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      const td = makeTdMock({ quote: TD_OK_QUOTE });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '0.5',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      for (let i = 0; i < 100; i++) {
+        await router.getQuote(`SYM${i}.US`);
+      }
+      // Distribution attendue ~50/50, on accepte large [30..70]
+      expect(td.quoteCalls).toBeGreaterThanOrEqual(30);
+      expect(td.quoteCalls).toBeLessThanOrEqual(70);
+      expect(eodhd.quoteCalls).toBe(100 - td.quoteCalls);
+    });
+  });
+
+  describe('TD null → fallback EODHD', () => {
+    it('getQuote : TD null → EODHD appelé, provider=eodhd', async () => {
+      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      const td = makeTdMock({ quote: null });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      const r = await router.getQuote('AAPL.US');
+      expect(r!.provider).toBe('eodhd');
+      expect(td.quoteCalls).toBe(1);
+      expect(eodhd.quoteCalls).toBe(1);
+    });
+
+    it('getCandles : TD null → EODHD fallback', async () => {
+      const eodhd = makeEodhdMock({ candles: EODHD_OK_CANDLES });
+      const td = makeTdMock({ candles: null });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      const r = await router.getCandles('AAPL.US', '1m', 20);
+      expect(r!.provider).toBe('eodhd');
+      expect(td.candlesCalls).toBe(1);
+      expect(eodhd.candlesCalls).toBe(1);
+    });
+
+    it('getCandles : TD candles=[] → EODHD fallback', async () => {
+      const eodhd = makeEodhdMock({ candles: EODHD_OK_CANDLES });
+      const td = makeTdMock({ candles: { symbol: 'AAPL', interval: '1min', candles: [], asOf: 0 } });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      const r = await router.getCandles('AAPL.US', '1m', 20);
+      expect(r!.provider).toBe('eodhd');
+      expect(td.candlesCalls).toBe(1);
+      expect(eodhd.candlesCalls).toBe(1);
+    });
+  });
+
+  describe('TD success → EODHD jamais appelé', () => {
+    it('getQuote TD OK', async () => {
+      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      const td = makeTdMock({ quote: TD_OK_QUOTE });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      await router.getQuote('AAPL.US');
+      expect(eodhd.quoteCalls).toBe(0);
+    });
+  });
+
+  describe('Symbol unmappable (asia/HK) → EODHD direct', () => {
+    it('.KO → EODHD direct, TD jamais appelé', async () => {
+      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      const td = makeTdMock({ quote: TD_OK_QUOTE });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      const r = await router.getQuote('005930.KO');
+      expect(r!.provider).toBe('eodhd');
+      expect(td.quoteCalls).toBe(0);
+      expect(eodhd.quoteCalls).toBe(1);
+    });
+
+    it('.HK / .T / .AU / .SHG / .SHE → unmappable', () => {
+      const router = new IntradayProviderRouter(
+        makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true' }),
+        makeEodhdMock().service,
+        makeTdMock().service,
+      );
+      expect(router.convertToTdSymbol('0700.HK')).toBeNull();
+      expect(router.convertToTdSymbol('7203.T')).toBeNull();
+      expect(router.convertToTdSymbol('CBA.AU')).toBeNull();
+      expect(router.convertToTdSymbol('600519.SHG')).toBeNull();
+      expect(router.convertToTdSymbol('300024.SHE')).toBeNull();
+    });
+
+    it('mapping suffixes connus', () => {
+      const router = new IntradayProviderRouter(
+        makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true' }),
+        makeEodhdMock().service,
+        makeTdMock().service,
+      );
+      expect(router.convertToTdSymbol('AAPL.US')).toBe('AAPL');
+      expect(router.convertToTdSymbol('AAPL')).toBe('AAPL'); // sans suffixe
+      expect(router.convertToTdSymbol('BARC.LSE')).toBe('BARC:LSE');
+      expect(router.convertToTdSymbol('BARC.L')).toBe('BARC:LSE');
+      expect(router.convertToTdSymbol('BNP.PA')).toBe('BNP:Euronext');
+      expect(router.convertToTdSymbol('BMW.XETRA')).toBe('BMW:XETR');
+      expect(router.convertToTdSymbol('BMW.DE')).toBe('BMW:XETR');
+      expect(router.convertToTdSymbol('NESN.SW')).toBe('NESN:SIX');
+    });
+  });
+
+  describe('Hash déterministe', () => {
+    it('shouldRouteToTd(symbol) retourne toujours pareil pour le même symbol', () => {
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '0.5',
+        }),
+        makeEodhdMock().service,
+        makeTdMock().service,
+      );
+      const first = router.shouldRouteToTd('AAPL');
+      for (let i = 0; i < 50; i++) {
+        expect(router.shouldRouteToTd('AAPL')).toBe(first);
+      }
+    });
+  });
+
+  describe('Sans TwelveDataService injecté → 100% EODHD', () => {
+    it('getQuote utilise EODHD même si flag ON', async () => {
+      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
+        }),
+        eodhd.service,
+        null,
+      );
+      const r = await router.getQuote('AAPL.US');
+      expect(r!.provider).toBe('eodhd');
+      expect(eodhd.quoteCalls).toBe(1);
+    });
+  });
+
+  describe('Ratio invalide → fallback à 1.0', () => {
+    it('ratio="-1" ou "2.0" → 100% TD (default 1.0)', async () => {
+      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      const td = makeTdMock({ quote: TD_OK_QUOTE });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '2.0',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      await router.getQuote('AAPL.US');
+      expect(td.quoteCalls).toBe(1);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/__tests__/twelve-data.service.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/twelve-data.service.spec.ts
@@ -167,7 +167,7 @@ describe('TwelveDataService — PR #342 POC', () => {
     });
   });
 
-  describe('rate limit minute (7 credits/min)', () => {
+  describe('rate limit minute (Basic plan override 7 credits/min)', () => {
     it('8e appel consécutif → null sans HTTP', async () => {
       const fetchMock = jest.fn().mockResolvedValue({
         ok: true,
@@ -176,7 +176,13 @@ describe('TwelveDataService — PR #342 POC', () => {
       });
       (global as { fetch?: unknown }).fetch = fetchMock;
 
-      const svc = makeService();
+      // PR #352 — defaults Pro (8000/min) ; ce test cible la logique rate-limit
+      // via un override Basic explicite.
+      const svc = makeService({
+        TWELVEDATA_API_KEY: 'test-key',
+        TWELVEDATA_PER_MINUTE_LIMIT: '7',
+        TWELVEDATA_PER_DAY_LIMIT: '750',
+      });
       for (let i = 0; i < 7; i++) {
         const r = await svc.getRsi('BTC/USD');
         expect(r).not.toBeNull();
@@ -190,9 +196,13 @@ describe('TwelveDataService — PR #342 POC', () => {
     });
   });
 
-  describe('rate limit jour (750 credits/jour)', () => {
+  describe('rate limit jour (Basic plan override 750 credits/jour)', () => {
     it('au-delà de 750 daily_usage → null silencieux', async () => {
-      const svc = makeService();
+      const svc = makeService({
+        TWELVEDATA_API_KEY: 'test-key',
+        TWELVEDATA_PER_MINUTE_LIMIT: '7',
+        TWELVEDATA_PER_DAY_LIMIT: '750',
+      });
       // Force le tracker à 750 via 750 appels mockés successifs serait trop lent ;
       // on accède au tracker via reflection minimale.
       type Internals = { creditTracker: { consume: (n: number) => void } };
@@ -342,6 +352,177 @@ describe('TwelveDataService — PR #342 POC', () => {
       expect(svc.getDailyUsage()).toBe(0);
       await svc.getRsi('BTC/USD');
       expect(svc.getDailyUsage()).toBe(1);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // PR #352 — méthodes intraday getQuote + getCandles
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('getQuote', () => {
+    it('happy path → parse price + percent_change + timestamp', async () => {
+      mockFetchOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          symbol: 'AAPL',
+          close: '180.45',
+          percent_change: '1.25',
+          timestamp: 1747353600,
+        }),
+      });
+      const svc = makeService();
+      const q = await svc.getQuote('AAPL');
+      expect(q).not.toBeNull();
+      expect(q!.price).toBe(180.45);
+      expect(q!.changePct).toBe(1.25);
+      expect(q!.timestamp).toBe(1747353600 * 1000);
+    });
+
+    it('réponse sans champ close → null', async () => {
+      mockFetchOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ symbol: 'AAPL' }),
+      });
+      const svc = makeService();
+      expect(await svc.getQuote('AAPL')).toBeNull();
+    });
+
+    it('réponse status=error → null', async () => {
+      mockFetchOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'error', message: 'symbol not found' }),
+      });
+      const svc = makeService();
+      expect(await svc.getQuote('UNKNOWN')).toBeNull();
+    });
+
+    it('clé manquante → null sans HTTP', async () => {
+      const fetchSpy = jest.fn();
+      (global as { fetch?: unknown }).fetch = fetchSpy;
+      const svc = makeService({});
+      expect(await svc.getQuote('AAPL')).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('price invalide (négatif) → null', async () => {
+      mockFetchOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ close: '-1.5' }),
+      });
+      const svc = makeService();
+      expect(await svc.getQuote('AAPL')).toBeNull();
+    });
+
+    it('HTTP 500 → null + 1 credit consommé', async () => {
+      mockFetchOnce({ ok: false, status: 500, json: async () => ({}) });
+      const svc = makeService();
+      const q = await svc.getQuote('AAPL');
+      expect(q).toBeNull();
+      expect(svc.getDailyUsage()).toBe(1);
+    });
+  });
+
+  describe('getCandles', () => {
+    it('happy path 1min count=20 → 20 candles asc, 4 credits', async () => {
+      const values = Array.from({ length: 20 }, (_, i) => ({
+        datetime: `2026-05-18 14:${String(i).padStart(2, '0')}:00`,
+        open: '180.0',
+        high: '181.0',
+        low: '179.5',
+        close: `${180 + i * 0.1}`,
+        volume: '100000',
+      }));
+      mockFetchOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ values, status: 'ok' }),
+      });
+      const svc = makeService();
+      const r = await svc.getCandles('AAPL', '1min', 20);
+      expect(r).not.toBeNull();
+      expect(r!.candles).toHaveLength(20);
+      // TD renvoie desc, le service doit retourner asc → le premier est i=19 dans la source
+      expect(r!.candles[0].close).toBeCloseTo(180 + 19 * 0.1);
+      expect(r!.candles[19].close).toBe(180);
+      // Forfait : ceil(20/5) = 4 credits
+      expect(svc.getDailyUsage()).toBe(4);
+    });
+
+    it('réponse status=error → null', async () => {
+      mockFetchOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'error', message: 'no data' }),
+      });
+      const svc = makeService();
+      expect(await svc.getCandles('UNKNOWN')).toBeNull();
+    });
+
+    it('values vide → candles=[] + success log', async () => {
+      mockFetchOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ values: [] }),
+      });
+      const svc = makeService();
+      const r = await svc.getCandles('AAPL');
+      expect(r).not.toBeNull();
+      expect(r!.candles).toHaveLength(0);
+    });
+
+    it('candle avec close invalide → filtrée', async () => {
+      mockFetchOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          values: [
+            { datetime: '2026-05-18 14:00:00', open: '1', high: '1', low: '1', close: '1.5', volume: '100' },
+            { datetime: '2026-05-18 14:01:00', open: '1', high: '1', low: '1', close: 'NaN', volume: '0' },
+          ],
+        }),
+      });
+      const svc = makeService();
+      const r = await svc.getCandles('AAPL');
+      expect(r!.candles).toHaveLength(1);
+      expect(r!.candles[0].close).toBe(1.5);
+    });
+
+    it('clé manquante → null sans HTTP', async () => {
+      const fetchSpy = jest.fn();
+      (global as { fetch?: unknown }).fetch = fetchSpy;
+      const svc = makeService({});
+      expect(await svc.getCandles('AAPL')).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('rate limit (override Basic 750/day) → null sans HTTP', async () => {
+      const svc = makeService({
+        TWELVEDATA_API_KEY: 'test-key',
+        TWELVEDATA_PER_MINUTE_LIMIT: '8000',
+        TWELVEDATA_PER_DAY_LIMIT: '750',
+      });
+      type Internals = { creditTracker: { consume: (n: number) => void } };
+      (svc as unknown as Internals).creditTracker.consume(749);
+      const fetchSpy = jest.fn();
+      (global as { fetch?: unknown }).fetch = fetchSpy;
+      // outputsize=20 → 4 credits ; 749 + 4 > 750 → block
+      const r = await svc.getCandles('AAPL', '1min', 20);
+      expect(r).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PR #352 — Pro plan defaults', () => {
+    it('sans override env → limits 8000/min, 1M/day', () => {
+      const svc = makeService();
+      type Internals = { creditTracker: { canConsume: (n: number) => boolean } };
+      // Conservatively probe: 8000 doit passer, 8001 non
+      expect((svc as unknown as Internals).creditTracker.canConsume(8000)).toBe(true);
+      expect((svc as unknown as Internals).creditTracker.canConsume(8001)).toBe(false);
     });
   });
 });

--- a/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
+++ b/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
@@ -1,0 +1,184 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { TwelveDataService } from './twelve-data.service';
+import { EodhdIntradayService, type CandleSeries } from './eodhd-intraday.service';
+
+/**
+ * PR #352 — Routeur intraday TwelveData-first avec fallback EODHD.
+ *
+ * Activation :
+ *   TWELVEDATA_INTRADAY_SCANNER_ENABLED  bool string  (default false)
+ *   TWELVEDATA_INTRADAY_AB_TEST_RATIO    float [0..1] (default 1.0 = 100% TD)
+ *
+ * Routage :
+ *   - Flag OFF → 100% EODHD passthrough
+ *   - Flag ON  → hash(symbol) % 100 < ratio*100 → TD, sinon EODHD
+ *   - TD null   → fallback EODHD obligatoire
+ *   - Symbol non mappable TD (asia/HK exotiques) → fallback EODHD direct
+ *
+ * Fail-safe : si TwelveDataService non injecté (clé absente) OU flag OFF →
+ * 100% EODHD. Le router est strictement additif, ne peut pas dégrader le
+ * scanner existant.
+ *
+ * Kill-switch instantané :
+ *   flyctl secrets set TWELVEDATA_INTRADAY_SCANNER_ENABLED=false --app smartvest
+ */
+
+export interface IntradayQuote {
+  price: number;
+  changePct: number;
+  timestamp: number;
+  provider: 'td' | 'eodhd';
+}
+
+export type IntradayCandleSeries = CandleSeries & { provider: 'td' | 'eodhd' };
+
+@Injectable()
+export class IntradayProviderRouter {
+  private readonly logger = new Logger(IntradayProviderRouter.name);
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly eodhd: EodhdIntradayService,
+    @Optional() private readonly td: TwelveDataService | null = null,
+  ) {
+    const enabled = this.isEnabled();
+    const ratio = this.getRatio();
+    this.logger.log(
+      `[intraday-router] init enabled=${enabled} ratio=${ratio} td=${this.td ? 'available' : 'unavailable'}`,
+    );
+  }
+
+  private isEnabled(): boolean {
+    if (!this.td) return false;
+    return (
+      (this.config.get<string>('TWELVEDATA_INTRADAY_SCANNER_ENABLED') ?? 'false').toLowerCase() ===
+      'true'
+    );
+  }
+
+  private getRatio(): number {
+    const raw = this.config.get<string>('TWELVEDATA_INTRADAY_AB_TEST_RATIO') ?? '1.0';
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < 0 || n > 1) return 1.0;
+    return n;
+  }
+
+  /**
+   * Hash déterministe FNV-1a (32 bits) → stabilité A/B par symbol :
+   * un symbol donné est toujours routé sur le même provider tant que le
+   * ratio est inchangé.
+   */
+  shouldRouteToTd(symbol: string): boolean {
+    if (!this.isEnabled()) return false;
+    const ratio = this.getRatio();
+    if (ratio >= 1.0) return true;
+    if (ratio <= 0.0) return false;
+    let hash = 2166136261;
+    for (let i = 0; i < symbol.length; i++) {
+      hash ^= symbol.charCodeAt(i);
+      hash = (hash * 16777619) >>> 0;
+    }
+    return hash % 100 < ratio * 100;
+  }
+
+  /**
+   * Quote temps réel. Caller passe un ticker EODHD-style (ex `AAPL.US`,
+   * `005930.KO`). Le router convertit pour TD si nécessaire.
+   */
+  async getQuote(eodhdTicker: string): Promise<IntradayQuote | null> {
+    if (this.shouldRouteToTd(eodhdTicker) && this.td) {
+      const tdSymbol = this.convertToTdSymbol(eodhdTicker);
+      if (tdSymbol !== null) {
+        const tdResult = await this.td.getQuote(tdSymbol, 'intraday_router');
+        if (tdResult) {
+          this.logger.debug(
+            `[intraday-router] ${eodhdTicker} provider=td source=primary price=${tdResult.price}`,
+          );
+          return { ...tdResult, provider: 'td' };
+        }
+        this.logger.debug(
+          `[intraday-router] ${eodhdTicker} provider=td source=fallback (td returned null)`,
+        );
+      } else {
+        this.logger.debug(
+          `[intraday-router] ${eodhdTicker} provider=eodhd source=fallback (td unmappable)`,
+        );
+      }
+    }
+    const eodhdResult = await this.eodhd.getQuote(eodhdTicker);
+    if (!eodhdResult) return null;
+    return { ...eodhdResult, provider: 'eodhd' };
+  }
+
+  /**
+   * Candles intraday au format CandleSeries (compat caller scanner). TD
+   * interval mapping : 1m → 1min, 5m → 5min, 1h → 1h.
+   */
+  async getCandles(
+    eodhdTicker: string,
+    interval: '1m' | '5m' | '1h' = '1m',
+    count = 20,
+  ): Promise<IntradayCandleSeries | null> {
+    if (this.shouldRouteToTd(eodhdTicker) && this.td) {
+      const tdSymbol = this.convertToTdSymbol(eodhdTicker);
+      if (tdSymbol !== null) {
+        const tdInterval = interval === '1m' ? '1min' : interval === '5m' ? '5min' : '1h';
+        const tdResult = await this.td.getCandles(tdSymbol, tdInterval, count, 'intraday_router');
+        if (tdResult && tdResult.candles.length > 0) {
+          this.logger.debug(
+            `[intraday-router] ${eodhdTicker} provider=td source=primary candles=${tdResult.candles.length}`,
+          );
+          return {
+            ticker: eodhdTicker,
+            interval,
+            candles: tdResult.candles,
+            asOf: tdResult.asOf,
+            rawCount: tdResult.candles.length,
+            provider: 'td',
+          };
+        }
+        this.logger.debug(
+          `[intraday-router] ${eodhdTicker} provider=td source=fallback (td empty/null)`,
+        );
+      } else {
+        this.logger.debug(
+          `[intraday-router] ${eodhdTicker} provider=eodhd source=fallback (td unmappable)`,
+        );
+      }
+    }
+    const eodhdResult = await this.eodhd.getCandles(eodhdTicker, interval, count);
+    if (!eodhdResult) return null;
+    return { ...eodhdResult, provider: 'eodhd' };
+  }
+
+  /**
+   * Convertit ticker EODHD → symbol TwelveData.
+   *   EODHD : AAPL.US, 005930.KO, BMW.XETRA, BNP.PA, BARC.LSE
+   *   TD    : AAPL, (asia=null), BMW:XETR, BNP:Euronext, BARC:LSE
+   *
+   * Conservateur : suffixe asia/HK/AU exotique → null → fallback EODHD direct.
+   * Évite signal pourri / symbol non reconnu côté TD.
+   *
+   * Visible pour tests.
+   */
+  convertToTdSymbol(eodhdTicker: string): string | null {
+    if (!eodhdTicker.includes('.')) return eodhdTicker; // US sans suffixe
+    const [base, suffix] = eodhdTicker.split('.');
+    const map: Record<string, string> = {
+      US: '', // AAPL.US → AAPL
+      L: ':LSE',
+      LSE: ':LSE',
+      PA: ':Euronext',
+      AS: ':Euronext',
+      AMS: ':Euronext',
+      XETRA: ':XETR',
+      DE: ':XETR',
+      SW: ':SIX',
+      MI: ':MIL',
+      TO: ':TSX',
+    };
+    if (!(suffix in map)) return null; // KO/KQ/SHG/SHE/HK/T/AU → fallback EODHD
+    return map[suffix] ? `${base}${map[suffix]}` : base;
+  }
+}

--- a/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
+++ b/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
@@ -25,6 +25,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { BinanceMarketService } from './binance-market.service';
 import { EodhdIntradayService } from './eodhd-intraday.service';
+import { IntradayProviderRouter } from './intraday-provider-router.service';
 import { YahooIntradayService } from './yahoo-intraday.service';
 import { IntradayCacheService, CachedCandle } from './intraday-cache.service';
 import { EodhdQuotaService } from './eodhd-quota.service';
@@ -149,6 +150,13 @@ export class MultiTimeframePersistenceService {
      * `multitfPaused` flag actif.
      */
     private readonly quotaService: EodhdQuotaService,
+    /**
+     * PR #352 — Router intraday TD-first avec fallback EODHD. Quand le flag
+     * TWELVEDATA_INTRADAY_SCANNER_ENABLED=true, les fetch candles 1m/5m du
+     * scanner intraday (hot path persistence MTF) passent par TwelveData
+     * avec fallback EODHD obligatoire si null. Flag OFF → 100% EODHD.
+     */
+    private readonly intradayRouter: IntradayProviderRouter,
   ) {}
 
   /** P18e — Métriques cumulatives pour observability. */
@@ -406,7 +414,10 @@ export class MultiTimeframePersistenceService {
     //
     // Quota impact : ~+19k calls/jour worst-case (1 call/ticker × 20 × 6
     // cycles/h × 16h). Plan ALL-IN-ONE = 100k/jour, on reste à ~38k total.
-    const oneMinSeries = await this.eodhd.getCandles(eodhdTicker, '1m', 65).catch(() => null);
+    // PR #352 — Routage TD-first via IntradayProviderRouter (flag-gated).
+    // Flag OFF (défaut) → passthrough EODHD identique. Flag ON → TD avec
+    // fallback EODHD automatique.
+    const oneMinSeries = await this.intradayRouter.getCandles(eodhdTicker, '1m', 65).catch(() => null);
     if (oneMinSeries && oneMinSeries.candles.length >= 60) {
       const prices = extractPricesFromOneMinSeries(oneMinSeries.candles);
       const persistence = evaluatePersistence(c.currentPrice, prices);
@@ -428,7 +439,8 @@ export class MultiTimeframePersistenceService {
     );
 
     // 2bis. EODHD intraday 5m (fallback dégradé — tf1m=null mais 5 TFs OK)
-    const series = await this.eodhd.getCandles(eodhdTicker, '5m', 13).catch(() => null);
+    // PR #352 — routé via IntradayProviderRouter (TD-first si flag ON)
+    const series = await this.intradayRouter.getCandles(eodhdTicker, '5m', 13).catch(() => null);
     if (series && series.candles.length > 0) {
       const prices = extractPricesFromFiveMinSeries(series.candles);
       const persistence = evaluatePersistence(c.currentPrice, prices);
@@ -542,7 +554,8 @@ export class MultiTimeframePersistenceService {
     // EODHD ticker convention : SYMBOL.EXCHANGE
     const eodhdTicker = this.toEodhdTicker(c);
     // 13 candles 5-min couvre 1h05 — assez pour les TFs 5m..1h
-    const series = await this.eodhd.getCandles(eodhdTicker, '5m', 13);
+    // PR #352 — routé via IntradayProviderRouter (TD-first si flag ON)
+    const series = await this.intradayRouter.getCandles(eodhdTicker, '5m', 13);
     if (!series || series.candles.length === 0) {
       this.logger.debug(`[mtf-persist] ${c.symbol} no eodhd intraday`);
       return null;

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -676,7 +676,18 @@ export class TopGainersScannerService implements OnModuleInit {
       );
     }
     if (validated < 5) {
-      this.logger.warn('[top-gainers] interval <5min — risque rate-limit EODHD/Binance');
+      // PR #352 — Si le routage intraday TD-first est actif, on peut descendre
+      // sous 5min (plan Pro 8000 credits/min suffit largement pour 3000 tickers
+      // en 1min = 3000 quotes = 37% du plafond). On suppress le warn dans ce cas.
+      const tdScannerEnabled =
+        (this.config.get<string>('TWELVEDATA_INTRADAY_SCANNER_ENABLED') ?? 'false').toLowerCase() === 'true';
+      if (!tdScannerEnabled) {
+        this.logger.warn('[top-gainers] interval <5min — risque rate-limit EODHD/Binance');
+      } else {
+        this.logger.log(
+          `[top-gainers] interval ${validated}min autorisé (TWELVEDATA_INTRADAY_SCANNER_ENABLED=true)`,
+        );
+      }
     }
     if (validated > 60) {
       this.logger.warn('[top-gainers] interval >60min — opportunités intraday potentiellement ratées');
@@ -1299,71 +1310,117 @@ export class TopGainersScannerService implements OnModuleInit {
     }
     filtersList.push(['market_capitalization', '>', 50_000_000]);
     const filters = encodeURIComponent(JSON.stringify(filtersList));
-    const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}&limit=100&offset=0&fmt=json`;
-    this.logger.debug(`[top-gainers] EODHD screener exchange=${exUpper} filters=${filtersList.length}`);
-    const tStart = Date.now();
+
+    // PR #352 — Pagination screener pour étendre l'univers à 3000 tickers.
+    //   SCANNER_SCREENER_PAGE_SIZE (default 100) : page size par appel EODHD
+    //   SCANNER_UNIVERSE_MAX_TICKERS (default 1500, max 3000) : cap global
+    // Cap par exchange = ceil(MAX / nbExchanges). Stop précoce si page < pageSize.
+    // Hard limit : 10 pages max par exchange (anti-runaway).
+    const pageSize = Math.max(
+      1,
+      Math.min(500, Number(this.config.get<string>('SCANNER_SCREENER_PAGE_SIZE') ?? '100')),
+    );
+    const universeMax = Math.max(
+      pageSize,
+      Math.min(3000, Number(this.config.get<string>('SCANNER_UNIVERSE_MAX_TICKERS') ?? '1500')),
+    );
+    const nbExchanges = Math.max(1, EU_EXCHANGES.length + NON_EU_EXCHANGES.length);
+    const perExchangeCap = Math.ceil(universeMax / nbExchanges);
+    const maxPages = 10;
+
+    this.logger.debug(
+      `[top-gainers] EODHD screener exchange=${exUpper} filters=${filtersList.length} pageSize=${pageSize} perExchangeCap=${perExchangeCap}`,
+    );
+
+    const allMapped: TopGainerCandidate[] = [];
+    let pagesFetched = 0;
+    let totalRowsReturned = 0;
+    let lastLatencyMs = 0;
+    let lastStatus: number | null = null;
+
+    const tStartAll = Date.now();
     try {
-      const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
-      const latencyMs = Date.now() - tStart;
-      if (!res.ok) {
-        // P18c — log le body pour diagnostic (422 = champ filter invalide,
-        // 401 = token expiré, 403 = plan insuffisant). Tronqué à 200 char.
-        const body = await res.text().catch(() => '');
-        this.logger.warn(
-          `[top-gainers] eodhd ${exUpper} HTTP ${res.status} — body: ${body.slice(0, 200)}`,
-        );
-        // PR #344 P1 — instrumentation log EODHD screener (error path).
+      for (let page = 0; page < maxPages; page++) {
+        if (allMapped.length >= perExchangeCap) break;
+        const offset = page * pageSize;
+        const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}&limit=${pageSize}&offset=${offset}&fmt=json`;
+        const tStart = Date.now();
+        const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+        lastLatencyMs = Date.now() - tStart;
+        lastStatus = res.status;
+        pagesFetched += 1;
+        if (!res.ok) {
+          // P18c — log le body pour diagnostic (422 = champ filter invalide,
+          // 401 = token expiré, 403 = plan insuffisant). Tronqué à 200 char.
+          const body = await res.text().catch(() => '');
+          this.logger.warn(
+            `[top-gainers] eodhd ${exUpper} page=${page} HTTP ${res.status} — body: ${body.slice(0, 200)}`,
+          );
+          // PR #344 P1 — instrumentation log EODHD screener (error path).
+          this.eodhdLogger?.log({
+            ticker: `gainers_screener_${exUpper}`,
+            eodhdTicker: `gainers_screener_${exUpper}`,
+            source: 'eodhd',
+            success: false,
+            statusCode: res.status,
+            latencyMs: lastLatencyMs,
+            calledBy: 'gainers_screener',
+            endpoint: 'screener',
+            extras: {
+              exchange: exUpper,
+              filters_count: filtersList.length,
+              page,
+              page_size: pageSize,
+              credits_estimes: 5, // base only, pas de symboles retournés
+            },
+            errorMessage: `HTTP_${res.status} · ${body.slice(0, 200)}`,
+          });
+          break; // stop pagination sur erreur, retour ce qu'on a déjà
+        }
+        const json = (await res.json()) as { data?: EodhdScreenerRow[] } | EodhdScreenerRow[];
+        const rows: EodhdScreenerRow[] = Array.isArray(json) ? json : (json.data ?? []);
+        totalRowsReturned += rows.length;
+        let pageMapped = rows
+          .map((r) => this.mapEodhdRow(r, exUpper))
+          .filter((c): c is TopGainerCandidate => c !== null);
+        // P19s++ — Post-filter client-side pour non-US (filter serveur dropped).
+        if (!isUs) {
+          pageMapped = pageMapped.filter((c) => (c.changePct ?? 0) > 3);
+        }
+        allMapped.push(...pageMapped);
+        // PR #344 P1 — log par page (cardinalité OK, max 10 pages/exchange).
         this.eodhdLogger?.log({
           ticker: `gainers_screener_${exUpper}`,
           eodhdTicker: `gainers_screener_${exUpper}`,
           source: 'eodhd',
-          success: false,
+          success: true,
           statusCode: res.status,
-          latencyMs,
+          latencyMs: lastLatencyMs,
           calledBy: 'gainers_screener',
           endpoint: 'screener',
           extras: {
             exchange: exUpper,
             filters_count: filtersList.length,
-            credits_estimes: 5, // base only, pas de symboles retournés
-          },
-          errorMessage: `HTTP_${res.status} · ${body.slice(0, 200)}`,
-        });
-        return [];
-      }
-      const json = await res.json() as { data?: EodhdScreenerRow[] } | EodhdScreenerRow[];
-      const rows: EodhdScreenerRow[] = Array.isArray(json) ? json : (json.data ?? []);
-      let mapped = rows
-        .map((r) => this.mapEodhdRow(r, exUpper))
-        .filter((c): c is TopGainerCandidate => c !== null);
-      // P19s++ — Post-filter client-side pour non-US (filter serveur dropped).
-      // Garde rows changePct > 3 cohérent avec filtre serveur côté US.
-      if (!isUs) {
-        mapped = mapped.filter((c) => (c.changePct ?? 0) > 3);
-      }
-      // PR #344 P1 — instrumentation log EODHD screener (success path).
-      // Coût EODHD réel = 5 (base call) + N symboles retournés (cf. pricing-and-plans.md).
-      this.eodhdLogger?.log({
-        ticker: `gainers_screener_${exUpper}`,
-        eodhdTicker: `gainers_screener_${exUpper}`,
-        source: 'eodhd',
-        success: true,
-        statusCode: res.status,
-        latencyMs,
-        calledBy: 'gainers_screener',
-        endpoint: 'screener',
-        extras: {
-          exchange: exUpper,
-          filters_count: filtersList.length,
-          n_symbols_returned: rows.length,
-          n_symbols_mapped: mapped.length,
-          credits_estimes: EodhdLoggerService.estimateCredits('screener', {
+            page,
+            page_size: pageSize,
             n_symbols_returned: rows.length,
-          }),
-        },
-      });
-      return mapped;
+            n_symbols_mapped: pageMapped.length,
+            credits_estimes: EodhdLoggerService.estimateCredits('screener', {
+              n_symbols_returned: rows.length,
+            }),
+          },
+        });
+        if (rows.length < pageSize) break; // fin de la liste exchange
+      }
+      if (allMapped.length > perExchangeCap) {
+        allMapped.length = perExchangeCap; // trim
+      }
+      this.logger.log(
+        `[top-gainers] screener ${exUpper} fetched ${allMapped.length} mapped in ${pagesFetched} pages (raw=${totalRowsReturned}, latency_last=${lastLatencyMs}ms)`,
+      );
+      return allMapped;
     } catch (e) {
+      void lastStatus; // référence conservée pour parité avec l'ancien log d'erreur
       this.logger.debug(`[top-gainers] eodhd ${exUpper} fetch error: ${String(e).slice(0, 120)}`);
       // PR #344 P1 — instrumentation log EODHD screener (exception path).
       this.eodhdLogger?.log({
@@ -1371,12 +1428,13 @@ export class TopGainersScannerService implements OnModuleInit {
         eodhdTicker: `gainers_screener_${exUpper}`,
         source: 'eodhd',
         success: false,
-        latencyMs: Date.now() - tStart,
+        latencyMs: Date.now() - tStartAll,
         calledBy: 'gainers_screener',
         endpoint: 'screener',
         extras: {
           exchange: exUpper,
           filters_count: filtersList.length,
+          pages_fetched: pagesFetched,
           credits_estimes: 0, // exception → call probablement non-débité
         },
         errorMessage: String(e).slice(0, 200),

--- a/apps/api/src/modules/lisa/services/twelve-data.service.ts
+++ b/apps/api/src/modules/lisa/services/twelve-data.service.ts
@@ -100,10 +100,7 @@ const RETRY_5XX_DELAY_MS = 2000;
 export class TwelveDataService {
   private readonly logger = new Logger(TwelveDataService.name);
   private readonly apiKey: string | null;
-  private readonly creditTracker = new CreditTracker({
-    perMinuteLimit: 7,
-    perDayLimit: 750,
-  });
+  private readonly creditTracker: CreditTracker;
 
   constructor(
     private readonly config: ConfigService,
@@ -118,6 +115,12 @@ export class TwelveDataService {
       const tail = key.length >= 4 ? key.slice(-4) : '****';
       this.logger.log(`[twelvedata] provider initialized, key=***${tail} (length=${key.length})`);
     }
+    // PR #352 — Pro plan defaults (8000/min, ~1M/jour). Override via env si
+    // downgrade (Basic=7/750). Précédemment hardcodé Basic, sous-utilisait Pro.
+    const perMinuteLimit = Number(this.config.get<string>('TWELVEDATA_PER_MINUTE_LIMIT') ?? '8000');
+    const perDayLimit = Number(this.config.get<string>('TWELVEDATA_PER_DAY_LIMIT') ?? '1000000');
+    this.creditTracker = new CreditTracker({ perMinuteLimit, perDayLimit });
+    this.logger.log(`[twelvedata] credit tracker init: ${perMinuteLimit}/min, ${perDayLimit}/day`);
   }
 
   /** Convertit Binance pair (POLUSDT) → TwelveData crypto symbol (POL/USD). */
@@ -246,6 +249,233 @@ export class TwelveDataService {
   }
 
   /**
+   * PR #352 — Quote temps réel (1 credit). Endpoint : GET /quote.
+   * Doc : https://twelvedata.com/docs#real-time-quote
+   * Retourne null si rate limit / erreur / champ close manquant.
+   */
+  async getQuote(
+    symbol: string,
+    calledBy = 'intraday',
+  ): Promise<{ price: number; changePct: number; timestamp: number } | null> {
+    if (!this.apiKey) return null;
+    if (!this.creditTracker.canConsume(1)) {
+      this.logger.warn(
+        `[twelvedata] rate limit hit for getQuote(${symbol}) — daily=${this.creditTracker.getDailyUsage()}`,
+      );
+      void this.logCall({
+        endpoint: 'quote',
+        symbol,
+        interval: null,
+        success: false,
+        statusCode: 0,
+        creditsUsed: 0,
+        latencyMs: 0,
+        errorMessage: 'rate_limit_internal',
+        calledBy,
+      });
+      return null;
+    }
+    const tStart = Date.now();
+    try {
+      const params = new URLSearchParams({ symbol, apikey: this.apiKey });
+      const url = `${BASE_URL}/quote?${params.toString()}`;
+      const res = await this.fetchWithTimeout(url);
+      const latencyMs = Date.now() - tStart;
+      this.creditTracker.consume(1);
+      if (!res.ok) {
+        void this.logCall({
+          endpoint: 'quote',
+          symbol,
+          interval: null,
+          success: false,
+          statusCode: res.status,
+          creditsUsed: 1,
+          latencyMs,
+          errorMessage: `HTTP_${res.status}`,
+          calledBy,
+        });
+        return null;
+      }
+      const data = (await res.json()) as Record<string, unknown>;
+      if (data?.status === 'error' || data?.close == null) {
+        void this.logCall({
+          endpoint: 'quote',
+          symbol,
+          interval: null,
+          success: false,
+          statusCode: res.status,
+          creditsUsed: 1,
+          latencyMs,
+          errorMessage: String(data?.message ?? 'no_close_field').slice(0, 200),
+          calledBy,
+        });
+        return null;
+      }
+      const price = Number(data.close);
+      const changePct = Number(data.percent_change ?? 0);
+      const timestamp = data.timestamp ? Number(data.timestamp) * 1000 : Date.now();
+      if (!Number.isFinite(price) || price <= 0) {
+        void this.logCall({
+          endpoint: 'quote',
+          symbol,
+          interval: null,
+          success: false,
+          statusCode: res.status,
+          creditsUsed: 1,
+          latencyMs,
+          errorMessage: `invalid_price=${String(data.close)}`,
+          calledBy,
+        });
+        return null;
+      }
+      this.logStructured('quote', symbol, '', 'ok', 1, latencyMs);
+      void this.logCall({
+        endpoint: 'quote',
+        symbol,
+        interval: null,
+        success: true,
+        statusCode: res.status,
+        creditsUsed: 1,
+        latencyMs,
+        calledBy,
+      });
+      return { price, changePct, timestamp };
+    } catch (err) {
+      const latencyMs = Date.now() - tStart;
+      void this.logCall({
+        endpoint: 'quote',
+        symbol,
+        interval: null,
+        success: false,
+        statusCode: null,
+        creditsUsed: 1,
+        latencyMs,
+        errorMessage: String((err as Error).message).slice(0, 200),
+        calledBy,
+      });
+      return null;
+    }
+  }
+
+  /**
+   * PR #352 — Time series intraday. Endpoint : GET /time_series.
+   * Doc : https://twelvedata.com/docs#time-series
+   * Coût forfaitisé : ceil(outputsize / 5) credits (1m count=20 = 4 credits).
+   * Renvoie les candles en ordre chronologique asc (TD renvoie desc).
+   */
+  async getCandles(
+    symbol: string,
+    interval: '1min' | '5min' | '15min' | '1h' = '1min',
+    outputsize = 20,
+    calledBy = 'intraday',
+  ): Promise<{
+    symbol: string;
+    interval: string;
+    candles: Array<{ timestamp: number; open: number; high: number; low: number; close: number; volume: number }>;
+    asOf: number;
+  } | null> {
+    if (!this.apiKey) return null;
+    const credits = Math.max(1, Math.ceil(outputsize / 5));
+    if (!this.creditTracker.canConsume(credits)) {
+      this.logger.warn(
+        `[twelvedata] rate limit hit for getCandles(${symbol}) credits=${credits} daily=${this.creditTracker.getDailyUsage()}`,
+      );
+      void this.logCall({
+        endpoint: 'time_series',
+        symbol,
+        interval,
+        success: false,
+        statusCode: 0,
+        creditsUsed: 0,
+        latencyMs: 0,
+        errorMessage: 'rate_limit_internal',
+        calledBy,
+      });
+      return null;
+    }
+    const tStart = Date.now();
+    try {
+      const params = new URLSearchParams({
+        symbol,
+        interval,
+        outputsize: String(outputsize),
+        apikey: this.apiKey,
+      });
+      const url = `${BASE_URL}/time_series?${params.toString()}`;
+      const res = await this.fetchWithTimeout(url);
+      const latencyMs = Date.now() - tStart;
+      this.creditTracker.consume(credits);
+      if (!res.ok) {
+        void this.logCall({
+          endpoint: 'time_series',
+          symbol,
+          interval,
+          success: false,
+          statusCode: res.status,
+          creditsUsed: credits,
+          latencyMs,
+          errorMessage: `HTTP_${res.status}`,
+          calledBy,
+        });
+        return null;
+      }
+      const data = (await res.json()) as Record<string, unknown>;
+      const values = data?.values;
+      if (data?.status === 'error' || !Array.isArray(values)) {
+        void this.logCall({
+          endpoint: 'time_series',
+          symbol,
+          interval,
+          success: false,
+          statusCode: res.status,
+          creditsUsed: credits,
+          latencyMs,
+          errorMessage: String(data?.message ?? 'no_values').slice(0, 200),
+          calledBy,
+        });
+        return null;
+      }
+      const candles = (values as Array<Record<string, string>>)
+        .map((v) => ({
+          timestamp: Math.floor(new Date(v.datetime).getTime() / 1000),
+          open: Number(v.open),
+          high: Number(v.high),
+          low: Number(v.low),
+          close: Number(v.close),
+          volume: Number(v.volume ?? 0),
+        }))
+        .filter((c) => Number.isFinite(c.close) && c.close > 0)
+        .reverse(); // TD renvoie desc, on veut asc
+      this.logStructured('time_series', symbol, interval, 'ok', credits, latencyMs);
+      void this.logCall({
+        endpoint: 'time_series',
+        symbol,
+        interval,
+        success: true,
+        statusCode: res.status,
+        creditsUsed: credits,
+        latencyMs,
+        calledBy,
+      });
+      return { symbol, interval, candles, asOf: Date.now() };
+    } catch (err) {
+      const latencyMs = Date.now() - tStart;
+      void this.logCall({
+        endpoint: 'time_series',
+        symbol,
+        interval,
+        success: false,
+        statusCode: null,
+        creditsUsed: credits,
+        latencyMs,
+        errorMessage: String((err as Error).message).slice(0, 200),
+        calledBy,
+      });
+      return null;
+    }
+  }
+
+  /**
    * Cœur HTTP partagé : rate-limit check + 1 retry sur 429/5xx + log structuré
    * + insert Supabase.
    */
@@ -259,7 +489,7 @@ export class TwelveDataService {
     if (!this.apiKey) return null;
     if (!this.creditTracker.canConsume(1)) {
       this.logger.warn(
-        `[twelvedata] rate limit reached (minute=${this.creditTracker.getMinuteWindowSize()}/7, daily=${this.creditTracker.getDailyUsage()}/750) — skip ${endpoint} ${symbol}`,
+        `[twelvedata] rate limit reached (minute=${this.creditTracker.getMinuteWindowSize()}, daily=${this.creditTracker.getDailyUsage()}) — skip ${endpoint} ${symbol}`,
       );
       void this.logCall({
         endpoint,


### PR DESCRIPTION
## Contexte business

Plan TwelveData Pro activé samedi 17/05 ($229/mo, 8000 credits/min, ~1M/jour) mais **sous-utilisé** : les filtres existants PR #345 consomment <0.01% du quota. Le scanner intraday principal reste 100% EODHD, cycle 5 minutes.

Cible : **scanner intraday TD-first** + univers 3000 tickers + cycle 1 min, avec **flag A/B test pour rollback instantané**. EODHD reste backbone pour screener / EOD / news / calendar / technicals.

## Scope (toutes sections du brief)

### 3.1 — `CreditTracker` Pro defaults
- Avant : hardcoded Basic (7/min, 750/day)
- Après : env `TWELVEDATA_PER_MINUTE_LIMIT` (default **8000**), `TWELVEDATA_PER_DAY_LIMIT` (default **1000000**)

### 3.2 — Méthodes intraday `TwelveDataService`
- `getQuote(symbol, calledBy)` : 1 credit, `/quote` endpoint, parse `close`/`percent_change`/`timestamp`
- `getCandles(symbol, interval, outputsize, calledBy)` : forfait `ceil(outputsize/5)` credits, `/time_series` endpoint, ordre chronologique asc
- Toutes les méthodes loggent dans `twelve_data_request_log` + retournent null (fail-safe)

### 3.3 — `IntradayProviderRouter` (nouveau service)
- Flag OFF → 100% EODHD passthrough
- Flag ON + ratio 1.0 → 100% TD
- Flag ON + ratio 0.5 → ~50/50 par hash FNV-1a déterministe sur symbol
- TD null OU symbol unmappable → fallback EODHD obligatoire
- Suffixes mappables TD : `.US`, `.L/.LSE`, `.PA/.AS/.AMS` (Euronext), `.XETRA/.DE` (XETR), `.SW` (SIX), `.MI` (MIL), `.TO` (TSX)
- Asia/HK/AU/SHG/SHE/T → unmappable → EODHD direct

### 3.4 — Enregistrement module
`IntradayProviderRouter` ajouté aux providers de `lisa.module.ts`.

### 3.5 — Câblage scanner intraday — **divergence brief/code documentée**

Le brief assumait des call sites `this.eodhdIntraday.getCandles` dans `top-gainers-scanner.service.ts`. **En réalité ces call sites sont dans `multi-tf-persistence.service.ts`** (hot path persistence MTF, appelé par le scanner via `mtfPersistence.analyzeBatch`).

3 call sites migrés vers le router :

| Ligne | Avant | Après |
|---|---|---|
| 409 | `eodhd.getCandles('1m', 65)` | `intradayRouter.getCandles` |
| 431 | `eodhd.getCandles('5m', 13)` (fallback 5m) | `intradayRouter.getCandles` |
| 545 | `eodhd.getCandles('5m', 13)` (analyzeSingle path) | `intradayRouter.getCandles` |

**Non touchés** :
- Ligne 453 `getCandlesViaTicks` : API séparée (tick-data US-only), hors scope router
- `lisa.service.ts` ligne 1147 `eodhdIntraday.getCandles` pour positions ouvertes (hors hot path scanner)

`EodhdIntradayService` reste injecté pour les callers non-scanner. 2 specs existants (`p18e`, `p19i`) adaptés au nouveau constructor avec mock router passthrough.

### 3.6 — Pagination screener jusqu'à 3000 tickers

`fetchEodhdScreener` boucle l'offset jusqu'au minimum entre :
- `ceil(SCANNER_UNIVERSE_MAX_TICKERS / nbExchanges)` par exchange
- retour `< SCANNER_SCREENER_PAGE_SIZE` (fin de liste)
- **10 pages max** par exchange (anti-runaway)

Defaults : `pageSize=100`, `universeMax=1500` (cap 3000). Log par page : `[top-gainers] screener ${ex} fetched ${total} mapped in ${pages} pages`.

Bump à 3000 = manuel via secret `SCANNER_UNIVERSE_MAX_TICKERS=3000` (jour 7 du plan déploiement §8).

### 3.7 — Garde cycle < 5 min levée conditionnellement

Le warn `interval <5min risque rate-limit` est désormais skippé si `TWELVEDATA_INTRADAY_SCANNER_ENABLED=true`. Default `TOP_GAINERS_SCAN_INTERVAL_MIN=5` inchangé — bascule 1 min = manuelle (jour 10 du plan).

## Variables d'env ajoutées (toutes optionnelles, defaults safe)

| Var | Type | Default | Effet |
|---|---|---|---|
| `TWELVEDATA_PER_MINUTE_LIMIT` | int | 8000 | Override quota Pro minute |
| `TWELVEDATA_PER_DAY_LIMIT` | int | 1000000 | Override quota Pro jour |
| `TWELVEDATA_INTRADAY_SCANNER_ENABLED` | bool | false | Active routage TD-first |
| `TWELVEDATA_INTRADAY_AB_TEST_RATIO` | float [0..1] | 1.0 | Fraction symbols routés TD |
| `SCANNER_UNIVERSE_MAX_TICKERS` | int | 1500 | Cap univers total (max 3000) |
| `SCANNER_SCREENER_PAGE_SIZE` | int | 100 | Page size screener EODHD (max 500) |

Flags PR #345 (`TWELVEDATA_FILTER_US_SUPERTREND_ENABLED`, `TWELVEDATA_FILTER_CRYPTO_RSI_ENABLED`) inchangés.

## Tests

| Suite | Cas | Statut |
|---|---:|---|
| `twelve-data.service.spec.ts` (sections 3.1 + 3.2) | 41 | ✅ |
| `intraday-provider-router.spec.ts` (3.3) | 16 | ✅ |
| `multi-tf-persistence.p18e.spec.ts` (régression) | 16 | ✅ |
| `multi-tf-persistence.p19i.spec.ts` (régression) | 10 | ✅ |
| `top-gainers-scanner.*` (régression, 10 specs) | 115 | ✅ |
| **Total** | **198** | **✅** |

Typecheck full repo OK. Aucune migration DB.

## Sécurité / fail-safe

- `TWELVEDATA_API_KEY` absent → service TD warn une fois, router 100% EODHD
- Flag OFF → router 100% EODHD passthrough
- TD null/empty → fallback EODHD obligatoire
- CreditTracker rate limit hit → TD retourne null → fallback EODHD
- Symbol unmappable (asia/HK) → fallback EODHD direct
- **Kill-switch** : `flyctl secrets set TWELVEDATA_INTRADAY_SCANNER_ENABLED=false --app smartvest`

Le router est strictement **additif** — aucun cas de figure ne dégrade le scanner.

## Plan déploiement (cf. brief §8)

| Jour | Action |
|---|---|
| J0 (merge) | Flags OFF, cycle 5min EODHD inchangé |
| J1 | `TWELVEDATA_INTRADAY_SCANNER_ENABLED=true` + ratio 0.2 |
| J3 | Ratio 0.5 si métriques OK |
| J5 | Ratio 1.0 |
| J7 | `SCANNER_UNIVERSE_MAX_TICKERS=3000` |
| J10 | `TOP_GAINERS_SCAN_INTERVAL_MIN=1` |

Critères GO/NO_GO à T+24h :
- `pct_quote_success_td >= 95%`
- `pct_fallback_eodhd <= 10%`
- `wr_global_td_routed >= wr_global_eodhd_routed - 3 pts`
- `pnl_jour_global >= baseline J-1`

## Notes

- **Auto-merge OFF** (cf. brief §10) — l'opérateur cron mergera après validation T+2h
- Aucun secret posé depuis cette PR
- Brief §10 demandait de "lister chaque call site rencontré et choisir explicitement lesquels migrer" → fait, cf. tableau §3.5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_