### PR TITLE
feat(intraday-router): PR #353 — câblage universel + asia mapping + dual-call

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
@@ -1,17 +1,15 @@
 /**
- * PR #352 — Tests IntradayProviderRouter.
+ * PR #352/PR #353 — Tests IntradayProviderRouter dual-call.
  *
  * Couverture :
- *   - Flag OFF → 100% EODHD (passthrough)
- *   - Flag ON + ratio 1.0 → 100% TD (mock TD success)
- *   - Flag ON + ratio 0.0 → 100% EODHD
- *   - Flag ON + ratio 0.5 → ~50/50 (statistique sur 100 symbols)
- *   - TD null → fallback EODHD obligatoire
- *   - TD success → EODHD jamais appelé
- *   - Symbol asia (.KO) → routed EODHD direct (unmappable)
- *   - Symbol US → routed TD si flag ON
- *   - Hash déterministe : shouldRouteToTd retourne toujours pareil
- *   - Sans TwelveDataService injecté → 100% EODHD
+ *   - Flag OFF → EODHD only (TD jamais appelé)
+ *   - Flag ON + symbol mappable + ratio positif → dual-call EODHD + TD
+ *   - TD null/empty → EODHD prend la main, mais EODHD reste appelé
+ *   - TD success → préféré, MAIS EODHD reste appelé en parallèle
+ *   - Symbol unmappable (suffixe inconnu) → EODHD only
+ *   - options.fromTs/toTs → EODHD only (TD ne supporte pas time-range)
+ *   - convertToTdSymbol couvre US, EU, asia (KO/KQ/SHG/SHE/HK/T/AU)
+ *   - Hash A/B déterministe par symbol
  */
 
 import { Logger } from '@nestjs/common';
@@ -36,15 +34,21 @@ function makeEodhdMock(opts?: {
   service: EodhdIntradayService;
   quoteCalls: number;
   candlesCalls: number;
+  lastCandlesOptions: unknown;
 } {
-  const counters = { quoteCalls: 0, candlesCalls: 0 };
+  const counters = {
+    quoteCalls: 0,
+    candlesCalls: 0,
+    lastCandlesOptions: undefined as unknown,
+  };
   const service = {
     getQuote: (_t: string) => {
       counters.quoteCalls += 1;
       return Promise.resolve(opts?.quote ?? null);
     },
-    getCandles: (_t: string, _i: '1m' | '5m' | '1h', _c: number) => {
+    getCandles: (_t: string, _i: '1m' | '5m' | '1h', _c: number, options?: unknown) => {
       counters.candlesCalls += 1;
+      counters.lastCandlesOptions = options;
       return Promise.resolve(opts?.candles ?? null);
     },
   } as unknown as EodhdIntradayService;
@@ -56,6 +60,9 @@ function makeEodhdMock(opts?: {
     get candlesCalls() {
       return counters.candlesCalls;
     },
+    get lastCandlesOptions() {
+      return counters.lastCandlesOptions;
+    },
   };
 }
 
@@ -66,15 +73,22 @@ function makeTdMock(opts?: {
   service: TwelveDataService;
   quoteCalls: number;
   candlesCalls: number;
+  lastSymbol: string | null;
 } {
-  const counters = { quoteCalls: 0, candlesCalls: 0 };
+  const counters = {
+    quoteCalls: 0,
+    candlesCalls: 0,
+    lastSymbol: null as string | null,
+  };
   const service = {
-    getQuote: (_s: string, _by?: string) => {
+    getQuote: (s: string, _by?: string) => {
       counters.quoteCalls += 1;
+      counters.lastSymbol = s;
       return Promise.resolve(opts?.quote ?? null);
     },
-    getCandles: (_s: string, _i: string, _o?: number, _by?: string) => {
+    getCandles: (s: string, _i: string, _o?: number, _by?: string) => {
       counters.candlesCalls += 1;
+      counters.lastSymbol = s;
       return Promise.resolve(opts?.candles ?? null);
     },
   } as unknown as TwelveDataService;
@@ -86,6 +100,9 @@ function makeTdMock(opts?: {
     get candlesCalls() {
       return counters.candlesCalls;
     },
+    get lastSymbol() {
+      return counters.lastSymbol;
+    },
   };
 }
 
@@ -94,23 +111,19 @@ const EODHD_OK_QUOTE = { price: 180.4, changePct: 1.1, timestamp: 1747353500000 
 const TD_OK_CANDLES = {
   symbol: 'AAPL',
   interval: '1min',
-  candles: [
-    { timestamp: 1747353600, open: 1, high: 1, low: 1, close: 180.5, volume: 100 },
-  ],
+  candles: [{ timestamp: 1747353600, open: 1, high: 1, low: 1, close: 180.5, volume: 100 }],
   asOf: 1747353600000,
 };
 const EODHD_OK_CANDLES = {
   ticker: 'AAPL.US',
   interval: '1m' as const,
-  candles: [
-    { timestamp: 1747353500, open: 1, high: 1, low: 1, close: 180.4, volume: 100 },
-  ],
+  candles: [{ timestamp: 1747353500, open: 1, high: 1, low: 1, close: 180.4, volume: 100 }],
   asOf: 1747353500000,
 };
 
-describe('IntradayProviderRouter — PR #352', () => {
-  describe('flag OFF → 100% EODHD', () => {
-    it('getQuote utilise EODHD, jamais TD', async () => {
+describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
+  describe('flag OFF → EODHD only', () => {
+    it('getQuote n\'appelle jamais TD', async () => {
       const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
       const td = makeTdMock({ quote: TD_OK_QUOTE });
       const router = new IntradayProviderRouter(
@@ -119,14 +132,12 @@ describe('IntradayProviderRouter — PR #352', () => {
         td.service,
       );
       const r = await router.getQuote('AAPL.US');
-      expect(r).not.toBeNull();
       expect(r!.provider).toBe('eodhd');
-      expect(r!.price).toBe(EODHD_OK_QUOTE.price);
       expect(eodhd.quoteCalls).toBe(1);
       expect(td.quoteCalls).toBe(0);
     });
 
-    it('getCandles utilise EODHD, jamais TD', async () => {
+    it('getCandles n\'appelle jamais TD', async () => {
       const eodhd = makeEodhdMock({ candles: EODHD_OK_CANDLES });
       const td = makeTdMock({ candles: TD_OK_CANDLES });
       const router = new IntradayProviderRouter(
@@ -135,15 +146,14 @@ describe('IntradayProviderRouter — PR #352', () => {
         td.service,
       );
       const r = await router.getCandles('AAPL.US', '1m', 20);
-      expect(r).not.toBeNull();
       expect(r!.provider).toBe('eodhd');
       expect(eodhd.candlesCalls).toBe(1);
       expect(td.candlesCalls).toBe(0);
     });
   });
 
-  describe('flag ON + ratio 1.0 → 100% TD', () => {
-    it('getQuote utilise TD, EODHD jamais appelé', async () => {
+  describe('flag ON + ratio 1.0 → dual-call EODHD + TD', () => {
+    it('getQuote appelle EODHD ET TD, préfère TD si succès', async () => {
       const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
       const td = makeTdMock({ quote: TD_OK_QUOTE });
       const router = new IntradayProviderRouter(
@@ -157,11 +167,12 @@ describe('IntradayProviderRouter — PR #352', () => {
       const r = await router.getQuote('AAPL.US');
       expect(r!.provider).toBe('td');
       expect(r!.price).toBe(TD_OK_QUOTE.price);
+      // EODHD ET TD appelés en parallèle (contrainte user ZERO offload)
+      expect(eodhd.quoteCalls).toBe(1);
       expect(td.quoteCalls).toBe(1);
-      expect(eodhd.quoteCalls).toBe(0);
     });
 
-    it('getCandles 1m utilise TD avec interval mappé 1min', async () => {
+    it('getCandles 1m appelle TD avec symbol mappé', async () => {
       const eodhd = makeEodhdMock({ candles: EODHD_OK_CANDLES });
       const td = makeTdMock({ candles: TD_OK_CANDLES });
       const router = new IntradayProviderRouter(
@@ -174,55 +185,14 @@ describe('IntradayProviderRouter — PR #352', () => {
       );
       const r = await router.getCandles('AAPL.US', '1m', 20);
       expect(r!.provider).toBe('td');
-      expect(r!.candles).toHaveLength(1);
-      expect(r!.candles[0].close).toBe(180.5);
+      expect(td.lastSymbol).toBe('AAPL');
+      expect(eodhd.candlesCalls).toBe(1);
       expect(td.candlesCalls).toBe(1);
-      expect(eodhd.candlesCalls).toBe(0);
     });
   });
 
-  describe('flag ON + ratio 0.0 → 100% EODHD', () => {
-    it('getQuote utilise EODHD, TD jamais appelé', async () => {
-      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
-      const td = makeTdMock({ quote: TD_OK_QUOTE });
-      const router = new IntradayProviderRouter(
-        makeConfig({
-          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
-          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '0.0',
-        }),
-        eodhd.service,
-        td.service,
-      );
-      await router.getQuote('AAPL.US');
-      expect(eodhd.quoteCalls).toBe(1);
-      expect(td.quoteCalls).toBe(0);
-    });
-  });
-
-  describe('flag ON + ratio 0.5 → ~50/50 split déterministe', () => {
-    it('100 symbols différents → entre 30 et 70 routés TD', async () => {
-      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
-      const td = makeTdMock({ quote: TD_OK_QUOTE });
-      const router = new IntradayProviderRouter(
-        makeConfig({
-          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
-          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '0.5',
-        }),
-        eodhd.service,
-        td.service,
-      );
-      for (let i = 0; i < 100; i++) {
-        await router.getQuote(`SYM${i}.US`);
-      }
-      // Distribution attendue ~50/50, on accepte large [30..70]
-      expect(td.quoteCalls).toBeGreaterThanOrEqual(30);
-      expect(td.quoteCalls).toBeLessThanOrEqual(70);
-      expect(eodhd.quoteCalls).toBe(100 - td.quoteCalls);
-    });
-  });
-
-  describe('TD null → fallback EODHD', () => {
-    it('getQuote : TD null → EODHD appelé, provider=eodhd', async () => {
+  describe('TD null/empty → fallback EODHD (EODHD reste appelé)', () => {
+    it('TD null → return EODHD, EODHD compté 1×', async () => {
       const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
       const td = makeTdMock({ quote: null });
       const router = new IntradayProviderRouter(
@@ -239,26 +209,11 @@ describe('IntradayProviderRouter — PR #352', () => {
       expect(eodhd.quoteCalls).toBe(1);
     });
 
-    it('getCandles : TD null → EODHD fallback', async () => {
+    it('TD candles=[] → fallback EODHD', async () => {
       const eodhd = makeEodhdMock({ candles: EODHD_OK_CANDLES });
-      const td = makeTdMock({ candles: null });
-      const router = new IntradayProviderRouter(
-        makeConfig({
-          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
-          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
-        }),
-        eodhd.service,
-        td.service,
-      );
-      const r = await router.getCandles('AAPL.US', '1m', 20);
-      expect(r!.provider).toBe('eodhd');
-      expect(td.candlesCalls).toBe(1);
-      expect(eodhd.candlesCalls).toBe(1);
-    });
-
-    it('getCandles : TD candles=[] → EODHD fallback', async () => {
-      const eodhd = makeEodhdMock({ candles: EODHD_OK_CANDLES });
-      const td = makeTdMock({ candles: { symbol: 'AAPL', interval: '1min', candles: [], asOf: 0 } });
+      const td = makeTdMock({
+        candles: { symbol: 'AAPL', interval: '1min', candles: [], asOf: 0 },
+      });
       const router = new IntradayProviderRouter(
         makeConfig({
           TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
@@ -274,10 +229,10 @@ describe('IntradayProviderRouter — PR #352', () => {
     });
   });
 
-  describe('TD success → EODHD jamais appelé', () => {
-    it('getQuote TD OK', async () => {
-      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
-      const td = makeTdMock({ quote: TD_OK_QUOTE });
+  describe('options.fromTs/toTs → EODHD only (pas de TD)', () => {
+    it('fromTs présent → TD pas appelé, EODHD appelé avec options propagées', async () => {
+      const eodhd = makeEodhdMock({ candles: EODHD_OK_CANDLES });
+      const td = makeTdMock({ candles: TD_OK_CANDLES });
       const router = new IntradayProviderRouter(
         makeConfig({
           TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
@@ -286,15 +241,17 @@ describe('IntradayProviderRouter — PR #352', () => {
         eodhd.service,
         td.service,
       );
-      await router.getQuote('AAPL.US');
-      expect(eodhd.quoteCalls).toBe(0);
+      await router.getCandles('AAPL.US', '5m', 20, { fromTs: 1000, toTs: 2000 });
+      expect(td.candlesCalls).toBe(0);
+      expect(eodhd.candlesCalls).toBe(1);
+      expect(eodhd.lastCandlesOptions).toEqual({ fromTs: 1000, toTs: 2000 });
     });
   });
 
-  describe('Symbol unmappable (asia/HK) → EODHD direct', () => {
-    it('.KO → EODHD direct, TD jamais appelé', async () => {
-      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
-      const td = makeTdMock({ quote: TD_OK_QUOTE });
+  describe('Symbol unmappable → EODHD only', () => {
+    it('suffixe .XYZ inconnu → EODHD only', async () => {
+      const eodhd = makeEodhdMock({ candles: EODHD_OK_CANDLES });
+      const td = makeTdMock({ candles: TD_OK_CANDLES });
       const router = new IntradayProviderRouter(
         makeConfig({
           TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
@@ -303,44 +260,74 @@ describe('IntradayProviderRouter — PR #352', () => {
         eodhd.service,
         td.service,
       );
-      const r = await router.getQuote('005930.KO');
-      expect(r!.provider).toBe('eodhd');
-      expect(td.quoteCalls).toBe(0);
-      expect(eodhd.quoteCalls).toBe(1);
-    });
-
-    it('.HK / .T / .AU / .SHG / .SHE → unmappable', () => {
-      const router = new IntradayProviderRouter(
-        makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true' }),
-        makeEodhdMock().service,
-        makeTdMock().service,
-      );
-      expect(router.convertToTdSymbol('0700.HK')).toBeNull();
-      expect(router.convertToTdSymbol('7203.T')).toBeNull();
-      expect(router.convertToTdSymbol('CBA.AU')).toBeNull();
-      expect(router.convertToTdSymbol('600519.SHG')).toBeNull();
-      expect(router.convertToTdSymbol('300024.SHE')).toBeNull();
-    });
-
-    it('mapping suffixes connus', () => {
-      const router = new IntradayProviderRouter(
-        makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true' }),
-        makeEodhdMock().service,
-        makeTdMock().service,
-      );
-      expect(router.convertToTdSymbol('AAPL.US')).toBe('AAPL');
-      expect(router.convertToTdSymbol('AAPL')).toBe('AAPL'); // sans suffixe
-      expect(router.convertToTdSymbol('BARC.LSE')).toBe('BARC:LSE');
-      expect(router.convertToTdSymbol('BARC.L')).toBe('BARC:LSE');
-      expect(router.convertToTdSymbol('BNP.PA')).toBe('BNP:Euronext');
-      expect(router.convertToTdSymbol('BMW.XETRA')).toBe('BMW:XETR');
-      expect(router.convertToTdSymbol('BMW.DE')).toBe('BMW:XETR');
-      expect(router.convertToTdSymbol('NESN.SW')).toBe('NESN:SIX');
+      await router.getCandles('SOMETHING.XYZ', '1m', 20);
+      expect(td.candlesCalls).toBe(0);
+      expect(eodhd.candlesCalls).toBe(1);
     });
   });
 
-  describe('Hash déterministe', () => {
-    it('shouldRouteToTd(symbol) retourne toujours pareil pour le même symbol', () => {
+  describe('convertToTdSymbol — US + EU + asia (PR #353)', () => {
+    const router = new IntradayProviderRouter(
+      makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true' }),
+      makeEodhdMock().service,
+      makeTdMock().service,
+    );
+
+    it.each([
+      ['AAPL', 'AAPL'], // sans suffixe
+      ['AAPL.US', 'AAPL'],
+      ['BARC.LSE', 'BARC:LSE'],
+      ['BARC.L', 'BARC:LSE'],
+      ['BNP.PA', 'BNP:Euronext'],
+      ['ASML.AS', 'ASML:Euronext'],
+      ['BMW.XETRA', 'BMW:XETR'],
+      ['BMW.DE', 'BMW:XETR'],
+      ['NESN.SW', 'NESN:SIX'],
+      ['STM.MI', 'STM:MIL'],
+      ['SHOP.TO', 'SHOP:TSX'],
+      // PR #353 — asia (76% du trafic intraday)
+      ['005930.KO', '005930:KRX'], // Samsung KOSPI
+      ['086790.KQ', '086790:KRX'], // KOSDAQ
+      ['600519.SHG', '600519:SSE'], // Shanghai
+      ['300024.SHE', '300024:SZSE'], // Shenzhen
+      ['0700.HK', '0700:HKEX'], // Tencent HK
+      ['7203.T', '7203:XTKS'], // Toyota Tokyo
+      ['CBA.AU', 'CBA:XASX'], // ASX
+    ])('%s → %s', (input, expected) => {
+      expect(router.convertToTdSymbol(input)).toBe(expected);
+    });
+
+    it.each([
+      'SOMETHING.XYZ',
+      'FOO.BAR',
+      'TEST.ZZZ',
+    ])('%s → null (suffixe inconnu)', (input) => {
+      expect(router.convertToTdSymbol(input)).toBeNull();
+    });
+  });
+
+  describe('A/B ratio déterministe par symbol', () => {
+    it('ratio 0.5 → ~50/50 split sur 100 symbols', async () => {
+      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      const td = makeTdMock({ quote: TD_OK_QUOTE });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '0.5',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      for (let i = 0; i < 100; i++) {
+        await router.getQuote(`SYM${i}.US`);
+      }
+      // EODHD toujours appelé 100×, TD appelé ~50× (entre 30 et 70)
+      expect(eodhd.quoteCalls).toBe(100);
+      expect(td.quoteCalls).toBeGreaterThanOrEqual(30);
+      expect(td.quoteCalls).toBeLessThanOrEqual(70);
+    });
+
+    it('shouldRouteToTd déterministe pour un même symbol', () => {
       const router = new IntradayProviderRouter(
         makeConfig({
           TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
@@ -354,10 +341,41 @@ describe('IntradayProviderRouter — PR #352', () => {
         expect(router.shouldRouteToTd('AAPL')).toBe(first);
       }
     });
+
+    it('ratio 0.0 → TD jamais appelé', async () => {
+      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      const td = makeTdMock({ quote: TD_OK_QUOTE });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '0.0',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      await router.getQuote('AAPL.US');
+      expect(td.quoteCalls).toBe(0);
+      expect(eodhd.quoteCalls).toBe(1);
+    });
+
+    it('ratio invalide ("2.0") → fallback 1.0 (100% TD)', async () => {
+      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      const td = makeTdMock({ quote: TD_OK_QUOTE });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '2.0',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      await router.getQuote('AAPL.US');
+      expect(td.quoteCalls).toBe(1);
+    });
   });
 
-  describe('Sans TwelveDataService injecté → 100% EODHD', () => {
-    it('getQuote utilise EODHD même si flag ON', async () => {
+  describe('Sans TwelveDataService injecté → EODHD only', () => {
+    it('flag ON mais td=null → EODHD only', async () => {
       const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
       const router = new IntradayProviderRouter(
         makeConfig({
@@ -373,20 +391,42 @@ describe('IntradayProviderRouter — PR #352', () => {
     });
   });
 
-  describe('Ratio invalide → fallback à 1.0', () => {
-    it('ratio="-1" ou "2.0" → 100% TD (default 1.0)', async () => {
-      const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
-      const td = makeTdMock({ quote: TD_OK_QUOTE });
+  describe('Asia routing — scénario PR #353 (76% du trafic)', () => {
+    it('005930.KO routé vers TD avec symbol mappé 005930:KRX', async () => {
+      const eodhd = makeEodhdMock({
+        candles: { ...EODHD_OK_CANDLES, ticker: '005930.KO' },
+      });
+      const td = makeTdMock({
+        candles: { ...TD_OK_CANDLES, symbol: '005930:KRX' },
+      });
       const router = new IntradayProviderRouter(
         makeConfig({
           TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
-          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '2.0',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
         }),
         eodhd.service,
         td.service,
       );
-      await router.getQuote('AAPL.US');
-      expect(td.quoteCalls).toBe(1);
+      const r = await router.getCandles('005930.KO', '5m', 100, { calledBy: 'shadow_walkforward' });
+      expect(r!.provider).toBe('td');
+      expect(td.lastSymbol).toBe('005930:KRX');
+      expect(eodhd.candlesCalls).toBe(1);
+      expect(td.candlesCalls).toBe(1);
+    });
+
+    it('600519.SHG routé vers TD avec symbol 600519:SSE', async () => {
+      const eodhd = makeEodhdMock({ candles: EODHD_OK_CANDLES });
+      const td = makeTdMock({ candles: TD_OK_CANDLES });
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
+        }),
+        eodhd.service,
+        td.service,
+      );
+      await router.getCandles('600519.SHG', '1m', 20);
+      expect(td.lastSymbol).toBe('600519:SSE');
     });
   });
 });

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { EodhdIntradayService } from './eodhd-intraday.service';
+import { IntradayProviderRouter } from './intraday-provider-router.service';
 import { YahooIntradayService } from './yahoo-intraday.service';
 import { BinanceMarketService } from './binance-market.service';
 import { bootstrapMeanCI, verdictFromCI, GateVerdict } from '@smartvest/ai-analyst';
@@ -535,6 +536,9 @@ export class GainersUserShadowService {
      * Si non injecté OU flag off → short-circuit legacy crypto_not_supported préservé.
      */
     private readonly binance?: BinanceMarketService,
+    // PR #353 — Router intraday dual-call EODHD + TD. Optional pour back-compat
+    // avec tests qui n'injectent pas le router (fallback EODHD direct préservé).
+    private readonly intradayRouter?: IntradayProviderRouter,
   ) {}
 
   /**
@@ -921,30 +925,47 @@ export class GainersUserShadowService {
       fn: () => Promise<{ candles: Array<{ timestamp: number; open: number; high: number; low: number; close: number; volume: number }>; rawCount?: number; requestedSymbol?: string } | null>;
       rangeMode: boolean;
     };
+    // PR #353 — router quand injecté, fallback EODHD direct sinon. Pour les
+    // call sites range (fromTs/toTs) le router branche EODHD-only mais logge
+    // structuré ; pour le call default (947) le router peut router vers TD.
+    const router = this.intradayRouter;
     const stepDefs: StepDef[] = [
       {
         endpoint: 'eodhd_getCandles_5m_range',
         interval: '5m',
         rangeMode: true,
-        fn: () => this.eodhd.getCandles(eodhdTicker, '5m', candleCount, { fromTs, toTs }).catch(() => null),
+        fn: () =>
+          (router
+            ? router.getCandles(eodhdTicker, '5m', candleCount, { fromTs, toTs, calledBy: 'shadow_walkforward' })
+            : this.eodhd.getCandles(eodhdTicker, '5m', candleCount, { fromTs, toTs })
+          ).catch(() => null),
       },
       {
         endpoint: 'eodhd_ticks_5m_range',
         interval: '5m',
         rangeMode: true,
+        // getCandlesViaTicks reste EODHD direct (pas dans l'API router).
         fn: () => this.eodhd.getCandlesViaTicks(eodhdTicker, '5m', candleCount, { fromTs, toTs }).catch(() => null),
       },
       {
         endpoint: 'eodhd_getCandles_1m_range',
         interval: '1m',
         rangeMode: true,
-        fn: () => this.eodhd.getCandles(eodhdTicker, '1m', 65, { fromTs, toTs }).catch(() => null),
+        fn: () =>
+          (router
+            ? router.getCandles(eodhdTicker, '1m', 65, { fromTs, toTs, calledBy: 'shadow_walkforward' })
+            : this.eodhd.getCandles(eodhdTicker, '1m', 65, { fromTs, toTs })
+          ).catch(() => null),
       },
       {
         endpoint: 'eodhd_getCandles_5m_default',
         interval: '5m',
         rangeMode: false,
-        fn: () => this.eodhd.getCandles(eodhdTicker, '5m', candleCount).catch(() => null),
+        fn: () =>
+          (router
+            ? router.getCandles(eodhdTicker, '5m', candleCount, { calledBy: 'shadow_walkforward' })
+            : this.eodhd.getCandles(eodhdTicker, '5m', candleCount)
+          ).catch(() => null),
       },
     ];
 

--- a/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
+++ b/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
@@ -4,21 +4,29 @@ import { TwelveDataService } from './twelve-data.service';
 import { EodhdIntradayService, type CandleSeries } from './eodhd-intraday.service';
 
 /**
- * PR #352 — Routeur intraday TwelveData-first avec fallback EODHD.
+ * PR #352 (original) — Routeur intraday TwelveData-first avec fallback EODHD.
+ * PR #353 (cette PR) — Cablage universel + asia mapping + dual-call.
  *
  * Activation :
  *   TWELVEDATA_INTRADAY_SCANNER_ENABLED  bool string  (default false)
  *   TWELVEDATA_INTRADAY_AB_TEST_RATIO    float [0..1] (default 1.0 = 100% TD)
  *
- * Routage :
- *   - Flag OFF → 100% EODHD passthrough
- *   - Flag ON  → hash(symbol) % 100 < ratio*100 → TD, sinon EODHD
- *   - TD null   → fallback EODHD obligatoire
- *   - Symbol non mappable TD (asia/HK exotiques) → fallback EODHD direct
+ * Architecture dual-call (PR #353) :
+ *   Quand TD est éligible (flag ON + ratio + symbol mappable + pas de
+ *   fenêtre historique fromTs/toTs), on appelle EODHD ET TD en parallèle
+ *   via Promise.allSettled — pas de fallback séquentiel.
  *
- * Fail-safe : si TwelveDataService non injecté (clé absente) OU flag OFF →
- * 100% EODHD. Le router est strictement additif, ne peut pas dégrader le
- * scanner existant.
+ *   - Préfère TD si retour non vide et valide
+ *   - Sinon EODHD comme source de vérité
+ *   - EODHD reste TOUJOURS appelé (contrainte user "ZERO offload")
+ *   - Log structuré `intraday_router_dual_call` sur chaque appel
+ *
+ * Branche EODHD-only (pas de TD) si :
+ *   - flag OFF / pas de TwelveDataService injecté
+ *   - symbol non mappable TD (suffixe inconnu)
+ *   - hash % 100 >= ratio*100 (A/B négatif sur ce symbol)
+ *   - options.fromTs ou options.toTs présent (TD ne supporte pas time-range
+ *     simple dans notre wrapper, historique = EODHD only)
  *
  * Kill-switch instantané :
  *   flyctl secrets set TWELVEDATA_INTRADAY_SCANNER_ENABLED=false --app smartvest
@@ -32,6 +40,15 @@ export interface IntradayQuote {
 }
 
 export type IntradayCandleSeries = CandleSeries & { provider: 'td' | 'eodhd' };
+
+export interface IntradayCandlesOptions {
+  /** Historical window start (epoch seconds). Si présent → EODHD only. */
+  fromTs?: number;
+  /** Historical window end (epoch seconds). Si présent → EODHD only. */
+  toTs?: number;
+  /** Étiquette du caller pour logs Supabase (twelve_data_request_log.called_by). */
+  calledBy?: string;
+}
 
 @Injectable()
 export class IntradayProviderRouter {
@@ -84,89 +101,156 @@ export class IntradayProviderRouter {
 
   /**
    * Quote temps réel. Caller passe un ticker EODHD-style (ex `AAPL.US`,
-   * `005930.KO`). Le router convertit pour TD si nécessaire.
+   * `005930.KO`). Dual-call EODHD+TD si éligible.
    */
-  async getQuote(eodhdTicker: string): Promise<IntradayQuote | null> {
-    if (this.shouldRouteToTd(eodhdTicker) && this.td) {
-      const tdSymbol = this.convertToTdSymbol(eodhdTicker);
-      if (tdSymbol !== null) {
-        const tdResult = await this.td.getQuote(tdSymbol, 'intraday_router');
-        if (tdResult) {
-          this.logger.debug(
-            `[intraday-router] ${eodhdTicker} provider=td source=primary price=${tdResult.price}`,
-          );
-          return { ...tdResult, provider: 'td' };
-        }
-        this.logger.debug(
-          `[intraday-router] ${eodhdTicker} provider=td source=fallback (td returned null)`,
-        );
-      } else {
-        this.logger.debug(
-          `[intraday-router] ${eodhdTicker} provider=eodhd source=fallback (td unmappable)`,
-        );
-      }
-    }
-    const eodhdResult = await this.eodhd.getQuote(eodhdTicker);
-    if (!eodhdResult) return null;
-    return { ...eodhdResult, provider: 'eodhd' };
+  async getQuote(eodhdTicker: string, calledBy = 'intraday_router'): Promise<IntradayQuote | null> {
+    const tdSymbol = this.shouldRouteToTd(eodhdTicker) ? this.convertToTdSymbol(eodhdTicker) : null;
+    const tdEligible = tdSymbol !== null && this.td !== null;
+
+    const eodhdPromise = this.eodhd.getQuote(eodhdTicker);
+    const tdPromise = tdEligible
+      ? this.td!.getQuote(tdSymbol!, calledBy)
+      : Promise.resolve(null);
+
+    const [eodhdResult, tdResult] = await Promise.allSettled([eodhdPromise, tdPromise]);
+    const eodhdVal =
+      eodhdResult.status === 'fulfilled' && eodhdResult.value !== null ? eodhdResult.value : null;
+    const tdVal =
+      tdResult.status === 'fulfilled' && tdResult.value !== null ? tdResult.value : null;
+
+    this.logger.log(
+      JSON.stringify({
+        event: 'intraday_router_dual_call',
+        endpoint: 'quote',
+        symbol: eodhdTicker,
+        td_symbol: tdSymbol,
+        td_attempted: tdEligible,
+        td_success: tdVal !== null,
+        eodhd_success: eodhdVal !== null,
+        called_by: calledBy,
+      }),
+    );
+
+    if (tdVal !== null) return { ...tdVal, provider: 'td' };
+    if (eodhdVal !== null) return { ...eodhdVal, provider: 'eodhd' };
+    return null;
   }
 
   /**
-   * Candles intraday au format CandleSeries (compat caller scanner). TD
-   * interval mapping : 1m → 1min, 5m → 5min, 1h → 1h.
+   * Candles intraday au format CandleSeries (compat caller scanner).
+   *
+   * Branches :
+   *   - options.fromTs / options.toTs présents → EODHD only (TD wrapper ne
+   *     supporte pas le time-range arbitraire)
+   *   - Symbol mappable TD + flag ON + ratio positif → dual-call parallèle,
+   *     préférer TD si non vide
+   *   - Sinon → EODHD only
+   *
+   * EODHD est TOUJOURS appelé (contrainte user "ZERO offload").
    */
   async getCandles(
     eodhdTicker: string,
     interval: '1m' | '5m' | '1h' = '1m',
     count = 20,
+    options: IntradayCandlesOptions = {},
   ): Promise<IntradayCandleSeries | null> {
-    if (this.shouldRouteToTd(eodhdTicker) && this.td) {
-      const tdSymbol = this.convertToTdSymbol(eodhdTicker);
-      if (tdSymbol !== null) {
-        const tdInterval = interval === '1m' ? '1min' : interval === '5m' ? '5min' : '1h';
-        const tdResult = await this.td.getCandles(tdSymbol, tdInterval, count, 'intraday_router');
-        if (tdResult && tdResult.candles.length > 0) {
-          this.logger.debug(
-            `[intraday-router] ${eodhdTicker} provider=td source=primary candles=${tdResult.candles.length}`,
-          );
-          return {
-            ticker: eodhdTicker,
-            interval,
-            candles: tdResult.candles,
-            asOf: tdResult.asOf,
-            rawCount: tdResult.candles.length,
-            provider: 'td',
-          };
-        }
-        this.logger.debug(
-          `[intraday-router] ${eodhdTicker} provider=td source=fallback (td empty/null)`,
-        );
-      } else {
-        this.logger.debug(
-          `[intraday-router] ${eodhdTicker} provider=eodhd source=fallback (td unmappable)`,
-        );
-      }
+    const calledBy = options.calledBy ?? 'intraday_router';
+    const hasTimeWindow = options.fromTs != null || options.toTs != null;
+    const tdSymbol = !hasTimeWindow && this.shouldRouteToTd(eodhdTicker)
+      ? this.convertToTdSymbol(eodhdTicker)
+      : null;
+    const tdEligible = tdSymbol !== null && this.td !== null;
+
+    const eodhdPromise = this.eodhd.getCandles(
+      eodhdTicker,
+      interval,
+      count,
+      hasTimeWindow
+        ? {
+            ...(options.fromTs != null ? { fromTs: options.fromTs } : {}),
+            ...(options.toTs != null ? { toTs: options.toTs } : {}),
+          }
+        : undefined,
+    );
+    const tdPromise = tdEligible
+      ? this.td!.getCandles(
+          tdSymbol!,
+          interval === '1m' ? '1min' : interval === '5m' ? '5min' : '1h',
+          count,
+          calledBy,
+        )
+      : Promise.resolve(null);
+
+    const [eodhdResult, tdResult] = await Promise.allSettled([eodhdPromise, tdPromise]);
+    const eodhdVal =
+      eodhdResult.status === 'fulfilled' && eodhdResult.value !== null ? eodhdResult.value : null;
+    const tdVal =
+      tdResult.status === 'fulfilled' && tdResult.value !== null && tdResult.value.candles.length > 0
+        ? tdResult.value
+        : null;
+
+    this.logger.log(
+      JSON.stringify({
+        event: 'intraday_router_dual_call',
+        endpoint: 'time_series',
+        symbol: eodhdTicker,
+        td_symbol: tdSymbol,
+        td_attempted: tdEligible,
+        td_success: tdVal !== null,
+        eodhd_success: eodhdVal !== null,
+        interval,
+        count,
+        time_window: hasTimeWindow,
+        called_by: calledBy,
+      }),
+    );
+
+    if (tdVal !== null) {
+      return {
+        ticker: eodhdTicker,
+        interval,
+        candles: tdVal.candles,
+        asOf: tdVal.asOf,
+        rawCount: tdVal.candles.length,
+        provider: 'td',
+      };
     }
-    const eodhdResult = await this.eodhd.getCandles(eodhdTicker, interval, count);
-    if (!eodhdResult) return null;
-    return { ...eodhdResult, provider: 'eodhd' };
+    if (eodhdVal !== null) return { ...eodhdVal, provider: 'eodhd' };
+    return null;
   }
 
   /**
    * Convertit ticker EODHD → symbol TwelveData.
-   *   EODHD : AAPL.US, 005930.KO, BMW.XETRA, BNP.PA, BARC.LSE
-   *   TD    : AAPL, (asia=null), BMW:XETR, BNP:Euronext, BARC:LSE
    *
-   * Conservateur : suffixe asia/HK/AU exotique → null → fallback EODHD direct.
-   * Évite signal pourri / symbol non reconnu côté TD.
+   * Mapping :
+   *   - Sans suffixe                  → ticker tel quel (US)
+   *   - .US                           → ticker nu (AAPL.US → AAPL)
+   *   - .L / .LSE                     → :LSE (London)
+   *   - .PA / .AS / .AMS              → :Euronext (Paris / Amsterdam)
+   *   - .XETRA / .DE                  → :XETR (Frankfurt)
+   *   - .SW                           → :SIX (Swiss)
+   *   - .MI                           → :MIL (Milan)
+   *   - .TO                           → :TSX (Toronto)
+   *
+   * PR #353 — extension asia (76% du trafic intraday actuel) :
+   *   - .KO  (KOSPI)                  → :KRX (Korea Exchange)
+   *   - .KQ  (KOSDAQ)                 → :KRX
+   *   - .SHG (Shanghai SSE)           → :SSE
+   *   - .SHE (Shenzhen SZSE)          → :SZSE
+   *   - .HK  (Hong Kong)              → :HKEX
+   *   - .T   (Tokyo)                  → :XTKS
+   *   - .AU  (ASX)                    → :XASX
+   *
+   * Suffixe inconnu → null → fallback EODHD direct (EODHD reste systématique
+   * de toute façon en dual-call).
    *
    * Visible pour tests.
    */
   convertToTdSymbol(eodhdTicker: string): string | null {
-    if (!eodhdTicker.includes('.')) return eodhdTicker; // US sans suffixe
+    if (!eodhdTicker.includes('.')) return eodhdTicker;
     const [base, suffix] = eodhdTicker.split('.');
     const map: Record<string, string> = {
-      US: '', // AAPL.US → AAPL
+      US: '',
       L: ':LSE',
       LSE: ':LSE',
       PA: ':Euronext',
@@ -177,8 +261,16 @@ export class IntradayProviderRouter {
       SW: ':SIX',
       MI: ':MIL',
       TO: ':TSX',
+      // PR #353 — asia mapping (TwelveData Pro)
+      KO: ':KRX',
+      KQ: ':KRX',
+      SHG: ':SSE',
+      SHE: ':SZSE',
+      HK: ':HKEX',
+      T: ':XTKS',
+      AU: ':XASX',
     };
-    if (!(suffix in map)) return null; // KO/KQ/SHG/SHE/HK/T/AU → fallback EODHD
+    if (!(suffix in map)) return null;
     return map[suffix] ? `${base}${map[suffix]}` : base;
   }
 }

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -42,6 +42,7 @@ import { PatternAdoptionService } from '../../bot-lab/services/pattern-adoption.
 import { LisaPerformanceAnalyticsService } from './lisa-performance-analytics.service';
 import { EodhdTechnicalService } from './eodhd-technical.service';
 import { EodhdIntradayService } from './eodhd-intraday.service';
+import { IntradayProviderRouter } from './intraday-provider-router.service';
 import { BinanceMarketService } from './binance-market.service';
 import { EodhdMacroService } from './eodhd-macro.service';
 import { EodhdScreenerService } from './eodhd-screener.service';
@@ -140,6 +141,8 @@ export class LisaService {
     // P1 PR E — direct access pour redditSpikeSigma (déjà injecté via newsAggregator
     // mais on a besoin du sigma rolling explicit, pas le résultat ranked)
     private readonly redditService: RedditService,
+    // PR #353 — Router intraday dual-call EODHD + TD pour summarizePositions.
+    private readonly intradayRouter: IntradayProviderRouter,
   ) {
     const anthropicKey = this.config.get<string>('ANTHROPIC_API_KEY');
     if (anthropicKey) {
@@ -1144,7 +1147,8 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
           );
         } else {
           tasks.push(
-            this.eodhdIntraday.getCandles(eodhdTicker, '5m', 20)
+            // PR #353 — router dual-call (TD + EODHD) si flag ON, EODHD only sinon.
+            this.intradayRouter.getCandles(eodhdTicker, '5m', 20, { calledBy: 'lisa_summarize' })
               .then((series) => {
                 if (series) intradayBySymbol[pos.symbol] = this.eodhdIntraday.summarize(series);
               })

--- a/apps/api/src/modules/lisa/services/post-sl-backfill.service.ts
+++ b/apps/api/src/modules/lisa/services/post-sl-backfill.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { EodhdIntradayService } from './eodhd-intraday.service';
+import { IntradayProviderRouter } from './intraday-provider-router.service';
 import {
   computePostSlAnalysis,
   type OhlcCandle,
@@ -29,6 +30,11 @@ export class PostSlBackfillService implements OnApplicationBootstrap {
   constructor(
     private readonly supabase: SupabaseService,
     private readonly eodhd: EodhdIntradayService,
+    // PR #353 — Router intraday. Tous les call sites de ce service utilisent
+    // fromTs/toTs → router branche EODHD-only (TD wrapper ne supporte pas
+    // time-range arbitraire), mais l'unification API permet logging structuré
+    // et bascule future si TD ajoute le support.
+    private readonly intradayRouter: IntradayProviderRouter,
   ) {}
 
   /**
@@ -103,8 +109,13 @@ export class PostSlBackfillService implements OnApplicationBootstrap {
     // Fetch 1m post-SL : window = [exitTs, exitTs + 30min + 60s buffer]
     const postFromTs = exitTs;
     const postToTs = exitTs + 30 * 60 + 60;
-    const seriesPost = await this.eodhd
-      .getCandles(String(pos.symbol), '1m', 35, { fromTs: postFromTs, toTs: postToTs })
+    // PR #353 — router (EODHD-only car fromTs/toTs présents, log structuré).
+    const seriesPost = await this.intradayRouter
+      .getCandles(String(pos.symbol), '1m', 35, {
+        fromTs: postFromTs,
+        toTs: postToTs,
+        calledBy: 'post_sl_backfill',
+      })
       .catch(() => null);
 
     if (!seriesPost || seriesPost.candles.length === 0) {
@@ -127,8 +138,13 @@ export class PostSlBackfillService implements OnApplicationBootstrap {
     // 14 ATR periods × 5min = 70min, +5min buffer
     const priorFromTs = exitTs - 75 * 60;
     const priorToTs = exitTs;
-    const seriesPrior = await this.eodhd
-      .getCandles(String(pos.symbol), '5m', 20, { fromTs: priorFromTs, toTs: priorToTs })
+    // PR #353 — router (EODHD-only car fromTs/toTs présents).
+    const seriesPrior = await this.intradayRouter
+      .getCandles(String(pos.symbol), '5m', 20, {
+        fromTs: priorFromTs,
+        toTs: priorToTs,
+        calledBy: 'post_sl_backfill',
+      })
       .catch(() => null);
 
     const candlesPriorAtr: OhlcCandle[] = seriesPrior?.candles

--- a/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
@@ -23,6 +23,7 @@ import {
 } from '../../gainers-scanner/bloc4/trailing-engine';
 import { PositionState, ExitReason } from '../../gainers-scanner/domain/gainers-enums';
 import { EodhdIntradayService } from './eodhd-intraday.service';
+import { IntradayProviderRouter } from './intraday-provider-router.service';
 import { BinanceMarketService } from './binance-market.service';
 import { ensureEodhdSuffix } from './eodhd-symbol.util';
 import { isLikelyOtcForeignOrdinaryUS } from './otc-prefilter.helper';
@@ -58,6 +59,9 @@ export class ShadowExitSimulatorService {
     private readonly supabase: SupabaseService,
     private readonly eodhd: EodhdIntradayService,
     private readonly binance: BinanceMarketService,
+    // PR #353 — Router intraday : dual-call EODHD + TD si flag ON.
+    // Conserve eodhd pour helpers (summarize, getCandlesViaTicks).
+    private readonly intradayRouter: IntradayProviderRouter,
   ) {}
 
   /** Cron 5 min — replay state machine pour signals ACCEPT non encore simulés. */
@@ -212,7 +216,10 @@ export class ShadowExitSimulatorService {
     if (isLikelyOtcForeignOrdinaryUS(eodhdTicker)) {
       return null;
     }
-    const series = await this.eodhd.getCandles(eodhdTicker, '1m', count);
+    // PR #353 — router dual-call (TD + EODHD) si éligible, sinon EODHD-only.
+    const series = await this.intradayRouter.getCandles(eodhdTicker, '1m', count, {
+      calledBy: 'shadow_exit_sim',
+    });
     return series ? series.candles.map((c) => ({ close: c.close })) : null;
   }
 


### PR DESCRIPTION
## Diagnostic (18/05 10h36 CEST, mesures live)

Router PR #352 actif mais **inerte** : `current_usage=1/1597` TD stable depuis 24h, `twelve_data_request_log` vide, alors que tous les secrets Fly sont posés (`TWELVEDATA_INTRADAY_SCANNER_ENABLED=true`, ratio 0.2).

**Root causes** :

1. **Router câblé sur 1 service / 6** — uniquement `multi-tf-persistence.service.ts` (PR #352). Les 5 autres services intraday bypassent.
2. **Asia non mappable** — 76% du trafic intraday est `.SHE/.SHG/.KQ/.KO`, mais `convertToTdSymbol` retournait `null` → fallback EODHD silent.
3. (Yahoo UA banni — hors scope cette PR.)

## Architecture AVANT → APRÈS

### AVANT (PR #352)
- Router : fallback séquentiel `TD → EODHD on null`
- Mapping TD : US + 8 suffixes EU. Asia/HK/T/AU → `null`
- Câblage : 3 sites dans `multi-tf-persistence` uniquement
- Comportement : si TD réussit, EODHD pas appelé (offload partiel)

### APRÈS (PR #353)
- Router : **dual-call** `Promise.allSettled([eodhd, td])`, préfère TD si non vide, EODHD reste appelé en parallèle (ZERO offload)
- Mapping TD : US + 8 EU + **7 nouveaux asia/HK** (`:KRX`, `:SSE`, `:SZSE`, `:HKEX`, `:XTKS`, `:XASX`)
- Câblage : **+4 services** (shadow-exit-simulator, post-sl-backfill, gainers-user-shadow, lisa.service summarize)
- Logs structurés `intraday_router_dual_call` JSON sur chaque appel

## Mapping asia étendu

| Suffix | Marché | Symbol TD |
|---|---|---|
| .KO | KOSPI | `:KRX` |
| .KQ | KOSDAQ | `:KRX` |
| .SHG | Shanghai SSE | `:SSE` |
| .SHE | Shenzhen SZSE | `:SZSE` |
| .HK | Hong Kong | `:HKEX` |
| .T | Tokyo | `:XTKS` |
| .AU | ASX | `:XASX` |

## Services migrés

| Service | Sites | calledBy | Notes |
|---|---:|---|---|
| `shadow-exit-simulator.service.ts` | 1 (l.219) | `shadow_exit_sim` | Direct |
| `post-sl-backfill.service.ts` | 2 (l.107, 141) | `post_sl_backfill` | `fromTs/toTs` → EODHD-only via router (log structuré) |
| `gainers-user-shadow.service.ts` | 3 (walkforward steps) | `shadow_walkforward` | Router `@Optional` pour back-compat tests. `getCandlesViaTicks` reste EODHD direct (API séparée) |
| `lisa.service.ts` summarize | 1 (l.1150) | `lisa_summarize` | Direct |

**Divergences brief documentées** :
- Brief listait `top-gainers-scanner.service.ts:1346` ; c'est en réalité une URL screener HTTP, pas un `getCandles` → hors scope router. Le scanner intraday passe déjà par `multi-tf-persistence` (câblé PR #352).
- Signature router conservée EODHD-style (`'1m'|'5m'|'1h'`, `count`, `options?`) pour back-compat. `options.calledBy` ajouté.

## Sémantique dual-call

```ts
async getCandles(eodhdTicker, interval, count, options) {
  const hasTimeWindow = options.fromTs != null || options.toTs != null;
  const tdSymbol = !hasTimeWindow && shouldRouteToTd(eodhdTicker)
    ? convertToTdSymbol(eodhdTicker) : null;
  const tdEligible = tdSymbol !== null && td !== null;

  // EODHD toujours appelé. TD en parallèle si éligible.
  const [eodhdRes, tdRes] = await Promise.allSettled([
    eodhd.getCandles(ticker, interval, count, hasTimeWindow ? {fromTs, toTs} : undefined),
    tdEligible ? td.getCandles(tdSymbol, ...) : Promise.resolve(null),
  ]);

  logger.log(JSON.stringify({ event: 'intraday_router_dual_call', ... }));

  if (tdRes ok et non vide) return TD;
  if (eodhdRes ok) return EODHD;
  return null;
}
```

**Branches EODHD-only** (TD skip) :
- Flag OFF ou TwelveDataService non injecté
- Suffix non mappable
- A/B hash négatif
- `options.fromTs` ou `options.toTs` présent (TD wrapper ne supporte pas time-range)

## Tests

| Suite | Cas | Statut |
|---|---:|---|
| `intraday-provider-router.spec.ts` (nouveau scope dual-call + asia) | 36 | ✅ |
| Régression Lisa module complet | 1611 | ✅ |

Typecheck full repo OK. Aucune migration DB.

## Plan rollout post-merge (cf. brief §5)

| Jour | Action | Critères GO |
|---|---|---|
| J0 (merge) | Garder ratio 0.2 | — |
| J+2 | Bump 0.5 si OK | `td_calls_24h >= 100` + latence < 500ms |
| J+4 | Bump 1.0 si OK | Idem + 0 régression trade |

## Critères validation T+24h post-deploy (SQL fournis dans brief §6)

```sql
-- Volume TD logué (cible >= 100 calls/jour)
SELECT COUNT(*), DATE_TRUNC('hour', timestamp) AS h
FROM twelve_data_request_log
WHERE timestamp >= NOW() - INTERVAL '24 hours'
GROUP BY h ORDER BY h;

-- Répartition called_by
SELECT called_by, COUNT(*) FROM twelve_data_request_log
WHERE timestamp >= NOW() - INTERVAL '24 hours' GROUP BY called_by;
```

Attendu : nouvelles entrées avec `called_by IN ('shadow_walkforward', 'shadow_exit_sim', 'post_sl_backfill', 'lisa_summarize', 'intraday_router')`.

## Contraintes user respectées

- ✅ EODHD reste appelé sur **100%** des tickers (dual-call parallèle, ZERO offload)
- ✅ Aucune dégradation : TD échoue → EODHD reste source de vérité
- ✅ Logging structuré sur tous call sites (provenance traçable)
- ✅ Pas de hardcode tokens (lecture env)
- ✅ Tests unitaires asia mapping (7 marchés couverts)
- ✅ Commit messages français cohérents
- ✅ Branche `feat/twelvedata-intraday-universal-cabling`

## Kill-switch

```bash
flyctl secrets set TWELVEDATA_INTRADAY_SCANNER_ENABLED=false --app smartvest
```

Aucun auto-merge — l'opérateur cron mergera après validation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_