### PR TITLE
feat(blacklist): PR #355 — 31 tickers DEAD + fix R10 empty-response

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/ticker-blacklist.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/ticker-blacklist.spec.ts
@@ -198,7 +198,7 @@ describe('TickerBlacklistService', () => {
       const t0 = Date.now();
       const stats = svc.getStats();
       expect(stats.staticEnabled).toBe(true);
-      expect(stats.staticSize).toBe(23); // PR #337 : 9 NSE + 13 asia empty + 1 saigneur
+      expect(stats.staticSize).toBe(54); // PR #337 (23) + PR #355 (31)
       expect(stats.dynamicCount).toBe(0);
 
       // Add a dynamic blacklist
@@ -218,6 +218,35 @@ describe('TickerBlacklistService', () => {
       expect(svc.isBlacklisted('A.LSE')).toBe(true);
       svc.clear();
       expect(svc.isBlacklisted('A.LSE')).toBe(false);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // PR #355 — recordStrike supporte HTTP_200_EMPTY (fix R10 silent)
+  //
+  // Avant : recordStrike fire uniquement sur HTTP 404 strict côté
+  // eodhd-intraday.service.ts:329. Les tickers asia/EU qui retournent
+  // 200 + body vide (~80% des cas réels) ne déclenchaient jamais le
+  // compteur. Désormais l'empty-response 200 fire aussi via reason
+  // 'HTTP_200_EMPTY'.
+  // ─────────────────────────────────────────────────────────────────────
+  describe('PR #355 — recordStrike sur HTTP_200_EMPTY', () => {
+    it('3 strikes HTTP_200_EMPTY → ticker blacklisté', () => {
+      const svc = makeService();
+      const t0 = Date.now();
+      svc.recordStrike('FOO.KQ', 'HTTP_200_EMPTY', t0);
+      svc.recordStrike('FOO.KQ', 'HTTP_200_EMPTY', t0 + 1);
+      svc.recordStrike('FOO.KQ', 'HTTP_200_EMPTY', t0 + 2);
+      expect(svc.isBlacklisted('FOO.KQ', t0 + 3)).toBe(true);
+    });
+
+    it('mix HTTP_404 + HTTP_200_EMPTY compte ensemble', () => {
+      const svc = makeService();
+      const t0 = Date.now();
+      svc.recordStrike('BAR.KO', 'HTTP_404', t0);
+      svc.recordStrike('BAR.KO', 'HTTP_200_EMPTY', t0 + 1);
+      svc.recordStrike('BAR.KO', 'HTTP_404', t0 + 2);
+      expect(svc.isBlacklisted('BAR.KO', t0 + 3)).toBe(true);
     });
   });
 });

--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -339,6 +339,12 @@ export class EodhdIntradayService {
         // Bug #R12 — log empty response with success=true (HTTP 200, no payload)
         // distinguishable from parsed-price rows by price_usd IS NULL.
         this.logCall({ ticker: eodhdTicker, success: true, statusCode: res.status, latencyMs });
+        // PR #355 — Fix R10 : enregistrer un strike empty 200 (avant : seul
+        // HTTP 404 firait recordStrike, donc les tickers asia/EU retournant
+        // 200+empty (~80% des cas) ne déclenchaient jamais l'auto-blacklist
+        // dynamique. Résultat : ~9000 calls gaspillés/24h. Désormais R10
+        // catch aussi cette branche silencieuse.
+        this.blacklist?.recordStrike(eodhdTicker, 'HTTP_200_EMPTY');
         return null;
       }
 

--- a/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
+++ b/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { TwelveDataService } from './twelve-data.service';
 import { EodhdIntradayService, type CandleSeries } from './eodhd-intraday.service';
+import { TickerBlacklistService } from './ticker-blacklist.service';
 
 /**
  * PR #352 (original) — Routeur intraday TwelveData-first avec fallback EODHD.
@@ -63,11 +64,15 @@ export class IntradayProviderRouter {
     private readonly config: ConfigService,
     private readonly eodhd: EodhdIntradayService,
     @Optional() private readonly td: TwelveDataService | null = null,
+    // PR #355 — check blacklist avant TD pour ne pas reporter le gaspillage
+    // côté TD (avant : EODHD short-circuit dans this.eodhd.getCandles, mais
+    // TD était appelé en parallèle sans aucun check).
+    @Optional() private readonly blacklist: TickerBlacklistService | null = null,
   ) {
     const enabled = this.isEnabled();
     const ratio = this.getRatio();
     this.logger.log(
-      `[intraday-router] init enabled=${enabled} ratio=${ratio} td=${this.td ? 'available' : 'unavailable'}`,
+      `[intraday-router] init enabled=${enabled} ratio=${ratio} td=${this.td ? 'available' : 'unavailable'} blacklist=${this.blacklist ? 'available' : 'unavailable'}`,
     );
   }
 
@@ -129,7 +134,7 @@ export class IntradayProviderRouter {
   private computeTdSkipReason(
     eodhdTicker: string,
     hasTimeWindow: boolean,
-  ): 'flag_off' | 'td_not_injected' | 'time_window_present' | 'ab_test_sent_to_eodhd' | 'unsupported_suffix' | null {
+  ): 'flag_off' | 'td_not_injected' | 'time_window_present' | 'ab_test_sent_to_eodhd' | 'unsupported_suffix' | 'ticker_blacklisted' | null {
     if (!this.td) return 'td_not_injected';
     if (
       (this.config.get<string>('TWELVEDATA_INTRADAY_SCANNER_ENABLED') ?? 'false').toLowerCase() !==
@@ -137,6 +142,10 @@ export class IntradayProviderRouter {
     ) {
       return 'flag_off';
     }
+    // PR #355 — éviter de tirer TD sur les tickers déjà skippés EODHD-side
+    // pour cause de blacklist (statique ou dynamique R10). Sinon TD répète
+    // les calls inutiles que EODHD a évités.
+    if (this.blacklist?.isBlacklisted(eodhdTicker)) return 'ticker_blacklisted';
     if (hasTimeWindow) return 'time_window_present';
     if (!this.shouldRouteToTd(eodhdTicker)) return 'ab_test_sent_to_eodhd';
     if (this.convertToTdSymbol(eodhdTicker) === null) return 'unsupported_suffix';

--- a/packages/ai-analyst/src/strategies/__tests__/session-filter.spec.ts
+++ b/packages/ai-analyst/src/strategies/__tests__/session-filter.spec.ts
@@ -94,8 +94,8 @@ describe('session-filter helpers', () => {
   });
 
   describe('DEAD_NSE_TICKERS (alias) + DEAD_TICKERS_STATIC', () => {
-    it('total = 23 tickers (9 NSE legacy + 13 asia empty + 1 saigneur)', () => {
-      expect(DEAD_NSE_TICKERS.size).toBe(23);
+    it('total = 54 tickers (23 PR #337 + 31 PR #355)', () => {
+      expect(DEAD_NSE_TICKERS.size).toBe(54);
     });
 
     it.each([
@@ -130,6 +130,30 @@ describe('session-filter helpers', () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { DEAD_TICKERS_STATIC } = require('../session-filter');
       expect(DEAD_NSE_TICKERS).toBe(DEAD_TICKERS_STATIC);
+    });
+
+    // PR #355 — 31 tickers ajoutés (audit Supabase 19/05/2026 9h30)
+    it.each([
+      // Asia KOSPI/KOSDAQ (12)
+      '003690.KO', '001450.KO',
+      '080220.KQ', '066430.KQ', '412350.KQ', '274090.KQ',
+      '211270.KQ', '027360.KQ', '036930.KQ', '446540.KQ',
+      '032580.KQ', '092190.KQ',
+      // Asia SHG/SHE (4)
+      '600500.SHG', '600578.SHG', '002421.SHE', '300259.SHE',
+      // Asia saigneurs (4)
+      '295310.KQ', '100790.KQ', '321370.KQ', '601678.SHG',
+      // EU LSE (4)
+      'SCLP.LSE', 'PANR.LSE', 'ABDN.LSE', 'GAMA.LSE',
+      // US/TO (7)
+      'ENPH.US', 'PZZA.US', 'TTGT.US', 'AXTI.US',
+      'BLDP.TO', 'KEY.TO', 'SDE.TO',
+    ])('PR #355 blacklist statique %s', (ticker) => {
+      expect(DEAD_NSE_TICKERS.has(ticker)).toBe(true);
+    });
+
+    it('PR #355 — 002900.KO toujours autorisé (preuve TP +$177/30j)', () => {
+      expect(DEAD_NSE_TICKERS.has('002900.KO')).toBe(false);
     });
   });
 });

--- a/packages/ai-analyst/src/strategies/session-filter.ts
+++ b/packages/ai-analyst/src/strategies/session-filter.ts
@@ -117,6 +117,60 @@ export const DEAD_TICKERS_STATIC: ReadonlySet<string> = new Set<string>([
   // --- Asia saigneur (PR #337, 1 ticker) ---
   // 222420.KQ : 102 SL / 0 TP sur 30j, PnL -$3582 (-$119/j). Arrêt hémorragie.
   '222420.KQ',
+
+  // --- PR #355 (19/05/2026) — 31 tickers récurrents 404/empty 24h ---
+  // Audit Supabase 19/05 9h30 : ~9000 calls gaspillés/24h (9% quota EODHD)
+  // sur ces 31 tickers, 0 accept sauf résidus. R10 dynamic ne triggered pas
+  // car les réponses sont majoritairement HTTP 200 + body empty (cf. fix
+  // recordStrike empty-response simultané, eodhd-intraday.service.ts).
+  // À retirer si EODHD republie data ou si audit manuel prouve valeur.
+  // `002900.KO` volontairement conservé (preuve TP positive 30j).
+
+  // Asia KOSPI/KOSDAQ (12 tickers, 70+ strikes/24h chacun)
+  '003690.KO',
+  '001450.KO',
+  '080220.KQ',
+  '066430.KQ',
+  '412350.KQ',
+  '274090.KQ',
+  '211270.KQ',
+  '027360.KQ',
+  '036930.KQ',
+  '446540.KQ',
+  '032580.KQ',
+  '092190.KQ',
+
+  // Asia Shanghai/Shenzhen (4 tickers)
+  '600500.SHG',
+  '600578.SHG',
+  '002421.SHE',
+  '300259.SHE',
+
+  // Asia saigneurs PnL négatif fort + 404 récurrent (4 tickers)
+  // 295310.KQ : -$136 sur 7 positions, 4 SL dont -5.37% en 1.8min
+  // 100790.KQ : -$153 sur 5 positions, 2 SL dont -7.69% en 14min
+  // 321370.KQ : -$13.82 sur 6 positions, 17% rate 404
+  // 601678.SHG : -$65.99 sur 2 positions
+  '295310.KQ',
+  '100790.KQ',
+  '321370.KQ',
+  '601678.SHG',
+
+  // EU LSE saigneur + obscurs (4 tickers)
+  // SCLP.LSE : -$170.74 sur 7 positions, penny stock pump-and-dump
+  'SCLP.LSE',
+  'PANR.LSE',
+  'ABDN.LSE',
+  'GAMA.LSE',
+
+  // US/TO obscurs (7 tickers, calls élevés 0 accept)
+  'ENPH.US',
+  'PZZA.US',
+  'TTGT.US',
+  'AXTI.US',
+  'BLDP.TO',
+  'KEY.TO',
+  'SDE.TO',
 ]);
 
 /**


### PR DESCRIPTION
## Diagnostic

Audit Supabase 19/05 9h30 : 30 tickers >= 20 errors/24h chacun, ~9000 calls EODHD gaspillés/24h (9% quota), 0 accept sauf 002900.KO conservé.

Root cause R10 : recordStrike fire uniquement sur HTTP 404 strict. Tickers asia/EU qui retournent 200 + body vide (80% des cas) ne déclenchaient jamais le compteur strikes.

## Changements

1. **31 tickers** ajoutés à DEAD_TICKERS_STATIC (12 KR + 4 CN + 4 saigneurs + 4 EU LSE + 7 US/TO). Total 23+31 = 54.
2. **Fix R10** : recordStrike sur HTTP_200_EMPTY aussi.
3. **Router check blacklist** avant TD (sinon TD double-tire).

## Tests

2273/2275 verts (2 todos pré-existants). Aucune régression.

## Impact

-9000 calls EODHD/24h, fin saigneur SCLP.LSE, fin saigneurs asia.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_