### PR TITLE
fix(intraday-router): PR #356 — fix DI TwelveDataService (td_not_injected v569)

### DIFF
--- a/apps/api/src/modules/admin/admin-providers-status.controller.ts
+++ b/apps/api/src/modules/admin/admin-providers-status.controller.ts
@@ -1,0 +1,91 @@
+/**
+ * PR #356 (19/05/2026) — /admin/providers-status endpoint.
+ *
+ * Diagnostic en 1 curl post-deploy de l'état DI du IntradayProviderRouter :
+ *   - td_injected   : TwelveDataService bien câblé ?
+ *   - blacklist_injected : TickerBlacklistService bien câblé ?
+ *   - enabled       : flag TWELVEDATA_INTRADAY_SCANNER_ENABLED actif ?
+ *   - ratio         : valeur effective TWELVEDATA_INTRADAY_AB_TEST_RATIO
+ *   - flag_raw      : valeur brute du flag (debug typos)
+ *   - td_apikey_set : TwelveDataService a bien sa clé API ?
+ *
+ * Symptôme historique (v569) : 100% des appels router avec
+ * td_skip_reason="td_not_injected" alors que TwelveDataService logge
+ * apiKey=set au boot. Cet endpoint permet de confirmer le fix PR #356
+ * post-deploy v570.
+ *
+ * Auth : header `x-admin-token` (même secret que /admin/eodhd-status).
+ */
+
+import { Controller, Get, Headers, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { IntradayProviderRouter } from '../lisa/services/intraday-provider-router.service';
+
+@Controller('admin/providers-status')
+export class AdminProvidersStatusController {
+  private readonly logger = new Logger(AdminProvidersStatusController.name);
+
+  constructor(
+    private readonly router: IntradayProviderRouter,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Get()
+  async getStatus(@Headers('x-admin-token') providedToken: string | undefined) {
+    this.assertAdmin(providedToken);
+
+    const routerStatus = this.router.getInjectionStatus();
+    const tdApiKey = this.config.get<string>('TWELVEDATA_API_KEY');
+    const apikeySet = !!tdApiKey && tdApiKey.trim().length > 0;
+    const apikeyTail = apikeySet && tdApiKey ? tdApiKey.slice(-4) : null;
+
+    return {
+      router: routerStatus,
+      td_service: {
+        apikey_set: apikeySet,
+        apikey_tail: apikeyTail,
+        apikey_length: tdApiKey ? tdApiKey.length : 0,
+      },
+      env: {
+        scanner_enabled: this.config.get<string>('TWELVEDATA_INTRADAY_SCANNER_ENABLED'),
+        ab_test_ratio: this.config.get<string>('TWELVEDATA_INTRADAY_AB_TEST_RATIO'),
+        ab_ratio_legacy_fossil: this.config.get<string>('TWELVEDATA_INTRADAY_AB_RATIO'),
+        per_minute_limit: this.config.get<string>('TWELVEDATA_PER_MINUTE_LIMIT'),
+        per_day_limit: this.config.get<string>('TWELVEDATA_PER_DAY_LIMIT'),
+      },
+      verdict: this.computeVerdict(routerStatus, apikeySet),
+    };
+  }
+
+  private computeVerdict(
+    routerStatus: { td_injected: boolean; blacklist_injected: boolean; enabled: boolean; ratio: number },
+    apikeySet: boolean,
+  ): { status: 'OK' | 'KO'; reasons: string[] } {
+    const reasons: string[] = [];
+    if (!routerStatus.td_injected) reasons.push('td_not_injected');
+    if (!routerStatus.blacklist_injected) reasons.push('blacklist_not_injected');
+    if (!apikeySet) reasons.push('td_apikey_missing');
+    if (!routerStatus.enabled) reasons.push('flag_off');
+    if (routerStatus.ratio <= 0) reasons.push('ratio_zero');
+    return {
+      status: reasons.length === 0 ? 'OK' : 'KO',
+      reasons,
+    };
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (providedToken !== expected) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'ADMIN_FORBIDDEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -34,6 +34,7 @@ import { AdminGainersSeedUniverseController } from './admin-gainers-seed-univers
 import { AdminGainersInsightsController } from './admin-gainers-insights.controller';
 import { AdminRejectedInsightsController } from './admin-rejected-insights.controller';
 import { AdminThresholdTunerController } from './admin-threshold-tuner.controller';
+import { AdminProvidersStatusController } from './admin-providers-status.controller';
 
 @Module({
   imports: [SupabaseModule, forwardRef(() => LisaModule), GainersModule],
@@ -52,6 +53,8 @@ import { AdminThresholdTunerController } from './admin-threshold-tuner.controlle
     AdminGainersInsightsController,
     AdminRejectedInsightsController,
     AdminThresholdTunerController,
+    // PR #356 — diagnostic DI IntradayProviderRouter + TwelveDataService.
+    AdminProvidersStatusController,
   ],
 })
 export class AdminModule {}

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -258,6 +258,12 @@ import { IntradayProviderRouter } from './services/intraday-provider-router.serv
     // in the AdminModule context." → empêchait app.listen → port 3001 jamais bindé →
     // Fly proxy fail. Cf. PR #200.
     TopGainersScannerService,
+    // PR #356 — exports TD + router pour AdminProvidersStatusController qui
+    // expose /admin/providers-status. Même pattern que TopGainersScannerService
+    // export hotfix PR #200 (forwardRef LisaModule ↔ AdminModule).
+    TwelveDataService,
+    IntradayProviderRouter,
+    TickerBlacklistService,
   ],
 })
 export class LisaModule {}

--- a/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
@@ -385,13 +385,16 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
   describe('Sans TwelveDataService injecté → EODHD only', () => {
     it('flag ON mais td=null → EODHD only', async () => {
       const eodhd = makeEodhdMock({ quote: EODHD_OK_QUOTE });
+      // PR #356 : td est désormais required par DI. On simule la pathologie
+      // historique (DI cassé qui injectait null silencieusement) via cast,
+      // pour vérifier que le guard défensif isEnabled()→false tient toujours.
       const router = new IntradayProviderRouter(
         makeConfig({
           TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
           TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
         }),
         eodhd.service,
-        null,
+        null as unknown as TwelveDataService,
       );
       const r = await router.getQuote('AAPL.US');
       expect(r!.provider).toBe('eodhd');
@@ -567,13 +570,14 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
 
     it('TD non injecté + flag ON → td_skip_reason="td_not_injected"', async () => {
       const { calls, restore } = captureLogs();
+      // PR #356 : cast pour simuler pathologie DI (td required mais null en runtime).
       const router = new IntradayProviderRouter(
         makeConfig({
           TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
           TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
         }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
-        null,
+        null as unknown as TwelveDataService,
       );
       await router.getCandles('AAPL.US', '1m', 20);
       const log = lastDualCall(calls);

--- a/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
+++ b/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { TwelveDataService } from './twelve-data.service';
 import { EodhdIntradayService, type CandleSeries } from './eodhd-intraday.service';
@@ -53,7 +53,7 @@ export interface IntradayCandlesOptions {
 }
 
 @Injectable()
-export class IntradayProviderRouter {
+export class IntradayProviderRouter implements OnModuleInit {
   private readonly logger = new Logger(IntradayProviderRouter.name);
   // PR #354 — first-call witness pour confirmer que le router est invoqué.
   // Loggue un événement unique au premier passage dans getCandles/getQuote
@@ -64,10 +64,19 @@ export class IntradayProviderRouter {
   constructor(
     private readonly config: ConfigService,
     private readonly eodhd: EodhdIntradayService,
-    @Optional() private readonly td: TwelveDataService | null = null,
+    // PR #356 — @Optional() retiré sur td : en prod v569 le DI silencieusement
+    // injectait null malgré TwelveDataService instancié OK ailleurs (apiKey=set
+    // dans logs init). Résultat : 100% des appels router avec
+    // td_skip_reason="td_not_injected". Sans @Optional, NestJS crash boot
+    // visible si DI échoue → diagnostic immédiat. Tests doivent désormais
+    // injecter un mock TwelveDataService explicite (cf. .spec.ts mise à jour).
+    private readonly td: TwelveDataService,
     // PR #355 — check blacklist avant TD pour ne pas reporter le gaspillage
     // côté TD (avant : EODHD short-circuit dans this.eodhd.getCandles, mais
     // TD était appelé en parallèle sans aucun check).
+    // PR #356 — @Optional() conservé sur blacklist pour back-compat tests
+    // existants (23 .spec.ts qui n'injectent pas le 4e arg). Si null en prod,
+    // simplement perte d'optim blacklist pre-TD, pas de bug critique sur TD.
     @Optional() private readonly blacklist: TickerBlacklistService | null = null,
   ) {
     const enabled = this.isEnabled();
@@ -77,12 +86,59 @@ export class IntradayProviderRouter {
     );
   }
 
+  /**
+   * PR #356 — assertion post-boot. Si td ou blacklist sont null malgré
+   * la suppression de @Optional (cas pathologique DI), on log un ERROR
+   * explicite plutôt que d'échouer silencieusement.
+   */
+  onModuleInit(): void {
+    if (!this.td) {
+      // Ne devrait JAMAIS arriver depuis PR #356 (td required par DI).
+      // Si on voit ce log en prod → NestJS DI cassé critique.
+      this.logger.error(
+        '[intraday-router] FATAL onModuleInit: TwelveDataService not injected. Vérifier LisaModule providers et imports SupabaseModule global.',
+      );
+    }
+    if (!this.blacklist) {
+      // Warning seulement : @Optional() conservé pour tests, perte d'optim
+      // mais pas de bug fonctionnel TD.
+      this.logger.warn(
+        '[intraday-router] onModuleInit: TickerBlacklistService not injected (loss of pre-TD blacklist optim, non-critique).',
+      );
+    }
+  }
+
   private isEnabled(): boolean {
+    // PR #356 — guard défensif conservé : td est désormais required par DI,
+    // mais on garde un faux-fail si jamais une instance custom contourne le
+    // graph DI (ex : test mal isolé qui passerait undefined).
     if (!this.td) return false;
     return (
       (this.config.get<string>('TWELVEDATA_INTRADAY_SCANNER_ENABLED') ?? 'false').toLowerCase() ===
       'true'
     );
+  }
+
+  /**
+   * PR #356 — état d'injection pour endpoint /admin/providers-status.
+   * Permet une vérification post-deploy en 1 curl pour confirmer que le DI
+   * a bien câblé TwelveDataService et TickerBlacklistService. À combiner
+   * avec apikey_set du TwelveDataService pour diag complet.
+   */
+  getInjectionStatus(): {
+    td_injected: boolean;
+    blacklist_injected: boolean;
+    enabled: boolean;
+    ratio: number;
+    flag_raw: string | undefined;
+  } {
+    return {
+      td_injected: !!this.td,
+      blacklist_injected: !!this.blacklist,
+      enabled: this.isEnabled(),
+      ratio: this.getRatio(),
+      flag_raw: this.config.get<string>('TWELVEDATA_INTRADAY_SCANNER_ENABLED'),
+    };
   }
 
   private getRatio(): number {


### PR DESCRIPTION
## Contexte

En prod v569, 100% des appels `IntradayProviderRouter` retournent `td_skip_reason="td_not_injected"` alors que `TwelveDataService init apiKey=set` est OK dans les logs boot.

Vérifié via `GET /admin/logs/recent` :
- `TwelveDataService init apiKey=set key=***05ab` ✅
- `IntradayProviderRouter init enabled=false ratio=0.2 td=unavailable blacklist=unavailable` ❌

## Cause racine

Anti-pattern NestJS combinant :
- `@Optional()` sur `td` dans le constructor du router
- `forwardRef(() => LisaModule)` dans `admin.module.ts` (cycle module)
- Pas d'export de `TwelveDataService` / `IntradayProviderRouter` depuis `LisaModule`

Résultat : NestJS injecte `null` silencieusement au lieu de crash. Même bug historique que PR #200 (hotfix `TopGainersScannerService`).

## Fix

1. **Retire `@Optional()` sur `td`** → si DI échoue, crash boot visible immédiatement.
2. **Conserve `@Optional()` sur `blacklist`** → back-compat avec 23 `.spec.ts` qui n'injectent pas le 4e arg.
3. **Ajoute `OnModuleInit`** → assertion FATAL si `!td`, WARN si `!blacklist`.
4. **Ajoute `getInjectionStatus()`** → expose `{td_injected, blacklist_injected, enabled, ratio, flag_raw}`.
5. **Crée `GET /admin/providers-status`** (auth `x-admin-token`) avec verdict `OK/KO` + `reasons[]`. Diag post-deploy en 1 curl.
6. **Exporte `TwelveDataService`, `IntradayProviderRouter`, `TickerBlacklistService`** depuis `LisaModule` (même pattern que PR #200).

## Validation post-deploy v570

```bash
curl -H "x-admin-token: $ADMIN_TOKEN" \
  https://smartvest.fly.dev/admin/providers-status
```

Attendu :
```json
{
  "router": { "td_injected": true, "blacklist_injected": true, "enabled": true, "ratio": 0.2 },
  "td_service": { "apikey_set": true, "apikey_tail": "05ab", "apikey_length": 32 },
  "verdict": { "status": "OK", "reasons": [] }
}
```

## Refs

- Objectif immuable : $400/jour
- TD additif (pas remplacement EODHD), zero offload
- Hotfix historique : PR #200 (`TopGainersScannerService`)
- Diag prod : v569 endpoint `/admin/logs/recent`
