### PR TITLE
fix(intraday-router): PR #357 — retire @Optional() blacklist (suite PR #356)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
@@ -16,6 +16,7 @@ import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { IntradayProviderRouter } from '../intraday-provider-router.service';
 import { TwelveDataService } from '../twelve-data.service';
+import { TickerBlacklistService } from '../ticker-blacklist.service';
 import { EodhdIntradayService } from '../eodhd-intraday.service';
 
 jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
@@ -106,6 +107,18 @@ function makeTdMock(opts?: {
   };
 }
 
+// PR #357 — mock minimal TickerBlacklistService. Par défaut, aucun ticker
+// blacklisté (comportement neutre identique à l'ancien @Optional null).
+// Tests qui veulent simuler une blacklist active passent { blacklisted: ['XYZ.US'] }.
+function makeBlacklistMock(opts?: { blacklisted?: string[] }): TickerBlacklistService {
+  const set = new Set(opts?.blacklisted ?? []);
+  return {
+    isBlacklisted: (ticker: string) => set.has(ticker),
+    recordStrike: () => undefined,
+    getStats: () => ({ staticEnabled: true, staticSize: 0, dynamicCount: 0, strikesThreshold: 3, ttlHours: 24 }),
+  } as unknown as TickerBlacklistService;
+}
+
 const TD_OK_QUOTE = { price: 180.5, changePct: 1.2, timestamp: 1747353600000 };
 const EODHD_OK_QUOTE = { price: 180.4, changePct: 1.1, timestamp: 1747353500000 };
 const TD_OK_CANDLES = {
@@ -130,6 +143,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'false' }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       const r = await router.getQuote('AAPL.US');
       expect(r!.provider).toBe('eodhd');
@@ -144,6 +158,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'false' }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       const r = await router.getCandles('AAPL.US', '1m', 20);
       expect(r!.provider).toBe('eodhd');
@@ -163,6 +178,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       const r = await router.getQuote('AAPL.US');
       expect(r!.provider).toBe('td');
@@ -182,6 +198,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       const r = await router.getCandles('AAPL.US', '1m', 20);
       expect(r!.provider).toBe('td');
@@ -202,6 +219,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       const r = await router.getQuote('AAPL.US');
       expect(r!.provider).toBe('eodhd');
@@ -221,6 +239,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       const r = await router.getCandles('AAPL.US', '1m', 20);
       expect(r!.provider).toBe('eodhd');
@@ -240,6 +259,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       await router.getCandles('AAPL.US', '5m', 20, { fromTs: 1000, toTs: 2000 });
       expect(td.candlesCalls).toBe(0);
@@ -259,6 +279,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       await router.getCandles('SOMETHING.XYZ', '1m', 20);
       expect(td.candlesCalls).toBe(0);
@@ -271,6 +292,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
       makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true' }),
       makeEodhdMock().service,
       makeTdMock().service,
+      makeBlacklistMock(),
     );
 
     it.each([
@@ -325,6 +347,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       for (let i = 0; i < 100; i++) {
         await router.getQuote(`SYM${i}.US`);
@@ -343,6 +366,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         makeEodhdMock().service,
         makeTdMock().service,
+        makeBlacklistMock(),
       );
       const first = router.shouldRouteToTd('AAPL');
       for (let i = 0; i < 50; i++) {
@@ -360,6 +384,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       await router.getQuote('AAPL.US');
       expect(td.quoteCalls).toBe(0);
@@ -376,6 +401,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       await router.getQuote('AAPL.US');
       expect(td.quoteCalls).toBe(1);
@@ -395,6 +421,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         null as unknown as TwelveDataService,
+        makeBlacklistMock(),
       );
       const r = await router.getQuote('AAPL.US');
       expect(r!.provider).toBe('eodhd');
@@ -417,6 +444,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       const r = await router.getCandles('005930.KO', '5m', 100, { calledBy: 'shadow_walkforward' });
       expect(r!.provider).toBe('td');
@@ -435,6 +463,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
+        makeBlacklistMock(),
       );
       await router.getCandles('600519.SHG', '1m', 20);
       expect(td.lastSymbol).toBe('600519:SSE');
@@ -456,6 +485,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
       makeConfig({}),
       makeEodhdMock().service,
       makeTdMock().service,
+      makeBlacklistMock(),
     );
 
     it('AAPL.US → AAPL (strip suffixe)', () => {
@@ -511,6 +541,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'false' }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
         makeTdMock({ candles: TD_OK_CANDLES }).service,
+        makeBlacklistMock(),
       );
       await router.getCandles('AAPL.US', '1m', 20);
       const log = lastDualCall(calls);
@@ -529,6 +560,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
         makeTdMock({ candles: TD_OK_CANDLES }).service,
+        makeBlacklistMock(),
       );
       await router.getCandles('AAPL.US', '5m', 20, { fromTs: 1000, toTs: 2000 });
       const log = lastDualCall(calls);
@@ -545,6 +577,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
         makeTdMock({ candles: TD_OK_CANDLES }).service,
+        makeBlacklistMock(),
       );
       await router.getCandles('AAPL.US', '1m', 20);
       const log = lastDualCall(calls);
@@ -561,6 +594,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
         makeTdMock({ candles: TD_OK_CANDLES }).service,
+        makeBlacklistMock(),
       );
       await router.getCandles('SOMETHING.XYZ', '1m', 20);
       const log = lastDualCall(calls);
@@ -578,6 +612,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
         null as unknown as TwelveDataService,
+        makeBlacklistMock(),
       );
       await router.getCandles('AAPL.US', '1m', 20);
       const log = lastDualCall(calls);
@@ -594,6 +629,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
         makeTdMock({ candles: TD_OK_CANDLES }).service,
+        makeBlacklistMock(),
       );
       await router.getCandles('AAPL.US', '1m', 20);
       const log = lastDualCall(calls);

--- a/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
+++ b/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { TwelveDataService } from './twelve-data.service';
 import { EodhdIntradayService, type CandleSeries } from './eodhd-intraday.service';
@@ -74,10 +74,13 @@ export class IntradayProviderRouter implements OnModuleInit {
     // PR #355 — check blacklist avant TD pour ne pas reporter le gaspillage
     // côté TD (avant : EODHD short-circuit dans this.eodhd.getCandles, mais
     // TD était appelé en parallèle sans aucun check).
-    // PR #356 — @Optional() conservé sur blacklist pour back-compat tests
-    // existants (23 .spec.ts qui n'injectent pas le 4e arg). Si null en prod,
-    // simplement perte d'optim blacklist pre-TD, pas de bug critique sur TD.
-    @Optional() private readonly blacklist: TickerBlacklistService | null = null,
+    // PR #357 — @Optional() retiré sur blacklist (même bug DI que td en PR #356).
+    // Post-deploy v570, /admin/providers-status retournait blacklist_injected=false
+    // malgré TickerBlacklistService bien exporté depuis LisaModule. Cause :
+    // forwardRef(LisaModule ↔ AdminModule) + @Optional() = NestJS injecte null.
+    // Fix identique à PR #356 sur td : suppression @Optional + tests mis à jour
+    // pour passer un mock TickerBlacklistService (4 args obligatoires).
+    private readonly blacklist: TickerBlacklistService,
   ) {
     const enabled = this.isEnabled();
     const ratio = this.getRatio();
@@ -100,10 +103,10 @@ export class IntradayProviderRouter implements OnModuleInit {
       );
     }
     if (!this.blacklist) {
-      // Warning seulement : @Optional() conservé pour tests, perte d'optim
-      // mais pas de bug fonctionnel TD.
-      this.logger.warn(
-        '[intraday-router] onModuleInit: TickerBlacklistService not injected (loss of pre-TD blacklist optim, non-critique).',
+      // PR #357 — @Optional() retiré, ce log ne devrait plus jamais apparaître.
+      // Si visible : NestJS DI cassé critique sur TickerBlacklistService.
+      this.logger.error(
+        '[intraday-router] FATAL onModuleInit: TickerBlacklistService not injected. Vérifier LisaModule exports.',
       );
     }
   }


### PR DESCRIPTION
## Contexte

Suite à PR #356 qui a résolu `td_not_injected` en prod, le nouvel endpoint `/admin/providers-status` v570 retourne :

```json
{
  "router": {
    "td_injected": true,
    "blacklist_injected": false,
    "enabled": true,
    "ratio": 0.2
  },
  "verdict": { "status": "KO", "reasons": ["blacklist_not_injected"] }
}
```

Logs boot v570 confirment :
- `[intraday-router] init enabled=true ratio=0.2 td=available blacklist=unavailable`
- `[intraday-router] onModuleInit: TickerBlacklistService not injected`

## Cause racine

Identique à PR #356 sur `td` : `@Optional()` + `forwardRef(LisaModule ↔ AdminModule)` = NestJS injecte `null` silencieusement, même si `TickerBlacklistService` est correctement déclaré dans `providers` (L116) et `exports` (L266) de `LisaModule`.

## Fix

1. Retire `@Optional()` sur `blacklist` dans le constructor du router.
2. Retire import `Optional` (plus utilisé).
3. `onModuleInit` log `error` (au lieu de `warn`) si `!blacklist`.
4. Helper `makeBlacklistMock` ajouté dans le `.spec.ts` (mock neutre `isBlacklisted` always-false).
5. 23 instantiations `new IntradayProviderRouter()` mises à jour avec le 4e arg.

## Conséquence opérationnelle

Récupération de l'optim pre-TD blacklist :
- 23 tickers DEAD statiques (cf. PR #337 + PR #355)
- Strikes 404 dynamiques 24h
- Réduction estimée des calls TD gaspillés sur tickers `.NSE` morts et asia `.KO/.KQ` empty-response

## Validation post-deploy v571

```bash
curl -H "x-admin-token: $ADMIN_TOKEN" \
  https://smartvest.fly.dev/admin/providers-status
```

Attendu :
```json
{
  "router": { "td_injected": true, "blacklist_injected": true, "enabled": true, "ratio": 0.2 },
  "verdict": { "status": "OK", "reasons": [] }
}
```
