### PR TITLE
feat(qw-pipeline): PR #358 — runtime toggle QUICK_WINS_PIPELINE_ENABLED + endpoint admin

### DIFF
--- a/apps/api/src/modules/admin/admin-qw-pipeline-toggle.controller.ts
+++ b/apps/api/src/modules/admin/admin-qw-pipeline-toggle.controller.ts
@@ -1,0 +1,96 @@
+/**
+ * PR #358 (19/05/2026) — /admin/qw-pipeline-toggle endpoint.
+ *
+ * Permet de toggle le master flag QUICK_WINS_PIPELINE_ENABLED en runtime sans
+ * redéployer Fly. Override survit jusqu'au prochain restart de process (puis
+ * revient au flag env). Pour persister, l'utilisateur doit mettre à jour le
+ * secret Fly via UI.
+ *
+ * Usage :
+ *   GET  /admin/qw-pipeline-toggle              → status courant
+ *   POST /admin/qw-pipeline-toggle { enabled }  → flip à enabled (bool ou null)
+ *
+ * Auth : header `x-admin-token` (même secret que /admin/providers-status).
+ *
+ * Contexte 19 mai : QW pipeline était OFF par défaut (default 'false'), résultait
+ * en table qw_decision_log vide et 295310.KQ traded 7× (cap asia 4× ignoré).
+ * Cet endpoint permet d'activer immédiatement post-merge sans risque deploy.
+ */
+
+import { Body, Controller, Get, Headers, HttpException, HttpStatus, Logger, Post } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { QuickWinsPipelineService } from '../lisa/quick-wins/quick-wins-pipeline.service';
+
+interface ToggleBody {
+  enabled?: boolean | null;
+}
+
+@Controller('admin/qw-pipeline-toggle')
+export class AdminQwPipelineToggleController {
+  private readonly logger = new Logger(AdminQwPipelineToggleController.name);
+
+  constructor(
+    private readonly qwPipeline: QuickWinsPipelineService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Get()
+  async getStatus(@Headers('x-admin-token') providedToken: string | undefined) {
+    this.assertAdmin(providedToken);
+    return {
+      status: this.qwPipeline.getStatus(),
+      help: {
+        runtime_override:
+          'POST { "enabled": true|false } pour override runtime. POST { "enabled": null } pour relâcher l override et revenir au flag env. POST { "enabled": true } équivaut à activer QW pipeline sans redeploy.',
+        persistence:
+          'Override runtime survit jusqu au prochain restart de process. Pour persister, l utilisateur doit mettre à jour le secret Fly QUICK_WINS_PIPELINE_ENABLED via UI.',
+      },
+    };
+  }
+
+  @Post()
+  async toggle(
+    @Headers('x-admin-token') providedToken: string | undefined,
+    @Body() body: ToggleBody,
+  ) {
+    this.assertAdmin(providedToken);
+
+    if (!body || (body.enabled !== true && body.enabled !== false && body.enabled !== null)) {
+      throw new HttpException(
+        {
+          message: 'Body must contain { enabled: true|false|null }',
+          code: 'INVALID_BODY',
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const result = this.qwPipeline.setEnabledRuntime(body.enabled);
+    this.logger.log(
+      `[admin] qw-pipeline-toggle previous=${result.previous} current=${result.current} (override=${body.enabled})`,
+    );
+
+    return {
+      ok: true,
+      previous_effective: result.previous,
+      current_effective: result.current,
+      status: this.qwPipeline.getStatus(),
+    };
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (providedToken !== expected) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'ADMIN_FORBIDDEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -35,6 +35,7 @@ import { AdminGainersInsightsController } from './admin-gainers-insights.control
 import { AdminRejectedInsightsController } from './admin-rejected-insights.controller';
 import { AdminThresholdTunerController } from './admin-threshold-tuner.controller';
 import { AdminProvidersStatusController } from './admin-providers-status.controller';
+import { AdminQwPipelineToggleController } from './admin-qw-pipeline-toggle.controller';
 
 @Module({
   imports: [SupabaseModule, forwardRef(() => LisaModule), GainersModule],
@@ -55,6 +56,8 @@ import { AdminProvidersStatusController } from './admin-providers-status.control
     AdminThresholdTunerController,
     // PR #356 — diagnostic DI IntradayProviderRouter + TwelveDataService.
     AdminProvidersStatusController,
+    // PR #358 — toggle runtime QUICK_WINS_PIPELINE_ENABLED sans redeploy.
+    AdminQwPipelineToggleController,
   ],
 })
 export class AdminModule {}

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -264,6 +264,9 @@ import { IntradayProviderRouter } from './services/intraday-provider-router.serv
     TwelveDataService,
     IntradayProviderRouter,
     TickerBlacklistService,
+    // PR #358 — export pour AdminQwPipelineToggleController qui expose
+    // /admin/qw-pipeline-toggle (toggle runtime QUICK_WINS_PIPELINE_ENABLED).
+    QuickWinsPipelineService,
   ],
 })
 export class LisaModule {}

--- a/apps/api/src/modules/lisa/quick-wins/quick-wins-pipeline.service.ts
+++ b/apps/api/src/modules/lisa/quick-wins/quick-wins-pipeline.service.ts
@@ -34,11 +34,20 @@ import type { QwId, QwResult, QwSignal, QwTrace } from './types';
  *
  * Master flag QUICK_WINS_PIPELINE_ENABLED. Default 'false' jusqu'à validation
  * post-merge par l'agent (Perplexity Computer).
+ *
+ * PR #358 (19/05/2026) — runtime toggle :
+ *   - lecture initiale depuis ConfigService (QUICK_WINS_PIPELINE_ENABLED)
+ *   - override runtime possible via setEnabledRuntime() (utilisé par
+ *     /admin/qw-pipeline-toggle), survit jusqu'au prochain restart
+ *   - chaque appel logge le verdict pour audit (compteur in-memory)
  */
 @Injectable()
 export class QuickWinsPipelineService {
   private readonly logger = new Logger(QuickWinsPipelineService.name);
-  private readonly masterEnabled: boolean;
+  private masterEnabled: boolean;
+  private runtimeOverride: boolean | null = null;
+  private evalCount = 0;
+  private lastDecisionAt: string | null = null;
 
   constructor(
     private readonly config: ConfigService,
@@ -57,19 +66,55 @@ export class QuickWinsPipelineService {
     private readonly qw14a: Qw14aFridayEuBoostService,
   ) {
     this.masterEnabled = (this.config.get<string>('QUICK_WINS_PIPELINE_ENABLED') ?? 'false') === 'true';
-    if (this.masterEnabled) {
-      this.logger.log('Quick Wins pipeline ENABLED (master flag on)');
-    }
+    this.logger.log(
+      `[QW] boot masterEnabled=${this.masterEnabled} (env QUICK_WINS_PIPELINE_ENABLED=${this.config.get<string>('QUICK_WINS_PIPELINE_ENABLED') ?? 'unset'})`,
+    );
   }
 
   isEnabled(): boolean {
-    return this.masterEnabled;
+    return this.runtimeOverride !== null ? this.runtimeOverride : this.masterEnabled;
+  }
+
+  /**
+   * PR #358 — toggle runtime via endpoint admin. Override survit jusqu'au
+   * prochain restart de process (puis revient à QUICK_WINS_PIPELINE_ENABLED env).
+   * Passer null pour relâcher l'override (revient au flag env).
+   */
+  setEnabledRuntime(value: boolean | null): { previous: boolean; current: boolean } {
+    const previous = this.isEnabled();
+    this.runtimeOverride = value;
+    const current = this.isEnabled();
+    this.logger.log(
+      `[QW] runtime toggle previous=${previous} current=${current} override=${value === null ? 'null(use_env)' : value}`,
+    );
+    return { previous, current };
+  }
+
+  /** Diagnostic pour /admin/qw-pipeline-toggle GET. */
+  getStatus(): {
+    masterEnabled: boolean;
+    envFlag: string | null;
+    runtimeOverride: boolean | null;
+    effective: boolean;
+    evalCount: number;
+    lastDecisionAt: string | null;
+  } {
+    return {
+      masterEnabled: this.masterEnabled,
+      envFlag: this.config.get<string>('QUICK_WINS_PIPELINE_ENABLED') ?? null,
+      runtimeOverride: this.runtimeOverride,
+      effective: this.isEnabled(),
+      evalCount: this.evalCount,
+      lastDecisionAt: this.lastDecisionAt,
+    };
   }
 
   async evaluate(signal: QwSignal): Promise<QwResult> {
-    if (!this.masterEnabled) {
+    if (!this.isEnabled()) {
       return { decision: 'pass', sizingMultiplier: 1.0, modifications: [], qwTrace: [] };
     }
+    this.evalCount += 1;
+    this.lastDecisionAt = new Date().toISOString();
 
     const trace: QwTrace[] = [];
     let sizingMultiplier = 1.0;


### PR DESCRIPTION
## Contexte 19 mai 2026

QW pipeline était OFF par défaut (default 'false') depuis le merge initial. Conséquence directe mesurée aujourd'hui :
- Table `qw_decision_log` VIDE
- Logs pattern QUICK_WINS = 0 entrées
- 295310.KQ traded 7× (cap asia QW#17 = 4× ignoré)
- 100790.KQ ×5, 321370.KQ ×6
- PnL jour -$534.74 / WR 12.9% / 4 TP sur 34 positions
- Coût estimé du QW pipeline OFF : +$200 à +$300 perdus/jour

## Solution

Permettre de toggle le master flag en runtime sans redeploy Fly.

## Changements

1. `QuickWinsPipelineService.setEnabledRuntime()` + `getStatus()`
   - lecture initiale `ConfigService('QUICK_WINS_PIPELINE_ENABLED')`
   - override runtime null|true|false via setter
   - survit jusqu'au prochain restart de process
   - compteurs `evalCount` + `lastDecisionAt` pour audit

2. `AdminQwPipelineToggleController` :
   - `GET /admin/qw-pipeline-toggle` → status courant
   - `POST /admin/qw-pipeline-toggle { enabled }` → flip
   - auth via header `x-admin-token` (même secret que `/admin/providers-status`)

3. Export `QuickWinsPipelineService` du LisaModule pour injection AdminModule (même pattern hotfix PR #200 / #356 forwardRef LisaModule ↔ AdminModule)

## Post-merge action user

```bash
curl -X POST -H 'x-admin-token: $TOKEN' -H 'Content-Type: application/json' \
  -d '{"enabled": true}' https://smartvest.fly.dev/admin/qw-pipeline-toggle

curl -H 'x-admin-token: $TOKEN' https://smartvest.fly.dev/admin/qw-pipeline-toggle
```

Pour persister entre restarts, mettre à jour le secret Fly `QUICK_WINS_PIPELINE_ENABLED=true` via UI (n'augmente PAS la surface car ce flag existe déjà comme secret depuis 16/05).

## Pas de changement fonctionnel du pipeline

Aucune modification du flux QW lui-même : pass-through si flag OFF (inchangé), cascade complète si flag ON (inchangé). Pure couche de contrôle.