### PR TITLE
feat(kelly): PR #359 — no-edge reducer pour WR<20% + sample>=30 → notional $800

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/kelly-recompute.service.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/kelly-recompute.service.spec.ts
@@ -202,6 +202,58 @@ describe('KellyRecomputeService', () => {
     expect(upserts).toHaveLength(0);
   });
 
+  // ---------------------------------------------------------------------------
+  // PR #359 — no-edge reducer : WR < 20% + sample >= 30 → notional $800
+  // ---------------------------------------------------------------------------
+  it('PR #359 — edge négatif + WR<20% + n>=30 → notional=800 source=auto_recompute_reduced_low_wr', async () => {
+    // 5 TP / 35 SL = WR 12.5% sur 40 trades (cas réel 19 mai us_large WR=19.3%)
+    const rows: FetchRow[] = [
+      ...Array.from({ length: 5 }, () => mkRow('closed_target', 2.0)),
+      ...Array.from({ length: 35 }, () => mkRow('closed_stop', -1.3)),
+    ];
+    const { service: supabase, upserts } = makeSupabaseStub(rows);
+    const sizing = makeKellySizingMock({
+      fractionSuggested: 0,
+      fullKelly: -0.5,
+      winRateLowerWilson: 0.08,
+    });
+    const svc = new KellyRecomputeService(makeConfig(), supabase, sizing);
+
+    await svc.recomputeForClass('us_equity_large');
+
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]).toMatchObject({
+      asset_class: 'us_equity_large',
+      notional_usd: 800,
+      kelly_fraction: 0,
+      source: 'auto_recompute_reduced_low_wr',
+      sample_size: 40,
+    });
+  });
+
+  it('PR #359 — edge négatif + WR>=20% → reste sur notional=1575 (pas de reducer)', async () => {
+    // 10 TP / 30 SL = WR 25% → au-dessus du seuil 20%, fallback historique
+    const rows: FetchRow[] = [
+      ...Array.from({ length: 10 }, () => mkRow('closed_target', 2.0)),
+      ...Array.from({ length: 30 }, () => mkRow('closed_stop', -1.5)),
+    ];
+    const { service: supabase, upserts } = makeSupabaseStub(rows);
+    const sizing = makeKellySizingMock({
+      fractionSuggested: 0,
+      fullKelly: -0.2,
+      winRateLowerWilson: 0.15,
+    });
+    const svc = new KellyRecomputeService(makeConfig(), supabase, sizing);
+
+    await svc.recomputeForClass('asia_equity');
+
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]).toMatchObject({
+      notional_usd: 1575,
+      source: 'auto_recompute_no_edge',
+    });
+  });
+
   it('CAPITAL via env var KELLY_CAPITAL_ESTIME_USD prend le pas', async () => {
     const rows: FetchRow[] = [
       ...Array.from({ length: 25 }, () => mkRow('closed_target', 3.0)),

--- a/apps/api/src/modules/lisa/services/kelly-recompute.service.ts
+++ b/apps/api/src/modules/lisa/services/kelly-recompute.service.ts
@@ -18,6 +18,12 @@ import { KellySizingService } from '../../gainers-scanner/kelly/kelly-sizing.ser
  * Si edge négatif (fullKelly ≤ 0) : upsert notional=1575 (fallback), fraction=0,
  * source='auto_recompute_no_edge'. Le service consommateur lit la fraction et
  * désactive l override → caller utilise le notional uniforme historique.
+ *
+ * PR #359 (19/05/2026) — no-edge reducer :
+ *   Quand edge négatif ET WR observé < 20% sur sample suffisant (>= 30), le
+ *   baseline $1575 reste trop agressif : le 19 mai PnL -$534/jour avec
+ *   WR=12.9%. On réduit à $800 (NOTIONAL_REDUCED_USD) pour bridger jusqu'à
+ *   retour edge positif. Source = 'auto_recompute_reduced_low_wr'.
  */
 
 const ASSET_CLASSES = [
@@ -29,8 +35,11 @@ const ASSET_CLASSES = [
 ] as const;
 
 const NOTIONAL_FALLBACK_USD = 1575;
+const NOTIONAL_REDUCED_USD = 800; // PR #359 — reducer no-edge + WR low
 const NOTIONAL_MIN = 500;
 const NOTIONAL_MAX = 3000;
+const LOW_WR_THRESHOLD = 0.20; // PR #359 — WR observé < 20% = signal dégradé
+const LOW_WR_MIN_SAMPLE = 30; // PR #359 — sample minimal pour appliquer le reducer
 
 // TODO Phase 5 N3 : récupérer le capital réel via portfolios.equity_usd au lieu
 // de la constante. Pour MVP, baseline = notional_avg actuel × max positions.
@@ -113,8 +122,16 @@ export class KellyRecomputeService {
     let source: string;
 
     if (edgeNegative || fraction === 0) {
-      notionalUsd = NOTIONAL_FALLBACK_USD;
-      source = 'auto_recompute_no_edge';
+      // PR #359 — si edge négatif ET WR observé < 20% sur sample suffisant, on
+      // descend à $800 au lieu de $1575 pour limiter le saignement (jour 19 mai
+      // PnL -$534 avec WR 12.9%). Sinon baseline historique conservé.
+      if (stats.wr < LOW_WR_THRESHOLD && stats.n_closed >= LOW_WR_MIN_SAMPLE) {
+        notionalUsd = NOTIONAL_REDUCED_USD;
+        source = 'auto_recompute_reduced_low_wr';
+      } else {
+        notionalUsd = NOTIONAL_FALLBACK_USD;
+        source = 'auto_recompute_no_edge';
+      }
     } else {
       const raw = fraction * this.capitalUsd;
       notionalUsd = Math.max(NOTIONAL_MIN, Math.min(NOTIONAL_MAX, raw));


### PR DESCRIPTION
## Contexte 19 mai 2026

- PnL jour -$534.74 / WR global 12.9% / 4 TP sur 34 positions
- Table `asset_class_kelly_config` : toutes lignes `kelly_fraction=0` `source=auto_recompute_no_edge`
- KellyRecompute logs détaillés :
  - us_large WR 19.3% payoff 0.956 → fullKelly négatif
  - asia WR 17.8% payoff 1.317 → fullKelly négatif
  - eu WR 36.8% payoff 0.841 → fullKelly négatif
- Mécanisme actuel : edge négatif → notional=$1575 (NOTIONAL_FALLBACK_USD baseline historique)
- Problème : ce baseline reste trop agressif quand WR observé < 20% sur sample >= 30

## Changement

Ajout d'un palier intermédiaire :

```ts
if (edgeNegative || fraction === 0) {
  if (stats.wr < 0.20 && stats.n_closed >= 30) {
    notional = NOTIONAL_REDUCED_USD = $800;
    source = 'auto_recompute_reduced_low_wr';
  } else {
    notional = NOTIONAL_FALLBACK_USD = $1575;
    source = 'auto_recompute_no_edge';
  }
}
```

## Impact attendu sur 19 mai

- Perte moyenne par SL : $1575 × 1.3% = $20.48 → $800 × 1.3% = $10.40 (-49%)
- Gain moyen par TP : $1575 × 2.0% = $31.50 → $800 × 2.0% = $16.00 (-49%)
- Sur 34 positions WR 12.9% : 4 TP × 16 - 16 SL × 10.40 ≈ -$102 (vs réel -$534)
- Bridge jusqu'à retour edge positif (3-7j attendu avec QW pipeline #358 activé)

## Tests

- ✅ `PR #359 — edge négatif + WR<20% + n>=30 → notional=800`
- ✅ `PR #359 — edge négatif + WR>=20% → reste sur notional=1575`
- ✅ 8 tests existants restent verts (notamment celui à 10 TP / 30 SL = WR 25%)

## Pas de dépendance avec #358

#358 active le pipeline QW (filtres + caps). #359 ajuste le sizing baseline. Les deux PRs sont orthogonales et déployables séparément, mais agissent en synergie.