### PR TITLE
feat(scanner): PR #360 Supertrend asia 30m filter via TwelveData

### DIFF
--- a/apps/api/src/modules/lisa/quick-wins/types.ts
+++ b/apps/api/src/modules/lisa/quick-wins/types.ts
@@ -31,8 +31,9 @@ export type QwId =
   | 'QW_46'
   | 'QW_47'
   | 'CIRCUIT_BREAKER'
-  | 'TD_SUPERTREND_US'   // PR #345 — filtre TwelveData Supertrend US equity
-  | 'TD_RSI_CRYPTO';     // PR #345 — filtre TwelveData RSI crypto overbought
+  | 'TD_SUPERTREND_US'    // PR #345 — filtre TwelveData Supertrend US equity
+  | 'TD_RSI_CRYPTO'       // PR #345 — filtre TwelveData RSI crypto overbought
+  | 'TD_SUPERTREND_ASIA'; // PR #360 — filtre TwelveData Supertrend asia equity 30m
 
 export type QwDecision = 'pass' | 'block' | 'modify';
 

--- a/apps/api/src/modules/lisa/services/__tests__/twelve-data-scanner-filters.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/twelve-data-scanner-filters.spec.ts
@@ -329,4 +329,129 @@ describe('evaluateTwelveDataFilters — PR #345', () => {
       expect(r.decision).toBe('accept');
     });
   });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // PR #360 — Filtre Supertrend asia 30m. Mapping .KO/.KQ → :KRX, .SHG → :SSE,
+  // .SHE → :SZSE déjà défini dans td-symbol-mapper (PR #355).
+  // ─────────────────────────────────────────────────────────────────────
+  describe('PR #360 — Filtre Supertrend asia 30m', () => {
+    it('flag OFF (default) → no call même si signal asia', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 100, direction: 'down', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: '002900.KO',
+        assetClass: 'asia_equity',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        // asiaSupertrendEnabled non spécifié → default false
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(0);
+    });
+
+    it('flag ON + asia direction=down → reject_supertrend_asia_down', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 1234.5, direction: 'down', timestamp: '2026-05-19 02:30' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: '002900.KO',
+        assetClass: 'asia_equity',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        asiaSupertrendEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('reject_supertrend_asia_down');
+      if (r.decision === 'reject_supertrend_asia_down') {
+        expect(r.reason).toContain('asia supertrend');
+        expect(r.reason).toContain('direction=down');
+        expect(r.reason).toContain('1234.5');
+      }
+      expect(counters.supertrendCalls).toBe(1);
+    });
+
+    it('flag ON + asia direction=up → accept', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 1500, direction: 'up', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: '601318.SHG',
+        assetClass: 'asia_equity',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        asiaSupertrendEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(1);
+    });
+
+    it('flag ON + TD null (rate limit) → fail-open accept', async () => {
+      const { service: td, counters } = makeTwelveDataMock({ supertrend: null });
+      const r = await evaluateTwelveDataFilters({
+        symbol: '222420.KQ',
+        assetClass: 'asia_equity',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        asiaSupertrendEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(1);
+    });
+
+    it('flag ON + asset_class us_equity_large → bypass (filtre asia only)', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 100, direction: 'down', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'AAPL.US',
+        assetClass: 'us_equity_large',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        asiaSupertrendEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(0);
+    });
+
+    it('asia + .T suffix (non mappé dans td-symbol-mapper) → bypass fail-open', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 100, direction: 'down', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: '7203.T',
+        assetClass: 'asia_equity',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        asiaSupertrendEnabled: true,
+        twelveData: td,
+      });
+      // .T n'est pas mappé (TD ne couvre pas Tokyo sur ce plan), eodhdToTdSymbol
+      // retourne null → pas d'appel → fail-open accept.
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(0);
+    });
+
+    it('US supertrend OFF + asia supertrend ON sur signal asia down → reject_supertrend_asia_down (pas confondu)', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 80, direction: 'down', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: '300750.SHE',
+        assetClass: 'asia_equity',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        asiaSupertrendEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('reject_supertrend_asia_down');
+      expect(counters.supertrendCalls).toBe(1);
+      // Vérifier que le called_by est bien le bon (scanner_asia_supertrend, pas scanner_us_supertrend)
+      expect(counters.lastSupertrendArgs?.[4]).toBe('scanner_asia_supertrend');
+    });
+  });
 });

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -39,6 +39,7 @@ export type ShadowDecision =
   | 'reject_opening_buffer'     // PR Phase 1 — premières N min après open
   | 'reject_supertrend_down'    // PR #345 — TwelveData Supertrend 30m direction=down (us_equity)
   | 'reject_rsi_overbought'     // PR #345 — TwelveData RSI 5m > 75 (crypto_major)
+  | 'reject_supertrend_asia_down' // PR #360 — TwelveData Supertrend 30m direction=down (asia_equity)
   | 'reject_other';
 
 export interface RecordDecisionInput {

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -2283,27 +2283,36 @@ export class TopGainersScannerService implements OnModuleInit {
           recordShadowDecision(cand, 'reject_path_eff', persistence);
           continue;
         }
-        // PR #345 — Filtres TwelveData (Supertrend US + RSI crypto). No-op si
+        // PR #345 + #360 — Filtres TwelveData (Supertrend US + RSI crypto + Supertrend asia 30m). No-op si
         // flags OFF ou service non injecté. Fail-open total (null TD = pass).
         if (this.twelveData) {
           const supertrendEnabled =
             (this.config.get<string>('TWELVEDATA_FILTER_US_SUPERTREND_ENABLED') ?? 'false') === 'true';
           const cryptoRsiEnabled =
             (this.config.get<string>('TWELVEDATA_FILTER_CRYPTO_RSI_ENABLED') ?? 'false') === 'true';
-          if (supertrendEnabled || cryptoRsiEnabled) {
+          const asiaSupertrendEnabled =
+            (this.config.get<string>('TWELVEDATA_FILTER_ASIA_SUPERTREND_ENABLED') ?? 'false') === 'true';
+          if (supertrendEnabled || cryptoRsiEnabled || asiaSupertrendEnabled) {
             const tdFilter = await evaluateTwelveDataFilters({
               symbol: cand.symbol,
               assetClass: cand.assetClass,
               supertrendEnabled,
               cryptoRsiEnabled,
+              asiaSupertrendEnabled,
               twelveData: this.twelveData,
             });
             if (tdFilter.decision !== 'accept') {
               this.logger.log(
                 `[top-gainers] ${cand.symbol} TwelveData filter ${tdFilter.decision}: ${tdFilter.reason}`,
               );
+              const qwId =
+                tdFilter.decision === 'reject_supertrend_down'
+                  ? 'TD_SUPERTREND_US'
+                  : tdFilter.decision === 'reject_supertrend_asia_down'
+                    ? 'TD_SUPERTREND_ASIA'
+                    : 'TD_RSI_CRYPTO';
               this.qwLogger?.log({
-                qwId: tdFilter.decision === 'reject_supertrend_down' ? 'TD_SUPERTREND_US' : 'TD_RSI_CRYPTO',
+                qwId,
                 symbol: cand.symbol,
                 assetClass: cand.assetClass,
                 decision: 'block',

--- a/apps/api/src/modules/lisa/services/twelve-data-scanner-filters.ts
+++ b/apps/api/src/modules/lisa/services/twelve-data-scanner-filters.ts
@@ -7,12 +7,13 @@
  * Filtres :
  *   1. Supertrend US equity 30m   : reject si direction='down' (us_equity_large/small_mid)
  *   2. RSI crypto 5m surachat     : reject si value > 75 (crypto_major)
+ *   3. Supertrend asia equity 30m : reject si direction='down' (asia_equity) — PR #360
  *
  * Le filtre ne court PAS si :
  *   - le flag d'env est désactivé (default OFF)
  *   - asset_class ne correspond pas
  *   - TwelveData retourne null (fail-open : signal passe)
- *   - le symbole n'est pas mappable (crypto seulement)
+ *   - le symbole n'est pas mappable (.MI / .T / .HK / .AU non supportés sur TD Pro)
  */
 
 import type { TwelveDataService } from './twelve-data.service';
@@ -21,10 +22,12 @@ import { eodhdToTdSymbol } from './td-symbol-mapper';
 export type ScannerFilterDecision =
   | { decision: 'accept' }
   | { decision: 'reject_supertrend_down'; reason: string }
-  | { decision: 'reject_rsi_overbought'; reason: string };
+  | { decision: 'reject_rsi_overbought'; reason: string }
+  | { decision: 'reject_supertrend_asia_down'; reason: string };
 
 const US_CLASSES = new Set(['us_equity_large', 'us_equity_small_mid']);
 const CRYPTO_CLASSES = new Set(['crypto_major']);
+const ASIA_CLASSES = new Set(['asia_equity']);
 const RSI_OVERBOUGHT_THRESHOLD = 75;
 
 export interface FilterContext {
@@ -32,6 +35,8 @@ export interface FilterContext {
   assetClass: string;
   supertrendEnabled: boolean;
   cryptoRsiEnabled: boolean;
+  /** PR #360 — default false pour rétro-compat avec callers existants (PR #345). */
+  asiaSupertrendEnabled?: boolean;
   twelveData: TwelveDataService;
 }
 
@@ -76,6 +81,31 @@ export async function evaluateTwelveDataFilters(
         return {
           decision: 'reject_rsi_overbought',
           reason: `RSI ${rsi.value.toFixed(2)} > ${RSI_OVERBOUGHT_THRESHOLD} (overbought) at ${rsi.timestamp}`,
+        };
+      }
+    }
+  }
+
+  // Filtre 3 — Supertrend asia equity 30m (PR #360)
+  //
+  // Contexte 19/05/2026 : asia_equity était la classe la plus saigneuse du jour
+  // (-$368 sur 22 positions, WR 18.2%). Hurst exponent (PR S7a) a augmenté le TP
+  // ratio asia à 1.30 mais sans filtre de tendance, le scanner accepte des
+  // signaux contre-tendance qui se font stopper rapidement. Le filtre Supertrend
+  // 30m sur tickers asia (mapping .KO/.KQ → :KRX, .SHG → :SSE, .SHE → :SZSE
+  // déjà dans td-symbol-mapper PR #355) rejette les signaux avec tendance baissière
+  // confirmée.
+  //
+  // Fail-open identique au filtre US : null TD ou symbole non-mappable (.T/.HK)
+  // → laisse passer.
+  if (ctx.asiaSupertrendEnabled && ASIA_CLASSES.has(ctx.assetClass)) {
+    const tdSymbol = eodhdToTdSymbol(ctx.symbol);
+    if (tdSymbol !== null) {
+      const st = await ctx.twelveData.getSupertrendSignal(tdSymbol, '30min', 10, 3, 'scanner_asia_supertrend');
+      if (st !== null && st.direction === 'down') {
+        return {
+          decision: 'reject_supertrend_asia_down',
+          reason: `asia supertrend direction=down at ${st.timestamp} value=${st.value.toFixed(4)}`,
         };
       }
     }


### PR DESCRIPTION
## Contexte

Catastrophe 19/05/2026 : asia_equity = classe la plus saigneuse (-\$368 sur 22 positions, WR 18.2%). Hurst exponent S7a a élargi le TP ratio asia (×1.30) sans filtre de tendance amont → scanner accepte des signaux contre-tendance qui se font stopper rapidement.

## Solution

Filtre Supertrend 30m sur classe asia_equity, reproduisant exactement la logique du filtre US (PR #345). Le mapping symbol .KO/.KQ → :KRX, .SHG → :SSE, .SHE → :SZSE existe déjà (PR #355).

## Détails techniques

- **twelve-data-scanner-filters.ts** :
  - Nouveau `decision: 'reject_supertrend_asia_down'` dans `ScannerFilterDecision`
  - `ASIA_CLASSES = new Set(['asia_equity'])`
  - `FilterContext.asiaSupertrendEnabled` rendu **optionnel** (rétro-compat callers existants PR #345)
  - Filter 3 ajouté après filter 2 RSI crypto, structure identique au filter 1 US
- **top-gainers-scanner.service.ts** L2286-2324 :
  - Lecture flag `TWELVEDATA_FILTER_ASIA_SUPERTREND_ENABLED` (default `'false'`)
  - Ajout `asiaSupertrendEnabled` au context `evaluateTwelveDataFilters`
  - Nouveau `qwId='TD_SUPERTREND_ASIA'` loggé dans `qw_decision_log`
- **twelve-data-scanner-filters.spec.ts** : 7 tests asia ajoutés
  - flag OFF (default) → no call
  - direction=down → reject_supertrend_asia_down
  - direction=up → accept
  - TD null (rate limit) → fail-open accept
  - asset_class us_equity_large → bypass
  - .T suffix non mappé → bypass fail-open
  - vérif `called_by='scanner_asia_supertrend'` distinct du US

## Fail-open

Comportement identique aux filtres existants : null TD ou symbole non mappable (.T/.HK/.AU) → laisse passer le signal.

## Comportement live

- Flag OFF (default) → **no-op zéro impact**
- Flag ON → scanner appelle TD Supertrend 30m uniquement pour candidats asia mappables (~80% sur .KO/.KQ/.SHG/.SHE), reject si `direction='down'`

## Activation post-merge

Secret Fly à set via UI : `TWELVEDATA_FILTER_ASIA_SUPERTREND_ENABLED=true`

## Réf

Phase 5 N2 dev launch 19 mai — 3 PRs en autonomie pendant absence user (Cannes festival)
PR #358 (toggle runtime QW pipeline) → PR #359 (Kelly no-edge reducer) → **PR #360 (Supertrend asia)**