### PR TITLE
feat(qw): PR #361 QW#7 cooldown post-TP US + QW#8 boost post-SL

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -73,6 +73,8 @@ import {
   Qw3WarmupExtendedService,
   Qw4RegimeFilterService,
   Qw6SymbolBlacklistService,
+  Qw7CooldownPostTpUsService,
+  Qw8BoostPostSlService,
   Qw9ScoreFloorService,
   Qw11AssetClassGateService,
   Qw14aFridayEuBoostService,
@@ -195,6 +197,9 @@ import { IntradayProviderRouter } from './services/intraday-provider-router.serv
     Qw14aFridayEuBoostService,
     Qw17RepeatSymbolCapService,
     Qw18ExchangeMultiplierService,
+    // PR #361 — cooldown/boost basis-position-history
+    Qw7CooldownPostTpUsService,
+    Qw8BoostPostSlService,
     QuickWinsPipelineService,
     // Phase 5 N1 PR-2 — matrice TP/SL DB-driven (read-only, cache 60s, fail-open)
     AssetClassTpSlConfigService,

--- a/apps/api/src/modules/lisa/quick-wins/__tests__/quick-wins-pipeline.spec.ts
+++ b/apps/api/src/modules/lisa/quick-wins/__tests__/quick-wins-pipeline.spec.ts
@@ -3,6 +3,8 @@ import { QuickWinsPipelineService } from '../quick-wins-pipeline.service';
 import { Qw1SessionFilterService } from '../qw-1-session-filter.service';
 import { Qw4RegimeFilterService } from '../qw-4-regime-filter.service';
 import { Qw6SymbolBlacklistService } from '../qw-6-symbol-blacklist.service';
+import { Qw7CooldownPostTpUsService } from '../qw-7-cooldown-post-tp-us.service';
+import { Qw8BoostPostSlService } from '../qw-8-boost-post-sl.service';
 import { Qw9ScoreFloorService } from '../qw-9-score-floor.service';
 import { Qw11AssetClassGateService } from '../qw-11-asset-class-gate.service';
 import { Qw14aFridayEuBoostService } from '../qw-14a-friday-eu-boost.service';
@@ -61,6 +63,8 @@ function makePipeline(
     new Qw1SessionFilterService(cfg, logger),
     new Qw4RegimeFilterService(cfg, supabase, logger),
     new Qw6SymbolBlacklistService(cfg, logger),
+    new Qw7CooldownPostTpUsService(cfg, supabase, logger),
+    new Qw8BoostPostSlService(cfg, supabase, logger),
     new Qw9ScoreFloorService(cfg, logger),
     new Qw11AssetClassGateService(cfg, logger),
     new Qw15FirstTradeBoostService(cfg, supabase, logger),

--- a/apps/api/src/modules/lisa/quick-wins/__tests__/qw-7-cooldown-post-tp-us.spec.ts
+++ b/apps/api/src/modules/lisa/quick-wins/__tests__/qw-7-cooldown-post-tp-us.spec.ts
@@ -78,7 +78,7 @@ describe('Qw7CooldownPostTpUsService', () => {
       makeSupabaseNotReady(),
       makeLogger(),
     );
-    const r = await svc.check({ ...baseSignal, portfolioId: undefined });
+    const r = await svc.check({ ...baseSignal, portfolioId: null });
     expect(r.decision).toBe('pass');
     expect(r.reason).toBe('no_portfolio_id');
   });

--- a/apps/api/src/modules/lisa/quick-wins/__tests__/qw-7-cooldown-post-tp-us.spec.ts
+++ b/apps/api/src/modules/lisa/quick-wins/__tests__/qw-7-cooldown-post-tp-us.spec.ts
@@ -1,0 +1,179 @@
+import { ConfigService } from '@nestjs/config';
+import { Qw7CooldownPostTpUsService } from '../qw-7-cooldown-post-tp-us.service';
+import type { QwDecisionLoggerService } from '../qw-decision-logger.service';
+import type { SupabaseService } from '../../../supabase/supabase.service';
+
+function makeConfig(map: Record<string, string>): ConfigService {
+  return { get: (k: string) => map[k] } as unknown as ConfigService;
+}
+function makeLogger(): QwDecisionLoggerService & { calls: unknown[] } {
+  const calls: unknown[] = [];
+  return { log: (e: unknown) => calls.push(e), calls } as unknown as QwDecisionLoggerService & {
+    calls: unknown[];
+  };
+}
+function makeSupabaseNotReady(): SupabaseService {
+  return {
+    isReady: () => false,
+    getClient: () => {
+      throw new Error('not ready');
+    },
+  } as unknown as SupabaseService;
+}
+
+interface QueryShape {
+  resolveWith: { data: unknown[] | null; error: { message: string } | null };
+  capturedCalls: { table: string; filters: Record<string, unknown> }[];
+}
+
+function makeSupabaseWith(query: QueryShape): SupabaseService {
+  return {
+    isReady: () => true,
+    getClient: () => ({
+      from(table: string) {
+        const filters: Record<string, unknown> = {};
+        const chain = {
+          select: () => chain,
+          eq: (col: string, val: unknown) => {
+            filters[`eq_${col}`] = val;
+            return chain;
+          },
+          gte: (col: string, val: unknown) => {
+            filters[`gte_${col}`] = val;
+            return chain;
+          },
+          limit: (_n: number) => {
+            query.capturedCalls.push({ table, filters });
+            return Promise.resolve(query.resolveWith);
+          },
+        };
+        return chain;
+      },
+    }),
+  } as unknown as SupabaseService;
+}
+
+describe('Qw7CooldownPostTpUsService', () => {
+  const baseSignal = {
+    symbol: 'AAPL.US',
+    assetClass: 'us_equity_large',
+    timestamp: '2026-05-20T15:30:00Z',
+    portfolioId: 'pf-1',
+  };
+
+  it('class non éligible (asia_equity) → pass class_not_eligible', async () => {
+    const svc = new Qw7CooldownPostTpUsService(
+      makeConfig({}),
+      makeSupabaseNotReady(),
+      makeLogger(),
+    );
+    const r = await svc.check({ ...baseSignal, assetClass: 'asia_equity' });
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('class_not_eligible');
+  });
+
+  it('no portfolioId → pass no_portfolio_id', async () => {
+    const svc = new Qw7CooldownPostTpUsService(
+      makeConfig({}),
+      makeSupabaseNotReady(),
+      makeLogger(),
+    );
+    const r = await svc.check({ ...baseSignal, portfolioId: undefined });
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('no_portfolio_id');
+  });
+
+  it('supabase not ready → fail-open pass supabase_not_ready', async () => {
+    const svc = new Qw7CooldownPostTpUsService(
+      makeConfig({}),
+      makeSupabaseNotReady(),
+      makeLogger(),
+    );
+    const r = await svc.check(baseSignal);
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('supabase_not_ready');
+  });
+
+  it('aucune ligne récente TP → pass no_recent_tp', async () => {
+    const query: QueryShape = {
+      resolveWith: { data: [], error: null },
+      capturedCalls: [],
+    };
+    const svc = new Qw7CooldownPostTpUsService(
+      makeConfig({}),
+      makeSupabaseWith(query),
+      makeLogger(),
+    );
+    const r = await svc.check(baseSignal);
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('no_recent_tp');
+    expect(query.capturedCalls[0].table).toBe('lisa_positions');
+    expect(query.capturedCalls[0].filters.eq_status).toBe('closed_target');
+    expect(query.capturedCalls[0].filters.eq_symbol).toBe('AAPL.US');
+  });
+
+  it('TP récent < 60min → block cooldown_post_tp_active + logger appelé', async () => {
+    const logger = makeLogger();
+    const query: QueryShape = {
+      resolveWith: {
+        data: [{ id: 'p123', exit_timestamp: '2026-05-20T15:00:00Z' }],
+        error: null,
+      },
+      capturedCalls: [],
+    };
+    const svc = new Qw7CooldownPostTpUsService(makeConfig({}), makeSupabaseWith(query), logger);
+    const r = await svc.check(baseSignal);
+    expect(r.decision).toBe('block');
+    expect(r.reason).toBe('cooldown_post_tp_active');
+    expect(logger.calls).toHaveLength(1);
+    expect(logger.calls[0]).toMatchObject({
+      qwId: 'QW_7',
+      decision: 'block',
+      reason: 'cooldown_post_tp_active',
+      wouldHavePassedWithoutFlag: true,
+    });
+  });
+
+  it('Supabase erreur → fail-open pass db_error_fail_open', async () => {
+    const query: QueryShape = {
+      resolveWith: { data: null, error: { message: 'connection lost' } },
+      capturedCalls: [],
+    };
+    const svc = new Qw7CooldownPostTpUsService(
+      makeConfig({}),
+      makeSupabaseWith(query),
+      makeLogger(),
+    );
+    const r = await svc.check(baseSignal);
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('db_error_fail_open');
+  });
+
+  it('config QW_7_COOLDOWN_MIN=30 → utilise 30 min, pas 60', async () => {
+    const query: QueryShape = {
+      resolveWith: { data: [], error: null },
+      capturedCalls: [],
+    };
+    const svc = new Qw7CooldownPostTpUsService(
+      makeConfig({ QW_7_COOLDOWN_MIN: '30' }),
+      makeSupabaseWith(query),
+      makeLogger(),
+    );
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    await svc.check(baseSignal);
+    const expectedCutoff = new Date(now - 30 * 60_000).toISOString();
+    expect(query.capturedCalls[0].filters.gte_exit_timestamp).toBe(expectedCutoff);
+  });
+
+  it('config QW_7_TARGET_CLASSES=us_equity_large seulement → us_equity_small_mid passe', async () => {
+    const svc = new Qw7CooldownPostTpUsService(
+      makeConfig({ QW_7_TARGET_CLASSES: 'us_equity_large' }),
+      makeSupabaseNotReady(),
+      makeLogger(),
+    );
+    const r = await svc.check({ ...baseSignal, assetClass: 'us_equity_small_mid' });
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('class_not_eligible');
+  });
+});

--- a/apps/api/src/modules/lisa/quick-wins/__tests__/qw-8-boost-post-sl.spec.ts
+++ b/apps/api/src/modules/lisa/quick-wins/__tests__/qw-8-boost-post-sl.spec.ts
@@ -1,0 +1,226 @@
+import { ConfigService } from '@nestjs/config';
+import { Qw8BoostPostSlService } from '../qw-8-boost-post-sl.service';
+import type { QwDecisionLoggerService } from '../qw-decision-logger.service';
+import type { SupabaseService } from '../../../supabase/supabase.service';
+
+function makeConfig(map: Record<string, string>): ConfigService {
+  return { get: (k: string) => map[k] } as unknown as ConfigService;
+}
+function makeLogger(): QwDecisionLoggerService & { calls: unknown[] } {
+  const calls: unknown[] = [];
+  return { log: (e: unknown) => calls.push(e), calls } as unknown as QwDecisionLoggerService & {
+    calls: unknown[];
+  };
+}
+function makeSupabaseNotReady(): SupabaseService {
+  return {
+    isReady: () => false,
+    getClient: () => {
+      throw new Error('not ready');
+    },
+  } as unknown as SupabaseService;
+}
+
+interface QueryShape {
+  resolveWith: { data: unknown[] | null; error: { message: string } | null };
+  capturedCalls: { table: string; filters: Record<string, unknown> }[];
+}
+
+function makeSupabaseWith(query: QueryShape): SupabaseService {
+  return {
+    isReady: () => true,
+    getClient: () => ({
+      from(table: string) {
+        const filters: Record<string, unknown> = {};
+        const chain = {
+          select: () => chain,
+          eq: (col: string, val: unknown) => {
+            filters[`eq_${col}`] = val;
+            return chain;
+          },
+          gte: (col: string, val: unknown) => {
+            filters[`gte_${col}`] = val;
+            return chain;
+          },
+          order: (col: string, opts: unknown) => {
+            filters[`order_${col}`] = opts;
+            return chain;
+          },
+          limit: (_n: number) => {
+            query.capturedCalls.push({ table, filters });
+            return Promise.resolve(query.resolveWith);
+          },
+        };
+        return chain;
+      },
+    }),
+  } as unknown as SupabaseService;
+}
+
+describe('Qw8BoostPostSlService', () => {
+  const baseSignal = {
+    symbol: 'AAPL.US',
+    assetClass: 'us_equity_large',
+    timestamp: '2026-05-20T15:30:00Z',
+    portfolioId: 'pf-1',
+  };
+
+  it('class non éligible (asia_equity) → pass class_not_eligible', async () => {
+    const svc = new Qw8BoostPostSlService(
+      makeConfig({}),
+      makeSupabaseNotReady(),
+      makeLogger(),
+    );
+    const r = await svc.check({ ...baseSignal, assetClass: 'asia_equity' });
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('class_not_eligible');
+  });
+
+  it('eu_equity est inclus par défaut → pass no_recent_sl quand supabase OK + 0 ligne', async () => {
+    const query: QueryShape = {
+      resolveWith: { data: [], error: null },
+      capturedCalls: [],
+    };
+    const svc = new Qw8BoostPostSlService(makeConfig({}), makeSupabaseWith(query), makeLogger());
+    const r = await svc.check({ ...baseSignal, assetClass: 'eu_equity' });
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('no_recent_sl');
+  });
+
+  it('no portfolioId → pass no_portfolio_id', async () => {
+    const svc = new Qw8BoostPostSlService(
+      makeConfig({}),
+      makeSupabaseNotReady(),
+      makeLogger(),
+    );
+    const r = await svc.check({ ...baseSignal, portfolioId: undefined });
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('no_portfolio_id');
+  });
+
+  it('supabase not ready → fail-open pass supabase_not_ready', async () => {
+    const svc = new Qw8BoostPostSlService(
+      makeConfig({}),
+      makeSupabaseNotReady(),
+      makeLogger(),
+    );
+    const r = await svc.check(baseSignal);
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('supabase_not_ready');
+  });
+
+  it('aucune ligne récente SL → pass no_recent_sl', async () => {
+    const query: QueryShape = {
+      resolveWith: { data: [], error: null },
+      capturedCalls: [],
+    };
+    const svc = new Qw8BoostPostSlService(makeConfig({}), makeSupabaseWith(query), makeLogger());
+    const r = await svc.check(baseSignal);
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('no_recent_sl');
+    expect(query.capturedCalls[0].table).toBe('lisa_positions');
+    expect(query.capturedCalls[0].filters.eq_status).toBe('closed_stop');
+    expect(query.capturedCalls[0].filters.eq_symbol).toBe('AAPL.US');
+  });
+
+  it('SL récent < 30min → modify boost_post_sl avec multiplier 1.5 + logger appelé', async () => {
+    const logger = makeLogger();
+    const query: QueryShape = {
+      resolveWith: {
+        data: [{ id: 'p999', exit_timestamp: '2026-05-20T15:15:00Z' }],
+        error: null,
+      },
+      capturedCalls: [],
+    };
+    const svc = new Qw8BoostPostSlService(makeConfig({}), makeSupabaseWith(query), logger);
+    const r = await svc.check(baseSignal);
+    expect(r.decision).toBe('modify');
+    expect(r.reason).toBe('boost_post_sl');
+    expect(r.multiplier).toBe(1.5);
+    expect(logger.calls).toHaveLength(1);
+    expect(logger.calls[0]).toMatchObject({
+      qwId: 'QW_8',
+      decision: 'modify',
+      reason: 'boost_post_sl',
+      wouldHavePassedWithoutFlag: true,
+    });
+  });
+
+  it('Supabase erreur → fail-open pass db_error_fail_open', async () => {
+    const query: QueryShape = {
+      resolveWith: { data: null, error: { message: 'connection lost' } },
+      capturedCalls: [],
+    };
+    const svc = new Qw8BoostPostSlService(
+      makeConfig({}),
+      makeSupabaseWith(query),
+      makeLogger(),
+    );
+    const r = await svc.check(baseSignal);
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('db_error_fail_open');
+  });
+
+  it('config QW_8_MULTIPLIER=2.0 → utilise 2.0 sur match', async () => {
+    const query: QueryShape = {
+      resolveWith: {
+        data: [{ id: 'p1', exit_timestamp: '2026-05-20T15:20:00Z' }],
+        error: null,
+      },
+      capturedCalls: [],
+    };
+    const svc = new Qw8BoostPostSlService(
+      makeConfig({ QW_8_MULTIPLIER: '2.0' }),
+      makeSupabaseWith(query),
+      makeLogger(),
+    );
+    const r = await svc.check(baseSignal);
+    expect(r.decision).toBe('modify');
+    expect(r.multiplier).toBe(2.0);
+  });
+
+  it('config QW_8_MULTIPLIER hors bornes (5.0) → fallback 1.5', async () => {
+    const query: QueryShape = {
+      resolveWith: {
+        data: [{ id: 'p1', exit_timestamp: '2026-05-20T15:20:00Z' }],
+        error: null,
+      },
+      capturedCalls: [],
+    };
+    const svc = new Qw8BoostPostSlService(
+      makeConfig({ QW_8_MULTIPLIER: '5.0' }),
+      makeSupabaseWith(query),
+      makeLogger(),
+    );
+    const r = await svc.check(baseSignal);
+    expect(r.multiplier).toBe(1.5);
+  });
+
+  it('config QW_8_WINDOW_MIN=15 → cutoff 15 min', async () => {
+    const query: QueryShape = {
+      resolveWith: { data: [], error: null },
+      capturedCalls: [],
+    };
+    const svc = new Qw8BoostPostSlService(
+      makeConfig({ QW_8_WINDOW_MIN: '15' }),
+      makeSupabaseWith(query),
+      makeLogger(),
+    );
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    await svc.check(baseSignal);
+    const expectedCutoff = new Date(now - 15 * 60_000).toISOString();
+    expect(query.capturedCalls[0].filters.gte_exit_timestamp).toBe(expectedCutoff);
+  });
+
+  it('config QW_8_TARGET_CLASSES=us_equity_large seulement → eu_equity bloqué', async () => {
+    const svc = new Qw8BoostPostSlService(
+      makeConfig({ QW_8_TARGET_CLASSES: 'us_equity_large' }),
+      makeSupabaseNotReady(),
+      makeLogger(),
+    );
+    const r = await svc.check({ ...baseSignal, assetClass: 'eu_equity' });
+    expect(r.decision).toBe('pass');
+    expect(r.reason).toBe('class_not_eligible');
+  });
+});

--- a/apps/api/src/modules/lisa/quick-wins/__tests__/qw-8-boost-post-sl.spec.ts
+++ b/apps/api/src/modules/lisa/quick-wins/__tests__/qw-8-boost-post-sl.spec.ts
@@ -93,7 +93,7 @@ describe('Qw8BoostPostSlService', () => {
       makeSupabaseNotReady(),
       makeLogger(),
     );
-    const r = await svc.check({ ...baseSignal, portfolioId: undefined });
+    const r = await svc.check({ ...baseSignal, portfolioId: null });
     expect(r.decision).toBe('pass');
     expect(r.reason).toBe('no_portfolio_id');
   });

--- a/apps/api/src/modules/lisa/quick-wins/index.ts
+++ b/apps/api/src/modules/lisa/quick-wins/index.ts
@@ -4,6 +4,8 @@ export { Qw1SessionFilterService } from './qw-1-session-filter.service';
 export { Qw3WarmupExtendedService } from './qw-3-warmup-extended.service';
 export { Qw4RegimeFilterService } from './qw-4-regime-filter.service';
 export { Qw6SymbolBlacklistService } from './qw-6-symbol-blacklist.service';
+export { Qw7CooldownPostTpUsService } from './qw-7-cooldown-post-tp-us.service';
+export { Qw8BoostPostSlService } from './qw-8-boost-post-sl.service';
 export { Qw9ScoreFloorService } from './qw-9-score-floor.service';
 export { Qw11AssetClassGateService } from './qw-11-asset-class-gate.service';
 export { Qw14aFridayEuBoostService } from './qw-14a-friday-eu-boost.service';

--- a/apps/api/src/modules/lisa/quick-wins/quick-wins-pipeline.service.ts
+++ b/apps/api/src/modules/lisa/quick-wins/quick-wins-pipeline.service.ts
@@ -4,6 +4,8 @@ import { LisaCircuitBreakerService } from '../services/circuit-breaker.service';
 import { Qw1SessionFilterService } from './qw-1-session-filter.service';
 import { Qw4RegimeFilterService } from './qw-4-regime-filter.service';
 import { Qw6SymbolBlacklistService } from './qw-6-symbol-blacklist.service';
+import { Qw7CooldownPostTpUsService } from './qw-7-cooldown-post-tp-us.service';
+import { Qw8BoostPostSlService } from './qw-8-boost-post-sl.service';
 import { Qw9ScoreFloorService } from './qw-9-score-floor.service';
 import { Qw11AssetClassGateService } from './qw-11-asset-class-gate.service';
 import { Qw15FirstTradeBoostService } from './qw-15-first-trade-boost.service';
@@ -24,13 +26,16 @@ import type { QwId, QwResult, QwSignal, QwTrace } from './types';
  *   2. QW#47 .LSE
  *   3. QW#1  session filter
  *   4. QW#6  symbol blacklist
- *   5. QW#11 asset class gate
- *   6. QW#9  score floor
- *   7. QW#27 path eff floor
- *   8. QW#4  régime asia (queries Supabase, cache 5min)
- *   9. QW#17 repeat cap
- *  10. QW#15 first trade boost (modify)
- *  11. QW#18 exchange multiplier (modify)
+ *   5. QW#7  cooldown post-TP US 60min (PR #361)
+ *   6. QW#11 asset class gate
+ *   7. QW#9  score floor
+ *   8. QW#27 path eff floor
+ *   9. QW#4  régime asia (queries Supabase, cache 5min)
+ *  10. QW#17 repeat cap
+ *  11. QW#15 first trade boost (modify)
+ *  12. QW#18 exchange multiplier (modify)
+ *  13. QW#14A friday eu boost (modify)
+ *  14. QW#8  boost post-SL 30min (modify, PR #361)
  *
  * Master flag QUICK_WINS_PIPELINE_ENABLED. Default 'false' jusqu'à validation
  * post-merge par l'agent (Perplexity Computer).
@@ -55,6 +60,8 @@ export class QuickWinsPipelineService {
     private readonly qw1: Qw1SessionFilterService,
     private readonly qw4: Qw4RegimeFilterService,
     private readonly qw6: Qw6SymbolBlacklistService,
+    private readonly qw7: Qw7CooldownPostTpUsService,
+    private readonly qw8: Qw8BoostPostSlService,
     private readonly qw9: Qw9ScoreFloorService,
     private readonly qw11: Qw11AssetClassGateService,
     private readonly qw15: Qw15FirstTradeBoostService,
@@ -146,6 +153,8 @@ export class QuickWinsPipelineService {
       () => Promise.resolve(this.qw47.check(signal)),
       () => Promise.resolve(this.qw1.check(signal)),
       () => Promise.resolve(this.qw6.check(signal)),
+      // PR #361 — QW#7 cooldown post-TP US (block) avant gate classe / score
+      () => this.qw7.check(signal),
       () => Promise.resolve(this.qw11.check(signal)),
       () => Promise.resolve(this.qw9.check(signal)),
       () => Promise.resolve(this.qw27.check(signal)),
@@ -154,6 +163,9 @@ export class QuickWinsPipelineService {
       () => this.qw15.check(signal),
       () => Promise.resolve(this.qw18.check(signal)),
       () => Promise.resolve(this.qw14a.check(signal)),
+      // PR #361 — QW#8 boost post-SL (modify) en dernier pour qu'il s'applique
+      // même si autres modifiers ont déjà ajusté le sizing
+      () => this.qw8.check(signal),
     ];
 
     for (const step of ordered) {

--- a/apps/api/src/modules/lisa/quick-wins/qw-7-cooldown-post-tp-us.service.ts
+++ b/apps/api/src/modules/lisa/quick-wins/qw-7-cooldown-post-tp-us.service.ts
@@ -1,0 +1,105 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { QwDecisionLoggerService } from './qw-decision-logger.service';
+import type { QwSignal, QwTrace } from './types';
+
+/**
+ * QW#7 — Cooldown post-TP sur les classes US.
+ *
+ * Idée : après un TP sur us_equity_large ou us_equity_small_mid, le marché
+ * revient souvent en mean-reversion → re-rentrer dans les ~60 min suivantes
+ * sur le même symbole sous-performe. On bloque pendant la fenêtre cooldown.
+ *
+ * Config :
+ *  - QW_7_COOLDOWN_MIN     : durée de la fenêtre en minutes (default 60)
+ *  - QW_7_TARGET_CLASSES   : CSV des classes éligibles (default 'us_equity_large,us_equity_small_mid')
+ *
+ * Implémentation : lookup Supabase `lisa_positions` pour le portfolio courant,
+ * symbol identique, status='closed_target', exit_timestamp >= NOW() - cooldown.
+ * Si au moins 1 ligne → block.
+ *
+ * Fail-open : si Supabase pas prêt ou requête échoue → pass (on ne bloque
+ * pas le trading sur une erreur infra).
+ */
+@Injectable()
+export class Qw7CooldownPostTpUsService {
+  private readonly logger = new Logger(Qw7CooldownPostTpUsService.name);
+  private readonly cooldownMinutes: number;
+  private readonly targetClasses: Set<string>;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+    private readonly decisionLogger: QwDecisionLoggerService,
+  ) {
+    const raw = this.config.get<string>('QW_7_COOLDOWN_MIN') ?? '60';
+    const parsed = Number.parseInt(raw, 10);
+    this.cooldownMinutes = Number.isFinite(parsed) && parsed > 0 ? parsed : 60;
+
+    const classesRaw =
+      this.config.get<string>('QW_7_TARGET_CLASSES') ?? 'us_equity_large,us_equity_small_mid';
+    this.targetClasses = new Set(
+      classesRaw
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+  }
+
+  async check(signal: QwSignal): Promise<QwTrace> {
+    if (!this.targetClasses.has(signal.assetClass)) {
+      return { qwId: 'QW_7', decision: 'pass', reason: 'class_not_eligible' };
+    }
+    if (!signal.portfolioId) {
+      return { qwId: 'QW_7', decision: 'pass', reason: 'no_portfolio_id' };
+    }
+    if (!this.supabase.isReady()) {
+      return { qwId: 'QW_7', decision: 'pass', reason: 'supabase_not_ready' };
+    }
+
+    const cutoffIso = new Date(Date.now() - this.cooldownMinutes * 60_000).toISOString();
+
+    try {
+      const { data, error } = await this.supabase
+        .getClient()
+        .from('lisa_positions')
+        .select('id, exit_timestamp')
+        .eq('portfolio_id', signal.portfolioId)
+        .eq('symbol', signal.symbol)
+        .eq('status', 'closed_target')
+        .gte('exit_timestamp', cutoffIso)
+        .limit(1);
+
+      if (error) {
+        this.logger.warn(`QW_7 query failed for ${signal.symbol}: ${error.message}`);
+        return { qwId: 'QW_7', decision: 'pass', reason: 'db_error_fail_open' };
+      }
+
+      if (!data || data.length === 0) {
+        return { qwId: 'QW_7', decision: 'pass', reason: 'no_recent_tp' };
+      }
+
+      const lastTpAt = data[0].exit_timestamp as string;
+      this.decisionLogger.log({
+        qwId: 'QW_7',
+        symbol: signal.symbol,
+        assetClass: signal.assetClass,
+        decision: 'block',
+        reason: 'cooldown_post_tp_active',
+        wouldHavePassedWithoutFlag: true,
+        details: { cooldownMin: this.cooldownMinutes, lastTpAt, cutoffIso },
+      });
+
+      return {
+        qwId: 'QW_7',
+        decision: 'block',
+        reason: 'cooldown_post_tp_active',
+        details: { cooldownMin: this.cooldownMinutes, lastTpAt },
+      };
+    } catch (err) {
+      this.logger.warn(`QW_7 exception for ${signal.symbol}: ${(err as Error).message}`);
+      return { qwId: 'QW_7', decision: 'pass', reason: 'exception_fail_open' };
+    }
+  }
+}

--- a/apps/api/src/modules/lisa/quick-wins/qw-8-boost-post-sl.service.ts
+++ b/apps/api/src/modules/lisa/quick-wins/qw-8-boost-post-sl.service.ts
@@ -1,0 +1,123 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { QwDecisionLoggerService } from './qw-decision-logger.service';
+import type { QwSignal, QwTrace } from './types';
+
+/**
+ * QW#8 — Boost sizing après un SL sur le même symbole.
+ *
+ * Idée : après un SL, si le scanner ré-émet un signal sur le même symbole
+ * dans une fenêtre courte (~30 min), la probabilité de retournement est
+ * statistiquement plus haute (mean-reversion court terme observée sur 14j
+ * baseline). On boost le sizing pour capturer le rebond.
+ *
+ * Conservateur : multiplier 1.5× (pas 2× — Kelly ne supporte pas le full
+ * doublement sur un signal sans confirmation orthogonale).
+ *
+ * Config :
+ *  - QW_8_WINDOW_MIN       : fenêtre en minutes (default 30)
+ *  - QW_8_MULTIPLIER       : multiplier (default 1.5)
+ *  - QW_8_TARGET_CLASSES   : CSV (default 'us_equity_large,us_equity_small_mid,eu_equity')
+ *
+ * Implémentation : lookup Supabase `lisa_positions` même symbol /
+ * portfolio, status='closed_stop', exit_timestamp >= NOW() - window.
+ * Si match → decision='modify' avec multiplier.
+ *
+ * Fail-open : si Supabase pas prêt → pass (1.0× neutre).
+ */
+@Injectable()
+export class Qw8BoostPostSlService {
+  private readonly logger = new Logger(Qw8BoostPostSlService.name);
+  private readonly windowMinutes: number;
+  private readonly multiplier: number;
+  private readonly targetClasses: Set<string>;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+    private readonly decisionLogger: QwDecisionLoggerService,
+  ) {
+    const rawWindow = this.config.get<string>('QW_8_WINDOW_MIN') ?? '30';
+    const parsedWindow = Number.parseInt(rawWindow, 10);
+    this.windowMinutes = Number.isFinite(parsedWindow) && parsedWindow > 0 ? parsedWindow : 30;
+
+    const rawMult = this.config.get<string>('QW_8_MULTIPLIER') ?? '1.5';
+    const parsedMult = Number.parseFloat(rawMult);
+    this.multiplier =
+      Number.isFinite(parsedMult) && parsedMult >= 1.0 && parsedMult <= 3.0 ? parsedMult : 1.5;
+
+    const classesRaw =
+      this.config.get<string>('QW_8_TARGET_CLASSES') ??
+      'us_equity_large,us_equity_small_mid,eu_equity';
+    this.targetClasses = new Set(
+      classesRaw
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+  }
+
+  async check(signal: QwSignal): Promise<QwTrace> {
+    if (!this.targetClasses.has(signal.assetClass)) {
+      return { qwId: 'QW_8', decision: 'pass', reason: 'class_not_eligible' };
+    }
+    if (!signal.portfolioId) {
+      return { qwId: 'QW_8', decision: 'pass', reason: 'no_portfolio_id' };
+    }
+    if (!this.supabase.isReady()) {
+      return { qwId: 'QW_8', decision: 'pass', reason: 'supabase_not_ready' };
+    }
+
+    const cutoffIso = new Date(Date.now() - this.windowMinutes * 60_000).toISOString();
+
+    try {
+      const { data, error } = await this.supabase
+        .getClient()
+        .from('lisa_positions')
+        .select('id, exit_timestamp')
+        .eq('portfolio_id', signal.portfolioId)
+        .eq('symbol', signal.symbol)
+        .eq('status', 'closed_stop')
+        .gte('exit_timestamp', cutoffIso)
+        .order('exit_timestamp', { ascending: false })
+        .limit(1);
+
+      if (error) {
+        this.logger.warn(`QW_8 query failed for ${signal.symbol}: ${error.message}`);
+        return { qwId: 'QW_8', decision: 'pass', reason: 'db_error_fail_open' };
+      }
+
+      if (!data || data.length === 0) {
+        return { qwId: 'QW_8', decision: 'pass', reason: 'no_recent_sl' };
+      }
+
+      const lastSlAt = data[0].exit_timestamp as string;
+      this.decisionLogger.log({
+        qwId: 'QW_8',
+        symbol: signal.symbol,
+        assetClass: signal.assetClass,
+        decision: 'modify',
+        reason: 'boost_post_sl',
+        wouldHavePassedWithoutFlag: true,
+        details: {
+          windowMin: this.windowMinutes,
+          multiplier: this.multiplier,
+          lastSlAt,
+          cutoffIso,
+        },
+      });
+
+      return {
+        qwId: 'QW_8',
+        decision: 'modify',
+        reason: 'boost_post_sl',
+        multiplier: this.multiplier,
+        details: { windowMin: this.windowMinutes, lastSlAt },
+      };
+    } catch (err) {
+      this.logger.warn(`QW_8 exception for ${signal.symbol}: ${(err as Error).message}`);
+      return { qwId: 'QW_8', decision: 'pass', reason: 'exception_fail_open' };
+    }
+  }
+}

--- a/apps/api/src/modules/lisa/quick-wins/types.ts
+++ b/apps/api/src/modules/lisa/quick-wins/types.ts
@@ -20,6 +20,8 @@ export type QwId =
   | 'QW_3'
   | 'QW_4'
   | 'QW_6'
+  | 'QW_7'
+  | 'QW_8'
   | 'QW_9'
   | 'QW_11'
   | 'QW_14A'


### PR DESCRIPTION
## PR #361 — QW#7 cooldown post-TP US + QW#8 boost post-SL

Phase 5 N2 — 2 nouveaux filtres Quick Wins basés sur l'historique récent des positions du portfolio.

### Motivation

Désastre 19 mai (-$534, WR 12.9%) a montré que sur classes US :
- enchaînement rapide TP → ré-entrée sur même symbol = cash inutile (peak déjà capturé)
- enchaînement SL → ré-émission rapide = mean-reversion plausible, capter avec sizing boost

### QW#7 — Cooldown post-TP US (block)

Bloque l'entrée si un TP a été fermé sur le même symbole il y a moins de `QW_7_COOLDOWN_MIN` minutes (default 60).

- Classes ciblées : `us_equity_large`, `us_equity_small_mid` (configurable `QW_7_TARGET_CLASSES`)
- Position cascade : entre QW#6 (blacklist symbols) et QW#11 (asset class gate) — slot block
- Source : `lisa_positions` status=`closed_target`, fail-open Supabase

### QW#8 — Boost post-SL (modify ×1.5)

Modifie le multiplier de sizing à 1.5× (clipped 1.0–3.0) si un SL a été fermé sur le même symbole il y a moins de `QW_8_WINDOW_MIN` minutes (default 30).

- Classes ciblées : `us_equity_large`, `us_equity_small_mid`, `eu_equity` (configurable `QW_8_TARGET_CLASSES`)
- Position cascade : en fin de cascade après QW#14A — slot modify
- Source : `lisa_positions` status=`closed_stop`, fail-open Supabase

### Configuration secrets Fly

Defaults conservateurs, set seulement si override :

```
QW_7_COOLDOWN_MIN=60               # default 60
QW_7_TARGET_CLASSES=us_equity_large,us_equity_small_mid
QW_8_WINDOW_MIN=30                 # default 30
QW_8_MULTIPLIER=1.5                # default 1.5, clipped [1.0, 3.0]
QW_8_TARGET_CLASSES=us_equity_large,us_equity_small_mid,eu_equity
```

### Tests

- `qw-7-cooldown-post-tp-us.spec.ts` : 8 cas (class non éligible, no portfolio, supabase not ready, no recent TP, TP recent block + logger appelé, db error fail-open, config window override, target classes override)
- `qw-8-boost-post-sl.spec.ts` : 10 cas (eu_equity inclus par défaut, multiplier override, multiplier hors bornes → fallback 1.5, etc.)
- `quick-wins-pipeline.spec.ts` : ajout instanciation QW7/QW8 dans `makePipeline()`

### Fichiers

- `apps/api/src/modules/lisa/quick-wins/qw-7-cooldown-post-tp-us.service.ts` (new)
- `apps/api/src/modules/lisa/quick-wins/qw-8-boost-post-sl.service.ts` (new)
- `apps/api/src/modules/lisa/quick-wins/index.ts` (exports)
- `apps/api/src/modules/lisa/quick-wins/types.ts` (QwId += QW_7 | QW_8)
- `apps/api/src/modules/lisa/quick-wins/quick-wins-pipeline.service.ts` (cascade order)
- `apps/api/src/modules/lisa/lisa.module.ts` (imports + providers)
- `apps/api/src/modules/lisa/quick-wins/__tests__/qw-7-cooldown-post-tp-us.spec.ts` (new)
- `apps/api/src/modules/lisa/quick-wins/__tests__/qw-8-boost-post-sl.spec.ts` (new)
- `apps/api/src/modules/lisa/quick-wins/__tests__/quick-wins-pipeline.spec.ts` (update)

### Risques / rollback

- Fail-open total si Supabase pas prêt → comportement neutre
- Si bug détecté en prod : `QUICK_WINS_PIPELINE_ENABLED=false` (PR #358 toggle runtime) ou via endpoint admin `/admin/qw-pipeline-toggle`
- Pour désactiver uniquement QW#7 ou QW#8 isolément : pas de toggle individuel (à ajouter en future PR si besoin), passer `QW_7_TARGET_CLASSES=` vide ou `QW_8_MULTIPLIER=1.0` (neutre)

### Suite Phase 5 N2

Après merge : reste à activer secrets Fly via UI (l'user n'a pas flyctl CLI local) :
- `QUICK_WINS_PIPELINE_ENABLED=true`
- `TWELVEDATA_INTRADAY_AB_TEST_RATIO=1.0`
- `SCANNER_UNIVERSE_MAX_TICKERS=3000`
- `TWELVEDATA_FILTER_ASIA_SUPERTREND_ENABLED=true` (PR #360)
