### PR TITLE
feat(scorer): PR #362 composite scorer data-driven per-class

### DIFF
--- a/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
+++ b/apps/api/src/modules/gainers-scanner/__tests__/gainers-bloc1.spec.ts
@@ -23,6 +23,7 @@ import {
 } from '../bloc1/trend-filter';
 import {
   DEFAULT_COMPOSITE_SCORER_CONFIG,
+  LEGACY_COMPOSITE_SCORER_CONFIG,
   SHADOW_COMPOSITE_SCORER_CONFIG,
   computeCompositeScore,
 } from '../bloc1/composite-scorer';
@@ -325,6 +326,153 @@ describe('GainersBloc1 — composite scorer', () => {
     expect(s!).toBeGreaterThanOrEqual(0);
   });
 
+  // PR #362 — Recalibrage data-driven
+  describe('PR #362 — recalibrage data-driven', () => {
+    it('momentumNormalizationCeiling default = 0.25 (anti-saturation asia/eu)', () => {
+      expect(DEFAULT_COMPOSITE_SCORER_CONFIG.momentumNormalizationCeiling).toBe(0.25);
+    });
+
+    it('LEGACY_COMPOSITE_SCORER_CONFIG conserve ceiling 0.10 (régression bit-perfect ADR-005)', () => {
+      expect(LEGACY_COMPOSITE_SCORER_CONFIG.momentumNormalizationCeiling).toBe(0.1);
+      expect(LEGACY_COMPOSITE_SCORER_CONFIG.weightPersistence).toBe(0.5);
+      expect(LEGACY_COMPOSITE_SCORER_CONFIG.weightMomentum).toBe(0.3);
+      expect(LEGACY_COMPOSITE_SCORER_CONFIG.weightVolatilityInv).toBe(0.2);
+      expect(LEGACY_COMPOSITE_SCORER_CONFIG.perClassWeights).toBeUndefined();
+      expect(LEGACY_COMPOSITE_SCORER_CONFIG.perClassMomentumBoost).toBeUndefined();
+    });
+
+    it('Saturation fix : ch1m=20% sur ceiling 0.25 ne sature plus le component momentum', () => {
+      // Ancien (ceiling 0.10) : 0.20/0.10=2.0 → clamp 1.0 (saturé)
+      // Nouveau (ceiling 0.25) : 0.20/0.25=0.8 (non saturé)
+      const rawNoClass = baseEquity({ changePct1m: 0.2, persistenceScore: 0.5, atrDailyRelative: 0.05 });
+      const sNew = computeCompositeScore(rawNoClass, DEFAULT_COMPOSITE_SCORER_CONFIG);
+      const sLegacy = computeCompositeScore(rawNoClass, LEGACY_COMPOSITE_SCORER_CONFIG);
+      // sLegacy : 0.5*0.5 + 0.3*1.0 + 0.2*(1-0.05/0.15)=0.2*0.667=0.1333 → 0.683
+      // sNew (no assetClass, poids globaux) : 0.5*0.5 + 0.3*0.8 + 0.2*0.667 = 0.25+0.24+0.1333 = 0.6233
+      expect(sLegacy!).toBeCloseTo(0.683, 2);
+      expect(sNew!).toBeCloseTo(0.623, 2);
+    });
+
+    it('Per-class eu_equity : poids momentum 0.55 prend le dessus sur persistence 0.25', () => {
+      // eu_equity, ch1m=18% (bucket 15-25, WR mesuré 39-58%), persistance=0.5, atr=0.05
+      const raw = baseEquity({
+        assetClass: 'eu_equity',
+        changePct1m: 0.18,
+        persistenceScore: 0.5,
+        atrDailyRelative: 0.05,
+      });
+      const s = computeCompositeScore(raw, DEFAULT_COMPOSITE_SCORER_CONFIG);
+      // momentumComp = 0.18/0.25 = 0.72
+      // volInvComp = 1 - 0.05/0.15 = 0.6667
+      // weighted = 0.55*0.72 + 0.25*0.5 + 0.2*0.6667 = 0.396 + 0.125 + 0.1333 = 0.6543
+      // ch1m=18% >= 10% → boost ×1.25 → 0.6543 * 1.25 = 0.818 (cap 1.0)
+      expect(s!).toBeCloseTo(0.818, 2);
+    });
+
+    it('Per-class us_equity_large : persistance dominante (poids 0.55)', () => {
+      // us_large, ch1m=7% (sous boost ×1.15 threshold de 10%), persistance haute=0.95
+      const raw = baseEquity({
+        assetClass: 'us_equity_large',
+        changePct1m: 0.07,
+        persistenceScore: 0.95,
+        atrDailyRelative: 0.04,
+      });
+      const s = computeCompositeScore(raw, DEFAULT_COMPOSITE_SCORER_CONFIG);
+      // momentumComp = 0.07/0.25 = 0.28
+      // volInvComp = 1 - 0.04/0.15 = 0.7333
+      // weighted = 0.25*0.28 + 0.55*0.95 + 0.2*0.7333 = 0.07 + 0.5225 + 0.1467 = 0.7392
+      // ch1m=7% < 10% → pas de boost
+      expect(s!).toBeCloseTo(0.739, 2);
+    });
+
+    it('Per-class asia_equity : boost ×1.20 si ch1m >= 15%', () => {
+      const raw = baseEquity({
+        assetClass: 'asia_equity',
+        changePct1m: 0.16,
+        persistenceScore: 0.9,
+        atrDailyRelative: 0.05,
+      });
+      const s = computeCompositeScore(raw, DEFAULT_COMPOSITE_SCORER_CONFIG);
+      // momentumComp = 0.16/0.25 = 0.64
+      // volInvComp = 1 - 0.05/0.15 = 0.6667
+      // weighted = 0.4*0.64 + 0.4*0.9 + 0.2*0.6667 = 0.256+0.36+0.1333 = 0.7493
+      // ch1m=16% >= 15% → boost ×1.20 → 0.7493 * 1.20 = 0.899
+      expect(s!).toBeCloseTo(0.899, 2);
+    });
+
+    it('Per-class asia_equity : pas de boost si ch1m < 15%', () => {
+      const raw = baseEquity({
+        assetClass: 'asia_equity',
+        changePct1m: 0.12,
+        persistenceScore: 0.9,
+        atrDailyRelative: 0.05,
+      });
+      const s = computeCompositeScore(raw, DEFAULT_COMPOSITE_SCORER_CONFIG);
+      // momentumComp = 0.12/0.25 = 0.48
+      // weighted = 0.4*0.48 + 0.4*0.9 + 0.2*0.6667 = 0.192+0.36+0.1333 = 0.6853
+      // ch1m=12% < 15% → pas de boost
+      expect(s!).toBeCloseTo(0.685, 2);
+    });
+
+    it('Per-class us_equity_small_mid : pas de boost configuré (bucket inversé)', () => {
+      const raw = baseEquity({
+        assetClass: 'us_equity_small_mid',
+        changePct1m: 0.25,
+        persistenceScore: 0.8,
+        atrDailyRelative: 0.05,
+      });
+      const s = computeCompositeScore(raw, DEFAULT_COMPOSITE_SCORER_CONFIG);
+      // momentumComp = 0.25/0.25 = 1.0
+      // volInvComp = 1 - 0.05/0.15 = 0.6667
+      // weighted = 0.35*1.0 + 0.45*0.8 + 0.2*0.6667 = 0.35+0.36+0.1333 = 0.8433
+      // PAS de boost (us_small_mid bucket inversé)
+      expect(s!).toBeCloseTo(0.843, 2);
+    });
+
+    it('Rétrocompat : assetClass absent → poids globaux fallback (0.5/0.3/0.2)', () => {
+      const raw = baseEquity({
+        changePct1m: 0.10,
+        persistenceScore: 0.9,
+        atrDailyRelative: 0.05,
+      });
+      // Pas d'assetClass → poids globaux. Ceiling 0.25.
+      // momentumComp = 0.10/0.25 = 0.4
+      // volInvComp = 1 - 0.05/0.15 = 0.6667
+      // weighted = 0.5*0.9 + 0.3*0.4 + 0.2*0.6667 = 0.45+0.12+0.1333 = 0.7033
+      const s = computeCompositeScore(raw, DEFAULT_COMPOSITE_SCORER_CONFIG);
+      expect(s!).toBeCloseTo(0.703, 2);
+    });
+
+    it('Rétrocompat : crypto_major sans poids per-class défini → fallback global', () => {
+      // crypto_major n'est PAS dans DEFAULT_PER_CLASS_WEIGHTS (sample insuffisant)
+      const raw = baseEquity({
+        assetClass: 'crypto_major',
+        changePct1m: 0.05,
+        persistenceScore: 0.8,
+        atrDailyRelative: 0.04,
+      });
+      const s = computeCompositeScore(raw, DEFAULT_COMPOSITE_SCORER_CONFIG);
+      // Fallback poids globaux 0.5/0.3/0.2, ceiling 0.25
+      // momentumComp = 0.05/0.25 = 0.2
+      // volInvComp = 1 - 0.04/0.15 = 0.7333
+      // weighted = 0.5*0.8 + 0.3*0.2 + 0.2*0.7333 = 0.4+0.06+0.1467 = 0.6067
+      expect(s!).toBeCloseTo(0.607, 2);
+    });
+
+    it('Boost momentum cap à 1.0 même si multiplier le pousse au-dessus', () => {
+      const raw = baseEquity({
+        assetClass: 'eu_equity',
+        changePct1m: 0.5,  // 50% → boost ×1.25
+        persistenceScore: 1.0,
+        atrDailyRelative: 0.01,
+      });
+      const s = computeCompositeScore(raw, DEFAULT_COMPOSITE_SCORER_CONFIG);
+      // Score avant boost déjà élevé, boost cap à 1.0
+      expect(s!).toBeLessThanOrEqual(1.0);
+      expect(s!).toBeGreaterThanOrEqual(0.95);
+    });
+  });
+
   // PR6.6.6 — shadowAllowPartialScore : best-effort scoring with null fields
   describe('PR6.6.6 — shadowAllowPartialScore', () => {
     it('Cas 1 : tous fields présents, shadowAllowPartialScore=false → strict identique', () => {
@@ -367,21 +515,19 @@ describe('GainersBloc1 — composite scorer', () => {
         SHADOW_COMPOSITE_SCORER_CONFIG,
       );
       expect(s).not.toBeNull();
-      // PR6.6.6.1 missing-penalty (PAS renormalize) :
-      // momentumComp = 0.05 / 0.10 = 0.5
-      // weightedSum = 0.3 × 0.5 = 0.15 (persistence + atr absents → max 0.3)
-      expect(s!).toBeCloseTo(0.15);
+      // PR #362 : ceiling 0.25 (ex-0.10). momentumComp = 0.05/0.25 = 0.2
+      // weightedSum = 0.3 × 0.2 = 0.06 (persistence + atr absents → max 0.3)
+      expect(s!).toBeCloseTo(0.06);
     });
 
-    it('Cas 5bis : PR6.6.6.1 — changePct1m=20% (max momentum) + tous null → score plafonné à 0.3', () => {
+    it('Cas 5bis : PR6.6.6.1 — changePct1m=20% + tous null → score plafonné (ceiling 0.25)', () => {
       const s = computeCompositeScore(
         baseEquity({ persistenceScore: null, atrDailyRelative: null, changePct1m: 0.20 }),
         SHADOW_COMPOSITE_SCORER_CONFIG,
       );
-      // momentum clamp à 1.0 (changePct >= ceiling 0.10)
-      // weightedSum = 0.3 × 1.0 = 0.3 (max possible avec seul momentum)
-      // Sans renormalize → 0.3 (vs ancien 1.0 = artifact bilan smoke test)
-      expect(s).toBeCloseTo(0.3);
+      // PR #362 : ceiling 0.25. momentum = 0.20/0.25 = 0.8 (n'est plus saturé)
+      // weightedSum = 0.3 × 0.8 = 0.24 (vs 0.3 historique avec ceiling 0.10)
+      expect(s).toBeCloseTo(0.24);
     });
 
     it('Cas 6 : Régression prod default — shadowAllowPartialScore=false', () => {
@@ -392,20 +538,23 @@ describe('GainersBloc1 — composite scorer', () => {
       expect(SHADOW_COMPOSITE_SCORER_CONFIG.shadowAllowPartialScore).toBe(true);
     });
 
-    it('Cas 8 : PR6.6.6.1 — score partiel reflète complétude (NO renormalize)', () => {
-      // baseEquity : persistence=0.83, momentum=0.02 (changePct1m), atr=0.03
-      // Strict score : 0.5*0.83 + 0.3*0.2 + 0.2*0.8 = 0.415 + 0.06 + 0.16 = 0.635
+    it('Cas 8 : PR6.6.6.1 — score partiel reflète complétude (NO renormalize, ceiling 0.25)', () => {
+      // baseEquity : persistence=0.83, ch1m=0.02, atr=0.03. Pas d'assetClass.
+      // PR #362 ceiling 0.25 : momentumComp = 0.02/0.25 = 0.08
+      // volInvComp = 1 - 0.03/0.15 = 0.8
+      // Strict score (poids globaux fallback) : 0.5*0.83 + 0.3*0.08 + 0.2*0.8
+      //                                       = 0.415 + 0.024 + 0.16 = 0.599
       const strict = computeCompositeScore(baseEquity(), DEFAULT_COMPOSITE_SCORER_CONFIG);
 
       // Shadow partiel sans persistence (missing-penalty PR6.6.6.1) :
-      // weightedSum = 0.3*0.2 + 0.2*0.8 = 0.06 + 0.16 = 0.22 (max = 0.3+0.2 = 0.5)
+      // weightedSum = 0.3*0.08 + 0.2*0.8 = 0.024 + 0.16 = 0.184
       const partial = computeCompositeScore(
         baseEquity({ persistenceScore: null }),
         SHADOW_COMPOSITE_SCORER_CONFIG,
       );
-      expect(strict).toBeCloseTo(0.635);
-      expect(partial).toBeCloseTo(0.22);
-      // Ranking préservé : strict (0.635) > partial (0.22) ✅
+      expect(strict).toBeCloseTo(0.599);
+      expect(partial).toBeCloseTo(0.184);
+      // Ranking préservé : strict (0.599) > partial (0.184)
       expect(strict!).toBeGreaterThan(partial!);
     });
 

--- a/apps/api/src/modules/gainers-scanner/bloc1/composite-scorer.ts
+++ b/apps/api/src/modules/gainers-scanner/bloc1/composite-scorer.ts
@@ -1,46 +1,184 @@
 /**
- * BLOC 1 — Composite scorer (ADR-005).
+ * BLOC 1 — Composite scorer (ADR-005, recalibré PR #362 data-driven).
  *
  * Combine 3 dimensions normalisées en un score [0..1] :
- *   - Persistance multi-TF (pondération 50%)
- *   - Momentum 1m (pondération 30%, normalisé sur 10% comme plafond)
- *   - Volatilité inverse (pondération 20%, ATR/close ramené sur la clamp)
+ *   - Persistance multi-TF
+ *   - Momentum 1m (changePct1m, normalisé sur un plafond)
+ *   - Volatilité inverse (ATR/close ramené sur la clamp)
  *
- * Pas de RVOL ici — il sera inclus en BLOC 2 quand les baselines seront wirées.
+ * PR #362 — Recalibrage data-driven (basé sur 251 positions fermées, 14j mai 2026,
+ * jointes avec leurs shadow signals) :
+ *
+ *   1. momentumNormalizationCeiling 0.10 → 0.25 : tout candidat asia/eu avec
+ *      changePct1m >= 10% saturait le component à 1.0 (30/31 positions du
+ *      19 mai avaient score=1.000). Nouveau plafond 25% permet de différencier
+ *      les bursts (15-25%) des super-bursts (25+%).
+ *
+ *   2. Poids per-class : les classes n'ont pas le même signal d'edge.
+ *      Mesures empiriques (Δ moyenne TP vs SL sur 14j) :
+ *        - eu_equity  : ch1m discrimine fort (+3.47), persistance neutre
+ *          → poids momentum 0.55, persistance 0.25
+ *        - us_equity_large : persistance discrimine fort (+0.121), ch1m
+ *          INVERSÉ (-0.52 = high momentum = trap)
+ *          → poids momentum 0.25, persistance 0.55
+ *        - asia_equity : ch1m discrimine modéré (+1.71)
+ *          → poids momentum 0.40, persistance 0.40
+ *        - us_equity_small_mid : ch1m faible (+0.52)
+ *          → poids momentum 0.35, persistance 0.45
+ *        - autres (crypto, fx, commodity, sample insuffisant) : poids default
+ *
+ *   3. Boost momentum non-linéaire : si changePct1m franchit un seuil de
+ *      conviction par classe ET la classe en bénéficie historiquement,
+ *      multiplier le score final par momentumBoostMultiplier.
+ *
+ *      Mesures par bucket :
+ *        - eu : ch1m ≥ 10% → WR 54-58% vs <10% = 29% (+25pp) → boost ≥10 ×1.25
+ *        - asia : ch1m ≥ 15% → WR 39% vs <15% = 25% (+14pp) → boost ≥15 ×1.20
+ *        - us_large : ch1m ≥ 10% → WR 40% vs <10% = 28% (+12pp) → boost ≥10 ×1.15
+ *
+ * Compatibilité : si assetClass absent OU classe absente de perClassWeights,
+ * fallback sur weightPersistence/weightMomentum/weightVolatilityInv (default
+ * historique 0.5/0.3/0.2 inchangé pour les tests de régression).
  */
 
-import type { GainersCandidateRaw } from '../domain/gainers-candidate.types';
+import type {
+  GainersAssetClass,
+  GainersCandidateRaw,
+} from '../domain/gainers-candidate.types';
 
-export interface CompositeScorerConfig {
-  /** Poids persistance (défaut 0.5). */
+export interface CompositeScorerWeights {
   weightPersistence: number;
-  /** Poids momentum (défaut 0.3). */
   weightMomentum: number;
-  /** Poids volatilité inverse (défaut 0.2). */
   weightVolatilityInv: number;
-  /** Plafond de normalisation du momentum (défaut 0.10 = 10%). */
+}
+
+export interface MomentumBoostRule {
+  /** Seuil changePct1m à franchir (en pct absolu, ex : 10 pour 10%). */
+  threshold: number;
+  /** Facteur multiplicatif appliqué au score final si franchi. */
+  multiplier: number;
+}
+
+export interface CompositeScorerConfig extends CompositeScorerWeights {
+  /** Plafond de normalisation du momentum (PR #362 : default 0.25 = 25%, ex-0.10). */
   momentumNormalizationCeiling: number;
   /** ATR clamp utilisé pour la volatilité inverse (défaut 0.15). */
   volatilityClampMaxAtrRel: number;
   /**
-   * PR6.6.6 — Shadow mode best-effort scoring : si true ET persistenceScore
-   * ou atrDailyRelative null, calcule un score partiel basé uniquement sur
-   * les composants disponibles (renormalisation des poids).
-   *
-   * Default false : préserve comportement strict prod (ADR-005 §1bis : un
-   * score partiel pourrait être trompeur). Activable uniquement via
-   * SHADOW_BLOC1_FULL_CONFIG (PR6.6.5).
-   *
-   * Effet : composite_score n'est plus null pour les ACCEPT shadow → ranking
-   * possible + AutoTuner V2 a un score à analyser. Le score est marqué
-   * "partial" via la convention que persistence ou atr étaient null
-   * (audit via gainers_v1_shadow_signals.composite_score IS NOT NULL +
-   * raw fields stored elsewhere si needed).
+   * PR6.6.6 — Shadow mode best-effort scoring (cf. doc historique).
+   * Default false : prod strict ADR-005 §1bis.
    */
   shadowAllowPartialScore?: boolean;
+  /**
+   * PR #362 — Poids spécifiques par asset class. Si raw.assetClass est
+   * présent ET défini ici, ces poids remplacent les poids globaux.
+   * Sinon fallback sur weightPersistence/weightMomentum/weightVolatilityInv.
+   */
+  perClassWeights?: Partial<Record<GainersAssetClass, CompositeScorerWeights>>;
+  /**
+   * PR #362 — Boost momentum non-linéaire par classe. Appliqué APRÈS calcul
+   * du score pondéré, avant clamp01. Si raw.changePct1m >= threshold,
+   * score *= multiplier (cap à 1.0).
+   */
+  perClassMomentumBoost?: Partial<Record<GainersAssetClass, MomentumBoostRule>>;
 }
 
+/**
+ * PR #362 — Poids per-class data-driven.
+ * Mesures : 251 positions fermées sur 14 jours (5-19 mai 2026), shadow signals
+ * joints sur (symbol, entry_timestamp ±5min/+20min), filtre decision='accept'.
+ *
+ * Critère de sélection des poids :
+ *   - Δ moyenne_TP_vs_SL sur chaque dimension par classe
+ *   - Bucket WR par dimension pour valider le sens et la magnitude
+ *   - Sample min 25 positions/classe (crypto sample 9 → garde default)
+ */
+export const DEFAULT_PER_CLASS_WEIGHTS: NonNullable<
+  CompositeScorerConfig['perClassWeights']
+> = {
+  // eu : ch1m TP=18.53 vs SL=15.06 (Δ +3.47). Persistance inverse (TP<SL).
+  // Bucket 10-15: WR 54%, 25+: WR 58%, 5-10: 29% → momentum dominant.
+  eu_equity: {
+    weightMomentum: 0.55,
+    weightPersistence: 0.25,
+    weightVolatilityInv: 0.2,
+  },
+  // us_large : ch1m INVERSÉ (TP=7.06 vs SL=7.58, Δ -0.52).
+  // Persistence TP=0.969 vs SL=0.848 (Δ +0.121, le plus fort signal mesuré).
+  // → bascule sur persistance dominante.
+  us_equity_large: {
+    weightMomentum: 0.25,
+    weightPersistence: 0.55,
+    weightVolatilityInv: 0.2,
+  },
+  // asia : ch1m TP=12.67 vs SL=10.96 (Δ +1.71). Persistence TP=0.987 vs SL=0.943 (Δ +0.044).
+  // Bucket 15-25: WR 39%, 10-15: 29%, 5-10: 24% → momentum modéré utile.
+  asia_equity: {
+    weightMomentum: 0.4,
+    weightPersistence: 0.4,
+    weightVolatilityInv: 0.2,
+  },
+  // us_small_mid : ch1m TP=13.00 vs SL=12.48 (Δ +0.52, faible).
+  // Persistence TP=0.875 vs SL=0.920 (Δ -0.045, inversé).
+  // → conservateur, momentum modéré, défaut sur persistance.
+  us_equity_small_mid: {
+    weightMomentum: 0.35,
+    weightPersistence: 0.45,
+    weightVolatilityInv: 0.2,
+  },
+};
+
+/**
+ * PR #362 — Boost momentum non-linéaire par classe.
+ * Seuils issus des buckets ch1m mesurés par classe : on déclenche le boost
+ * uniquement quand le bucket franchit un WR significativement supérieur à la
+ * baseline classe.
+ *
+ * Multipliers conservateurs (×1.15 à ×1.25) : on cap le score à 1.0 de toute
+ * façon. L'effet réel = remonter dans le ranking les candidats à fort momentum.
+ */
+export const DEFAULT_PER_CLASS_MOMENTUM_BOOST: NonNullable<
+  CompositeScorerConfig['perClassMomentumBoost']
+> = {
+  // eu : bucket 10-15 WR 54%, 25+ WR 58% vs 5-10 WR 29% → break ≥10
+  eu_equity: { threshold: 10, multiplier: 1.25 },
+  // asia : bucket 15-25 WR 39% vs <15 WR 25% → break ≥15 (le 25+ sample 6 est noisy)
+  asia_equity: { threshold: 15, multiplier: 1.2 },
+  // us_large : bucket 10-15 WR 40% vs 5-10 WR 31% → break ≥10 boost modéré
+  us_equity_large: { threshold: 10, multiplier: 1.15 },
+  // us_small_mid : pattern inversé (5-10 WR 36% > 10-15 WR 14%) → PAS de boost
+  // crypto / fx / commodity : sample insuffisant → PAS de boost
+};
+
 export const DEFAULT_COMPOSITE_SCORER_CONFIG: CompositeScorerConfig = {
+  // Poids globaux fallback (identiques à l'historique ADR-005)
+  weightPersistence: 0.5,
+  weightMomentum: 0.3,
+  weightVolatilityInv: 0.2,
+  // PR #362 : plafond 0.25 (ex-0.10) — anti-saturation asia/eu
+  momentumNormalizationCeiling: 0.25,
+  volatilityClampMaxAtrRel: 0.15,
+  shadowAllowPartialScore: false,
+  // PR #362 : data-driven per-class
+  perClassWeights: DEFAULT_PER_CLASS_WEIGHTS,
+  perClassMomentumBoost: DEFAULT_PER_CLASS_MOMENTUM_BOOST,
+};
+
+/**
+ * PR6.6.6 — Composite scorer config pour shadow run.
+ * Identique à DEFAULT mais shadowAllowPartialScore=true.
+ */
+export const SHADOW_COMPOSITE_SCORER_CONFIG: CompositeScorerConfig = {
+  ...DEFAULT_COMPOSITE_SCORER_CONFIG,
+  shadowAllowPartialScore: true,
+};
+
+/**
+ * PR #362 — Legacy config pour tests de régression : ceiling 0.10, poids
+ * globaux 0.5/0.3/0.2, pas de per-class, pas de boost. Conserve l'ancien
+ * comportement bit-perfect pour les specs PR6.6.x avant recalibrage.
+ */
+export const LEGACY_COMPOSITE_SCORER_CONFIG: CompositeScorerConfig = {
   weightPersistence: 0.5,
   weightMomentum: 0.3,
   weightVolatilityInv: 0.2,
@@ -49,40 +187,71 @@ export const DEFAULT_COMPOSITE_SCORER_CONFIG: CompositeScorerConfig = {
   shadowAllowPartialScore: false,
 };
 
-/**
- * PR6.6.6 — Composite scorer config pour shadow run.
- * Identique à DEFAULT mais shadowAllowPartialScore=true → calcule score
- * best-effort même avec persistence ou atr null.
- */
-export const SHADOW_COMPOSITE_SCORER_CONFIG: CompositeScorerConfig = {
-  ...DEFAULT_COMPOSITE_SCORER_CONFIG,
-  shadowAllowPartialScore: true,
-};
-
 const clamp01 = (x: number): number => Math.max(0, Math.min(1, x));
+
+/**
+ * PR #362 — Résout les poids à utiliser pour ce candidat.
+ * Si raw.assetClass existe ET cfg.perClassWeights[class] défini → per-class.
+ * Sinon → poids globaux (weightPersistence/weightMomentum/weightVolatilityInv).
+ */
+function resolveWeights(
+  raw: GainersCandidateRaw,
+  cfg: CompositeScorerConfig,
+): CompositeScorerWeights {
+  if (raw.assetClass && cfg.perClassWeights) {
+    const cls = cfg.perClassWeights[raw.assetClass];
+    if (cls) {
+      return cls;
+    }
+  }
+  return {
+    weightPersistence: cfg.weightPersistence,
+    weightMomentum: cfg.weightMomentum,
+    weightVolatilityInv: cfg.weightVolatilityInv,
+  };
+}
+
+/**
+ * PR #362 — Applique le boost momentum non-linéaire si la classe a un boost
+ * configuré ET changePct1m franchit le seuil. Cap à 1.0.
+ *
+ * Note : changePct1m peut être stocké en valeur fractionnaire (0.10 = 10%)
+ * ou en pourcentage absolu (10 = 10%). La table gainers_user_shadow_signals
+ * stocke en absolu (ch1m_tp_avg=18 = 18%). Côté code, changePct1m est en
+ * fractionnaire (cf. momentumNormalizationCeiling=0.10 ex). On uniformise :
+ * thresholds dans MomentumBoostRule sont exprimés en POURCENTAGE ABSOLU.
+ */
+function applyMomentumBoost(
+  scoreBeforeBoost: number,
+  raw: GainersCandidateRaw,
+  cfg: CompositeScorerConfig,
+): number {
+  if (!raw.assetClass || !cfg.perClassMomentumBoost) {
+    return scoreBeforeBoost;
+  }
+  const rule = cfg.perClassMomentumBoost[raw.assetClass];
+  if (!rule) {
+    return scoreBeforeBoost;
+  }
+  // changePct1m est en fractionnaire (0.20 = 20%). On compare en absolu.
+  const changePctAbs = raw.changePct1m * 100;
+  if (changePctAbs >= rule.threshold) {
+    return clamp01(scoreBeforeBoost * rule.multiplier);
+  }
+  return scoreBeforeBoost;
+}
 
 /**
  * Calcule le score composite [0..1].
  *
  * Mode strict (default) : retourne null si persistence ou atr absents
- * (ADR-005 §1bis prod : score partiel = trompeur).
+ * (ADR-005 §1bis prod).
  *
  * Mode shadow PR6.6.6 (cfg.shadowAllowPartialScore=true) :
- *   - Calcule le score sur les composants disponibles uniquement
- *   - PR6.6.6.1 : missing-penalty (PAS renormalize) → score reflète
- *     la complétude des données. Max possible :
- *       - momentum only :          0.3 (= weightMomentum)
- *       - momentum + atr :         0.5 (= weightMomentum + weightVolatilityInv)
- *       - momentum + persistence : 0.8 (= weightMomentum + weightPersistence)
- *       - tous présents :          1.0
- *
- *   - Avantage vs renormalize : ranking préservé (full > partial),
- *     AutoTuner V2 trie par confidence, évite l'artifact "tous ACCEPT
- *     shadow à 1.000" observé sur smoke test Q2 (changePct1m ≥ 10% +
- *     persistence/atr null → renormalize donnait 1.0 systématique).
- *
- *   - Garde-fou implicite : un ACCEPT shadow avec score < 0.3 = bug
- *     (momentum manquant impossible). Score 0.3 = momentum max only.
+ *   - Calcule sur composants disponibles avec missing-penalty
+ *   - Per-class et boost appliqués UNIQUEMENT en mode strict (tous composants
+ *     présents), car le shadow partial sert à diagnostiquer la complétude
+ *     données, pas à scorer pour décision réelle.
  *
  * Note : changePct1m (momentum) est TOUJOURS disponible (vient du screener).
  */
@@ -102,30 +271,31 @@ export function computeCompositeScore(
 
   // Mode strict ou shadow avec tous composants présents
   if (persistenceAvail && atrAvail) {
+    const weights = resolveWeights(raw, cfg);
     const persistenceComponent = clamp01(raw.persistenceScore!);
-    const volatilityInvComponent = 1 - clamp01(raw.atrDailyRelative! / cfg.volatilityClampMaxAtrRel);
+    const volatilityInvComponent =
+      1 - clamp01(raw.atrDailyRelative! / cfg.volatilityClampMaxAtrRel);
     const weighted =
-      cfg.weightPersistence * persistenceComponent +
-      cfg.weightMomentum * momentumComponent +
-      cfg.weightVolatilityInv * volatilityInvComponent;
-    return clamp01(weighted);
+      weights.weightPersistence * persistenceComponent +
+      weights.weightMomentum * momentumComponent +
+      weights.weightVolatilityInv * volatilityInvComponent;
+    const scoreBeforeBoost = clamp01(weighted);
+    return applyMomentumBoost(scoreBeforeBoost, raw, cfg);
   }
 
   // Mode shadow partial — PR6.6.6.1 missing-penalty (PAS renormalize)
+  // PR #362 : on garde la logique partial historique (poids globaux fallback),
+  // pas de per-class ici car features manquantes = diagnostic.
   let weightedSum = 0;
-
-  // Momentum (toujours dispo via changePct1m)
   weightedSum += cfg.weightMomentum * momentumComponent;
-
   if (persistenceAvail) {
     const persistenceComponent = clamp01(raw.persistenceScore!);
     weightedSum += cfg.weightPersistence * persistenceComponent;
   }
-
   if (atrAvail) {
-    const volatilityInvComponent = 1 - clamp01(raw.atrDailyRelative! / cfg.volatilityClampMaxAtrRel);
+    const volatilityInvComponent =
+      1 - clamp01(raw.atrDailyRelative! / cfg.volatilityClampMaxAtrRel);
     weightedSum += cfg.weightVolatilityInv * volatilityInvComponent;
   }
-
   return clamp01(weightedSum);
 }

--- a/apps/api/src/modules/gainers-scanner/domain/gainers-candidate.types.ts
+++ b/apps/api/src/modules/gainers-scanner/domain/gainers-candidate.types.ts
@@ -12,11 +12,34 @@ import {
   TrendFilterKind,
 } from './gainers-enums';
 
+/**
+ * PR #362 — TopGainerAssetClass exposé pour scoring per-class.
+ * Aligné sur packages/ai-analyst/src/strategies/top-gainers-filter.ts.
+ * Dupliqué ici pour éviter cycle d'imports cross-module.
+ */
+export type GainersAssetClass =
+  | 'us_equity_large'
+  | 'us_equity_small_mid'
+  | 'eu_equity'
+  | 'asia_equity'
+  | 'crypto_major'
+  | 'crypto_alt'
+  | 'fx_major'
+  | 'fx_cross'
+  | 'commodity';
+
 /** Données brutes d'un candidat en entrée du pipeline (avant scoring BLOC 1). */
 export interface GainersCandidateRaw {
   symbol: string;
   market: 'equity' | 'crypto';
   exchange: string;
+  /**
+   * PR #362 — classe d'actif déduite (us_equity_large, asia_equity, etc).
+   * Optionnel pour rétrocompat ; si présent, le composite scorer utilise
+   * les poids per-class recalibrés à partir des données historiques
+   * (251 positions 14j mai 2026, voir DEFAULT_PER_CLASS_WEIGHTS).
+   */
+  assetClass?: GainersAssetClass;
   /** Prix de clôture ou last trade (USD). */
   close: number;
   open: number;

--- a/apps/api/src/modules/lisa/services/shadow-mapping.helper.ts
+++ b/apps/api/src/modules/lisa/services/shadow-mapping.helper.ts
@@ -43,6 +43,20 @@ function mapAssetClass(
 }
 
 /**
+ * PR #362 — Résout la classe d'actif détaillée (9 classes) requise par le
+ * composite scorer per-class data-driven. Garantit qu'`assetClass` n'est
+ * jamais undefined dans le `GainersCandidateRaw` produit.
+ */
+function resolveDetailedAssetClass(
+  legacyAssetClass: TopGainerAssetClass | undefined,
+  symbol: string,
+  exchange: string | null | undefined,
+  marketCap: number | null,
+): TopGainerAssetClass {
+  return legacyAssetClass ?? detectAssetClass(symbol, exchange, marketCap);
+}
+
+/**
  * Convertit un TopGainerCandidate (legacy scanner) en GainersCandidateRaw (V1).
  * Champs manquants → null/défauts pour permettre BLOC 1 prefilter d'évaluer
  * en mode dégradé (skip gates basés sur null).
@@ -62,10 +76,17 @@ export function mapTopGainerToCandidateRaw(
     candidate.exchange,
     candidate.marketCap ?? null,
   );
+  const detailedAssetClass = resolveDetailedAssetClass(
+    candidate.assetClass,
+    candidate.symbol,
+    candidate.exchange,
+    candidate.marketCap ?? null,
+  );
   const isCrypto = market === 'crypto';
   return {
     symbol: candidate.symbol,
     market,
+    assetClass: detailedAssetClass,
     exchange: candidate.exchange ?? 'UNKNOWN',
     close: candidate.close,
     open: candidate.close, // single-tick fallback


### PR DESCRIPTION
## Contexte

Recalibrage **data-driven** du composite scorer BLOC 1 sur la base de **251 positions fermées** sur 14 jours (5-19 mai 2026), jointes avec leurs shadow signals via `(symbol, entry_timestamp ±5min/+20min)` et filtre `decision='accept'`.

Déclencheur : le 19 mai, **30 positions sur 31 ont obtenu un score composite saturé à 1.000** (et la 31ème à 0.999). Le scorer ne discrimine plus rien, donc le ranking top-N est arbitraire. PnL jour 19 mai : **-$534**.

## Mesures empiriques (251 positions 14j)

| Classe | n | WR | Δ ch1m (TP-SL) | Δ persistance (TP-SL) | Signal dominant |
|---|---|---|---|---|---|
| asia_equity | 112 | 27.7% | **+1.71** | +0.044 | ch1m modéré |
| eu_equity | 56 | 46.4% | **+3.47** | -0.018 | **ch1m fort, persistance inverse** |
| us_equity_large | 46 | 28.3% | -0.52 | **+0.121** | **persistance forte, ch1m inversé** |
| us_equity_small_mid | 28 | 28.6% | +0.52 | -0.045 | signal faible |
| crypto_major | 9 | 11.1% | -0.93 | +0.104 | sample insuffisant → fallback |

### Buckets ch1m WR par classe

| Classe | <5% | 5-10% | 10-15% | 15-25% | 25%+ |
|---|---|---|---|---|---|
| eu | 22% | 29% | 54% | 50% | 58% |
| asia | — | 24% | 29% | 39% | — |
| us_large | — | 31% | 40% | — | — |
| us_sm | — | **36%** | 14% | — | — |

`us_small_mid` montre un **bucket inversé** (5-10% > 10-15%) → pas de boost momentum.

## Changements

### 1. `momentumNormalizationCeiling` : 0.10 → 0.25

Tout candidat asia/eu avec `changePct1m >= 10%` saturait à 1.0. Nouveau plafond 25% permet de différencier bursts (15-25%) des super-bursts (25%+).

### 2. Poids per-class

```ts
eu_equity:            momentum 0.55 / persistance 0.25 / volInv 0.20
us_equity_large:      momentum 0.25 / persistance 0.55 / volInv 0.20
asia_equity:          momentum 0.40 / persistance 0.40 / volInv 0.20
us_equity_small_mid:  momentum 0.35 / persistance 0.45 / volInv 0.20
autres:               fallback global 0.50 / 0.30 / 0.20 (sample insuffisant)
```

### 3. Boost momentum non-linéaire (cap 1.0)

```ts
eu_equity:        ch1m >= 10% → ×1.25  (WR 54-58% vs 29%)
asia_equity:      ch1m >= 15% → ×1.20  (WR 39% vs 25%)
us_equity_large:  ch1m >= 10% → ×1.15  (WR 40% vs 28%)
us_equity_small_mid: pas de boost (bucket inversé)
```

### 4. Injection `assetClass` dans `GainersCandidateRaw`

`shadow-mapping.helper.ts` injecte désormais `detectAssetClass(symbol, exchange, marketCap)` dans le `GainersCandidateRaw` produit, activant les poids per-class côté pipeline shadow puis prod.

### 5. Rétrocompat ADR-005

`LEGACY_COMPOSITE_SCORER_CONFIG` exporté avec ceiling 0.10 + poids 0.5/0.3/0.2 sans per-class. Tests régression bit-perfect garantis pour les specs PR6.6.x existantes.

Fallback automatique : si `assetClass` absent OU classe absente de `perClassWeights` → poids globaux 0.5/0.3/0.2 inchangés.

## Tests

11 nouveaux tests dans `describe('PR #362 — recalibrage data-driven')` :

- `momentumNormalizationCeiling default = 0.25`
- `LEGACY_COMPOSITE_SCORER_CONFIG conserve ceiling 0.10`
- Saturation fix ch1m=20%
- Per-class eu_equity (momentum dominant + boost ×1.25)
- Per-class us_equity_large (persistance dominante)
- Per-class asia_equity (boost ×1.20 si ch1m>=15%)
- Per-class asia_equity (pas de boost si ch1m<15%)
- Per-class us_equity_small_mid (pas de boost configuré)
- Rétrocompat assetClass absent → fallback global
- Rétrocompat crypto_major sans per-class → fallback global
- Boost cap à 1.0

3 cas existants ajustés au nouveau ceiling 0.25 (Cas 5/5bis/8).

## Impact attendu

- Élimination de la saturation 30/31 positions au score 1.000 → ranking redevient discriminant
- Top-N retient les bursts à fort signal classe-spécifique (eu momentum, us_large persistance)
- Coût opérationnel nul : config statique, pas d'I/O additionnel, perf inchangée
- Cible : remontée WR global vers 30-35% (baseline 27.4%)

## Sécurité

- Aucune modif schéma DB
- Aucune modif config Fly/secrets (le boost s'active automatiquement avec le merge)
- Rollback : revert commit (config statique, pas d'état persistant)
