### PR TITLE
feat(quota): PR #363 blacklist QW#6 fetch-level + FX Yahoo priorité

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/lisa-service.pr341-macro-weekend-cascade.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/lisa-service.pr341-macro-weekend-cascade.spec.ts
@@ -114,6 +114,45 @@ describe('LisaService.isCascadeFullyClosed — PR #341 macro weekend filter', ()
       expect(closed).toBe(false);
     });
 
+    // PR #363 — Yahoo FX (EURUSD=X, USDJPY=X) + futures (GC=F, SI=F) servent
+    // un last-close 24/7 même le weekend. Ne doivent PAS être considérés fermés.
+    it.each(['GC=F', 'SI=F', 'EURUSD=X', 'USDJPY=X'])(
+      'PR #363 Yahoo %s samedi → false (continuous quote 24/7)',
+      (ticker) => {
+        const sat = new Date('2026-05-16T15:00:00Z');
+        const closed = service.isCascadeFullyClosed(
+          [{ ticker, source: 'yahoo', quality: 'live' }],
+          sat,
+        );
+        expect(closed).toBe(false);
+      },
+    );
+
+    it('PR #363 cascade gold (GC=F yahoo + XAUUSD.FOREX + GLD.US) samedi → false', () => {
+      const sat = new Date('2026-05-16T10:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [
+          { ticker: 'GC=F', source: 'yahoo', quality: 'live' },
+          { ticker: 'XAUUSD.FOREX', source: 'eodhd', quality: 'live' },
+          { ticker: 'GLD.US', source: 'eodhd', multiplier: 10, quality: 'proxy' },
+        ],
+        sat,
+      );
+      expect(closed).toBe(false);
+    });
+
+    it('PR #363 cascade eurusd (EURUSD=X yahoo + EURUSD.FOREX) dimanche 12h UTC → false', () => {
+      const sun = new Date('2026-05-17T12:00:00Z');
+      const closed = service.isCascadeFullyClosed(
+        [
+          { ticker: 'EURUSD=X', source: 'yahoo', quality: 'live' },
+          { ticker: 'EURUSD.FOREX', source: 'eodhd', quality: 'live' },
+        ],
+        sun,
+      );
+      expect(closed).toBe(false);
+    });
+
     it('BTC-USD.CC dimanche → false (crypto 24/7)', () => {
       const sun = new Date('2026-05-17T03:00:00Z');
       const closed = service.isCascadeFullyClosed(

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -3071,6 +3071,9 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       if (src === 'fred') return false;
       if (a.ticker.startsWith('^') || a.ticker === 'DX-Y.NYB') return false;
       if (a.ticker.endsWith('.CC')) return false;
+      // PR #363 — Yahoo FX/futures continuous (GC=F, SI=F, EURUSD=X,
+      // USDJPY=X, etc.) servent un last-close 24/7. Ne pas skip weekend.
+      if (src === 'yahoo' && (a.ticker.endsWith('=F') || a.ticker.endsWith('=X'))) return false;
       return !this.isMacroTickerMarketOpen(a.ticker, now);
     });
   }
@@ -3502,20 +3505,38 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       fetchCascade('eth', [
         { ticker: 'ETH-USD.CC', quality: 'live' },
       ]),
-      // Gold : .COMM 404 → GLD ETF × 10 (GLD $300 ≈ Gold $3000)
+      // Gold cascade — PR #363 (19/05/2026) : YAHOO PRIMARY car EODHD
+      // XAUUSD.FOREX renvoie HTTP 200 empty_price_field 14-50% du temps
+      // (audit 19/05 18h UTC, 4 ERROR LisaService macro/h corrélés).
+      // Yahoo GC=F (gold futures continuous) = data temps réel sans auth.
+      //   1. yahoo:GC=F        (primary)
+      //   2. eodhd:XAUUSD.FOREX (legacy, fréquemment empty)
+      //   3. eodhd:GLD.US x10  (ETF proxy)
       fetchCascade('gold', [
-        { ticker: 'XAUUSD.FOREX', quality: 'live' },
-        { ticker: 'GLD.US', multiplier: 10, quality: 'proxy' },
+        { ticker: 'GC=F', source: 'yahoo', quality: 'live' },
+        { ticker: 'XAUUSD.FOREX', source: 'eodhd', quality: 'live' },
+        { ticker: 'GLD.US', source: 'eodhd', multiplier: 10, quality: 'proxy' },
       ]),
       // ETFs OK directs
       fetchCascade('spy', [{ ticker: 'SPY.US', quality: 'live' }]),
       fetchCascade('qqq', [{ ticker: 'QQQ.US', quality: 'live' }]),
-      fetchCascade('eurusd', [{ ticker: 'EURUSD.FOREX', quality: 'live' }]),
-      fetchCascade('usdjpy', [{ ticker: 'USDJPY.FOREX', quality: 'live' }]),
-      // Silver : .COMM 404 → SLV ETF
+      // EURUSD cascade — PR #363 : YAHOO PRIMARY (EURUSD=X) car EODHD
+      // EURUSD.FOREX renvoie occasionnellement empty_price_field.
+      fetchCascade('eurusd', [
+        { ticker: 'EURUSD=X', source: 'yahoo', quality: 'live' },
+        { ticker: 'EURUSD.FOREX', source: 'eodhd', quality: 'live' },
+      ]),
+      // USDJPY cascade — PR #363 : YAHOO PRIMARY (USDJPY=X) même motif.
+      fetchCascade('usdjpy', [
+        { ticker: 'USDJPY=X', source: 'yahoo', quality: 'live' },
+        { ticker: 'USDJPY.FOREX', source: 'eodhd', quality: 'live' },
+      ]),
+      // Silver cascade — PR #363 : YAHOO PRIMARY (SI=F silver futures)
+      // car XAGUSD.FOREX 16 empty/h observés 19/05 18h UTC.
       fetchCascade('silver', [
-        { ticker: 'XAGUSD.FOREX', quality: 'live' },
-        { ticker: 'SLV.US', quality: 'proxy' },
+        { ticker: 'SI=F', source: 'yahoo', quality: 'live' },
+        { ticker: 'XAGUSD.FOREX', source: 'eodhd', quality: 'live' },
+        { ticker: 'SLV.US', source: 'eodhd', quality: 'proxy' },
       ]),
       // HYG ETF pour proxy de credit HY OAS spread
       fetchCascade('hyg', [{ ticker: 'HYG.US', quality: 'live' }]),

--- a/packages/ai-analyst/src/strategies/__tests__/session-filter.spec.ts
+++ b/packages/ai-analyst/src/strategies/__tests__/session-filter.spec.ts
@@ -94,8 +94,8 @@ describe('session-filter helpers', () => {
   });
 
   describe('DEAD_NSE_TICKERS (alias) + DEAD_TICKERS_STATIC', () => {
-    it('total = 54 tickers (23 PR #337 + 31 PR #355)', () => {
-      expect(DEAD_NSE_TICKERS.size).toBe(54);
+    it('total = 63 tickers (23 PR #337 + 31 PR #355 + 9 PR #363)', () => {
+      expect(DEAD_NSE_TICKERS.size).toBe(63);
     });
 
     it.each([
@@ -154,6 +154,21 @@ describe('session-filter helpers', () => {
 
     it('PR #355 — 002900.KO toujours autorisé (preuve TP +$177/30j)', () => {
       expect(DEAD_NSE_TICKERS.has('002900.KO')).toBe(false);
+    });
+
+    // PR #363 — 9 tickers US ajoutés (audit 19/05/2026 19h UTC)
+    // 6 QW#6 deja bloqués ouverture + 3 saigneurs US 0 productivité
+    it.each([
+      // QW#6 ouverture-bloqués, ajout fetch-level (6)
+      'PODD.US', 'CGNX.US', 'ORA.US', 'QCOM.US', 'ST.US', 'PRU.US',
+      // Saigneurs US non-QW#6 (3)
+      'EXLS.US', 'CTSH.US', 'KBR.US',
+    ])('PR #363 blacklist statique %s', (ticker) => {
+      expect(DEAD_NSE_TICKERS.has(ticker)).toBe(true);
+    });
+
+    it('PR #363 — DXCM.US toujours autorisé (productif +$20.58/30j 1 TP)', () => {
+      expect(DEAD_NSE_TICKERS.has('DXCM.US')).toBe(false);
     });
   });
 });

--- a/packages/ai-analyst/src/strategies/session-filter.ts
+++ b/packages/ai-analyst/src/strategies/session-filter.ts
@@ -171,6 +171,31 @@ export const DEAD_TICKERS_STATIC: ReadonlySet<string> = new Set<string>([
   'BLDP.TO',
   'KEY.TO',
   'SDE.TO',
+
+  // --- PR #363 (19/05/2026 19h UTC) — Double blacklist QW#6 + fetch-level ---
+  // QW#6 (qw-6-symbol-blacklist.service.ts) bloque l'OUVERTURE de position via
+  // env QW_6_SYMBOL_BLACKLIST mais NE STOPPE PAS le fetch EODHD intraday.
+  // Conséquence : PODD/CGNX/ORA/QCOM/ST/PRU consomment ~65 calls/24h chacun
+  // pour 0 position ouverte. Cette section les bloque AUSSI au niveau scanner
+  // upstream (fetch-level) pour économiser ~700 calls EODHD/24h.
+  // EXLS et 3 autres US ajoutés en plus (audit 19/05 19h UTC : 14 erreurs
+  // 404/24h chacun, 0 accept, 0 ou 2 positions losing).
+  // DXCM.US volontairement CONSERVÉ malgré 17 erreurs/24h : 1 accept 24h,
+  // 1 TP / 0 SL sur 30j (+$20.58, productif) → bloquer serait perdre alpha.
+
+  // QW#6 backlist (6 tickers) — déjà bloqués à l'OUVERTURE, ajout fetch-level
+  // Audit 19/05/2026 19h UTC : 65-100 calls/24h chacun, 0 accept réel
+  'PODD.US', // QW#6 + 14 err/24h, 65 calls/24h, 0 accept, 9 positions 30j 0 TP/4 SL (-$24)
+  'CGNX.US', // QW#6 + tendance similaire PODD
+  'ORA.US',  // QW#6
+  'QCOM.US', // QW#6
+  'ST.US',   // QW#6
+  'PRU.US',  // QW#6
+
+  // Saigneurs US non-QW#6 (audit 19/05 19h UTC, 0 accept/24h, 0 TP)
+  'EXLS.US', // 14 err/24h, 69 calls/24h, 0 accept, 0 position 30j → pur gaspillage
+  'CTSH.US', // 14 err/24h, 234 calls/24h, 2 accept, 2 positions 30j 0 TP/1 SL (-$24.86)
+  'KBR.US',  // 13 err/24h, 256 calls/24h, 2 accept, 2 positions 30j 0 TP/1 SL (-$26.91)
 ]);
 
 /**


### PR DESCRIPTION
## Contexte audit 19/05/2026 19h UTC

Cron EODHD quota alerté 100% (100k/100k) + 64 erreurs réseau dont :
- 5 US 404 répétés (CTSH/PODD/EXLS/KBR/DXCM : 11-14 occurrences/h)
- 3 FX empty_price_field (DXY/XAUUSD/XAGUSD : 14-50% empty)
- 4 ERROR LisaService macro à 18:00 UTC (gold/silver/usdjpy/eurusd all sources failed AND no last-known cache)

## Découverte deux blacklists distinctes

- **QW#6** (qw-6-symbol-blacklist.service.ts) bloque l'OUVERTURE de position via env QW_6_SYMBOL_BLACKLIST mais NE STOPPE PAS le fetch EODHD intraday → ~65 calls/24h chacun pour 0 position.
- **DEAD_TICKERS_STATIC** (session-filter.ts) bloque au niveau scanner fetch-level → économie quota effective.

## Changements

### packages/ai-analyst/src/strategies/session-filter.ts
+9 tickers US ajoutés à DEAD_TICKERS_STATIC (total 54 → 63) :
- 6 QW#6 double-blacklist : PODD/CGNX/ORA/QCOM/ST/PRU
- 3 saigneurs US : EXLS.US (0 pos 30j), CTSH.US (-$24.86), KBR.US (-$26.91)
- DXCM.US **conservé** (productif +$20.58/30j, 1 TP)

### apps/api/src/modules/lisa/services/lisa.service.ts
Cascade gold/silver/eurusd/usdjpy → **Yahoo PRIMARY** :
- gold : GC=F (yahoo) → XAUUSD.FOREX (eodhd) → GLD.US x10 (proxy)
- silver : SI=F (yahoo) → XAGUSD.FOREX (eodhd) → SLV.US (proxy)
- eurusd : EURUSD=X (yahoo) → EURUSD.FOREX (eodhd)
- usdjpy : USDJPY=X (yahoo) → USDJPY.FOREX (eodhd)

isCascadeFullyClosed : exempter Yahoo =F/=X (continuous quote 24/7).

## Impact chiffré

~1100 calls EODHD/24h économisés :
- 700 calls sur 9 US blacklist statique
- ~400 calls FX reroutés Yahoo
- Suppression 4 ERROR LisaService macro/h
- ~1% quota EODHD/24h libéré (sur 100k quota actuel)

## Tests ajoutés

- session-filter.spec : 9 nouveaux tickers, total 63
- pr341-macro-weekend-cascade.spec : 4 Yahoo FX/futures exempts weekend + 2 cascades mixtes

## Sécurité

- Aucune modif TP/SL/sizing
- Aucune modif config trading
- DXCM.US préservé pour conserver alpha