### PR TITLE
fix(pr364): purge offset Gains du jour au rollover minuit UTC

### DIFF
--- a/apps/web/src/hooks/use-harvest-display-offset.ts
+++ b/apps/web/src/hooks/use-harvest-display-offset.ts
@@ -31,6 +31,17 @@ export interface HarvestOffset {
 
 const STORAGE_KEY_PREFIX = 'smartvest:harvest-display-offset:';
 
+/**
+ * PR #364 — Retourne le timestamp (ms epoch) de minuit UTC du jour courant.
+ * Utilisé pour invalider tout offset rebasé avant le rollover quotidien :
+ * le backend reset `closedTodayPnlUsd` à 00:00 UTC, donc un offset stocké
+ * avant cette barrière soustrait une valeur d'hier d'un compteur qui repart
+ * de zéro aujourd'hui (incident 20/05/2026 : -118.26 - (-534.74) = +416.48 faux).
+ */
+function startOfUtcDayMs(now: Date = new Date()): number {
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+}
+
 function readOffset(portfolioId: string): HarvestOffset | null {
   if (typeof window === 'undefined') return null;
   try {
@@ -51,7 +62,18 @@ function readOffset(portfolioId: string): HarvestOffset | null {
       const v = parsed[k];
       if (typeof v !== 'number' || !Number.isFinite(v)) return null;
     }
-    if (!parsed.rebasedAt || Number.isNaN(new Date(parsed.rebasedAt).getTime())) return null;
+    const rebasedAtMs = parsed.rebasedAt ? new Date(parsed.rebasedAt).getTime() : NaN;
+    if (Number.isNaN(rebasedAtMs)) {
+      // PR #364 — format inconnu ou rebasedAt absent (offset legacy) → expire par sécurité.
+      window.localStorage.removeItem(STORAGE_KEY_PREFIX + portfolioId);
+      return null;
+    }
+    // PR #364 — expire à chaque rollover 00:00 UTC. Le backend a reset
+    // closedTodayPnlUsd à minuit, donc l'offset n'a plus de sens.
+    if (rebasedAtMs < startOfUtcDayMs()) {
+      window.localStorage.removeItem(STORAGE_KEY_PREFIX + portfolioId);
+      return null;
+    }
     return parsed;
   } catch {
     return null;


### PR DESCRIPTION
## Cause root

Le compteur **« Gains du jour »** dans `DailyGainsCard` (`apps/web/src/components/lisa/gainers-status-tile.tsx:1249`) calcule :

```ts
total = data.closedTodayPnlUsd - (offset?.dailyRealized ?? 0)
```

L'`offset` provient du hook `useHarvestDisplayOffset` (`apps/web/src/hooks/use-harvest-display-offset.ts`) qui persiste l'état du clic « Rebaser » en `localStorage` (clé `smartvest:harvest-display-offset:{portfolioId}`). Avant ce PR, `readOffset()` retournait l'offset dès qu'il était syntaxiquement valide, sans aucune vérification temporelle.

Conséquence : un offset rebasé dans la journée J reste actif **indéfiniment** après le rollover backend de 00:00 UTC, qui remet `closedTodayPnlUsd` à zéro. L'offset soustrait alors une valeur d'hier d'un compteur qui repart de zéro aujourd'hui.

## Preuve SQL

Validé Supabase, portfolio en mode `gainers`, snapshot 20/05/2026 :

| Source | Valeur |
|---|---|
| Backend `closedTodayPnlUsd` (paper_trades fermés depuis 00:00 UTC) | **−\$118.26** |
| `localStorage.smartvest:harvest-display-offset.dailyRealized` | **−\$534.74** (rebasé le 19/05 19:46 UTC) |
| Affichage tile = `−118.26 − (−534.74)` | **+\$416.48** ❌ |
| Réel attendu | **−\$118.26** |

## Fix

`apps/web/src/hooks/use-harvest-display-offset.ts` :

1. Nouvelle fonction `startOfUtcDayMs(now)` = `Date.UTC(year, month, date)` ms epoch.
2. `readOffset()` parse `rebasedAt` en ms ; si `rebasedAt` absent / invalide, on supprime la clé localStorage et retourne `null` (cas offsets legacy d'avant le champ).
3. Si `rebasedAtMs < startOfUtcDayMs()`, idem : suppression localStorage + `null`.
4. `setRebase()` inchangé — il pose déjà `rebasedAt: new Date().toISOString()`.

L'offset n'est donc plus valide que **pour la journée UTC où il a été créé**.

## Impact utilisateur

- Plus besoin de cliquer manuellement « Annuler rebase » chaque matin.
- Cohérence garantie entre l'affichage tile et la table `paper_trades` à compter du premier render après 00:00 UTC.
- Compteurs MTD/YTD non touchés ce PR (ils ne souffrent pas du même rollover quotidien — patch séparé si besoin).

## Périmètre

- Frontend uniquement, **aucune modif backend** (PR séparée pour Hurst).
- Aucune migration, aucun changement de schéma.
- Compatible offsets existants (legacy sans `rebasedAt` → expirés par sécurité).

## Tests

- Typecheck `npm --workspace @smartvest/web run typecheck` ✅ vert local après build des packages dépendants.
- Pas de Jest configuré dans `apps/web` (pas de `jest.config`, pas de devDep) → tests unitaires non ajoutés ce PR. À étudier dans une PR infra séparée si on veut couvrir le hook.

## Test plan post-merge

- [ ] Sur portfolio en mode gainers, recharger `/lisa` après 00:00 UTC et vérifier que le tile « Gains du jour » affiche bien `closedTodayPnlUsd` brut (pas d'offset stale).
- [ ] Cliquer « Rebaser » → vérifier que l'offset s'applique pendant la journée en cours.
- [ ] Attendre le rollover UTC suivant (ou reproduire en avançant l'horloge) → vérifier que l'offset disparaît et que la clé localStorage est supprimée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)