### PR TITLE
fix(gainers): PR #365 — injecter matrice asset_class_tpsl_config à l'ouverture Gainers Direct (Hurst)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/ticker-blacklist.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/ticker-blacklist.spec.ts
@@ -198,7 +198,7 @@ describe('TickerBlacklistService', () => {
       const t0 = Date.now();
       const stats = svc.getStats();
       expect(stats.staticEnabled).toBe(true);
-      expect(stats.staticSize).toBe(54); // PR #337 (23) + PR #355 (31)
+      expect(stats.staticSize).toBe(63); // PR #337 (23) + PR #355 (31) + PR #363 (9)
       expect(stats.dynamicCount).toBe(0);
 
       // Add a dynamic blacklist

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -36,6 +36,9 @@ import { DecisionLogService } from './decision-log.service';
 import { BinanceMarketService } from './binance-market.service';
 import { MultiTimeframePersistenceService, type PersistenceWithPath } from './multi-tf-persistence.service';
 import { PersistenceProbabilityService } from './persistence-probability.service';
+// PR #365 — matrice TP/SL par asset_class (Hurst asia tp=3.90%, eu=3.25%).
+// Le scanner Gainers Direct (PR #250) ignorait cette matrice à l'ouverture.
+import { AssetClassTpSlConfigService } from './asset-class-tpsl-config.service';
 import { EodhdQuotaService } from './eodhd-quota.service';
 import { EodhdCalendarService } from './eodhd-calendar.service';
 import { MacroVetoService } from './macro-veto.service';
@@ -552,6 +555,13 @@ export class TopGainersScannerService implements OnModuleInit {
      */
     @Optional() private readonly twelveData?: TwelveDataService,
     @Optional() private readonly qwLogger?: QwDecisionLoggerService,
+    /**
+     * PR #365 — matrice TP/SL par asset_class. @Optional pour back-compat
+     * tests (mock scanner sans ce service). Quand injecté, override les
+     * tpPct/slPct UI uniformes par les valeurs Hurst par classe (asia 3.90%,
+     * eu 3.25%, etc.). Le flag GAINERS_TPSL_MATRIX_ENABLED gate l'activation.
+     */
+    @Optional() private readonly tpSlConfig?: AssetClassTpSlConfigService,
   ) {}
 
   /**
@@ -2482,14 +2492,39 @@ export class TopGainersScannerService implements OnModuleInit {
       //
       // ATR provenant de persistence.atrPct (calculé sur les candles 1m/5m
       // déjà fetchées, zéro EODHD call extra).
-      let effectiveSlPct = slPct;
+      // PR #365 — Override TP/SL par matrice asset_class (Hurst). Avant : le
+      // scanner Gainers Direct utilisait gainers_default_tp_pct/sl_pct (UI,
+      // uniforme 2.5%/1.5% toutes classes), ignorant asset_class_tpsl_config
+      // (asia tp=3.90% via Hurst ×1.30). Seul mechanical-trading consultait la
+      // matrice. Bug : 7 positions asia ouvertes à tp_pct=2.5% au lieu de 3.90%.
+      // getTpPct/getSlPct retournent des décimaux (0.039 / -0.013) → ×100 vers %.
+      // Gate GAINERS_TPSL_MATRIX_ENABLED (default ON si service injecté).
+      let effectiveTpPct = tpPct;
+      let baseSlPct = slPct;
+      const matrixEnabled =
+        (this.config.get<string>('GAINERS_TPSL_MATRIX_ENABLED') ?? 'true').toLowerCase() === 'true';
+      if (matrixEnabled && this.tpSlConfig) {
+        const matrixTp = this.tpSlConfig.getTpPct(cand.assetClass);
+        const matrixSl = this.tpSlConfig.getSlPct(cand.assetClass);
+        if (matrixTp != null) effectiveTpPct = matrixTp * 100;
+        if (matrixSl != null) baseSlPct = Math.abs(matrixSl) * 100;
+        if (matrixTp != null || matrixSl != null) {
+          this.logger.log(
+            `[top-gainers] ${cand.symbol} (${cand.assetClass}) matrice TP/SL: ` +
+            `tp=${effectiveTpPct.toFixed(2)}% sl=${baseSlPct.toFixed(2)}% ` +
+            `(UI defaults tp=${tpPct.toFixed(2)}% sl=${slPct.toFixed(2)}%)`,
+          );
+        }
+      }
+
+      let effectiveSlPct = baseSlPct;
       const atrMultiplier = Number(this.config.get<string>('GAINERS_SL_ATR_MULTIPLIER') ?? '0');
       if (atrMultiplier > 0 && persistence.atrPct != null && persistence.atrPct > 0) {
         const atrSlPct = persistence.atrPct * 100 * atrMultiplier;
-        if (atrSlPct > slPct) {
+        if (atrSlPct > baseSlPct) {
           effectiveSlPct = atrSlPct;
           this.logger.log(
-            `[top-gainers] ${cand.symbol} SL widened: base=${slPct.toFixed(2)}% → ATR×${atrMultiplier}=${atrSlPct.toFixed(2)}% (atrPct=${(persistence.atrPct * 100).toFixed(3)}%)`,
+            `[top-gainers] ${cand.symbol} SL widened: base=${baseSlPct.toFixed(2)}% → ATR×${atrMultiplier}=${atrSlPct.toFixed(2)}% (atrPct=${(persistence.atrPct * 100).toFixed(3)}%)`,
           );
         }
       }
@@ -2500,7 +2535,7 @@ export class TopGainersScannerService implements OnModuleInit {
         cand,
         persistence,
         {
-          tpPct,
+          tpPct: effectiveTpPct,
           slPct: effectiveSlPct,
           capitalUsd,
           positionPct,


### PR DESCRIPTION
## Bug confirmé (audit 20/05/2026)

Le scanner Gainers Direct (PR #250) lit `gainers_default_tp_pct`/`gainers_default_sl_pct` depuis la config UI (uniforme 2.5%/1.5% toutes classes) et **n'a jamais consulté** la matrice `asset_class_tpsl_config` (asia tp=3.90% via Hurst ×1.30, eu=3.25%).

### Asymétrie prouvée par grep

| Service | Injecte `AssetClassTpSlConfigService` | Consulte matrice |
|---|---|---|
| `mechanical-trading.service.ts` | ✅ l.196 | ✅ l.1130-1131 |
| `top-gainers-scanner.service.ts` | ❌ (0 réf avant ce PR) | ❌ |

### Conséquence mesurée
7 positions asia ouvertes avec `tp_pct=2.500%` au lieu de 3.90%. Perte ~1.4% de TP cible asia (compensée partiellement par gaps haussiers 1min mais non systématique).

## Fix

- Inject `AssetClassTpSlConfigService` `@Optional` dans le scanner
- Override **par-candidat** de `tpPct`/`slPct` via `getTpPct/getSlPct(cand.assetClass)` **avant** la logique ATR (le SL matrice devient la base que ATR peut élargir)
- Conversion d'unités : getters retournent décimal (`0.039` / `-0.013`) → `×100` + `Math.abs()` vers le pourcentage attendu par le scanner
- Gate `GAINERS_TPSL_MATRIX_ENABLED` (default `'true'` si service injecté)
- Log structuré par ouverture (matrice vs UI defaults)

### Précision vs proposition Perplexity
Perplexity proposait l'injection "après L.1687" (résolution globale unique). **Mauvais scope** — la matrice est per-classe, donc l'override doit être par-candidat (L.2485 area, là où `cand.assetClass` est disponible). Implémenté au bon endroit.

## Comportement préservé

- `@Optional` → 115/115 tests scanner existants non régressés
- Matrice absente pour une classe (`getTpPct` null) → fallback UI defaults
- ATR widening continue sur la base matrice
- `mechanical-trading` inchangé (déjà correct)

## Tests

- `npx tsc --noEmit` ✅
- 115/115 tests `top-gainers-scanner` verts

## Validation post-deploy

```sql
SELECT symbol, asset_class, entry_price, take_profit_price,
  ROUND(((take_profit_price - entry_price)/entry_price*100)::numeric, 2) AS tp_pct
FROM lisa_positions WHERE source='top_gainers' AND status='open'
  AND asset_class IN ('asia_equity','eu_equity')
  AND entry_timestamp > NOW() - INTERVAL '2 hours';
```

Attendu : asia_equity `tp_pct ≈ 3.90`, eu_equity `tp_pct ≈ 3.25` (vs 2.5 avant).

## Note PR #364

PR #364 (purge offset Gains du jour au rollover UTC) était déjà mergée (20/05 04:38 UTC), rien à faire.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_