### PR TITLE
feat(intraday-router): PR #366 — instrumentation comparative TD vs EODHD (divergence bps)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
@@ -119,6 +119,14 @@ function makeBlacklistMock(opts?: { blacklisted?: string[] }): TickerBlacklistSe
   } as unknown as TickerBlacklistService;
 }
 
+// PR #366 — SupabaseService mock (no-op insert) pour le compare-table.
+function makeSupabaseMock(): import('../../../supabase/supabase.service').SupabaseService {
+  return {
+    isReady: () => false, // false = pas d'insert tenté dans les tests par défaut
+    getClient: () => ({ from: () => ({ insert: () => Promise.resolve({ error: null }) }) }),
+  } as unknown as import('../../../supabase/supabase.service').SupabaseService;
+}
+
 const TD_OK_QUOTE = { price: 180.5, changePct: 1.2, timestamp: 1747353600000 };
 const EODHD_OK_QUOTE = { price: 180.4, changePct: 1.1, timestamp: 1747353500000 };
 const TD_OK_CANDLES = {
@@ -143,7 +151,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'false' }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       const r = await router.getQuote('AAPL.US');
       expect(r!.provider).toBe('eodhd');
@@ -158,7 +166,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'false' }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       const r = await router.getCandles('AAPL.US', '1m', 20);
       expect(r!.provider).toBe('eodhd');
@@ -178,7 +186,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       const r = await router.getQuote('AAPL.US');
       expect(r!.provider).toBe('td');
@@ -198,7 +206,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       const r = await router.getCandles('AAPL.US', '1m', 20);
       expect(r!.provider).toBe('td');
@@ -219,7 +227,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       const r = await router.getQuote('AAPL.US');
       expect(r!.provider).toBe('eodhd');
@@ -239,7 +247,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       const r = await router.getCandles('AAPL.US', '1m', 20);
       expect(r!.provider).toBe('eodhd');
@@ -259,7 +267,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       await router.getCandles('AAPL.US', '5m', 20, { fromTs: 1000, toTs: 2000 });
       expect(td.candlesCalls).toBe(0);
@@ -279,7 +287,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       await router.getCandles('SOMETHING.XYZ', '1m', 20);
       expect(td.candlesCalls).toBe(0);
@@ -292,7 +300,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
       makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true' }),
       makeEodhdMock().service,
       makeTdMock().service,
-      makeBlacklistMock(),
+      makeBlacklistMock(), makeSupabaseMock(),
     );
 
     it.each([
@@ -347,7 +355,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       for (let i = 0; i < 100; i++) {
         await router.getQuote(`SYM${i}.US`);
@@ -366,7 +374,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         makeEodhdMock().service,
         makeTdMock().service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       const first = router.shouldRouteToTd('AAPL');
       for (let i = 0; i < 50; i++) {
@@ -384,7 +392,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       await router.getQuote('AAPL.US');
       expect(td.quoteCalls).toBe(0);
@@ -401,7 +409,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       await router.getQuote('AAPL.US');
       expect(td.quoteCalls).toBe(1);
@@ -421,7 +429,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         null as unknown as TwelveDataService,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       const r = await router.getQuote('AAPL.US');
       expect(r!.provider).toBe('eodhd');
@@ -444,7 +452,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       const r = await router.getCandles('005930.KO', '5m', 100, { calledBy: 'shadow_walkforward' });
       expect(r!.provider).toBe('td');
@@ -463,7 +471,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         eodhd.service,
         td.service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       await router.getCandles('600519.SHG', '1m', 20);
       expect(td.lastSymbol).toBe('600519:SSE');
@@ -485,7 +493,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
       makeConfig({}),
       makeEodhdMock().service,
       makeTdMock().service,
-      makeBlacklistMock(),
+      makeBlacklistMock(), makeSupabaseMock(),
     );
 
     it('AAPL.US → AAPL (strip suffixe)', () => {
@@ -541,7 +549,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         makeConfig({ TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'false' }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
         makeTdMock({ candles: TD_OK_CANDLES }).service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       await router.getCandles('AAPL.US', '1m', 20);
       const log = lastDualCall(calls);
@@ -560,7 +568,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
         makeTdMock({ candles: TD_OK_CANDLES }).service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       await router.getCandles('AAPL.US', '5m', 20, { fromTs: 1000, toTs: 2000 });
       const log = lastDualCall(calls);
@@ -577,7 +585,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
         makeTdMock({ candles: TD_OK_CANDLES }).service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       await router.getCandles('AAPL.US', '1m', 20);
       const log = lastDualCall(calls);
@@ -594,7 +602,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
         makeTdMock({ candles: TD_OK_CANDLES }).service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       await router.getCandles('SOMETHING.XYZ', '1m', 20);
       const log = lastDualCall(calls);
@@ -612,7 +620,7 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
         null as unknown as TwelveDataService,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       await router.getCandles('AAPL.US', '1m', 20);
       const log = lastDualCall(calls);
@@ -629,13 +637,136 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
         }),
         makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
         makeTdMock({ candles: TD_OK_CANDLES }).service,
-        makeBlacklistMock(),
+        makeBlacklistMock(), makeSupabaseMock(),
       );
       await router.getCandles('AAPL.US', '1m', 20);
       const log = lastDualCall(calls);
       restore();
       expect(log!.td_skip_reason).toBeNull();
       expect(log!.td_attempted).toBe(true);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────
+  // PR #366 — recordProviderCompare (instrumentation TD vs EODHD)
+  // ───────────────────────────────────────────────────────────────────────
+  describe('PR #366 — recordProviderCompare divergence bps', () => {
+    function captureInsert(): {
+      supabase: import('../../../supabase/supabase.service').SupabaseService;
+      rows: Array<Record<string, unknown>>;
+    } {
+      const rows: Array<Record<string, unknown>> = [];
+      const supabase = {
+        isReady: () => true,
+        getClient: () => ({
+          from: () => ({
+            insert: (row: Record<string, unknown>) => {
+              rows.push(row);
+              return Promise.resolve({ error: null });
+            },
+          }),
+        }),
+      } as unknown as import('../../../supabase/supabase.service').SupabaseService;
+      return { supabase, rows };
+    }
+
+    it('divergence positive : TD plus haut → bps > 0', async () => {
+      const { supabase, rows } = captureInsert();
+      const router = new IntradayProviderRouter(
+        makeConfig({}),
+        makeEodhdMock().service,
+        makeTdMock().service,
+        makeBlacklistMock(),
+        supabase,
+      );
+      await router.recordProviderCompare(
+        '005930.KO',
+        '005930:KRX',
+        '5m',
+        { candles: [{ timestamp: 100, close: 101.0 }] }, // TD
+        { candles: [{ timestamp: 100, close: 100.0 }] }, // EODHD
+        'test',
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].td_close).toBe(101.0);
+      expect(rows[0].eodhd_close).toBe(100.0);
+      // (101 - 100) / 100 * 10000 = 100 bps
+      expect(rows[0].divergence_bps).toBe(100);
+      expect(rows[0].symbol).toBe('005930.KO');
+      expect(rows[0].td_symbol).toBe('005930:KRX');
+    });
+
+    it('divergence nulle : prix identiques → 0 bps', async () => {
+      const { supabase, rows } = captureInsert();
+      const router = new IntradayProviderRouter(
+        makeConfig({}),
+        makeEodhdMock().service,
+        makeTdMock().service,
+        makeBlacklistMock(),
+        supabase,
+      );
+      await router.recordProviderCompare(
+        'AAPL.US', 'AAPL', '1m',
+        { candles: [{ timestamp: 1, close: 180.0 }] },
+        { candles: [{ timestamp: 1, close: 180.0 }] },
+        'test',
+      );
+      expect(rows[0].divergence_bps).toBe(0);
+    });
+
+    it('eodhd_close <= 0 → divergence_bps null (pas de division)', async () => {
+      const { supabase, rows } = captureInsert();
+      const router = new IntradayProviderRouter(
+        makeConfig({}),
+        makeEodhdMock().service,
+        makeTdMock().service,
+        makeBlacklistMock(),
+        supabase,
+      );
+      await router.recordProviderCompare(
+        'X.US', 'X', '1m',
+        { candles: [{ timestamp: 1, close: 50 }] },
+        { candles: [{ timestamp: 1, close: 0 }] },
+        'test',
+      );
+      expect(rows[0].divergence_bps).toBeNull();
+    });
+
+    it('supabase non ready → pas d\'insert', async () => {
+      const rows: Array<Record<string, unknown>> = [];
+      const supabase = {
+        isReady: () => false,
+        getClient: () => ({ from: () => ({ insert: (r: Record<string, unknown>) => { rows.push(r); return Promise.resolve({ error: null }); } }) }),
+      } as unknown as import('../../../supabase/supabase.service').SupabaseService;
+      const router = new IntradayProviderRouter(
+        makeConfig({}), makeEodhdMock().service, makeTdMock().service, makeBlacklistMock(), supabase,
+      );
+      await router.recordProviderCompare(
+        'X.US', 'X', '1m',
+        { candles: [{ timestamp: 1, close: 50 }] },
+        { candles: [{ timestamp: 1, close: 49 }] },
+        'test',
+      );
+      expect(rows).toHaveLength(0);
+    });
+
+    it('dual-call getCandles avec 2 succès → insert auto', async () => {
+      const { supabase, rows } = captureInsert();
+      const router = new IntradayProviderRouter(
+        makeConfig({
+          TWELVEDATA_INTRADAY_SCANNER_ENABLED: 'true',
+          TWELVEDATA_INTRADAY_AB_TEST_RATIO: '1.0',
+        }),
+        makeEodhdMock({ candles: EODHD_OK_CANDLES }).service,
+        makeTdMock({ candles: TD_OK_CANDLES }).service,
+        makeBlacklistMock(),
+        supabase,
+      );
+      await router.getCandles('AAPL.US', '1m', 20);
+      // EODHD_OK_CANDLES close=180.4, TD_OK_CANDLES close=180.5
+      expect(rows).toHaveLength(1);
+      expect(rows[0].td_close).toBe(180.5);
+      expect(rows[0].eodhd_close).toBe(180.4);
     });
   });
 });

--- a/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
+++ b/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
@@ -4,6 +4,7 @@ import { TwelveDataService } from './twelve-data.service';
 import { EodhdIntradayService, type CandleSeries } from './eodhd-intraday.service';
 import { TickerBlacklistService } from './ticker-blacklist.service';
 import { eodhdToTdSymbol } from './td-symbol-mapper';
+import { SupabaseService } from '../../supabase/supabase.service';
 
 /**
  * PR #352 (original) — Routeur intraday TwelveData-first avec fallback EODHD.
@@ -81,6 +82,9 @@ export class IntradayProviderRouter implements OnModuleInit {
     // Fix identique à PR #356 sur td : suppression @Optional + tests mis à jour
     // pour passer un mock TickerBlacklistService (4 args obligatoires).
     private readonly blacklist: TickerBlacklistService,
+    // PR #366 — instrumentation comparative TD vs EODHD. Singleton stable
+    // (SupabaseModule importé), insert fire-and-forget non bloquant.
+    private readonly supabase: SupabaseService,
   ) {
     const enabled = this.isEnabled();
     const ratio = this.getRatio();
@@ -322,6 +326,20 @@ export class IntradayProviderRouter implements OnModuleInit {
       }),
     );
 
+    // PR #366 — quand les 2 providers réussissent, logge la comparaison
+    // close TD vs EODHD (fire-and-forget). Mesure la valeur ajoutée réelle
+    // de TD (divergence en bps) vs simple redondance.
+    if (tdVal !== null && eodhdVal !== null && eodhdVal.candles.length > 0) {
+      void this.recordProviderCompare(
+        eodhdTicker,
+        tdSymbol,
+        interval,
+        tdVal,
+        eodhdVal,
+        calledBy,
+      );
+    }
+
     if (tdVal !== null) {
       return {
         ticker: eodhdTicker,
@@ -334,6 +352,54 @@ export class IntradayProviderRouter implements OnModuleInit {
     }
     if (eodhdVal !== null) return { ...eodhdVal, provider: 'eodhd' };
     return null;
+  }
+
+  /**
+   * PR #366 — Enregistre la comparaison close TD vs EODHD (fire-and-forget).
+   * Calcule la divergence en bps sur la dernière bougie de chaque série.
+   * Visible pour tests.
+   */
+  async recordProviderCompare(
+    symbol: string,
+    tdSymbol: string | null,
+    interval: string,
+    tdSeries: { candles: Array<{ timestamp: number; close: number }> },
+    eodhdSeries: { candles: Array<{ timestamp: number; close: number }> },
+    calledBy: string,
+  ): Promise<void> {
+    try {
+      const tdLast = tdSeries.candles[tdSeries.candles.length - 1];
+      const eodhdLast = eodhdSeries.candles[eodhdSeries.candles.length - 1];
+      if (!tdLast || !eodhdLast) return;
+      const tdClose = tdLast.close;
+      const eodhdClose = eodhdLast.close;
+      const divergenceBps =
+        eodhdClose > 0 ? ((tdClose - eodhdClose) / eodhdClose) * 10000 : null;
+      if (!this.supabase?.isReady?.()) return;
+      const { error } = await this.supabase
+        .getClient()
+        .from('intraday_provider_compare')
+        .insert({
+          symbol,
+          td_symbol: tdSymbol,
+          interval,
+          td_close: tdClose,
+          eodhd_close: eodhdClose,
+          divergence_bps: divergenceBps != null ? Number(divergenceBps.toFixed(2)) : null,
+          td_candle_ts: tdLast.timestamp,
+          eodhd_candle_ts: eodhdLast.timestamp,
+          td_candle_count: tdSeries.candles.length,
+          eodhd_candle_count: eodhdSeries.candles.length,
+          called_by: calledBy,
+        });
+      if (error) {
+        this.logger.debug(`[intraday-router] provider-compare insert failed: ${error.message}`);
+      }
+    } catch (err) {
+      this.logger.debug(
+        `[intraday-router] provider-compare exception: ${(err as Error).message}`,
+      );
+    }
   }
 
   /**

--- a/supabase/migrations/0148_intraday_provider_compare.sql
+++ b/supabase/migrations/0148_intraday_provider_compare.sql
@@ -1,0 +1,44 @@
+-- PR #366 — Instrumentation comparative TD vs EODHD intraday.
+--
+-- Objectif : mesurer la VRAIE valeur ajoutée de TwelveData vs EODHD. Le router
+-- dual-call (PR #353) appelle les 2 providers en parallèle mais ne garde que TD
+-- quand dispo. On ne sait donc pas si TD apporte une donnée différente/plus
+-- fraîche qu'EODHD, ou juste de la redondance.
+--
+-- Cette table loggue, quand les 2 providers réussissent simultanément, le close
+-- de la dernière bougie de chaque série + la divergence en bps. Permet en 24h
+-- de chiffrer : divergence moyenne, % de cas où TD diffère significativement,
+-- distribution par marché.
+--
+-- Append-only, fire-and-forget côté router (échec insert ne bloque jamais le
+-- scanner). Rétention : purge manuelle / cron à prévoir si volume élevé.
+
+CREATE TABLE IF NOT EXISTS intraday_provider_compare (
+  id BIGSERIAL PRIMARY KEY,
+  timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  symbol TEXT NOT NULL,
+  td_symbol TEXT,
+  interval TEXT NOT NULL,
+  td_close NUMERIC(20,8),
+  eodhd_close NUMERIC(20,8),
+  -- Divergence relative en basis points : (td - eodhd) / eodhd * 10000.
+  -- Positif = TD plus haut qu'EODHD. NULL si eodhd_close <= 0.
+  divergence_bps NUMERIC(12,2),
+  td_candle_ts BIGINT,    -- timestamp epoch (s) de la dernière bougie TD
+  eodhd_candle_ts BIGINT, -- timestamp epoch (s) de la dernière bougie EODHD
+  td_candle_count INT,
+  eodhd_candle_count INT,
+  called_by TEXT NOT NULL DEFAULT 'unknown'
+);
+
+CREATE INDEX IF NOT EXISTS idx_intraday_provider_compare_timestamp
+  ON intraday_provider_compare(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_intraday_provider_compare_symbol
+  ON intraday_provider_compare(symbol, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_intraday_provider_compare_divergence
+  ON intraday_provider_compare(ABS(divergence_bps) DESC NULLS LAST, timestamp DESC);
+
+COMMENT ON TABLE intraday_provider_compare IS
+  'PR #366 — comparaison close TD vs EODHD quand les 2 réussissent (dual-call). Mesure valeur ajoutée TD.';
+COMMENT ON COLUMN intraday_provider_compare.divergence_bps IS
+  '(td_close - eodhd_close) / eodhd_close * 10000. Positif = TD plus haut.';


### PR DESCRIPTION
## Objectif

Mesurer la **vraie valeur ajoutée** de TwelveData. Le router dual-call (PR #353) appelle TD + EODHD en parallèle mais ne garde que TD quand dispo → on ne sait pas si TD apporte une donnée différente/plus fraîche, ou juste de la redondance.

Cette PR loggue, quand les 2 providers réussissent simultanément sur `getCandles`, le close de la dernière bougie de chaque série + la divergence en bps.

## Changements

1. **Migration `0148_intraday_provider_compare.sql`** — table append-only : `symbol`, `td_symbol`, `interval`, `td_close`, `eodhd_close`, `divergence_bps`, `td/eodhd_candle_ts`, candle counts, `called_by`. 3 index dont un sur `ABS(divergence_bps) DESC`.
2. **`IntradayProviderRouter.recordProviderCompare()`** — fire-and-forget, `divergence_bps = (td-eodhd)/eodhd*10000`, null si `eodhd_close<=0`. Appelée dans `getCandles` quand TD ET EODHD réussissent.
3. **`SupabaseService` injecté** dans le router (singleton stable, insert non-bloquant).

## Analyse cible (24h post-deploy)

```sql
SELECT interval, COUNT(*) AS n,
  ROUND(AVG(ABS(divergence_bps)),2) AS avg_abs_bps,
  ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ABS(divergence_bps)),2) AS p50_bps,
  ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY ABS(divergence_bps)),2) AS p95_bps,
  SUM((ABS(divergence_bps) > 10)::int) AS n_diverge_gt_10bps
FROM intraday_provider_compare
WHERE timestamp > NOW() - INTERVAL '24 hours'
GROUP BY interval;
```

**Interprétation** :
- `avg_abs_bps ≈ 0` → TD = redondance pure (même donnée qu'EODHD)
- `avg_abs_bps` élevé (>10-20) → TD apporte une donnée significativement différente (plus fraîche intraday 1min, source distincte)
- `n_diverge_gt_10bps` élevé → cas où le choix du provider change potentiellement le signal

## Tests

- 51/51 verts `intraday-provider-router` (dont 5 cas PR #366 : divergence positive/nulle/null + supabase-not-ready + dual-call auto-insert)
- 161/161 verts consumers du router (top-gainers-scanner, multi-tf-persistence, shadow-exit, post-sl, gainers-user-shadow)
- Typecheck OK

Aucun impact runtime sur les décisions : pur logging additif fire-and-forget. EODHD reste source de vérité, TD préféré quand dispo (inchangé).

## Post-merge

Migration `0148` à appliquer sur Supabase prod. Données exploitables ~24h après redeploy. Je pourrai alors te donner le verdict chiffré : TD apporte-t-il une donnée réellement différente, ou juste de la redondance ?

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_