### PR TITLE
feat(gainers): PR #367 — gate liquidité dollar-volume anti-slippage

### DIFF
--- a/apps/api/src/modules/lisa/quick-wins/types.ts
+++ b/apps/api/src/modules/lisa/quick-wins/types.ts
@@ -35,7 +35,8 @@ export type QwId =
   | 'CIRCUIT_BREAKER'
   | 'TD_SUPERTREND_US'    // PR #345 — filtre TwelveData Supertrend US equity
   | 'TD_RSI_CRYPTO'       // PR #345 — filtre TwelveData RSI crypto overbought
-  | 'TD_SUPERTREND_ASIA'; // PR #360 — filtre TwelveData Supertrend asia equity 30m
+  | 'TD_SUPERTREND_ASIA' // PR #360 — filtre TwelveData Supertrend asia equity 30m
+  | 'LIQUIDITY_GATE';    // PR #367 — gate dollar-volume anti-slippage
 
 export type QwDecision = 'pass' | 'block' | 'modify';
 

--- a/apps/api/src/modules/lisa/services/__tests__/liquidity-gate.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/liquidity-gate.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * PR #367 — Tests gate liquidité (anti-slippage).
+ */
+
+import { evaluateLiquidityGate, fxToUsd } from '../liquidity-gate.helper';
+
+describe('fxToUsd', () => {
+  it('US sans suffixe → 1', () => {
+    expect(fxToUsd('AAPL')).toBe(1);
+  });
+  it('US avec suffixe → 1', () => {
+    expect(fxToUsd('AAPL.US')).toBe(1);
+  });
+  it('KRW (.KO/.KQ) → ~0.00073', () => {
+    expect(fxToUsd('005930.KO')).toBeCloseTo(0.00073, 5);
+    expect(fxToUsd('100790.KQ')).toBeCloseTo(0.00073, 5);
+  });
+  it('LSE en pence → ~0.0127', () => {
+    expect(fxToUsd('SCLP.LSE')).toBeCloseTo(0.0127, 4);
+    expect(fxToUsd('VOD.L')).toBeCloseTo(0.0127, 4);
+  });
+  it('CNY (.SHG/.SHE) → 0.139', () => {
+    expect(fxToUsd('601678.SHG')).toBe(0.139);
+    expect(fxToUsd('300166.SHE')).toBe(0.139);
+  });
+  it('EUR (.PA) → 1.08', () => {
+    expect(fxToUsd('PUB.PA')).toBe(1.08);
+  });
+  it('devise inconnue → 1 (no-op)', () => {
+    expect(fxToUsd('FOO.XYZ')).toBe(1);
+  });
+});
+
+describe('evaluateLiquidityGate', () => {
+  const MIN = 2_000_000; // $2M/jour
+
+  it('US liquide (1M shares × $180) → pass', () => {
+    const r = evaluateLiquidityGate('AAPL.US', 180, 1_000_000, MIN);
+    expect(r.pass).toBe(true);
+    expect(r.dollarVolumeUsd).toBeCloseTo(180_000_000, -3);
+  });
+
+  it('KOSDAQ micro-cap illiquide (saigneur 100790.KQ) → block', () => {
+    // 100790.KQ : ~50k shares/j × ~5000 KRW × 0.00073 = ~182k USD < 2M
+    const r = evaluateLiquidityGate('100790.KQ', 5000, 50_000, MIN);
+    expect(r.pass).toBe(false);
+    expect(r.dollarVolumeUsd).toBeLessThan(MIN);
+    expect(r.reason).toContain('dollar_volume');
+  });
+
+  it('KOSPI large liquide → pass', () => {
+    // Samsung-like : 10M shares × 70000 KRW × 0.00073 = ~511M USD
+    const r = evaluateLiquidityGate('005930.KO', 70000, 10_000_000, MIN);
+    expect(r.pass).toBe(true);
+  });
+
+  it('penny LSE illiquide (SCLP) → block', () => {
+    // 200k shares × 30 pence × 0.0127 = ~76k USD < 2M
+    const r = evaluateLiquidityGate('SCLP.LSE', 30, 200_000, MIN);
+    expect(r.pass).toBe(false);
+  });
+
+  it('avgVol50d=0 → fail-open (pass, données manquantes)', () => {
+    const r = evaluateLiquidityGate('X.KQ', 5000, 0, MIN);
+    expect(r.pass).toBe(true);
+    expect(r.reason).toBe('no_volume_data_fail_open');
+  });
+
+  it('close<=0 → fail-open', () => {
+    const r = evaluateLiquidityGate('X.KQ', 0, 100000, MIN);
+    expect(r.pass).toBe(true);
+  });
+
+  it('minUsd=0 → gate désactivé (pass)', () => {
+    const r = evaluateLiquidityGate('100790.KQ', 5000, 50_000, 0);
+    expect(r.pass).toBe(true);
+    expect(r.dollarVolumeUsd).toBeNull();
+  });
+
+  it('seuil exact : dollar_volume == minUsd → pass (>=)', () => {
+    // construire un cas où dollarVol == 2M : US, close=2, vol=1M → 2M
+    const r = evaluateLiquidityGate('X.US', 2, 1_000_000, MIN);
+    expect(r.pass).toBe(true);
+  });
+});

--- a/apps/api/src/modules/lisa/services/liquidity-gate.helper.ts
+++ b/apps/api/src/modules/lisa/services/liquidity-gate.helper.ts
@@ -1,0 +1,91 @@
+/**
+ * PR #367 — Gate de liquidité minimum (anti-slippage).
+ *
+ * Diagnostic 20/05/2026 : sur 48h, le stop nominal -1.5% se réalisait en
+ * moyenne à -2.69% (jusqu'à -7.69%) sur les small-caps illiquides asia
+ * (.KQ KOSDAQ, .SHG/.SHE Chine) + penny LSE. Pas de liquidité au prix du
+ * stop → exécution gap-down 2-5× plus bas. R:R réel dégradé à 1.2:1 →
+ * saignée mécanique malgré WR 30%.
+ *
+ * Le champ market_cap est en DEVISE LOCALE (KRW/CNY/EUR/GBP), pas USD —
+ * inutilisable comme gate USD. On gate donc sur le DOLLAR-VOLUME quotidien :
+ *   dollar_volume_usd = avgVol50d (shares) × close (devise locale) × fx_to_usd
+ *
+ * FX statique (ordre de grandeur suffit pour un plancher de liquidité ;
+ * une erreur ±10% ne change pas le verdict $2M). À recalibrer si une devise
+ * dérive durablement. GBp (pence LSE) intégré dans le multiplicateur.
+ */
+
+// Multiplicateur devise locale → USD, clé = suffixe EODHD (sans point).
+// Pas de suffixe = US (USD = 1).
+const FX_TO_USD: Record<string, number> = {
+  US: 1,
+  TO: 0.73, // CAD
+  // Europe
+  L: 0.0127, // LSE en pence (GBp) : GBP/USD ÷ 100
+  LSE: 0.0127,
+  PA: 1.08, // EUR
+  AS: 1.08,
+  AMS: 1.08,
+  BR: 1.08,
+  LS: 1.08,
+  MI: 1.08,
+  XETRA: 1.08,
+  DE: 1.08,
+  MC: 1.08,
+  BME: 1.08,
+  SW: 1.10, // CHF
+  // Asia
+  KO: 0.00073, // KRW
+  KQ: 0.00073,
+  KS: 0.00073,
+  KE: 0.00073,
+  SHG: 0.139, // CNY
+  SHE: 0.139,
+  T: 0.00645, // JPY
+  HK: 0.128, // HKD
+  AU: 0.66, // AUD
+  NSE: 0.012, // INR
+  BSE: 0.012,
+};
+
+export function fxToUsd(symbol: string): number {
+  if (!symbol.includes('.')) return 1; // US sans suffixe
+  const suffix = symbol.split('.')[1];
+  return FX_TO_USD[suffix] ?? 1; // devise inconnue → no-op (multiplicateur 1)
+}
+
+export interface LiquidityGateResult {
+  pass: boolean;
+  dollarVolumeUsd: number | null;
+  reason?: string;
+}
+
+/**
+ * Évalue le gate liquidité.
+ *
+ * - `avgVol50d <= 0` ou `close <= 0` → fail-open (pass=true, données manquantes,
+ *   on ne bloque pas sur une absence de donnée).
+ * - `minUsd <= 0` → gate désactivé (pass=true).
+ * - Sinon : pass si dollar_volume_usd >= minUsd.
+ */
+export function evaluateLiquidityGate(
+  symbol: string,
+  close: number,
+  avgVol50d: number,
+  minUsd: number,
+): LiquidityGateResult {
+  if (minUsd <= 0) return { pass: true, dollarVolumeUsd: null };
+  if (!Number.isFinite(close) || close <= 0 || !Number.isFinite(avgVol50d) || avgVol50d <= 0) {
+    return { pass: true, dollarVolumeUsd: null, reason: 'no_volume_data_fail_open' };
+  }
+  const dollarVolumeUsd = avgVol50d * close * fxToUsd(symbol);
+  if (dollarVolumeUsd < minUsd) {
+    return {
+      pass: false,
+      dollarVolumeUsd,
+      reason: `dollar_volume $${(dollarVolumeUsd / 1e6).toFixed(2)}M < min $${(minUsd / 1e6).toFixed(2)}M`,
+    };
+  }
+  return { pass: true, dollarVolumeUsd };
+}

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -51,6 +51,7 @@ import { SHADOW_BLOC1_CONFIG } from '../../gainers-scanner/bloc1/prefilter-gates
 import { CandidateRejectReason } from '../../gainers-scanner/domain/gainers-enums';
 // PR6.4 — Enrichment helpers (ATR + EMA + persistence depuis ohlcv_cache_daily)
 import { enrichShadowCandidate } from './shadow-enrichment.helper';
+import { evaluateLiquidityGate } from './liquidity-gate.helper';
 import {
   calculateContinuousScore,
   type ScoringAssetClass,
@@ -2366,6 +2367,37 @@ export class TopGainersScannerService implements OnModuleInit {
           `[top-gainers:crypto_tradable] ${cand.symbol} not in CRYPTO_TRADABLE_WHITELIST → skip open (visible in scan, not traded)`,
         );
         continue;
+      }
+
+      // PR #367 — Gate liquidité (anti-slippage). Diagnostic 20/05 : les SL
+      // slippaient -2.69% moy (jusqu'à -7.69%) sur small-caps illiquides
+      // (.KQ/.SHG/.SHE/penny LSE) faute de liquidité au prix du stop. On
+      // refuse d'ouvrir si le dollar-volume quotidien (avgVol50d × close ×
+      // fx_to_usd) est sous le seuil. Crypto exempté (toujours liquide + FX
+      // table inadaptée aux paires Binance). Fail-open si données manquantes.
+      if (!isCryptoCand) {
+        // Défaut $500k/jour : attrape les saigneurs micro-caps (76k-182k mesurés
+        // 20/05) avec marge, préserve les mid-caps. Montable à $2M via env après
+        // observation. Mettre 0 désactive le gate.
+        const minDollarVol = Number(
+          this.config.get<string>('GAINERS_MIN_DOLLAR_VOLUME_USD') ?? '500000',
+        );
+        const liq = evaluateLiquidityGate(cand.symbol, cand.close, cand.avgVol50d, minDollarVol);
+        if (!liq.pass) {
+          this.logger.log(
+            `[top-gainers:liquidity] ${cand.symbol} (${cand.assetClass}) skip — ${liq.reason}`,
+          );
+          this.qwLogger?.log({
+            qwId: 'LIQUIDITY_GATE',
+            symbol: cand.symbol,
+            assetClass: cand.assetClass,
+            decision: 'block',
+            reason: liq.reason ?? 'low_dollar_volume',
+            wouldHavePassedWithoutFlag: true,
+            details: { dollar_volume_usd: liq.dollarVolumeUsd, min_usd: minDollarVol },
+          });
+          continue;
+        }
       }
 
       // PR #4 — pWin gate (ML logistic regression P9). Activable par portfolio


### PR DESCRIPTION
FERMÉE — non validée par le backtest.

Le backtest sur données réelles 48h montre que le gate dollar-volume aurait bloqué des trades NET-POSITIFS (+187$ au seuil $2M), pas évité les pertes. Preuve : 032500.KQ (saigneur -92$, SL slippé -3.3%) a ~$9M/jour de dollar-volume = liquide. Le slippage n'est PAS causé par l'illiquidité mais par les gaps de session / pump-and-dump.

Vrais leviers : PR #349 (gate session, déjà en prod) + path-quality gate (à investiguer). Analyse slippage = gap vs pump en cours.