### PR TITLE
feat(td-filter): PR #368 — étendre filtre Supertrend TD à eu_equity + fix constraint asia

### DIFF
--- a/apps/api/src/modules/lisa/quick-wins/types.ts
+++ b/apps/api/src/modules/lisa/quick-wins/types.ts
@@ -35,7 +35,8 @@ export type QwId =
   | 'CIRCUIT_BREAKER'
   | 'TD_SUPERTREND_US'    // PR #345 — filtre TwelveData Supertrend US equity
   | 'TD_RSI_CRYPTO'       // PR #345 — filtre TwelveData RSI crypto overbought
-  | 'TD_SUPERTREND_ASIA'; // PR #360 — filtre TwelveData Supertrend asia equity 30m
+  | 'TD_SUPERTREND_ASIA' // PR #360 — filtre TwelveData Supertrend asia equity 30m
+  | 'TD_SUPERTREND_EU';  // PR #368 — filtre TwelveData Supertrend eu equity 30m
 
 export type QwDecision = 'pass' | 'block' | 'modify';
 

--- a/apps/api/src/modules/lisa/services/__tests__/twelve-data-scanner-filters.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/twelve-data-scanner-filters.spec.ts
@@ -454,4 +454,105 @@ describe('evaluateTwelveDataFilters — PR #345', () => {
       expect(counters.lastSupertrendArgs?.[4]).toBe('scanner_asia_supertrend');
     });
   });
+
+  describe('PR #368 — Filtre Supertrend eu 30m', () => {
+    it('flag OFF → no call même si signal eu', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 80, direction: 'down', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'BNP.PA',
+        assetClass: 'eu_equity',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        // euSupertrendEnabled non spécifié → default false
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(0);
+    });
+
+    it('eu_equity + direction=down → reject_supertrend_eu_down', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 88.5, direction: 'down', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'BNP.PA',
+        assetClass: 'eu_equity',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        euSupertrendEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('reject_supertrend_eu_down');
+      if (r.decision === 'reject_supertrend_eu_down') {
+        expect(r.reason).toContain('eu supertrend direction=down');
+      }
+      expect(counters.supertrendCalls).toBe(1);
+      // mapping BNP.PA → BNP:Euronext + called_by=scanner_eu_supertrend
+      expect(counters.lastSupertrendArgs?.[0]).toBe('BNP:Euronext');
+      expect(counters.lastSupertrendArgs?.[4]).toBe('scanner_eu_supertrend');
+    });
+
+    it('eu_equity + direction=up → accept', async () => {
+      const { service: td } = makeTwelveDataMock({
+        supertrend: { value: 80, direction: 'up', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'SAP.XETRA',
+        assetClass: 'eu_equity',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        euSupertrendEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+    });
+
+    it('TwelveData null (rate limit) → fail-open accept', async () => {
+      const { service: td, counters } = makeTwelveDataMock({ supertrend: null });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'NESN.SW',
+        assetClass: 'eu_equity',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        euSupertrendEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(1); // appel tenté
+    });
+
+    it('Milan .MI non mappable TD → fail-open (pas d\'appel)', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 50, direction: 'down', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'ENEL.MI',
+        assetClass: 'eu_equity',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        euSupertrendEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(0); // .MI → eodhdToTdSymbol null → skip
+    });
+
+    it('asset_class us_equity + eu flag ON → bypass (filtre eu only)', async () => {
+      const { service: td, counters } = makeTwelveDataMock({
+        supertrend: { value: 50, direction: 'down', timestamp: 'now' },
+      });
+      const r = await evaluateTwelveDataFilters({
+        symbol: 'AAPL.US',
+        assetClass: 'us_equity_large',
+        supertrendEnabled: false,
+        cryptoRsiEnabled: false,
+        euSupertrendEnabled: true,
+        twelveData: td,
+      });
+      expect(r.decision).toBe('accept');
+      expect(counters.supertrendCalls).toBe(0);
+    });
+  });
 });

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -40,6 +40,7 @@ export type ShadowDecision =
   | 'reject_supertrend_down'    // PR #345 — TwelveData Supertrend 30m direction=down (us_equity)
   | 'reject_rsi_overbought'     // PR #345 — TwelveData RSI 5m > 75 (crypto_major)
   | 'reject_supertrend_asia_down' // PR #360 — TwelveData Supertrend 30m direction=down (asia_equity)
+  | 'reject_supertrend_eu_down' // PR #368 — TwelveData Supertrend 30m direction=down (eu_equity)
   | 'reject_other';
 
 export interface RecordDecisionInput {

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -2302,13 +2302,16 @@ export class TopGainersScannerService implements OnModuleInit {
             (this.config.get<string>('TWELVEDATA_FILTER_CRYPTO_RSI_ENABLED') ?? 'false') === 'true';
           const asiaSupertrendEnabled =
             (this.config.get<string>('TWELVEDATA_FILTER_ASIA_SUPERTREND_ENABLED') ?? 'false') === 'true';
-          if (supertrendEnabled || cryptoRsiEnabled || asiaSupertrendEnabled) {
+          const euSupertrendEnabled =
+            (this.config.get<string>('TWELVEDATA_FILTER_EU_SUPERTREND_ENABLED') ?? 'false') === 'true';
+          if (supertrendEnabled || cryptoRsiEnabled || asiaSupertrendEnabled || euSupertrendEnabled) {
             const tdFilter = await evaluateTwelveDataFilters({
               symbol: cand.symbol,
               assetClass: cand.assetClass,
               supertrendEnabled,
               cryptoRsiEnabled,
               asiaSupertrendEnabled,
+              euSupertrendEnabled,
               twelveData: this.twelveData,
             });
             if (tdFilter.decision !== 'accept') {
@@ -2320,7 +2323,9 @@ export class TopGainersScannerService implements OnModuleInit {
                   ? 'TD_SUPERTREND_US'
                   : tdFilter.decision === 'reject_supertrend_asia_down'
                     ? 'TD_SUPERTREND_ASIA'
-                    : 'TD_RSI_CRYPTO';
+                    : tdFilter.decision === 'reject_supertrend_eu_down'
+                      ? 'TD_SUPERTREND_EU'
+                      : 'TD_RSI_CRYPTO';
               this.qwLogger?.log({
                 qwId,
                 symbol: cand.symbol,

--- a/apps/api/src/modules/lisa/services/twelve-data-scanner-filters.ts
+++ b/apps/api/src/modules/lisa/services/twelve-data-scanner-filters.ts
@@ -8,6 +8,7 @@
  *   1. Supertrend US equity 30m   : reject si direction='down' (us_equity_large/small_mid)
  *   2. RSI crypto 5m surachat     : reject si value > 75 (crypto_major)
  *   3. Supertrend asia equity 30m : reject si direction='down' (asia_equity) — PR #360
+ *   4. Supertrend eu equity 30m   : reject si direction='down' (eu_equity) — PR #368
  *
  * Le filtre ne court PAS si :
  *   - le flag d'env est désactivé (default OFF)
@@ -23,11 +24,13 @@ export type ScannerFilterDecision =
   | { decision: 'accept' }
   | { decision: 'reject_supertrend_down'; reason: string }
   | { decision: 'reject_rsi_overbought'; reason: string }
-  | { decision: 'reject_supertrend_asia_down'; reason: string };
+  | { decision: 'reject_supertrend_asia_down'; reason: string }
+  | { decision: 'reject_supertrend_eu_down'; reason: string };
 
 const US_CLASSES = new Set(['us_equity_large', 'us_equity_small_mid']);
 const CRYPTO_CLASSES = new Set(['crypto_major']);
 const ASIA_CLASSES = new Set(['asia_equity']);
+const EU_CLASSES = new Set(['eu_equity']);
 const RSI_OVERBOUGHT_THRESHOLD = 75;
 
 export interface FilterContext {
@@ -37,6 +40,8 @@ export interface FilterContext {
   cryptoRsiEnabled: boolean;
   /** PR #360 — default false pour rétro-compat avec callers existants (PR #345). */
   asiaSupertrendEnabled?: boolean;
+  /** PR #368 — default false pour rétro-compat. */
+  euSupertrendEnabled?: boolean;
   twelveData: TwelveDataService;
 }
 
@@ -106,6 +111,27 @@ export async function evaluateTwelveDataFilters(
         return {
           decision: 'reject_supertrend_asia_down',
           reason: `asia supertrend direction=down at ${st.timestamp} value=${st.value.toFixed(4)}`,
+        };
+      }
+    }
+  }
+
+  // Filtre 4 — Supertrend eu equity 30m (PR #368)
+  //
+  // Contexte 20/05/2026 : eu_equity perdait -242$ sur 48h (WR 25%, 3TP/9SL).
+  // Mêmes signaux contre-tendance que asia : le scanner accepte des gainers
+  // 1min dont la tendance 30m est baissière confirmée → se font stopper.
+  // Bourses EU mappables TD validées live PR #354 : .PA/.AS/.AMS → :Euronext,
+  // .XETRA/.DE → :XETR, .SW → :SIX, .LSE/.L → :LSE. .MI (Milan) non supporté
+  // (add-on TD) → eodhdToTdSymbol retourne null → fail-open (skip filtre).
+  if (ctx.euSupertrendEnabled && EU_CLASSES.has(ctx.assetClass)) {
+    const tdSymbol = eodhdToTdSymbol(ctx.symbol);
+    if (tdSymbol !== null) {
+      const st = await ctx.twelveData.getSupertrendSignal(tdSymbol, '30min', 10, 3, 'scanner_eu_supertrend');
+      if (st !== null && st.direction === 'down') {
+        return {
+          decision: 'reject_supertrend_eu_down',
+          reason: `eu supertrend direction=down at ${st.timestamp} value=${st.value.toFixed(4)}`,
         };
       }
     }

--- a/supabase/migrations/0149_shadow_decision_supertrend_eu.sql
+++ b/supabase/migrations/0149_shadow_decision_supertrend_eu.sql
@@ -1,0 +1,39 @@
+-- 0149 — PR #368 : étend la CHECK constraint gainers_user_shadow_signals.decision
+--
+-- Bug latent : la migration 0146 (PR #345) a réinstauré la CHECK list mais a
+-- OUBLIÉ 'reject_supertrend_asia_down' (PR #360) — donc depuis PR #360 les
+-- shadow signals asia-supertrend sont silencieusement rejetés par la contrainte
+-- (inserts fire-and-forget → aucune alerte). Cette migration répare ça ET
+-- ajoute la nouvelle valeur PR #368 :
+--   - reject_supertrend_asia_down : Supertrend 30m down (asia_equity) — réparation PR #360
+--   - reject_supertrend_eu_down   : Supertrend 30m down (eu_equity)   — nouveau PR #368
+--
+-- Idempotent : DROP IF EXISTS + ADD.
+
+ALTER TABLE public.gainers_user_shadow_signals
+  DROP CONSTRAINT IF EXISTS gainers_user_shadow_signals_decision_check;
+
+ALTER TABLE public.gainers_user_shadow_signals
+  ADD CONSTRAINT gainers_user_shadow_signals_decision_check
+  CHECK (decision IN (
+    'accept',
+    'reject_path_eff',
+    'reject_persistence',
+    'reject_cooldown',
+    'reject_post_sl_cooldown',
+    'reject_p_win',
+    'reject_budget_cap',
+    'reject_no_tf_data',
+    'reject_other',
+    'reject_earnings_imminent',
+    'reject_opening_buffer',
+    'reject_supertrend_down',
+    'reject_rsi_overbought',
+    -- PR #360 (réparation silent failure) + PR #368
+    'reject_supertrend_asia_down',
+    'reject_supertrend_eu_down'
+  ));
+
+COMMENT ON CONSTRAINT gainers_user_shadow_signals_decision_check
+  ON public.gainers_user_shadow_signals IS
+  'PR #368 — ajoute reject_supertrend_asia_down (répare PR #360) + reject_supertrend_eu_down.';


### PR DESCRIPTION
## Contexte

`eu_equity` a perdu **-242$ sur 48h** (WR 25%, 3TP/9SL) — mêmes signaux contre-tendance que asia : le scanner accepte des gainers 1min dont la tendance 30m est baissière → stoppés rapidement.

Le filtre Supertrend TD existait pour **US** (PR #345) et **asia** (PR #360) mais **pas EU**. Cette PR l'étend, mirror exact du bloc asia.

## Changements

- **`twelve-data-scanner-filters.ts`** : `EU_CLASSES` + `euSupertrendEnabled` + filtre `reject_supertrend_eu_down` (Supertrend 30m direction=down). Bourses EU mappables TD validées live PR #354 : `.PA/.AS/.AMS` → `:Euronext`, `.XETRA/.DE` → `:XETR`, `.SW` → `:SIX`, `.LSE/.L` → `:LSE`. `.MI` (Milan, add-on TD non actif) → `eodhdToTdSymbol` null → **fail-open** (skip filtre).
- **`top-gainers-scanner`** : lit `TWELVEDATA_FILTER_EU_SUPERTREND_ENABLED` (default false), passe `euSupertrendEnabled`, mappe `qwId=TD_SUPERTREND_EU`.
- **QwId + ShadowDecision** : ajout `TD_SUPERTREND_EU` / `reject_supertrend_eu_down`.

## Migration 0149 — répare un bug latent + ajoute EU

La CHECK constraint `gainers_user_shadow_signals.decision` (migration 0146) avait **oublié `reject_supertrend_asia_down`** (PR #360) → depuis PR #360 les shadow signals asia-supertrend étaient **silencieusement rejetés** par la contrainte (insert fire-and-forget, aucune alerte). 0149 ajoute asia (réparation) + eu (nouveau).

## Tests

147/147 verts. 6 nouveaux cas EU :
- flag OFF → no call
- down → `reject_supertrend_eu_down` avec mapping `BNP:Euronext` + `called_by=scanner_eu_supertrend`
- up → accept
- TD null → fail-open
- `.MI` non-mappable → fail-open (pas d'appel)
- cross-class bypass (us flag eu ON → ignore)

Typecheck OK.

## Activation

Flag **OFF par défaut**. Activer après observation :
```bash
flyctl secrets set TWELVEDATA_FILTER_EU_SUPERTREND_ENABLED=true --app smartvest
```

## Place dans la stratégie

C'est un filtre de **tendance** (rejette les entrées contre-tendance), logique éprouvée US/asia — pas une nouvelle source de signal. **À activer après** `GAINERS_OPEN_BUFFER_MIN=90` qui traite la cause racine #1 (gap session, 68% des pertes). Le Supertrend EU attaque la cause #2 (entrées contre-tendance, -242$ eu).

## Validation post-activation

```sql
SELECT decision, COUNT(*) FROM qw_decision_log
WHERE qw_id='TD_SUPERTREND_EU' AND created_at > NOW() - INTERVAL '24 hours'
GROUP BY decision;
```
+ comparer WR/PnL eu_equity avant/après activation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_