### PR TITLE
feat(mfe): PR #369 — instrumentation MFE (peak_pre_exit) pour prouver les exits réactifs

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/mechanical-trading-mfe.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/mechanical-trading-mfe.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * PR #369 — Tests instrumentation MFE (recordMfe).
+ *
+ * recordMfe(positionId, price, isLong) doit faire un UPDATE conditionnel
+ * lisa_positions.peak_pre_exit avec le bon filtre OR :
+ *   - long  : peak_pre_exit IS NULL OR peak_pre_exit < price (on garde le max)
+ *   - short : peak_pre_exit IS NULL OR peak_pre_exit > price (on garde le min)
+ *
+ * On instancie via Object.create pour éviter le constructor lourd (DI).
+ */
+
+import { MechanicalTradingService } from '../mechanical-trading.service';
+
+interface Captured {
+  updatePayload?: Record<string, unknown>;
+  eqArgs?: [string, unknown];
+  orArg?: string;
+}
+
+function makeServiceWithCapture(): { svc: MechanicalTradingService; cap: Captured } {
+  const cap: Captured = {};
+  const chain = {
+    update(payload: Record<string, unknown>) {
+      cap.updatePayload = payload;
+      return this;
+    },
+    eq(col: string, val: unknown) {
+      cap.eqArgs = [col, val];
+      return this;
+    },
+    or(arg: string) {
+      cap.orArg = arg;
+      return Promise.resolve({ error: null });
+    },
+  };
+  const supabase = {
+    getClient: () => ({ from: () => chain }),
+  };
+  const svc = Object.create(MechanicalTradingService.prototype) as MechanicalTradingService;
+  (svc as unknown as { supabase: unknown }).supabase = supabase;
+  return { svc, cap };
+}
+
+describe('PR #369 — recordMfe', () => {
+  it('long : update peak_pre_exit + filtre OR null/lt', async () => {
+    const { svc, cap } = makeServiceWithCapture();
+    await (svc as unknown as { recordMfe: (id: string, p: number, l: boolean) => Promise<void> })
+      .recordMfe('pos-1', 181.5, true);
+    expect(cap.updatePayload).toEqual({ peak_pre_exit: 181.5 });
+    expect(cap.eqArgs).toEqual(['id', 'pos-1']);
+    expect(cap.orArg).toBe('peak_pre_exit.is.null,peak_pre_exit.lt.181.5');
+  });
+
+  it('short : filtre OR null/gt (on garde le min)', async () => {
+    const { svc, cap } = makeServiceWithCapture();
+    await (svc as unknown as { recordMfe: (id: string, p: number, l: boolean) => Promise<void> })
+      .recordMfe('pos-2', 50, false);
+    expect(cap.orArg).toBe('peak_pre_exit.is.null,peak_pre_exit.gt.50');
+  });
+
+  it('prix invalide (<=0 ou NaN) → no-op (pas d\'update)', async () => {
+    const { svc, cap } = makeServiceWithCapture();
+    await (svc as unknown as { recordMfe: (id: string, p: number, l: boolean) => Promise<void> })
+      .recordMfe('pos-3', 0, true);
+    expect(cap.updatePayload).toBeUndefined();
+    await (svc as unknown as { recordMfe: (id: string, p: number, l: boolean) => Promise<void> })
+      .recordMfe('pos-3', Number.NaN, true);
+    expect(cap.updatePayload).toBeUndefined();
+  });
+
+  it('erreur supabase avalée (fire-and-forget, ne throw pas)', async () => {
+    const svc = Object.create(MechanicalTradingService.prototype) as MechanicalTradingService;
+    (svc as unknown as { supabase: unknown }).supabase = {
+      getClient: () => {
+        throw new Error('boom');
+      },
+    };
+    await expect(
+      (svc as unknown as { recordMfe: (id: string, p: number, l: boolean) => Promise<void> })
+        .recordMfe('pos-4', 100, true),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -1801,6 +1801,28 @@ export class MechanicalTradingService {
     return 'ok';
   }
 
+  /**
+   * PR #369 — Met à jour peak_pre_exit (MFE) si le prix courant améliore le pic.
+   * Long : pic = prix max atteint. Short : pic = prix min. Update conditionnel
+   * SQL (`peak_pre_exit IS NULL OR <comparaison>`) → un seul aller-retour,
+   * pas de read préalable. Fire-and-forget : toute erreur est avalée (le
+   * tracking MFE ne doit jamais bloquer le cycle stop/target).
+   */
+  private async recordMfe(positionId: string, price: number, isLong: boolean): Promise<void> {
+    if (!Number.isFinite(price) || price <= 0) return;
+    try {
+      const cmp = isLong ? `peak_pre_exit.lt.${price}` : `peak_pre_exit.gt.${price}`;
+      await this.supabase
+        .getClient()
+        .from('lisa_positions')
+        .update({ peak_pre_exit: price })
+        .eq('id', positionId)
+        .or(`peak_pre_exit.is.null,${cmp}`);
+    } catch {
+      // non bloquant — instrumentation best-effort
+    }
+  }
+
   private async checkStopTarget(pos: OpenPosition, isHyperActive: boolean = false): Promise<void> {
     if (!pos.stopLossPrice && !pos.takeProfitPrice) return;
 
@@ -1861,6 +1883,16 @@ export class MechanicalTradingService {
     // Bug #314 #M4 — helper centralisé : reconnaît long/long_call/long_put.
     // Avant : `=== 'long'` strict → options gérées comme SHORT → stop/target inversés.
     const isLong = isLongPosition(pos.direction);
+
+    // PR #369 — Instrumentation MFE (Max Favorable Excursion). Enregistre le
+    // pic de prix favorable atteint avant la sortie, dans peak_pre_exit (jusqu'à
+    // présent jamais peuplé). Permet de mesurer a posteriori si les positions
+    // qui finissent en SL avaient atteint un gain significatif avant de se
+    // retourner → chiffre la valeur d'un exit réactif (lock partiel). Update
+    // conditionnel fire-and-forget : n'écrit que si le prix améliore le pic
+    // (long = plus haut, short = plus bas). Coût négligeable (~7 open × 1/60s).
+    void this.recordMfe(pos.id, currentPrice.toNumber(), isLong);
+
     const hitStop = stopPrice && (isLong ? currentPrice.lte(stopPrice) : currentPrice.gte(stopPrice));
     const hitTarget = tpPrice && (isLong ? currentPrice.gte(tpPrice) : currentPrice.lte(tpPrice));
 


### PR DESCRIPTION
## Objectif : rendre le levier "exits réactifs TD" PROUVABLE

Le diagnostic 20/05 a montré qu'on **ne peut pas** chiffrer l'intérêt d'un exit réactif avec les données actuelles :
- `lisa_positions.peak_pre_exit` (MFE) : **0% peuplé** sur 98 positions/48h
- `post_sl_path` : **100% en error** (`eodhd_post_sl_empty` pour asia)

Sans le MFE (jusqu'où une position est montée avant de retourner en SL), impossible de savoir si un exit réactif (lock partiel) aurait sauvé de l'argent. Construire le levier sans cette donnée = refaire l'erreur #367.

## Cette PR instrumente le MFE

- `checkStopTarget` (cron mécanique 60s) enregistre le pic de prix favorable via `recordMfe()` avant le check stop/target.
- `recordMfe` : **UPDATE conditionnel SQL** (un seul aller-retour, pas de read) — `peak_pre_exit = price WHERE id=X AND (peak_pre_exit IS NULL OR plus-haut-pour-long / plus-bas-pour-short)`. **Fire-and-forget** : toute erreur avalée, n'impacte jamais le cycle stop.
- Long = pic max, short = pic min (le plus favorable).

**Pas de migration** (colonne `peak_pre_exit` déjà présente, jamais utilisée). **Pas d'impact décisionnel** : pur logging. Coût ~7 positions × 1 update conditionnel/60s = négligeable.

## Tests

- 4 cas `recordMfe` : long (OR null/lt), short (OR null/gt), prix invalide (no-op), erreur supabase avalée
- 58/58 mechanical-trading non régressé
- Typecheck OK

## Playbook (identique PR #366 divergence)

Instrumenter → 48h collecte → décider sur preuve. Requête de décision à J+48h :

```sql
SELECT
  COUNT(*) FILTER (WHERE status='closed_stop') AS sl,
  COUNT(*) FILTER (WHERE status='closed_stop'
    AND peak_pre_exit IS NOT NULL
    AND (peak_pre_exit-entry_price)/entry_price > 0.015) AS sl_qui_avaient_atteint_1_5pct,
  ROUND(AVG((peak_pre_exit-entry_price)/entry_price*100)
    FILTER (WHERE status='closed_stop'),2) AS mfe_moyen_des_SL_pct
FROM lisa_positions
WHERE source='lisa' AND entry_timestamp > NOW() - INTERVAL '48 hours';
```

**Si beaucoup de SL avaient un MFE > +1.5% avant de retourner** → l'exit réactif a une valeur chiffrable, on le construit. **Sinon on l'abandonne** comme #367.

## Pourquoi cette approche

Après l'erreur #367 (gate liquidité construit sur une corrélation, invalidé au backtest), on ne construit plus rien sans preuve. Cette PR est le strict minimum pour générer la preuve, sans risque (instrumentation additive).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_