### PR TITLE
feat(shadow): A/B variante entrée pullback + SL élargi (zéro risque capital)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/shadow-exit-variant.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/shadow-exit-variant.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Migration 0150 — Shadow A/B variante entrée pullback.
+ *
+ * simulateVariant(row) doit :
+ *   - attendre un pullback de pullback_pct sous entry_price dans la fenêtre,
+ *   - entrer à ce close avec SL élargi (sl_pct) + TP (tp_pct),
+ *   - rejouer le moteur BLOC4 (applyTick) identique au live,
+ *   - retourner 'no_entry' si la fenêtre s'écoule sans pullback,
+ *   - retourner 'pending' si entrée touchée mais exit non résolu (< time-limit).
+ *
+ * On instancie via Object.create (DI lourd) + stub fetchCandles.
+ */
+
+import { ShadowExitSimulatorService } from '../shadow-exit-simulator.service';
+
+interface Svc {
+  variantPullbackPct: number;
+  variantWindowMin: number;
+  variantSlPct: number;
+  variantTpPct: number;
+  fetchCandles: (row: unknown, count: number) => Promise<Array<{ close: number }> | null>;
+  simulateVariant: (row: unknown) => Promise<unknown>;
+}
+
+function makeSvc(candles: Array<{ close: number }> | null): Svc {
+  const svc = Object.create(ShadowExitSimulatorService.prototype) as unknown as Svc;
+  svc.variantPullbackPct = 0.015;
+  svc.variantWindowMin = 30;
+  svc.variantSlPct = 0.025;
+  svc.variantTpPct = 0.03;
+  svc.fetchCandles = async () => candles;
+  return svc;
+}
+
+function row(createdMinAgo: number) {
+  return {
+    id: 'sig-1',
+    symbol: 'AAPL.US',
+    exchange: 'US',
+    asset_class: 'equity' as const,
+    entry_price: 100,
+    entry_path_eff: 0.6,
+    tp_price: 103,
+    sl_price: 98.5,
+    created_at: new Date(Date.now() - createdMinAgo * 60_000).toISOString(),
+  };
+}
+
+describe('Migration 0150 — simulateVariant', () => {
+  it('pullback touché puis TP → win, entrée au creux, SL à 2.5%', async () => {
+    // trigger pullback = 100*(1-0.015) = 98.5. idx1=98.4 touche, puis idx2=102 >= TP(98.4*1.03=101.35).
+    const candles = [{ close: 99.5 }, { close: 98.4 }, { close: 102 }];
+    const svc = makeSvc(candles);
+    const v = (await svc.simulateVariant(row(300))) as {
+      entryPrice: number; entryOffsetMin: number; exitReason: string; pnlPct: number;
+    };
+    expect(v.entryPrice).toBe(98.4);
+    expect(v.entryOffsetMin).toBe(2); // idx1 → minute 2
+    expect(v.exitReason).toBe('TP_FULL');
+    expect(v.pnlPct).toBeCloseTo((102 - 98.4) / 98.4, 5);
+  });
+
+  it('pullback puis SL élargi (2.5%) touché → loss', async () => {
+    // entrée 98.4, SL = 98.4*0.975 = 95.94. idx2=95 <= SL.
+    const candles = [{ close: 98.0 }, { close: 95 }];
+    const svc = makeSvc(candles);
+    const v = (await svc.simulateVariant(row(300))) as { exitReason: string; pnlPct: number };
+    expect(v.exitReason).toBe('SL');
+    expect(v.pnlPct).toBeLessThan(0);
+  });
+
+  it('aucun pullback + fenêtre écoulée → no_entry', async () => {
+    const candles = Array.from({ length: 35 }, () => ({ close: 100.5 })); // jamais sous 98.5
+    const svc = makeSvc(candles);
+    const v = await svc.simulateVariant(row(60)); // age 60 > window 30
+    expect(v).toBe('no_entry');
+  });
+
+  it('pullback touché mais exit non résolu et < time-limit → pending', async () => {
+    const candles = [{ close: 98.0 }, { close: 99 }, { close: 99.5 }]; // entrée idx0, pas de TP/SL
+    const svc = makeSvc(candles);
+    const v = await svc.simulateVariant(row(10)); // hold court, pas de time-limit
+    expect(v).toBe('pending');
+  });
+
+  it('trop jeune (fenêtre non écoulée, pas de pullback) → null', async () => {
+    const candles = [{ close: 100.2 }, { close: 100.1 }];
+    const svc = makeSvc(candles);
+    const v = await svc.simulateVariant(row(8)); // age 8 < window 30
+    expect(v).toBeNull();
+  });
+});

--- a/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
@@ -48,12 +48,31 @@ interface SimResult {
   slippagePct: number | null;
 }
 
+/** Shadow A/B — résultat de la variante entrée pullback (cf. migration 0150). */
+interface VariantResult {
+  entryPrice: number;
+  entryOffsetMin: number;
+  exitPrice: number;
+  exitAt: string;
+  exitReason: string;
+  pnlPct: number;
+  slippagePct: number | null;
+}
+
 const MIN_AGE_MIN_BEFORE_REPLAY = 5;
 const MAX_HOLD_HOURS = 3; // ADR-005 §2.4 time-stop
 
 @Injectable()
 export class ShadowExitSimulatorService {
   private readonly logger = new Logger(ShadowExitSimulatorService.name);
+
+  // Shadow A/B variante entrée pullback (migration 0150). Params env, defaults
+  // issus du backtest 48h crypto (pullback 1.5% + SL 2.5% + TP 3% → +0.47% net).
+  private readonly variantEnabled = process.env.SHADOW_ENTRY_VARIANT_ENABLED !== 'false';
+  private readonly variantPullbackPct = Number(process.env.SHADOW_VARIANT_PULLBACK_PCT ?? '0.015');
+  private readonly variantWindowMin = Number(process.env.SHADOW_VARIANT_WINDOW_MIN ?? '30');
+  private readonly variantSlPct = Number(process.env.SHADOW_VARIANT_SL_PCT ?? '0.025');
+  private readonly variantTpPct = Number(process.env.SHADOW_VARIANT_TP_PCT ?? '0.03');
 
   constructor(
     private readonly supabase: SupabaseService,
@@ -71,6 +90,15 @@ export class ShadowExitSimulatorService {
       await this.runInner();
     } catch (e) {
       this.logger.error(`[exit-sim] cron failed: ${String(e).slice(0, 200)}`);
+    }
+    // Shadow A/B variante pullback — indépendant du live (try/catch séparé pour
+    // qu'un échec variante n'affecte jamais la simulation live).
+    if (this.variantEnabled) {
+      try {
+        await this.runVariantInner();
+      } catch (e) {
+        this.logger.error(`[exit-sim:variant] cron failed: ${String(e).slice(0, 200)}`);
+      }
     }
   }
 
@@ -190,6 +218,159 @@ export class ShadowExitSimulatorService {
     return {
       exitPrice,
       exitAt: exitTime,
+      exitReason: String(exitReason),
+      pnlPct,
+      slippagePct,
+    };
+  }
+
+  /**
+   * Shadow A/B (migration 0150) — pour chaque signal ACCEPT dont la variante
+   * n'est pas encore tranchée, simule une entrée pullback + SL élargi.
+   */
+  private async runVariantInner(): Promise<void> {
+    const cutoff = new Date(Date.now() - MIN_AGE_MIN_BEFORE_REPLAY * 60_000).toISOString();
+    const { data, error } = await this.supabase
+      .getClient()
+      .from('gainers_v1_shadow_signals')
+      .select('id, symbol, exchange, asset_class, entry_price, entry_path_eff, tp_price, sl_price, created_at')
+      .eq('decision', 'ACCEPT')
+      .not('entry_price', 'is', null)
+      .is('variant_exit_at', null)
+      .is('variant_no_entry', null)
+      .lte('created_at', cutoff)
+      .order('created_at', { ascending: true })
+      .limit(50);
+
+    if (error || !data || data.length === 0) return;
+
+    const params = {
+      pullback_pct: this.variantPullbackPct,
+      window_min: this.variantWindowMin,
+      sl_pct: this.variantSlPct,
+      tp_pct: this.variantTpPct,
+    };
+    let resolved = 0;
+    let noEntry = 0;
+    for (const r of data as ShadowSignalRow[]) {
+      try {
+        const v = await this.simulateVariant(r);
+        if (v === 'pending' || v === null) continue;
+        const update = v === 'no_entry'
+          ? { variant_no_entry: true, variant_params: params }
+          : {
+              variant_entry_price: v.entryPrice,
+              variant_entry_offset_min: v.entryOffsetMin,
+              variant_no_entry: false,
+              variant_exit_price: v.exitPrice,
+              variant_exit_at: v.exitAt,
+              variant_exit_reason: v.exitReason,
+              variant_pnl_pct: v.pnlPct,
+              variant_slippage_pct: v.slippagePct,
+              variant_params: params,
+            };
+        const { error: upErr } = await this.supabase
+          .getClient()
+          .from('gainers_v1_shadow_signals')
+          .update(update)
+          .eq('id', r.id);
+        if (upErr) this.logger.warn(`[exit-sim:variant] update ${r.id} failed: ${upErr.message}`);
+        else if (v === 'no_entry') noEntry++;
+        else resolved++;
+      } catch (e) {
+        this.logger.warn(`[exit-sim:variant] ${r.symbol} (${r.id}) failed: ${String(e).slice(0, 80)}`);
+      }
+    }
+    this.logger.log(`[exit-sim:variant] resolved ${resolved}, no_entry ${noEntry}`);
+  }
+
+  /**
+   * Simule la variante pullback sur un signal. Retourne :
+   *   - 'no_entry' : fenêtre écoulée sans pullback (la variante n'aurait pas tradé)
+   *   - 'pending'  : pullback touché mais exit non encore résolu (réessayer)
+   *   - null       : pas assez de données / trop jeune pour conclure
+   *   - VariantResult : entrée+exit résolus
+   */
+  private async simulateVariant(row: ShadowSignalRow): Promise<VariantResult | 'no_entry' | 'pending' | null> {
+    const entryTimeMs = new Date(row.created_at).getTime();
+    const ageMin = (Date.now() - entryTimeMs) / 60_000;
+    // Fenêtre pullback + horizon de hold complet.
+    const maxCandles = this.variantWindowMin + 60 * MAX_HOLD_HOURS;
+    const replayCount = Math.min(maxCandles, Math.ceil(ageMin));
+    if (replayCount < 5) return null;
+
+    const candles = await this.fetchCandles(row, replayCount);
+    if (!candles || candles.length === 0) return null;
+
+    // 1. Cherche le 1er pullback sous entry_price*(1-pullback_pct) dans la fenêtre.
+    const pullbackTrigger = row.entry_price * (1 - this.variantPullbackPct);
+    const windowEnd = Math.min(this.variantWindowMin, candles.length);
+    let entryIdx = -1;
+    for (let i = 0; i < windowEnd; i++) {
+      if (candles[i].close <= pullbackTrigger) {
+        entryIdx = i;
+        break;
+      }
+    }
+
+    if (entryIdx === -1) {
+      // Pas de pullback observé. On ne peut conclure 'no_entry' que si la fenêtre
+      // est entièrement écoulée (sinon il peut encore arriver).
+      if (ageMin >= this.variantWindowMin) return 'no_entry';
+      return null;
+    }
+
+    // 2. Entrée à ce close, SL élargi + TP relatifs à l'entrée variante.
+    const variantEntry = candles[entryIdx].close;
+    const initialSl = variantEntry * (1 - this.variantSlPct);
+    let snap: PositionSnapshot = {
+      state: PositionState.OPEN,
+      entryPrice: variantEntry,
+      pathEff: row.entry_path_eff,
+      tpPrice: variantEntry * (1 + this.variantTpPct),
+      initialSlPrice: initialSl,
+      currentStopPrice: initialSl,
+      mfePrice: variantEntry,
+    };
+
+    // 3. Replay BLOC4 (identique au live) sur les candles post-entrée.
+    let exitIdx = -1;
+    let exitReason: ExitReason | null = null;
+    for (let i = entryIdx + 1; i < candles.length; i++) {
+      const r = applyTick({ position: snap, currentPrice: candles[i].close });
+      snap = { ...snap, state: r.newState, currentStopPrice: r.newStopPrice, mfePrice: r.newMfePrice };
+      if (r.exitReason) {
+        exitReason = r.exitReason;
+        exitIdx = i;
+        break;
+      }
+    }
+
+    if (exitIdx === -1) {
+      const variantEntryTimeMs = entryTimeMs + (entryIdx + 1) * 60_000;
+      const holdMin = (Date.now() - variantEntryTimeMs) / 60_000;
+      if (holdMin >= MAX_HOLD_HOURS * 60) {
+        exitReason = ExitReason.TIME_LIMIT;
+        exitIdx = candles.length - 1;
+      } else {
+        return 'pending';
+      }
+    }
+
+    const exitPrice = candles[exitIdx].close;
+    const exitAt = new Date(entryTimeMs + (exitIdx + 1) * 60_000).toISOString();
+    const pnlPct = (exitPrice - variantEntry) / variantEntry;
+    const theoretical =
+      exitReason === ExitReason.TP_FULL ? snap.tpPrice :
+      exitReason === ExitReason.SL ? initialSl :
+      snap.currentStopPrice;
+    const slippagePct = theoretical !== null ? (exitPrice - theoretical) / variantEntry : null;
+
+    return {
+      entryPrice: variantEntry,
+      entryOffsetMin: entryIdx + 1,
+      exitPrice,
+      exitAt,
       exitReason: String(exitReason),
       pnlPct,
       slippagePct,

--- a/supabase/migrations/0150_shadow_entry_variant.sql
+++ b/supabase/migrations/0150_shadow_entry_variant.sql
@@ -1,0 +1,46 @@
+-- 0150 — Shadow A/B entrée pullback + SL élargi (variante non-tradée).
+--
+-- Contexte (analyse 20/05/2026) : le scanner gainers live entre en momentum-chase
+-- (au sommet du pump) avec SL serré (~1.5%). Backtest crypto 48h + V1 shadow equity
+-- (83 trades, WR 34.9%, -3.87%/trade malgré SL 4.84%) montrent que :
+--   - momentum-chase => espérance NÉGATIVE (-0.29%/trade)
+--   - pullback-dans-tendance + SL adapté => espérance POSITIVE (+0.47%/trade net)
+-- L'edge vient de l'ENTRÉE (et de la géométrie d'exit), pas de la largeur d'univers.
+--
+-- Cette migration ajoute des colonnes pour shadow-simuler EN PARALLÈLE du live,
+-- sur les mêmes signaux ACCEPT, une variante d'entrée :
+--   - on attend un pullback de `pullback_pct` sous le prix signal dans une fenêtre
+--   - si touché : entrée à ce prix avec SL `sl_pct` (élargi) + TP `tp_pct`
+--   - si jamais touché dans la fenêtre : `variant_no_entry=true` (on rate, réaliste)
+-- Le moteur de trailing BLOC4 (applyTick) est strictement identique au live :
+-- seuls le prix d'entrée et la distance SL changent → isolation propre de l'effet.
+--
+-- ZÉRO risque capital : colonnes additives, aucune position réelle n'est ouverte.
+-- Remplies post-hoc par ShadowExitSimulatorService.runVariantInner (cron 5 min).
+
+ALTER TABLE public.gainers_v1_shadow_signals
+  ADD COLUMN IF NOT EXISTS variant_entry_price      NUMERIC(18,8),
+  ADD COLUMN IF NOT EXISTS variant_entry_offset_min INT,
+  ADD COLUMN IF NOT EXISTS variant_no_entry         BOOLEAN,
+  ADD COLUMN IF NOT EXISTS variant_exit_price       NUMERIC(18,8),
+  ADD COLUMN IF NOT EXISTS variant_exit_at          TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS variant_exit_reason      TEXT,
+  ADD COLUMN IF NOT EXISTS variant_pnl_pct          NUMERIC(8,5),
+  ADD COLUMN IF NOT EXISTS variant_slippage_pct     NUMERIC(7,5),
+  ADD COLUMN IF NOT EXISTS variant_params           JSONB;
+
+-- Index pour le worker : signaux ACCEPT dont la variante n'est pas encore tranchée
+-- (ni entrée résolue, ni no_entry). Partiel pour rester léger.
+CREATE INDEX IF NOT EXISTS gainers_v1_shadow_signals_variant_pending_idx
+  ON public.gainers_v1_shadow_signals (created_at ASC)
+  WHERE decision = 'ACCEPT'
+    AND entry_price IS NOT NULL
+    AND variant_exit_at IS NULL
+    AND variant_no_entry IS NULL;
+
+COMMENT ON COLUMN public.gainers_v1_shadow_signals.variant_entry_price IS
+  'Shadow A/B — prix d''entrée pullback (close ayant touché entry_price*(1-pullback_pct)).';
+COMMENT ON COLUMN public.gainers_v1_shadow_signals.variant_no_entry IS
+  'Shadow A/B — true si aucun pullback dans la fenêtre (la variante n''aurait pas tradé).';
+COMMENT ON COLUMN public.gainers_v1_shadow_signals.variant_params IS
+  'Shadow A/B — {pullback_pct, window_min, sl_pct, tp_pct} utilisés (reproductibilité).';


### PR DESCRIPTION
## Pourquoi

Diagnostic 20/05/2026 sur données réelles : le scanner gainers entre en **momentum-chase** (au sommet du pump) avec SL serré ~1.5%. Les chiffres montrent que **l'edge vient de l'entrée, pas de la largeur d'univers** :

- Backtest 48h crypto (univers élargi) : momentum-chase = **−0.29%/trade**, pullback-dans-tendance + SL 2.5% = **+0.47% net**.
- V1 shadow equity (83 trades) : WR 34.9%, **−3.87%/trade malgré un SL large à 4.84%** → élargir le stop seul ne suffit pas, c'est la **combinaison entrée pullback + SL adapté** qui marche.

Plutôt que de builder en prod sur un backtest 48h (échantillon réduit, 1 régime), on valide d'abord en **shadow A/B sur données réelles**, conformément à la discipline « prouver avant de construire ».

## Quoi

Pour chaque signal ACCEPT, on simule **en parallèle du live**, sur les mêmes candles, une variante d'entrée :
- attente d'un pullback de `pullback_pct` sous le prix signal dans une fenêtre,
- entrée à ce prix avec SL `sl_pct` (élargi) + TP `tp_pct`,
- moteur de trailing BLOC4 (`applyTick`) **strictement identique au live** → seuls le prix d'entrée et la distance SL changent (isolation propre de l'effet),
- `variant_no_entry=true` si le pullback ne se matérialise jamais (réaliste : on rate des signaux).

**Zéro risque capital** : colonnes additives, aucune position réelle ouverte. Try/catch isolé → un échec variante n'affecte jamais la simulation live.

## Comment on tranchera

Une fois quelques jours de données accumulées, comparaison SQL directe :
```
WR / espérance   live (momentum-chase, SL serré)   vs   variante (pullback, SL 2.5%)
```
sur plusieurs régimes de marché → décision sur preuve.

## Détail technique

- **Migration 0150** : colonnes `variant_*` sur `gainers_v1_shadow_signals` + index partiel pending.
- **`ShadowExitSimulatorService.runVariantInner`** : cron 5 min, backfill historique + nouveaux signaux.
- Params env (defaults backtest) : `SHADOW_VARIANT_PULLBACK_PCT=0.015`, `_WINDOW_MIN=30`, `_SL_PCT=0.025`, `_TP_PCT=0.03`, `SHADOW_ENTRY_VARIANT_ENABLED` (default on).

## Test plan

- [x] 5 tests unitaires `simulateVariant` (pullback/TP, SL élargi, no_entry, pending, too-young)
- [x] 72 tests shadow existants OK (non-régression)
- [x] tsc `--noEmit` clean
- [ ] Post-deploy : vérifier logs `[exit-sim:variant] resolved X, no_entry Y` + remplissage colonnes `variant_*`

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_