### PR TITLE
fix(mechanical): garde-fou prix-zéro sur stop/target (bug SEE.LSE -$1574)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/mechanical-trading-zero-price-guard.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/mechanical-trading-zero-price-guard.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * ZERO_PRICE_GUARD — régression de l'incident SEE.LSE (14/05/2026, -$1574).
+ *
+ * Un tick à prix <= 0 (ou NaN) d'une source NON taggée fallback contournait
+ * le sanity bound (gardé par `livePx.gt(0)`) dans checkStopTarget et déclenchait
+ * un stop à 0 → fausse liquidation -100%. Le garde doit skip tout prix non-positif.
+ *
+ * On instancie via Object.create (constructor DI lourd) + stubs minimaux.
+ */
+
+import { MechanicalTradingService } from '../mechanical-trading.service';
+
+interface Svc {
+  lisa: { getLivePrice: (s: string) => Promise<{ price: unknown; source: string } | null> };
+  logger: { warn: jest.Mock; log: jest.Mock; error: jest.Mock; debug: jest.Mock };
+  checkStopTarget: (pos: unknown, isHyperActive?: boolean) => Promise<void>;
+}
+
+function makeSvc(price: unknown, source = 'eodhd'): Svc {
+  const svc = Object.create(MechanicalTradingService.prototype) as unknown as Svc;
+  svc.lisa = { getLivePrice: async () => ({ price, source }) };
+  svc.logger = { warn: jest.fn(), log: jest.fn(), error: jest.fn(), debug: jest.fn() };
+  return svc;
+}
+
+const pos = {
+  symbol: 'SEE.LSE',
+  direction: 'long',
+  entryPrice: '5.0',
+  stopLossPrice: '4.89',
+  takeProfitPrice: '5.14',
+};
+
+describe('ZERO_PRICE_GUARD — checkStopTarget', () => {
+  it('prix 0 (source non-fallback) → skip, pas de close destructeur', async () => {
+    const svc = makeSvc('0', 'eodhd');
+    await expect(svc.checkStopTarget(pos)).resolves.toBeUndefined();
+    expect(svc.logger.warn).toHaveBeenCalledWith(expect.stringContaining('[ZERO_PRICE_GUARD]'));
+  });
+
+  it('prix négatif → skip', async () => {
+    const svc = makeSvc('-1.0', 'eodhd');
+    await expect(svc.checkStopTarget(pos)).resolves.toBeUndefined();
+    expect(svc.logger.warn).toHaveBeenCalledWith(expect.stringContaining('[ZERO_PRICE_GUARD]'));
+  });
+
+  it('prix NaN/non-numérique → skip', async () => {
+    const svc = makeSvc('abc', 'eodhd');
+    await expect(svc.checkStopTarget(pos)).resolves.toBeUndefined();
+    expect(svc.logger.warn).toHaveBeenCalledWith(expect.stringContaining('[ZERO_PRICE_GUARD]'));
+  });
+
+  it('prix valide entre stop et TP → NE déclenche PAS le zero-guard (pas de faux positif)', async () => {
+    const svc = makeSvc('5.0', 'eodhd'); // ni <=4.89 ni >=5.14 → aucun hit, retour propre
+    await expect(svc.checkStopTarget(pos)).resolves.toBeUndefined();
+    const zeroGuardCalls = svc.logger.warn.mock.calls.filter((c) =>
+      String(c[0]).includes('[ZERO_PRICE_GUARD]'),
+    );
+    expect(zeroGuardCalls).toHaveLength(0);
+  });
+});

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -1843,6 +1843,19 @@ export class MechanicalTradingService {
       return;
     }
 
+    // 🛡️ ZERO-PRICE GUARD (incident SEE.LSE 14/05/2026, perte -$1574) :
+    // un tick à prix <= 0 (ou NaN) provenant d'une source NON taggée fallback
+    // contourne le sanity bound ci-dessous (gardé par `livePx.gt(0)`) et
+    // déclenche un stop à 0 → fausse liquidation -100%. Tout prix non-positif
+    // est traité comme non fiable : on attend le tick suivant (comme le fallback).
+    const livePriceNum = Number(quote.price);
+    if (!Number.isFinite(livePriceNum) || livePriceNum <= 0) {
+      this.logger.warn(
+        `[ZERO_PRICE_GUARD] ${pos.symbol}: live price=${quote.price} (source=${quote.source}) <= 0 ou NaN — skip stop/target (tick corrompu)`,
+      );
+      return;
+    }
+
     // 🛡️ SANITY BOUND (incident 27/04, LMT closed at $100 from $513) :
     // refuse tout prix qui diverge > 30% de l'entry en un seul tick. Un
     // vrai mouvement >30% sur un asset liquide en 60s est virtuellement


### PR DESCRIPTION
## Pourquoi (incident chiffré)

Diagnostic 20/05/2026 sur la base : la perte la plus lourde du portfolio — **−$1 574, soit 46 % de la perte totale (−$3 396)** — vient d'un **seul trade** :

```
2026-05-14 09:12  SEE.LSE  closed_stop  entry=5.0182  exit=0.0
  reason="Stop-loss 4.8929 triggered at live price 0.0000"  pnl=−99.95%
```

Un **tick à prix 0.0** a déclenché un stop → fausse liquidation −100 %. Ce n'est pas une perte de marché, c'est une corruption de donnée — la classe d'incident que le CLAUDE.md interdit (LMT $513→$100, sentinel fallback price=0).

## Le trou (toujours présent avant ce fix)

Dans `checkStopTarget`, l'enchaînement des gardes :
1. `isFallbackSource(source)` → ne catche que les sources `fallback*`.
2. Sanity bound >30 % → **gardé par `entryPx.gt(0) && livePx.gt(0)`**.

Un prix **exactement 0** venant d'une source **non taggée fallback** (0 brut EODHD/parser) :
- passe `isFallbackSource` (false),
- **contourne le sanity bound** (`livePx.gt(0)` est faux),
- atteint `currentPrice.lte(stopPrice)` → `0 <= SL` → **stop déclenché à 0**.

Les autres chemins (`open_target`, `close-weakest`) gardent déjà `price <= 0` — mais **pas** le chemin stop/target. Aucune récidive depuis le 14/05 = pur hasard (pas de 0 non-taggé depuis), le code reste vulnérable.

## Le fix

`ZERO_PRICE_GUARD` juste après le fallback guard : tout `price <= 0` ou `NaN` est traité comme non fiable → skip, on attend le tick suivant. 3 lignes, aucun effet de bord (un prix ≤ 0 n'est jamais une donnée légitime).

## Impact

Garantit que l'incident SEE.LSE (−$1 574) ne peut **plus jamais** se reproduire. Meilleur ratio valeur/risque de la session : supprime la perte la plus idiote du portfolio sans toucher à la stratégie.

## Test plan

- [x] 4 tests unitaires : prix `0` / négatif / `NaN` → `[ZERO_PRICE_GUARD]` skip ; prix valide entre stop et TP → pas de faux positif
- [x] 42 tests `mechanical-trading*` passent (non-régression)
- [x] tsc `--noEmit` clean
- [ ] Post-deploy : surveiller `[ZERO_PRICE_GUARD]` dans les logs (devrait être rare)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_