### PR TITLE
feat(shadow): grille d'exits asymétriques (test forward "laisser courir les gagnants")

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/shadow-exit-variant.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/shadow-exit-variant.spec.ts
@@ -46,6 +46,40 @@ function row(createdMinAgo: number) {
   };
 }
 
+describe('Migration 0151 — variant_exit_grid', () => {
+  it('grille TP/SL calculée sur la même entrée pullback', async () => {
+    // entrée 98.4 (idx1). candle idx2=102.
+    // tp3% → 98.4*1.03=101.35 ; 102>=101.35 → TP_FULL +0.03.
+    // tp5% → 98.4*1.05=103.32 ; 102<103.32 → TIME_LIMIT pnl=(102-98.4)/98.4.
+    const candles = [{ close: 99.5 }, { close: 98.4 }, { close: 102 }];
+    const svc = makeSvc(candles);
+    const v = (await svc.simulateVariant(row(300))) as {
+      exitGrid: Array<{ tp_pct: number; sl_pct: number; pnl_pct: number; exit_reason: string }>;
+    };
+    expect(Array.isArray(v.exitGrid)).toBe(true);
+    expect(v.exitGrid.length).toBe(5);
+    const tp3 = v.exitGrid.find((g) => g.tp_pct === 0.03)!;
+    expect(tp3.exit_reason).toBe('TP_FULL');
+    expect(tp3.pnl_pct).toBeCloseTo(0.03, 5);
+    const tp20 = v.exitGrid.find((g) => g.tp_pct === 0.2)!;
+    expect(tp20.exit_reason).toBe('TIME_LIMIT');
+    expect(tp20.pnl_pct).toBeCloseTo((102 - 98.4) / 98.4, 5);
+  });
+
+  it('grille : SL serré touché avant un TP large → loss borné au SL', async () => {
+    // entrée 98.0 (idx0, <=98.5). idx1=95 → -3.06% < tous les SL (2.5/3%) → SL pour tous.
+    const candles = [{ close: 98.0 }, { close: 95 }];
+    const svc = makeSvc(candles);
+    const v = (await svc.simulateVariant(row(300))) as {
+      exitGrid: Array<{ tp_pct: number; sl_pct: number; pnl_pct: number; exit_reason: string }>;
+    };
+    for (const g of v.exitGrid) {
+      expect(g.exit_reason).toBe('SL');
+      expect(g.pnl_pct).toBeCloseTo(-g.sl_pct, 5);
+    }
+  });
+});
+
 describe('Migration 0150 — simulateVariant', () => {
   it('pullback touché puis TP → win, entrée au creux, SL à 2.5%', async () => {
     // trigger pullback = 100*(1-0.015) = 98.5. idx1=98.4 touche, puis idx2=102 >= TP(98.4*1.03=101.35).

--- a/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
@@ -57,7 +57,28 @@ interface VariantResult {
   exitReason: string;
   pnlPct: number;
   slippagePct: number | null;
+  /** Migration 0151 — issues simulées par couple (tp,sl) sur la même entrée pullback. */
+  exitGrid: ExitGridEntry[];
 }
+
+/** Migration 0151 — une issue d'exit pour un couple (tp_pct, sl_pct) donné. */
+interface ExitGridEntry {
+  tp_pct: number;
+  sl_pct: number;
+  pnl_pct: number;
+  exit_reason: 'TP_FULL' | 'SL' | 'TIME_LIMIT';
+  exit_offset_min: number;
+}
+
+// Migration 0151 — grille d'exits asymétriques testée en forward. Couples
+// (TP, SL) issus du backtest crypto où l'espérance monte avec la largeur du TP.
+const EXIT_GRID: ReadonlyArray<{ tp: number; sl: number }> = [
+  { tp: 0.03, sl: 0.025 },
+  { tp: 0.05, sl: 0.025 },
+  { tp: 0.08, sl: 0.025 },
+  { tp: 0.12, sl: 0.03 },
+  { tp: 0.20, sl: 0.03 },
+];
 
 const MIN_AGE_MIN_BEFORE_REPLAY = 5;
 const MAX_HOLD_HOURS = 3; // ADR-005 §2.4 time-stop
@@ -268,6 +289,7 @@ export class ShadowExitSimulatorService {
               variant_pnl_pct: v.pnlPct,
               variant_slippage_pct: v.slippagePct,
               variant_params: params,
+              variant_exit_grid: v.exitGrid,
             };
         const { error: upErr } = await this.supabase
           .getClient()
@@ -366,6 +388,9 @@ export class ShadowExitSimulatorService {
       snap.currentStopPrice;
     const slippagePct = theoretical !== null ? (exitPrice - theoretical) / variantEntry : null;
 
+    // Migration 0151 — grille d'exits asymétriques sur la MÊME entrée pullback.
+    const exitGrid = this.computeExitGrid(candles, entryIdx, variantEntry);
+
     return {
       entryPrice: variantEntry,
       entryOffsetMin: entryIdx + 1,
@@ -374,7 +399,37 @@ export class ShadowExitSimulatorService {
       exitReason: String(exitReason),
       pnlPct,
       slippagePct,
+      exitGrid,
     };
+  }
+
+  /**
+   * Migration 0151 — pour chaque couple (tp, sl) de la grille, course TP/SL
+   * close-based sur les candles post-entrée. TIME_LIMIT = sortie au dernier
+   * close si ni TP ni SL touché. Sert à mesurer forward l'edge des exits larges.
+   */
+  private computeExitGrid(
+    candles: Array<{ close: number }>,
+    entryIdx: number,
+    entry: number,
+  ): ExitGridEntry[] {
+    return EXIT_GRID.map(({ tp, sl }) => {
+      const tpPx = entry * (1 + tp);
+      const slPx = entry * (1 - sl);
+      for (let i = entryIdx + 1; i < candles.length; i++) {
+        const px = candles[i].close;
+        // SL prioritaire (protège le capital), comme la state machine BLOC4.
+        if (px <= slPx) {
+          return { tp_pct: tp, sl_pct: sl, pnl_pct: -sl, exit_reason: 'SL' as const, exit_offset_min: i + 1 };
+        }
+        if (px >= tpPx) {
+          return { tp_pct: tp, sl_pct: sl, pnl_pct: tp, exit_reason: 'TP_FULL' as const, exit_offset_min: i + 1 };
+        }
+      }
+      const lastIdx = candles.length - 1;
+      const pnl = (candles[lastIdx].close - entry) / entry;
+      return { tp_pct: tp, sl_pct: sl, pnl_pct: pnl, exit_reason: 'TIME_LIMIT' as const, exit_offset_min: lastIdx + 1 };
+    });
   }
 
   /** Fetch intraday 1m candles depuis le ticker (EODHD ou Binance). */

--- a/supabase/migrations/0151_shadow_exit_grid.sql
+++ b/supabase/migrations/0151_shadow_exit_grid.sql
@@ -1,0 +1,26 @@
+-- 0151 — Shadow : grille d'exits asymétriques sur l'entrée pullback.
+--
+-- Contexte (analyse 20/05/2026) : un backtest crypto montre que l'espérance
+-- monte de façon monotone avec la largeur du TP (TP3/SL2.5 = +0.14% net,
+-- TP20/SL3 = +1.32% net) — l'asymétrie "laisser courir les gagnants, couper
+-- les perdants serré" est le candidat le plus crédible pour un edge réel.
+-- MAIS le backtest a un biais de sélection (on teste le passé de noms gainers
+-- aujourd'hui). Seul un test FORWARD dé-biaise.
+--
+-- Cette colonne stocke, pour chaque entrée pullback résolue (cf. migration 0150),
+-- l'issue simulée sur une GRILLE de couples (TP%, SL%) — calculée sur les mêmes
+-- candles, moteur identique. Permet à l'analyse J+2 de lire quelle combinaison
+-- a la meilleure espérance sur données forward réelles, sans re-déployer.
+--
+-- Forme : variant_exit_grid = [
+--   { "tp_pct": 0.03, "sl_pct": 0.025, "pnl_pct": 0.012, "exit_reason": "TP_FULL", "exit_offset_min": 35 },
+--   { "tp_pct": 0.20, "sl_pct": 0.03,  "pnl_pct": -0.03,  "exit_reason": "SL", ... }, ...
+-- ]
+-- ZÉRO risque capital : colonne additive, aucune position réelle ouverte.
+
+ALTER TABLE public.gainers_v1_shadow_signals
+  ADD COLUMN IF NOT EXISTS variant_exit_grid JSONB;
+
+COMMENT ON COLUMN public.gainers_v1_shadow_signals.variant_exit_grid IS
+  'Shadow asymétrie — issues simulées par couple (tp_pct, sl_pct) sur l''entrée pullback. '
+  'Sert à mesurer forward (sans biais de sélection) l''edge des exits larges (TP15-20% / SL2.5-3%).';


### PR DESCRIPTION
## Pourquoi

Backtest crypto (20/05) sur gainers liquides : l'espérance/trade **monte de façon monotone avec la largeur du TP** —

| TP% | SL% | esp. nette/trade |
|---|---|---|
| 3 | 2.5 | +0.14 % (le scalp connu) |
| 8 | 2.5 | +0.89 % |
| 12 | 3.0 | +1.20 % |
| **20** | **3.0** | **+1.32 %** |

L'asymétrie « laisser courir les gagnants, couper les perdants serré » (WR ~48 % mais gagnants +20 % vs perdants −3 %) est le candidat le plus crédible pour un edge réel — et la première piste où l'arithmétique du ~$400/j ne se moque plus de nous.

**MAIS** ce backtest a un **biais de sélection** (on teste le passé de noms qui sont gainers aujourd'hui → ils avaient mécaniquement plus de chances de courir). Le +1.3 % est probablement optimiste. **Seul un test forward dé-biaise** — d'où ce shadow.

## Quoi

Pour chaque entrée pullback résolue (shadow A/B, migration 0150), on calcule désormais l'issue sur une **grille de 5 couples (TP%, SL%)** sur les mêmes candles (course close-based, SL prioritaire comme BLOC4). Stocké dans `variant_exit_grid` (JSONB).

L'analyse J+2 lira **quelle combinaison TP/SL a la meilleure espérance sur données forward réelles** (sans biais de sélection), croisé par marché et par couverture TD.

**ZÉRO risque capital** : colonne additive, aucune position réelle ouverte.

## Détail technique

- **Migration 0151** : `variant_exit_grid JSONB`.
- **`computeExitGrid`** : TP {3,5,8,12,20}% × SL {2.5,3}% (5 couples retenus), close-based, TIME_LIMIT au dernier close.
- Calculé dans `simulateVariant`, écrit par `runVariantInner`.

## Test plan

- [x] 2 tests grille : TP_FULL/TIME_LIMIT corrects + SL borné au sl_pct
- [x] 74 tests shadow passent (non-régression)
- [x] tsc `--noEmit` clean
- [ ] Post-deploy : `variant_exit_grid` se remplit ; à J+2, comparer l'espérance par couple TP/SL sur données forward

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_