### PR TITLE
fix(shadow): anti-famine exit-sim — ordre DESC + skip tickers non-couverts

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/shadow-exit-variant.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/shadow-exit-variant.spec.ts
@@ -123,4 +123,16 @@ describe('Migration 0150 — simulateVariant', () => {
     const v = await svc.simulateVariant(row(8)); // age 8 < window 30
     expect(v).toBeNull();
   });
+
+  it('ticker non-couvert + fenêtre écoulée → skip (anti-famine, candles inatteignables)', async () => {
+    const svc = makeSvc(null); // fetchCandles renvoie null (blacklist/suffixe absent)
+    const v = await svc.simulateVariant(row(300)); // age 300 >= window 30
+    expect(v).toBe('skip');
+  });
+
+  it('ticker non-couvert mais trop jeune → null (échec transitoire, on réessaie)', async () => {
+    const svc = makeSvc(null);
+    const v = await svc.simulateVariant(row(8)); // age 8 < window 30
+    expect(v).toBeNull();
+  });
 });

--- a/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
@@ -143,7 +143,7 @@ export class ShadowExitSimulatorService {
       .not('entry_price', 'is', null)
       .gte('created_at', recentFloor)
       .lte('created_at', cutoff)
-      .order('created_at', { ascending: true })
+      .order('created_at', { ascending: false })
       .limit(50);
 
     if (error || !data || data.length === 0) return;
@@ -270,7 +270,7 @@ export class ShadowExitSimulatorService {
       .is('variant_exit_at', null)
       .is('variant_no_entry', null)
       .lte('created_at', cutoff)
-      .order('created_at', { ascending: true })
+      .order('created_at', { ascending: false })
       .limit(50);
 
     if (error || !data || data.length === 0) return;
@@ -283,11 +283,14 @@ export class ShadowExitSimulatorService {
     };
     let resolved = 0;
     let noEntry = 0;
+    let skipped = 0;
     for (const r of data as ShadowSignalRow[]) {
       try {
         const v = await this.simulateVariant(r);
         if (v === 'pending' || v === null) continue;
-        const update = v === 'no_entry'
+        const update = v === 'skip'
+          ? { variant_no_entry: true, variant_params: { ...params, skip_reason: 'no_candles' } }
+          : v === 'no_entry'
           ? { variant_no_entry: true, variant_params: params }
           : {
               variant_entry_price: v.entryPrice,
@@ -307,23 +310,27 @@ export class ShadowExitSimulatorService {
           .update(update)
           .eq('id', r.id);
         if (upErr) this.logger.warn(`[exit-sim:variant] update ${r.id} failed: ${upErr.message}`);
+        else if (v === 'skip') skipped++;
         else if (v === 'no_entry') noEntry++;
         else resolved++;
       } catch (e) {
         this.logger.warn(`[exit-sim:variant] ${r.symbol} (${r.id}) failed: ${String(e).slice(0, 80)}`);
       }
     }
-    this.logger.log(`[exit-sim:variant] resolved ${resolved}, no_entry ${noEntry}`);
+    this.logger.log(`[exit-sim:variant] resolved ${resolved}, no_entry ${noEntry}, skipped ${skipped}`);
   }
 
   /**
    * Simule la variante pullback sur un signal. Retourne :
    *   - 'no_entry' : fenêtre écoulée sans pullback (la variante n'aurait pas tradé)
    *   - 'pending'  : pullback touché mais exit non encore résolu (réessayer)
-   *   - null       : pas assez de données / trop jeune pour conclure
+   *   - 'skip'     : ticker non-couvert (blacklist/suffixe) ET fenêtre écoulée →
+   *                  candles inatteignables à jamais ; marqueur terminal pour
+   *                  libérer le working set limit(50) (anti-famine).
+   *   - null       : pas assez de données / trop jeune pour conclure (réessayer)
    *   - VariantResult : entrée+exit résolus
    */
-  private async simulateVariant(row: ShadowSignalRow): Promise<VariantResult | 'no_entry' | 'pending' | null> {
+  private async simulateVariant(row: ShadowSignalRow): Promise<VariantResult | 'no_entry' | 'pending' | 'skip' | null> {
     const entryTimeMs = new Date(row.created_at).getTime();
     const ageMin = (Date.now() - entryTimeMs) / 60_000;
     // Fenêtre pullback + horizon de hold complet.
@@ -332,7 +339,15 @@ export class ShadowExitSimulatorService {
     if (replayCount < 5) return null;
 
     const candles = await this.fetchCandles(row, replayCount);
-    if (!candles || candles.length === 0) return null;
+    if (!candles || candles.length === 0) {
+      // Ticker non-couvert (blacklist Binance / suffixe EODHD absent) : si la
+      // fenêtre est déjà écoulée, les candles ne réapparaîtront jamais. On marque
+      // 'skip' (terminal) pour le sortir du working set limit(50) — sinon ces
+      // signaux non-résolubles saturent le batch et affament les signaux
+      // résolubles (famine observée 21/05, grille bloquée à 0).
+      if (ageMin >= this.variantWindowMin) return 'skip';
+      return null;
+    }
 
     // 1. Cherche le 1er pullback sous entry_price*(1-pullback_pct) dans la fenêtre.
     const pullbackTrigger = row.entry_price * (1 - this.variantPullbackPct);

--- a/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
@@ -83,6 +83,12 @@ const EXIT_GRID: ReadonlyArray<{ tp: number; sl: number }> = [
 const MIN_AGE_MIN_BEFORE_REPLAY = 5;
 const MAX_HOLD_HOURS = 3; // ADR-005 §2.4 time-stop
 
+// Fenêtre récente : ne traiter que les signaux des N derniers jours. Sans ça,
+// le worker (order created_at ASC) reste bloqué sur des milliers de vieux
+// signaux ACCEPT non-résolvables (data intraday expirée, tickers blacklistés)
+// et n'atteint jamais les signaux récents → famine, la grille ne se remplit pas.
+const SHADOW_RECENT_DAYS = Number(process.env.SHADOW_RECENT_DAYS ?? '3');
+
 @Injectable()
 export class ShadowExitSimulatorService {
   private readonly logger = new Logger(ShadowExitSimulatorService.name);
@@ -126,6 +132,7 @@ export class ShadowExitSimulatorService {
   private async runInner(): Promise<void> {
     const minAgeMs = MIN_AGE_MIN_BEFORE_REPLAY * 60_000;
     const cutoff = new Date(Date.now() - minAgeMs).toISOString();
+    const recentFloor = new Date(Date.now() - SHADOW_RECENT_DAYS * 86_400_000).toISOString();
 
     const { data, error } = await this.supabase
       .getClient()
@@ -134,6 +141,7 @@ export class ShadowExitSimulatorService {
       .eq('decision', 'ACCEPT')
       .is('simulated_exit_at', null)
       .not('entry_price', 'is', null)
+      .gte('created_at', recentFloor)
       .lte('created_at', cutoff)
       .order('created_at', { ascending: true })
       .limit(50);
@@ -251,12 +259,14 @@ export class ShadowExitSimulatorService {
    */
   private async runVariantInner(): Promise<void> {
     const cutoff = new Date(Date.now() - MIN_AGE_MIN_BEFORE_REPLAY * 60_000).toISOString();
+    const recentFloor = new Date(Date.now() - SHADOW_RECENT_DAYS * 86_400_000).toISOString();
     const { data, error } = await this.supabase
       .getClient()
       .from('gainers_v1_shadow_signals')
       .select('id, symbol, exchange, asset_class, entry_price, entry_path_eff, tp_price, sl_price, created_at')
       .eq('decision', 'ACCEPT')
       .not('entry_price', 'is', null)
+      .gte('created_at', recentFloor)
       .is('variant_exit_at', null)
       .is('variant_no_entry', null)
       .lte('created_at', cutoff)


### PR DESCRIPTION
## Problème

Malgré le floor `SHADOW_RECENT_DAYS` (#373), la grille `variant_exit_grid` restait **bloquée à 0** (`[exit-sim:variant] resolved 0` en boucle, logs 21/05 ~07:5x UTC).

Cause racine = **famine dans la fenêtre de 3 jours** : le working set `limit(50)` était saturé par des signaux ACCEPT sur tickers blacklistés / non-couverts (`SHG/SHE/KQ/KO`) qui renvoient `null` (candles inatteignables) **sans marqueur terminal** → re-sélectionnés à chaque cron, sans jamais atteindre les signaux résolubles (crypto/US).

## Fix

- **Ordre `DESC`** sur les deux selects (live + variant) : les signaux les plus récents (donc les plus résolubles : crypto Binance, US) sont traités d'abord.
- **Nouveau sentinel `'skip'`** : un ticker sans candles **et** dont la fenêtre est écoulée ne récupérera jamais de données → marqueur terminal `variant_no_entry=true` + `variant_params.skip_reason='no_candles'` pour libérer le batch.
- Un échec de fetch **transitoire** (signal encore jeune) reste `null` → réessai au prochain cron (pas de skip prématuré).
- `skip_reason='no_candles'` permet à l'analyse J+2 d'exclure ces faux `no_entry` du calcul d'edge (la grille n'utilise de toute façon que les entrées résolues).

## Tests

`shadow-exit-variant.spec.ts` : 9/9 ✅ (2 nouveaux cas — skip aged-out, null transitoire). Typecheck ✅.

ZÉRO risque capital : colonnes shadow additives, aucune position réelle.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_