### PR TITLE
fix(shadow): time-window sur exit-sim variant — grille TP/SL enfin valide

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/shadow-exit-variant.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/shadow-exit-variant.spec.ts
@@ -123,4 +123,16 @@ describe('Migration 0150 — simulateVariant', () => {
     const v = await svc.simulateVariant(row(8)); // age 8 < window 30
     expect(v).toBeNull();
   });
+
+  it('ticker non-couvert + fenêtre écoulée → skip (anti-famine, candles inatteignables)', async () => {
+    const svc = makeSvc(null); // fetchCandles renvoie null (blacklist/suffixe absent)
+    const v = await svc.simulateVariant(row(300)); // age 300 >= window 30
+    expect(v).toBe('skip');
+  });
+
+  it('ticker non-couvert mais trop jeune → null (échec transitoire, on réessaie)', async () => {
+    const svc = makeSvc(null);
+    const v = await svc.simulateVariant(row(8)); // age 8 < window 30
+    expect(v).toBeNull();
+  });
 });

--- a/apps/api/src/modules/lisa/services/__tests__/shadow-exit-variant.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/shadow-exit-variant.spec.ts
@@ -1,14 +1,17 @@
 /**
- * Migration 0150 — Shadow A/B variante entrée pullback.
+ * Migration 0150/0151 — Shadow A/B variante entrée pullback + grille d'exits.
  *
  * simulateVariant(row) doit :
- *   - attendre un pullback de pullback_pct sous entry_price dans la fenêtre,
- *   - entrer à ce close avec SL élargi (sl_pct) + TP (tp_pct),
- *   - rejouer le moteur BLOC4 (applyTick) identique au live,
- *   - retourner 'no_entry' si la fenêtre s'écoule sans pullback,
- *   - retourner 'pending' si entrée touchée mais exit non résolu (< time-limit).
+ *   - ne résoudre qu'une fois la fenêtre [created_at, +window+hold] écoulée en
+ *     temps réel (fix 21/05 : sinon les candles du futur n'existent pas → grille
+ *     d'exits larges = artefact). window+hold = 30 + 3*60 = 210 min.
+ *   - fetcher les VRAIES candles de la période via fetchCandlesWindow (time-window),
+ *   - attendre un pullback de pullback_pct sous entry_price dans la fenêtre pullback,
+ *   - entrer à ce close avec SL élargi (sl_pct) + TP (tp_pct), rejouer BLOC4 (applyTick),
+ *   - 'no_entry' si fenêtre écoulée sans pullback, 'skip' si couverture absente,
+ *     null si la fenêtre n'est pas encore écoulée.
  *
- * On instancie via Object.create (DI lourd) + stub fetchCandles.
+ * On instancie via Object.create (DI lourd) + stub fetchCandlesWindow.
  */
 
 import { ShadowExitSimulatorService } from '../shadow-exit-simulator.service';
@@ -18,7 +21,11 @@ interface Svc {
   variantWindowMin: number;
   variantSlPct: number;
   variantTpPct: number;
-  fetchCandles: (row: unknown, count: number) => Promise<Array<{ close: number }> | null>;
+  fetchCandlesWindow: (
+    row: unknown,
+    fromMs: number,
+    toMs: number,
+  ) => Promise<Array<{ close: number }> | null>;
   simulateVariant: (row: unknown) => Promise<unknown>;
 }
 
@@ -28,10 +35,11 @@ function makeSvc(candles: Array<{ close: number }> | null): Svc {
   svc.variantWindowMin = 30;
   svc.variantSlPct = 0.025;
   svc.variantTpPct = 0.03;
-  svc.fetchCandles = async () => candles;
+  svc.fetchCandlesWindow = async () => candles;
   return svc;
 }
 
+// window + hold = 30 + 3*60 = 210 min. RESOLVED = age >= 210 ; PENDING/null = age < 210.
 function row(createdMinAgo: number) {
   return {
     id: 'sig-1',
@@ -50,7 +58,7 @@ describe('Migration 0151 — variant_exit_grid', () => {
   it('grille TP/SL calculée sur la même entrée pullback', async () => {
     // entrée 98.4 (idx1). candle idx2=102.
     // tp3% → 98.4*1.03=101.35 ; 102>=101.35 → TP_FULL +0.03.
-    // tp5% → 98.4*1.05=103.32 ; 102<103.32 → TIME_LIMIT pnl=(102-98.4)/98.4.
+    // tp20% → 98.4*1.2=118.08 ; 102<118.08 → TIME_LIMIT pnl=(102-98.4)/98.4.
     const candles = [{ close: 99.5 }, { close: 98.4 }, { close: 102 }];
     const svc = makeSvc(candles);
     const v = (await svc.simulateVariant(row(300))) as {
@@ -106,33 +114,35 @@ describe('Migration 0150 — simulateVariant', () => {
   it('aucun pullback + fenêtre écoulée → no_entry', async () => {
     const candles = Array.from({ length: 35 }, () => ({ close: 100.5 })); // jamais sous 98.5
     const svc = makeSvc(candles);
-    const v = await svc.simulateVariant(row(60)); // age 60 > window 30
+    const v = await svc.simulateVariant(row(300)); // age 300 >= window 210
     expect(v).toBe('no_entry');
   });
 
-  it('pullback touché mais exit non résolu et < time-limit → pending', async () => {
-    const candles = [{ close: 98.0 }, { close: 99 }, { close: 99.5 }]; // entrée idx0, pas de TP/SL
+  it('pullback touché, ni TP ni SL sur la fenêtre écoulée → TIME_LIMIT', async () => {
+    // entrée idx0=98.0 ; 99/99.5 ne touchent ni TP (100.94) ni SL (95.55).
+    const candles = [{ close: 98.0 }, { close: 99 }, { close: 99.5 }];
     const svc = makeSvc(candles);
-    const v = await svc.simulateVariant(row(10)); // hold court, pas de time-limit
-    expect(v).toBe('pending');
+    const v = (await svc.simulateVariant(row(300))) as { exitReason: string; pnlPct: number };
+    expect(v.exitReason).toBe('TIME_LIMIT');
+    expect(v.pnlPct).toBeCloseTo((99.5 - 98.0) / 98.0, 5);
   });
 
-  it('trop jeune (fenêtre non écoulée, pas de pullback) → null', async () => {
+  it('fenêtre pas encore écoulée → null (réessai plus tard)', async () => {
     const candles = [{ close: 100.2 }, { close: 100.1 }];
     const svc = makeSvc(candles);
-    const v = await svc.simulateVariant(row(8)); // age 8 < window 30
+    const v = await svc.simulateVariant(row(8)); // age 8 < window 210
     expect(v).toBeNull();
   });
 
-  it('ticker non-couvert + fenêtre écoulée → skip (anti-famine, candles inatteignables)', async () => {
-    const svc = makeSvc(null); // fetchCandles renvoie null (blacklist/suffixe absent)
-    const v = await svc.simulateVariant(row(300)); // age 300 >= window 30
+  it('couverture absente + fenêtre écoulée → skip (anti-famine, candles inatteignables)', async () => {
+    const svc = makeSvc(null); // fetchCandlesWindow renvoie null (blacklist/suffixe/rétention)
+    const v = await svc.simulateVariant(row(300)); // age 300 >= window 210
     expect(v).toBe('skip');
   });
 
-  it('ticker non-couvert mais trop jeune → null (échec transitoire, on réessaie)', async () => {
+  it('couverture absente mais fenêtre pas écoulée → null (on réessaie)', async () => {
     const svc = makeSvc(null);
-    const v = await svc.simulateVariant(row(8)); // age 8 < window 30
+    const v = await svc.simulateVariant(row(8)); // age 8 < window 210
     expect(v).toBeNull();
   });
 });

--- a/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
@@ -287,7 +287,7 @@ export class ShadowExitSimulatorService {
     for (const r of data as ShadowSignalRow[]) {
       try {
         const v = await this.simulateVariant(r);
-        if (v === 'pending' || v === null) continue;
+        if (v === null) continue;
         const update = v === 'skip'
           ? { variant_no_entry: true, variant_params: { ...params, skip_reason: 'no_candles' } }
           : v === 'no_entry'
@@ -323,33 +323,38 @@ export class ShadowExitSimulatorService {
   /**
    * Simule la variante pullback sur un signal. Retourne :
    *   - 'no_entry' : fenêtre écoulée sans pullback (la variante n'aurait pas tradé)
-   *   - 'pending'  : pullback touché mais exit non encore résolu (réessayer)
-   *   - 'skip'     : ticker non-couvert (blacklist/suffixe) ET fenêtre écoulée →
-   *                  candles inatteignables à jamais ; marqueur terminal pour
-   *                  libérer le working set limit(50) (anti-famine).
-   *   - null       : pas assez de données / trop jeune pour conclure (réessayer)
+   *   - 'skip'     : couverture intraday absente sur la fenêtre (blacklist/suffixe/
+   *                  rétention EODHD/session fermée sans historique) → inatteignable
+   *                  à jamais ; marqueur terminal (anti-famine working set).
+   *   - null       : fenêtre de simulation pas encore entièrement écoulée (réessayer
+   *                  plus tard, quand les candles du futur existeront).
    *   - VariantResult : entrée+exit résolus
+   *
+   * IMPORTANT (fix 21/05) : on fetche les VRAIES candles de la période du signal
+   * via un time-window [created_at, created_at + window + hold], et on ne résout
+   * qu'une fois ce laps réellement écoulé. Avant, on fetchait les N dernières
+   * candles (N≈âge du signal → 6 min pour un signal frais) → un TP de 20% ne
+   * pouvait jamais être atteint sur 6 candles → grille = pur artefact.
    */
-  private async simulateVariant(row: ShadowSignalRow): Promise<VariantResult | 'no_entry' | 'pending' | 'skip' | null> {
+  private async simulateVariant(row: ShadowSignalRow): Promise<VariantResult | 'no_entry' | 'skip' | null> {
     const entryTimeMs = new Date(row.created_at).getTime();
-    const ageMin = (Date.now() - entryTimeMs) / 60_000;
-    // Fenêtre pullback + horizon de hold complet.
-    const maxCandles = this.variantWindowMin + 60 * MAX_HOLD_HOURS;
-    const replayCount = Math.min(maxCandles, Math.ceil(ageMin));
-    if (replayCount < 5) return null;
+    // Fenêtre complète à simuler : pullback (variantWindowMin) + horizon de hold.
+    const windowMin = this.variantWindowMin + 60 * MAX_HOLD_HOURS;
+    const simEndMs = entryTimeMs + windowMin * 60_000;
+    // Gate temporel : tant que la fenêtre n'est pas écoulée en temps réel, les
+    // candles du futur n'existent pas → on ne peut pas conclure. Réessai au prochain cron.
+    if (Date.now() < simEndMs) return null;
 
-    const candles = await this.fetchCandles(row, replayCount);
-    if (!candles || candles.length === 0) {
-      // Ticker non-couvert (blacklist Binance / suffixe EODHD absent) : si la
-      // fenêtre est déjà écoulée, les candles ne réapparaîtront jamais. On marque
-      // 'skip' (terminal) pour le sortir du working set limit(50) — sinon ces
-      // signaux non-résolubles saturent le batch et affament les signaux
-      // résolubles (famine observée 21/05, grille bloquée à 0).
-      if (ageMin >= this.variantWindowMin) return 'skip';
-      return null;
+    // Fetch fenêtré sur la période exacte du signal (pas les dernières candles).
+    const candles = await this.fetchCandlesWindow(row, entryTimeMs, simEndMs);
+    if (!candles || candles.length < 2) {
+      // Couverture intraday absente sur cette fenêtre. Comme la fenêtre est
+      // écoulée, elle ne réapparaîtra jamais → 'skip' terminal (libère le
+      // working set limit(50), sinon famine).
+      return 'skip';
     }
 
-    // 1. Cherche le 1er pullback sous entry_price*(1-pullback_pct) dans la fenêtre.
+    // 1. Cherche le 1er pullback sous entry_price*(1-pullback_pct) dans la fenêtre pullback.
     const pullbackTrigger = row.entry_price * (1 - this.variantPullbackPct);
     const windowEnd = Math.min(this.variantWindowMin, candles.length);
     let entryIdx = -1;
@@ -360,12 +365,8 @@ export class ShadowExitSimulatorService {
       }
     }
 
-    if (entryIdx === -1) {
-      // Pas de pullback observé. On ne peut conclure 'no_entry' que si la fenêtre
-      // est entièrement écoulée (sinon il peut encore arriver).
-      if (ageMin >= this.variantWindowMin) return 'no_entry';
-      return null;
-    }
+    // Fenêtre entièrement écoulée sans pullback → la variante n'aurait pas tradé.
+    if (entryIdx === -1) return 'no_entry';
 
     // 2. Entrée à ce close, SL élargi + TP relatifs à l'entrée variante.
     const variantEntry = candles[entryIdx].close;
@@ -393,15 +394,10 @@ export class ShadowExitSimulatorService {
       }
     }
 
+    // Fenêtre écoulée sans exit BLOC4 déclenché → time-stop sur la dernière candle.
     if (exitIdx === -1) {
-      const variantEntryTimeMs = entryTimeMs + (entryIdx + 1) * 60_000;
-      const holdMin = (Date.now() - variantEntryTimeMs) / 60_000;
-      if (holdMin >= MAX_HOLD_HOURS * 60) {
-        exitReason = ExitReason.TIME_LIMIT;
-        exitIdx = candles.length - 1;
-      } else {
-        return 'pending';
-      }
+      exitReason = ExitReason.TIME_LIMIT;
+      exitIdx = candles.length - 1;
     }
 
     const exitPrice = candles[exitIdx].close;
@@ -480,6 +476,34 @@ export class ShadowExitSimulatorService {
     // PR #353 — router dual-call (TD + EODHD) si éligible, sinon EODHD-only.
     const series = await this.intradayRouter.getCandles(eodhdTicker, '1m', count, {
       calledBy: 'shadow_exit_sim',
+    });
+    return series ? series.candles.map((c) => ({ close: c.close })) : null;
+  }
+
+  /**
+   * Fetch fenêtré [fromMs, toMs] — les VRAIES candles de la période du signal,
+   * pas les dernières en date. Indispensable pour évaluer des TP larges (la
+   * fenêtre couvre window + MAX_HOLD_HOURS). EODHD-only côté equities (le router
+   * skip TD sur time-window) ; rétention intraday EODHD = 5 jours.
+   */
+  private async fetchCandlesWindow(
+    row: ShadowSignalRow,
+    fromMs: number,
+    toMs: number,
+  ): Promise<Array<{ close: number }> | null> {
+    if (row.asset_class === 'crypto') {
+      const binanceSymbol = this.toBinanceSymbol(row.symbol);
+      if (!binanceSymbol) return null;
+      const candles = await this.binance.getKlinesRange(binanceSymbol, '1m', fromMs, toMs);
+      return candles ? candles.map((c) => ({ close: c.close })) : null;
+    }
+    const eodhdTicker = ensureEodhdSuffix(row.symbol, row.exchange);
+    if (isLikelyOtcForeignOrdinaryUS(eodhdTicker)) return null;
+    const minutes = Math.ceil((toMs - fromMs) / 60_000);
+    const series = await this.intradayRouter.getCandles(eodhdTicker, '1m', minutes, {
+      calledBy: 'shadow_exit_sim',
+      fromTs: Math.floor(fromMs / 1000),
+      toTs: Math.ceil(toMs / 1000),
     });
     return series ? series.candles.map((c) => ({ close: c.close })) : null;
   }

--- a/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
@@ -143,7 +143,7 @@ export class ShadowExitSimulatorService {
       .not('entry_price', 'is', null)
       .gte('created_at', recentFloor)
       .lte('created_at', cutoff)
-      .order('created_at', { ascending: true })
+      .order('created_at', { ascending: false })
       .limit(50);
 
     if (error || !data || data.length === 0) return;
@@ -270,7 +270,7 @@ export class ShadowExitSimulatorService {
       .is('variant_exit_at', null)
       .is('variant_no_entry', null)
       .lte('created_at', cutoff)
-      .order('created_at', { ascending: true })
+      .order('created_at', { ascending: false })
       .limit(50);
 
     if (error || !data || data.length === 0) return;
@@ -283,11 +283,14 @@ export class ShadowExitSimulatorService {
     };
     let resolved = 0;
     let noEntry = 0;
+    let skipped = 0;
     for (const r of data as ShadowSignalRow[]) {
       try {
         const v = await this.simulateVariant(r);
         if (v === 'pending' || v === null) continue;
-        const update = v === 'no_entry'
+        const update = v === 'skip'
+          ? { variant_no_entry: true, variant_params: { ...params, skip_reason: 'no_candles' } }
+          : v === 'no_entry'
           ? { variant_no_entry: true, variant_params: params }
           : {
               variant_entry_price: v.entryPrice,
@@ -307,23 +310,27 @@ export class ShadowExitSimulatorService {
           .update(update)
           .eq('id', r.id);
         if (upErr) this.logger.warn(`[exit-sim:variant] update ${r.id} failed: ${upErr.message}`);
+        else if (v === 'skip') skipped++;
         else if (v === 'no_entry') noEntry++;
         else resolved++;
       } catch (e) {
         this.logger.warn(`[exit-sim:variant] ${r.symbol} (${r.id}) failed: ${String(e).slice(0, 80)}`);
       }
     }
-    this.logger.log(`[exit-sim:variant] resolved ${resolved}, no_entry ${noEntry}`);
+    this.logger.log(`[exit-sim:variant] resolved ${resolved}, no_entry ${noEntry}, skipped ${skipped}`);
   }
 
   /**
    * Simule la variante pullback sur un signal. Retourne :
    *   - 'no_entry' : fenêtre écoulée sans pullback (la variante n'aurait pas tradé)
    *   - 'pending'  : pullback touché mais exit non encore résolu (réessayer)
-   *   - null       : pas assez de données / trop jeune pour conclure
+   *   - 'skip'     : ticker non-couvert (blacklist/suffixe) ET fenêtre écoulée →
+   *                  candles inatteignables à jamais ; marqueur terminal pour
+   *                  libérer le working set limit(50) (anti-famine).
+   *   - null       : pas assez de données / trop jeune pour conclure (réessayer)
    *   - VariantResult : entrée+exit résolus
    */
-  private async simulateVariant(row: ShadowSignalRow): Promise<VariantResult | 'no_entry' | 'pending' | null> {
+  private async simulateVariant(row: ShadowSignalRow): Promise<VariantResult | 'no_entry' | 'pending' | 'skip' | null> {
     const entryTimeMs = new Date(row.created_at).getTime();
     const ageMin = (Date.now() - entryTimeMs) / 60_000;
     // Fenêtre pullback + horizon de hold complet.
@@ -332,7 +339,15 @@ export class ShadowExitSimulatorService {
     if (replayCount < 5) return null;
 
     const candles = await this.fetchCandles(row, replayCount);
-    if (!candles || candles.length === 0) return null;
+    if (!candles || candles.length === 0) {
+      // Ticker non-couvert (blacklist Binance / suffixe EODHD absent) : si la
+      // fenêtre est déjà écoulée, les candles ne réapparaîtront jamais. On marque
+      // 'skip' (terminal) pour le sortir du working set limit(50) — sinon ces
+      // signaux non-résolubles saturent le batch et affament les signaux
+      // résolubles (famine observée 21/05, grille bloquée à 0).
+      if (ageMin >= this.variantWindowMin) return 'skip';
+      return null;
+    }
 
     // 1. Cherche le 1er pullback sous entry_price*(1-pullback_pct) dans la fenêtre.
     const pullbackTrigger = row.entry_price * (1 - this.variantPullbackPct);

--- a/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-exit-simulator.service.ts
@@ -83,6 +83,12 @@ const EXIT_GRID: ReadonlyArray<{ tp: number; sl: number }> = [
 const MIN_AGE_MIN_BEFORE_REPLAY = 5;
 const MAX_HOLD_HOURS = 3; // ADR-005 §2.4 time-stop
 
+// Fenêtre récente : ne traiter que les signaux des N derniers jours. Sans ça,
+// le worker (order created_at ASC) reste bloqué sur des milliers de vieux
+// signaux ACCEPT non-résolvables (data intraday expirée, tickers blacklistés)
+// et n'atteint jamais les signaux récents → famine, la grille ne se remplit pas.
+const SHADOW_RECENT_DAYS = Number(process.env.SHADOW_RECENT_DAYS ?? '3');
+
 @Injectable()
 export class ShadowExitSimulatorService {
   private readonly logger = new Logger(ShadowExitSimulatorService.name);
@@ -126,6 +132,7 @@ export class ShadowExitSimulatorService {
   private async runInner(): Promise<void> {
     const minAgeMs = MIN_AGE_MIN_BEFORE_REPLAY * 60_000;
     const cutoff = new Date(Date.now() - minAgeMs).toISOString();
+    const recentFloor = new Date(Date.now() - SHADOW_RECENT_DAYS * 86_400_000).toISOString();
 
     const { data, error } = await this.supabase
       .getClient()
@@ -134,6 +141,7 @@ export class ShadowExitSimulatorService {
       .eq('decision', 'ACCEPT')
       .is('simulated_exit_at', null)
       .not('entry_price', 'is', null)
+      .gte('created_at', recentFloor)
       .lte('created_at', cutoff)
       .order('created_at', { ascending: true })
       .limit(50);
@@ -251,12 +259,14 @@ export class ShadowExitSimulatorService {
    */
   private async runVariantInner(): Promise<void> {
     const cutoff = new Date(Date.now() - MIN_AGE_MIN_BEFORE_REPLAY * 60_000).toISOString();
+    const recentFloor = new Date(Date.now() - SHADOW_RECENT_DAYS * 86_400_000).toISOString();
     const { data, error } = await this.supabase
       .getClient()
       .from('gainers_v1_shadow_signals')
       .select('id, symbol, exchange, asset_class, entry_price, entry_path_eff, tp_price, sl_price, created_at')
       .eq('decision', 'ACCEPT')
       .not('entry_price', 'is', null)
+      .gte('created_at', recentFloor)
       .is('variant_exit_at', null)
       .is('variant_no_entry', null)
       .lte('created_at', cutoff)

--- a/scripts/reset-shadow-variant.ts
+++ b/scripts/reset-shadow-variant.ts
@@ -1,0 +1,101 @@
+/**
+ * Reset des colonnes variant_* du shadow A/B (manuel, dry-run par défaut).
+ *
+ * Contexte (21/05/2026) : avant le fix time-window, simulateVariant calculait
+ * la grille d'exits sur les N dernières candles (N≈âge du signal → ~6 min pour
+ * un signal frais). Un TP de 20% ne pouvait jamais se déclencher sur 6 candles
+ * → grille = pur artefact. Les lignes déjà résolues (variant_exit_at / no_entry)
+ * sont donc invalides et figées (écritures terminales).
+ *
+ * Ce script remet à NULL toutes les colonnes variant_* des signaux ACCEPT
+ * déjà tranchés et créés dans la fenêtre de rétention intraday EODHD (5 j par
+ * défaut, sinon le re-fetch fenêtré échouera). Le cron runVariantInner les
+ * re-sélectionne (variant_exit_at IS NULL AND variant_no_entry IS NULL) et les
+ * re-simule avec la fenêtre correcte → grille enfin valide. Idempotent.
+ *
+ * Usage :
+ *   pnpm tsx scripts/reset-shadow-variant.ts                 # dry-run (aucun write)
+ *   pnpm tsx scripts/reset-shadow-variant.ts --apply         # exécute le reset
+ *   pnpm tsx scripts/reset-shadow-variant.ts --days 5        # fenêtre rétention (défaut 5)
+ *
+ * Variables d'env requises :
+ *   SUPABASE_URL (ou NEXT_PUBLIC_SUPABASE_URL), SUPABASE_SERVICE_ROLE_KEY
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+interface Args {
+  apply: boolean;
+  days: number;
+}
+
+function parseArgs(argv: string[]): Args {
+  const di = argv.indexOf('--days');
+  const days = di >= 0 && argv[di + 1] ? Number(argv[di + 1]) : 5;
+  return { apply: argv.includes('--apply'), days };
+}
+
+const VARIANT_RESET = {
+  variant_entry_price: null,
+  variant_entry_offset_min: null,
+  variant_no_entry: null,
+  variant_exit_price: null,
+  variant_exit_at: null,
+  variant_exit_reason: null,
+  variant_pnl_pct: null,
+  variant_slippage_pct: null,
+  variant_params: null,
+  variant_exit_grid: null,
+};
+
+async function main(args: Args): Promise<void> {
+  const url = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('ERROR: SUPABASE_URL (ou NEXT_PUBLIC_SUPABASE_URL) et SUPABASE_SERVICE_ROLE_KEY requis.');
+    process.exit(1);
+  }
+  const supabase = createClient(url, key, { auth: { persistSession: false } });
+
+  const floor = new Date(Date.now() - args.days * 86_400_000).toISOString();
+  console.log(`[reset-shadow-variant] mode=${args.apply ? 'APPLY' : 'DRY-RUN'} days=${args.days} floor=${floor}`);
+
+  // Rows ACCEPT déjà tranchés (résolus OU no_entry) dans la fenêtre de rétention.
+  const matchFilter = (q: ReturnType<typeof supabase.from>) =>
+    q
+      .eq('decision', 'ACCEPT')
+      .gte('created_at', floor)
+      .or('variant_exit_at.not.is.null,variant_no_entry.not.is.null');
+
+  const { count, error: cntErr } = await matchFilter(
+    supabase.from('gainers_v1_shadow_signals').select('id', { count: 'exact', head: true }),
+  );
+  if (cntErr) {
+    console.error('SELECT count failed:', cntErr.message);
+    process.exit(1);
+  }
+  console.log(`${count ?? 0} signaux variant à réinitialiser (ACCEPT, tranchés, créés ≥ ${floor})`);
+
+  if (!args.apply) {
+    console.log('DRY-RUN : aucun write. Relancer avec --apply pour exécuter.');
+    return;
+  }
+  if (!count) {
+    console.log('Rien à réinitialiser.');
+    return;
+  }
+
+  const { error: upErr } = await matchFilter(
+    supabase.from('gainers_v1_shadow_signals').update(VARIANT_RESET),
+  );
+  if (upErr) {
+    console.error('UPDATE failed:', upErr.message);
+    process.exit(1);
+  }
+  console.log(`OK : ${count} signaux réinitialisés. Le cron runVariantInner les re-simulera (fenêtre time-window).`);
+}
+
+main(parseArgs(process.argv.slice(2))).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problème (vérifié en prod 21/05)

La grille `variant_exit_grid` était calculée sur les **N dernières candles** (N≈âge du signal → ~6 min pour un signal frais). Un TP de 20 % ne peut **mécaniquement jamais** se déclencher sur 6 candles → 72/80 finissaient au SL. Vérifié : `max exit_offset_min = 6 min` sur 80 lignes. **La grille était un pur artefact**, inexploitable pour mesurer l'edge des exits asymétriques.

## Fix

1. **`simulateVariant`** ne résout qu'une fois la fenêtre complète `[created_at, +window+hold]` (= 30 + 3×60 = **210 min**) réellement écoulée en temps réel. Sinon `null` → réessai au prochain cron (les candles du futur n'existent pas encore).
2. **`fetchCandlesWindow(row, fromMs, toMs)`** : récupère les **vraies candles de la période du signal** via time-window — EODHD `{fromTs,toTs}` (rétention intraday 5 j), Binance `getKlinesRange`. Plus les dernières en date.
3. Sentinel `pending` supprimé (la fenêtre est toujours complète à la résolution) ; `skip` terminal si couverture intraday absente sur la fenêtre.

## Script ops

`scripts/reset-shadow-variant.ts` (dry-run + `--apply`) : remet à NULL les `variant_*` des 83 signaux ACCEPT déjà tranchés < 5 j → le cron les re-simule avec la fenêtre correcte. À lancer **après déploiement** de ce fix.

## Tests
`shadow-exit-variant.spec.ts` : 9/9 ✅ (sémantique temporelle + skip + TIME_LIMIT). Typecheck workspace ✅.

ZÉRO risque capital : colonnes shadow additives, aucune position réelle.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_