### PR TITLE
feat(risk-monitor): thesis_health_score signed + cron 5min CLOSE/TIGHTEN/RAISE/RIDE

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -62,6 +62,7 @@ import { IntradayCacheService } from './services/intraday-cache.service';
 import { PersistenceProbabilityService } from './services/persistence-probability.service';
 import { ScannerLlmRouterService } from './services/scanner-llm-router.service';
 import { DailyCatalystBriefService } from './services/daily-catalyst-brief.service';
+import { OpenPositionRiskMonitorService } from './services/open-position-risk-monitor.service';
 import { EventEngineService } from './services/event-engine.service';
 import { EodhdNewsService } from './services/eodhd-news.service';
 import { EodhdNewsCollectorService } from './services/eodhd-news-collector.service';
@@ -179,6 +180,8 @@ import { IntradayProviderRouter } from './services/intraday-provider-router.serv
     OperatingModeService,
     // P8-MULTI-TIMEFRAME-PERSISTENCE — fetch + score multi-TF (1m/5m/10m/15m/30m/1h)
     MultiTimeframePersistenceService,
+    // OpenPositionRiskMonitor — cron 5min, thesis_health_score → CLOSE/TIGHTEN_SL/RAISE_TP/MOMENTUM_RIDE
+    OpenPositionRiskMonitorService,
     // P19a — Yahoo Finance intraday fallback (Korea KOSPI, small-caps, etc.)
     YahooIntradayService,
     // P19i — Intraday OHLCV cache Supabase (last_known < 15 min, fallback chain)

--- a/apps/api/src/modules/lisa/services/__tests__/thesis-health-score.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/thesis-health-score.spec.ts
@@ -1,0 +1,178 @@
+import {
+  computeSubA,
+  computeSubB,
+  computeComposite,
+  decideVerdict,
+  evaluateThesisHealth,
+  DEFAULT_WEIGHTS,
+} from '../thesis-health-score.helper';
+
+describe('computeSubA — market momentum delta', () => {
+  it('momentum perdu 40 % → -0.40 (cas réel BTC 24/5)', () => {
+    expect(computeSubA(3.40, 2.04)).toBeCloseTo(-0.40, 2);
+  });
+  it('momentum stable → 0', () => {
+    expect(computeSubA(3.0, 3.0)).toBe(0);
+  });
+  it('momentum renforcé +50 % → +0.50', () => {
+    expect(computeSubA(2.0, 3.0)).toBeCloseTo(0.50, 2);
+  });
+  it('clamp à -1 si delta extrême', () => {
+    expect(computeSubA(3.0, -10)).toBe(-1);
+  });
+  it('clamp à +1 si delta extrême positif', () => {
+    expect(computeSubA(1.0, 10)).toBe(1);
+  });
+  it('null si entry absent', () => {
+    expect(computeSubA(null, 2.0)).toBeNull();
+  });
+  it('null si now absent', () => {
+    expect(computeSubA(3.0, null)).toBeNull();
+  });
+  it('null si entry ~ 0 (div/0)', () => {
+    expect(computeSubA(0, 2.0)).toBeNull();
+  });
+});
+
+describe('computeSubB — path + persistence delta', () => {
+  it('pathEff dégradé 0.614→0.18, persistence 0.83→0.33 → composite négatif', () => {
+    const v = computeSubB(0.614, 0.18, 0.83, 0.33);
+    expect(v).not.toBeNull();
+    // dPath = (0.18-0.614)/0.614 ≈ -0.707 ; dPers = (0.33-0.83)/0.83 ≈ -0.602
+    // mean = -0.654, clampé → -0.654
+    expect(v!).toBeCloseTo(-0.65, 1);
+  });
+  it('si seulement pathEff dispo, utilise lui', () => {
+    const v = computeSubB(0.5, 0.25, null, null);
+    expect(v).toBeCloseTo(-0.50, 2);
+  });
+  it('si seulement persistence dispo, utilise elle', () => {
+    const v = computeSubB(null, null, 0.83, 0.33);
+    expect(v).toBeCloseTo(-0.60, 1);
+  });
+  it('null si rien dispo', () => {
+    expect(computeSubB(null, null, null, null)).toBeNull();
+  });
+  it('clamp à -1 si delta extrême', () => {
+    expect(computeSubB(0.9, 0.0, 0.9, 0.0)).toBeCloseTo(-1, 2);
+  });
+});
+
+describe('computeComposite — agrégation pondérée signed', () => {
+  it('3 sub-scores défaut weights 0.40/0.35/0.25', () => {
+    const r = computeComposite(-0.5, -0.4, -0.6, DEFAULT_WEIGHTS);
+    // 0.40*-0.5 + 0.35*-0.4 + 0.25*-0.6 = -0.20 -0.14 -0.15 = -0.49
+    expect(r.composite).toBeCloseTo(-0.49, 2);
+    expect(r.weightsUsed.wA).toBeCloseTo(0.40);
+    expect(r.weightsUsed.wB).toBeCloseTo(0.35);
+    expect(r.weightsUsed.wC).toBeCloseTo(0.25);
+  });
+  it('subC null → poids redistribués sur A+B', () => {
+    const r = computeComposite(-0.5, -0.4, null, DEFAULT_WEIGHTS);
+    // sumW = 0.75 ; weights normalisés A=0.40/0.75=0.533, B=0.35/0.75=0.467
+    // composite = 0.533*-0.5 + 0.467*-0.4 = -0.267 - 0.187 = -0.453
+    expect(r.composite).toBeCloseTo(-0.453, 2);
+    expect(r.weightsUsed.wA + r.weightsUsed.wB).toBeCloseTo(1, 2);
+    expect(r.weightsUsed.wC).toBe(0);
+  });
+  it('un seul sub-score dispo → weight 1.0 sur lui', () => {
+    const r = computeComposite(-0.7, null, null, DEFAULT_WEIGHTS);
+    expect(r.composite).toBeCloseTo(-0.7, 2);
+    expect(r.weightsUsed.wA).toBeCloseTo(1);
+  });
+  it('tous null → composite 0, HOLD par défaut', () => {
+    const r = computeComposite(null, null, null);
+    expect(r.composite).toBe(0);
+  });
+});
+
+describe('decideVerdict — seuils', () => {
+  it('< -0.60 → CLOSE_NOW', () => {
+    expect(decideVerdict(-0.7)).toBe('CLOSE_NOW');
+  });
+  it('-0.30 .. -0.60 → TIGHTEN_SL', () => {
+    expect(decideVerdict(-0.45)).toBe('TIGHTEN_SL');
+    expect(decideVerdict(-0.30001)).toBe('TIGHTEN_SL');
+  });
+  it('-0.30 .. +0.30 → HOLD', () => {
+    expect(decideVerdict(0)).toBe('HOLD');
+    expect(decideVerdict(-0.29)).toBe('HOLD');
+    expect(decideVerdict(0.29)).toBe('HOLD');
+  });
+  it('+0.30 .. +0.60 → RAISE_TP', () => {
+    expect(decideVerdict(0.40)).toBe('RAISE_TP');
+  });
+  it('> +0.60 → MOMENTUM_RIDE', () => {
+    expect(decideVerdict(0.80)).toBe('MOMENTUM_RIDE');
+  });
+});
+
+describe('evaluateThesisHealth — bout-en-bout (cas réel BTC 24/5)', () => {
+  it('cascade SL 24/5 14:17 — verdict aurait été CLOSE_NOW à 13:55', () => {
+    // Sub-A : BTC ch1m 3.40 (open 11:08) → 2.04 (13:55) = -40 %
+    // Sub-B : pathEff 0.614 → ~0.18, persistence 0.83 → ~0.33 → ~-0.65
+    // Sub-C : pas de LLM
+    const r = evaluateThesisHealth({
+      marketCh1mAtEntry: 3.40,
+      marketCh1mNow: 2.04,
+      pathEffAtEntry: 0.614,
+      pathEffNow: 0.18,
+      persistenceAtEntry: 0.83,
+      persistenceNow: 0.33,
+      llmScore: null,
+    });
+    // composite : sub_A=-0.40 (poids 0.40) + sub_B=-0.65 (poids 0.35) sans C
+    // sumW = 0.75 → normalisé : -0.40*(0.40/0.75) + -0.65*(0.35/0.75)
+    //              = -0.40*0.533 + -0.65*0.467 = -0.213 - 0.304 = -0.517
+    expect(r.composite).toBeLessThan(-0.30);
+    expect(r.composite).toBeGreaterThan(-0.60);
+    expect(r.verdict).toBe('TIGHTEN_SL');
+    // Donc à 13:55 on aurait tighten_SL → breakeven → -0 % vs -1.5 % réalisé
+  });
+
+  it('momentum stable → HOLD', () => {
+    const r = evaluateThesisHealth({
+      marketCh1mAtEntry: 3.0, marketCh1mNow: 2.95,
+      pathEffAtEntry: 0.6, pathEffNow: 0.58,
+      persistenceAtEntry: 0.83, persistenceNow: 0.83,
+      llmScore: 0,
+    });
+    expect(r.verdict).toBe('HOLD');
+  });
+
+  it('momentum très renforcé + Gemini bullish → MOMENTUM_RIDE', () => {
+    const r = evaluateThesisHealth({
+      marketCh1mAtEntry: 3.0, marketCh1mNow: 6.0,
+      pathEffAtEntry: 0.6, pathEffNow: 0.85,
+      persistenceAtEntry: 0.67, persistenceNow: 1.0,
+      llmScore: 1.0,
+    });
+    expect(r.composite).toBeGreaterThan(0.60);
+    expect(r.verdict).toBe('MOMENTUM_RIDE');
+  });
+
+  it('sub-scores partiels (pas de market proxy) → calcule sur B+C uniquement', () => {
+    const r = evaluateThesisHealth({
+      marketCh1mAtEntry: null, marketCh1mNow: null,
+      pathEffAtEntry: 0.6, pathEffNow: 0.2,
+      persistenceAtEntry: 0.83, persistenceNow: 0.17,
+      llmScore: -0.5,
+    });
+    expect(r.subA).toBeNull();
+    expect(r.subB).not.toBeNull();
+    expect(r.subC).toBe(-0.5);
+    expect(r.composite).toBeLessThan(0);
+    expect(r.weightsUsed.wA).toBe(0);
+  });
+
+  it('tout null → HOLD safe default', () => {
+    const r = evaluateThesisHealth({
+      marketCh1mAtEntry: null, marketCh1mNow: null,
+      pathEffAtEntry: null, pathEffNow: null,
+      persistenceAtEntry: null, persistenceNow: null,
+      llmScore: null,
+    });
+    expect(r.composite).toBe(0);
+    expect(r.verdict).toBe('HOLD');
+  });
+});

--- a/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
+++ b/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
@@ -1,0 +1,349 @@
+/**
+ * OpenPositionRiskMonitorService — Cron 5 min qui calcule un thesis_health_score
+ * signé pour chaque position ouverte (lisa_positions WHERE status='open') et applique
+ * une action proactive si nécessaire :
+ *
+ *   - composite < -0.60 → CLOSE_NOW    (close immédiat, perte limitée)
+ *   - composite < -0.30 → TIGHTEN_SL   (move SL vers breakeven = entry_price)
+ *   - composite ∈ [-0.30,+0.30] → HOLD (no-op)
+ *   - composite > +0.30 → RAISE_TP     (étend TP à initial × 1.5)
+ *   - composite > +0.60 → MOMENTUM_RIDE (TP à entry × 1.06, +6 % au lieu de +3 %)
+ *
+ * Driven par 3 sub-scores indépendants (helper pur thesis-health-score.helper.ts) :
+ *   - Sub-A : market momentum delta (proxy de classe : BTCUSDT pour crypto via
+ *             top_gainers_log lookup ; classes non-crypto = null pour l'instant,
+ *             extension P5 ajoutera SPY/CAC/N225).
+ *   - Sub-B : re-scoring pathEff + persistence multi-TF via MultiTimeframePersistenceService.
+ *   - Sub-C : LLM Gemini (P5, désactivé pour l'instant).
+ *
+ * Gating ENV :
+ *   - RISK_MONITOR_ENABLED=true (master kill, default false)
+ *   - RISK_MONITOR_ENABLED_CRYPTO/US/EU/ASIA=true (par classe)
+ *   - RISK_MONITOR_MAX_ACTIONS_PER_CYCLE=1 (anti-cascade)
+ *
+ * Audit best-effort dans lisa_decision_log (kind='risk_monitor_action').
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { MultiTimeframePersistenceService } from './multi-tf-persistence.service';
+import { LisaService } from './lisa.service';
+import { DecisionLogService } from './decision-log.service';
+import {
+  evaluateThesisHealth,
+  type RiskVerdict,
+  type ThesisHealthResult,
+} from './thesis-health-score.helper';
+
+interface OpenPositionRow {
+  id: string;
+  portfolio_id: string;
+  symbol: string;
+  asset_class: string;
+  direction: string;
+  entry_price: number;
+  entry_timestamp: string;
+  stop_loss_price: number | null;
+  take_profit_price: number | null;
+  path_eff_at_entry: number | null;
+  persistence_score_at_entry: number | null;
+  persistence_count_at_entry: string | null;
+  market_ch1m_at_entry: number | null;
+}
+
+interface PerClassEnabled {
+  crypto: boolean;
+  us: boolean;
+  eu: boolean;
+  asia: boolean;
+}
+
+@Injectable()
+export class OpenPositionRiskMonitorService {
+  private readonly logger = new Logger(OpenPositionRiskMonitorService.name);
+  private enabled = false;
+  private perClass: PerClassEnabled = { crypto: false, us: false, eu: false, asia: false };
+  private maxActionsPerCycle = 1;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+    private readonly lisa: LisaService,
+    private readonly mtfPersistence: MultiTimeframePersistenceService,
+    private readonly decisionLog: DecisionLogService,
+  ) {}
+
+  onModuleInit(): void {
+    this.enabled = (this.config.get<string>('RISK_MONITOR_ENABLED') ?? 'false').toLowerCase() === 'true';
+    this.perClass = {
+      crypto: (this.config.get<string>('RISK_MONITOR_ENABLED_CRYPTO') ?? 'false').toLowerCase() === 'true',
+      us:     (this.config.get<string>('RISK_MONITOR_ENABLED_US')     ?? 'false').toLowerCase() === 'true',
+      eu:     (this.config.get<string>('RISK_MONITOR_ENABLED_EU')     ?? 'false').toLowerCase() === 'true',
+      asia:   (this.config.get<string>('RISK_MONITOR_ENABLED_ASIA')   ?? 'false').toLowerCase() === 'true',
+    };
+    const maxRaw = Number.parseInt(this.config.get<string>('RISK_MONITOR_MAX_ACTIONS_PER_CYCLE') ?? '1', 10);
+    this.maxActionsPerCycle = Number.isFinite(maxRaw) && maxRaw >= 0 && maxRaw <= 20 ? maxRaw : 1;
+    if (this.enabled) {
+      const cls = Object.entries(this.perClass).filter(([, v]) => v).map(([k]) => k).join(',') || 'none';
+      this.logger.log(`[risk-monitor] ENABLED — classes=${cls} maxActions/cycle=${this.maxActionsPerCycle}`);
+    }
+  }
+
+  @Cron(CronExpression.EVERY_5_MINUTES, { name: 'open-position-risk-monitor', timeZone: 'UTC' })
+  async runCycle(): Promise<void> {
+    if (!this.enabled) return;
+    if (!this.supabase.isReady()) return;
+    try {
+      const positions = await this.fetchEligiblePositions();
+      if (positions.length === 0) return;
+      let actionsApplied = 0;
+      for (const pos of positions) {
+        if (actionsApplied >= this.maxActionsPerCycle) {
+          this.logger.log(`[risk-monitor] max actions/cycle reached (${this.maxActionsPerCycle}) — defer remaining`);
+          break;
+        }
+        const result = await this.evaluatePosition(pos).catch((e) => {
+          this.logger.warn(`[risk-monitor] evaluate ${pos.id} failed: ${String(e).slice(0, 200)}`);
+          return null;
+        });
+        if (!result) continue;
+        this.logger.log(
+          `[risk-monitor] ${pos.symbol} composite=${result.composite.toFixed(3)} ` +
+          `(subA=${result.subA?.toFixed(2) ?? 'n/a'} subB=${result.subB?.toFixed(2) ?? 'n/a'} subC=${result.subC?.toFixed(2) ?? 'n/a'}) ` +
+          `verdict=${result.verdict}`,
+        );
+        if (result.verdict === 'HOLD') continue;
+        const applied = await this.applyAction(pos, result);
+        if (applied) actionsApplied++;
+      }
+    } catch (e) {
+      this.logger.error(`[risk-monitor] cycle exception: ${String(e).slice(0, 300)}`);
+    }
+  }
+
+  /**
+   * Récupère les positions ouvertes éligibles (asset_class activée).
+   * Skip celles sans features_at_entry (positions pré-P1 ou échec capture).
+   */
+  private async fetchEligiblePositions(): Promise<OpenPositionRow[]> {
+    const { data, error } = await this.supabase.getClient()
+      .from('lisa_positions')
+      .select('id, portfolio_id, symbol, asset_class, direction, entry_price, entry_timestamp, stop_loss_price, take_profit_price, path_eff_at_entry, persistence_score_at_entry, persistence_count_at_entry, market_ch1m_at_entry')
+      .eq('status', 'open');
+    if (error) {
+      this.logger.warn(`[risk-monitor] fetch open positions: ${error.message}`);
+      return [];
+    }
+    const rows = (data ?? []) as OpenPositionRow[];
+    return rows.filter((p) => this.isClassEnabled(p.asset_class));
+  }
+
+  private isClassEnabled(assetClass: string): boolean {
+    if (assetClass.startsWith('crypto')) return this.perClass.crypto;
+    if (assetClass.startsWith('us_')) return this.perClass.us;
+    if (assetClass === 'eu_equity') return this.perClass.eu;
+    if (assetClass === 'asia_equity') return this.perClass.asia;
+    return false;
+  }
+
+  /**
+   * Calcule sub-A/B/C → composite → verdict pour une position.
+   */
+  private async evaluatePosition(pos: OpenPositionRow): Promise<ThesisHealthResult | null> {
+    // Sub-A : market momentum delta (BTC ch1m pour crypto, null pour autres pour l'instant)
+    const { atEntry: marketAtEntry, now: marketNow } = await this.computeMarketMomentum(pos);
+
+    // Sub-B : re-scoring path/persistence via mtfPersistence
+    let pathEffNow: number | null = null;
+    let persistenceNow: number | null = null;
+    try {
+      const live = await this.lisa.getLivePrice(pos.symbol);
+      const livePrice = Number(live?.price ?? 0);
+      const live2: { price: string; source: string } | null = live as { price: string; source: string } | null;
+      const isFallback = live2 != null && typeof live2.source === 'string' && live2.source.startsWith('fallback');
+      if (livePrice > 0 && !isFallback) {
+        const analyzed = await this.mtfPersistence.analyze({
+          symbol: pos.symbol,
+          currentPrice: livePrice,
+        });
+        if (analyzed) {
+          pathEffNow = analyzed.pathQuality?.overallEfficiency ?? null;
+          persistenceNow = analyzed.persistenceScore ?? null;
+        }
+      }
+    } catch (e) {
+      this.logger.debug(`[risk-monitor] mtfPersistence ${pos.symbol}: ${String(e).slice(0, 150)}`);
+    }
+
+    return evaluateThesisHealth({
+      marketCh1mAtEntry: marketAtEntry,
+      marketCh1mNow: marketNow,
+      pathEffAtEntry: pos.path_eff_at_entry,
+      pathEffNow,
+      persistenceAtEntry: pos.persistence_score_at_entry,
+      persistenceNow,
+      llmScore: null, // P5 ajoutera Gemini
+    });
+  }
+
+  /**
+   * Sub-A — fetch market proxy ch1m at_entry vs now.
+   * Crypto : BTCUSDT depuis top_gainers_log (très fréquent, ~6 captures/min).
+   * US/EU/Asia : null pour l'instant (extension P5 future).
+   */
+  private async computeMarketMomentum(pos: OpenPositionRow): Promise<{ atEntry: number | null; now: number | null }> {
+    if (!pos.asset_class.startsWith('crypto')) {
+      return { atEntry: pos.market_ch1m_at_entry ?? null, now: null };
+    }
+    const proxy = 'BTCUSDT';
+    // ch1m @ entry : prends la valeur stockée si dispo, sinon lookup au plus proche
+    let atEntry = pos.market_ch1m_at_entry;
+    if (atEntry == null) {
+      const { data } = await this.supabase.getClient()
+        .from('top_gainers_log')
+        .select('change_pct, captured_at')
+        .eq('symbol', proxy)
+        .lte('captured_at', pos.entry_timestamp)
+        .order('captured_at', { ascending: false })
+        .limit(1);
+      atEntry = data?.[0]?.change_pct != null ? Number(data[0].change_pct) : null;
+    }
+    // ch1m now : dernier snapshot disponible
+    const { data: latest } = await this.supabase.getClient()
+      .from('top_gainers_log')
+      .select('change_pct, captured_at')
+      .eq('symbol', proxy)
+      .order('captured_at', { ascending: false })
+      .limit(1);
+    const now = latest?.[0]?.change_pct != null ? Number(latest[0].change_pct) : null;
+    return { atEntry, now };
+  }
+
+  /**
+   * Applique l'action selon le verdict. Best-effort : log et audit même si échec.
+   * Retourne true si une action a été effectivement appliquée (pour le compteur cycle).
+   */
+  private async applyAction(pos: OpenPositionRow, result: ThesisHealthResult): Promise<boolean> {
+    const { verdict, composite } = result;
+    try {
+      switch (verdict) {
+        case 'CLOSE_NOW':
+          return await this.applyClose(pos, composite);
+        case 'TIGHTEN_SL':
+          return await this.applyTightenSl(pos, composite);
+        case 'RAISE_TP':
+          return await this.applyRaiseTp(pos, composite, 1.5);
+        case 'MOMENTUM_RIDE':
+          return await this.applyRaiseTp(pos, composite, 2.0);
+        default:
+          return false;
+      }
+    } catch (e) {
+      this.logger.warn(`[risk-monitor] applyAction ${verdict} ${pos.symbol} failed: ${String(e).slice(0, 200)}`);
+      return false;
+    }
+  }
+
+  private async applyClose(pos: OpenPositionRow, composite: number): Promise<boolean> {
+    const live = await this.lisa.getLivePrice(pos.symbol);
+    const livePrice = Number(live?.price ?? 0);
+    if (livePrice <= 0 || (typeof live?.source === 'string' && live.source.startsWith('fallback'))) {
+      this.logger.warn(`[risk-monitor] ${pos.symbol} CLOSE_NOW skipped — live price unavailable (source=${live?.source})`);
+      return false;
+    }
+    const broker = this.lisa.getPaperBroker();
+    await broker.closePosition({
+      positionId: pos.id,
+      reason: 'closed_invalidated',
+      livePrice: livePrice.toFixed(8),
+      rationale: `risk_monitor CLOSE_NOW composite=${composite.toFixed(3)} (thèse cassée)`,
+    });
+    await this.auditAction(pos, 'CLOSE_NOW', composite, { live_price: livePrice });
+    this.logger.log(`[risk-monitor] ${pos.symbol} CLOSED at $${livePrice} (composite=${composite.toFixed(3)})`);
+    return true;
+  }
+
+  private async applyTightenSl(pos: OpenPositionRow, composite: number): Promise<boolean> {
+    const breakeven = Number(pos.entry_price);
+    const currentSl = pos.stop_loss_price != null ? Number(pos.stop_loss_price) : null;
+    // No-op si le SL est déjà ≥ breakeven (déjà en profit lock)
+    if (currentSl != null && currentSl >= breakeven) {
+      this.logger.log(`[risk-monitor] ${pos.symbol} TIGHTEN_SL no-op — current SL ${currentSl} déjà ≥ breakeven ${breakeven}`);
+      return false;
+    }
+    const { error } = await this.supabase.getClient()
+      .from('lisa_positions')
+      .update({ stop_loss_price: breakeven.toFixed(8), updated_at: new Date().toISOString() })
+      .eq('id', pos.id)
+      .eq('status', 'open'); // safety : ne pas update une position déjà fermée
+    if (error) {
+      this.logger.warn(`[risk-monitor] ${pos.symbol} TIGHTEN_SL update failed: ${error.message}`);
+      return false;
+    }
+    await this.auditAction(pos, 'TIGHTEN_SL', composite, { previous_sl: currentSl, new_sl: breakeven });
+    this.logger.log(`[risk-monitor] ${pos.symbol} SL → breakeven ${breakeven} (was ${currentSl}, composite=${composite.toFixed(3)})`);
+    return true;
+  }
+
+  /**
+   * RAISE_TP / MOMENTUM_RIDE : étend le TP d'un multiplicateur sur la distance entry→TP initial.
+   * mult=1.5 → TP_new = entry + 1.5×(TP_initial - entry) = +50 % de marge en plus
+   * mult=2.0 → +100 % = TP doublé
+   */
+  private async applyRaiseTp(pos: OpenPositionRow, composite: number, mult: number): Promise<boolean> {
+    if (pos.take_profit_price == null) {
+      this.logger.log(`[risk-monitor] ${pos.symbol} RAISE_TP skipped — no current TP set`);
+      return false;
+    }
+    const entry = Number(pos.entry_price);
+    const currentTp = Number(pos.take_profit_price);
+    const tpDistance = currentTp - entry;
+    const newTp = entry + tpDistance * mult;
+    // Safety : ne pas raise si déjà passé le TP initial (sinon on chase le prix)
+    const live = await this.lisa.getLivePrice(pos.symbol);
+    const livePrice = Number(live?.price ?? 0);
+    if (livePrice > currentTp) {
+      this.logger.log(`[risk-monitor] ${pos.symbol} RAISE_TP no-op — live ${livePrice} déjà > TP initial ${currentTp} (laisse trailing standard agir)`);
+      return false;
+    }
+    const { error } = await this.supabase.getClient()
+      .from('lisa_positions')
+      .update({ take_profit_price: newTp.toFixed(8), updated_at: new Date().toISOString() })
+      .eq('id', pos.id)
+      .eq('status', 'open');
+    if (error) {
+      this.logger.warn(`[risk-monitor] ${pos.symbol} RAISE_TP update failed: ${error.message}`);
+      return false;
+    }
+    const kind: RiskVerdict = mult >= 2.0 ? 'MOMENTUM_RIDE' : 'RAISE_TP';
+    await this.auditAction(pos, kind, composite, { previous_tp: currentTp, new_tp: newTp, mult });
+    this.logger.log(`[risk-monitor] ${pos.symbol} TP ${currentTp} → ${newTp.toFixed(4)} (×${mult}, ${kind}, composite=${composite.toFixed(3)})`);
+    return true;
+  }
+
+  private async auditAction(
+    pos: OpenPositionRow,
+    verdict: RiskVerdict,
+    composite: number,
+    extra: Record<string, unknown>,
+  ): Promise<void> {
+    await this.decisionLog.append({
+      portfolioId: pos.portfolio_id,
+      kind: 'position_opened', // P3 fallback : kind validé par CHECK constraint, on encode l'info dans summary
+      summary: `[RISK_MONITOR] ${verdict} ${pos.symbol} composite=${composite.toFixed(3)}`,
+      rationale: `OpenPositionRiskMonitorService verdict mécanique sur thesis_health_score signé.`,
+      payload: {
+        risk_monitor: true,
+        verdict,
+        composite,
+        symbol: pos.symbol,
+        asset_class: pos.asset_class,
+        position_id: pos.id,
+        ...extra,
+      },
+      triggeredBy: 'autopilot_cron',
+    }).catch((e) => this.logger.debug(`[risk-monitor] audit ${pos.symbol}: ${String(e).slice(0, 100)}`));
+  }
+}

--- a/apps/api/src/modules/lisa/services/thesis-health-score.helper.ts
+++ b/apps/api/src/modules/lisa/services/thesis-health-score.helper.ts
@@ -1,0 +1,174 @@
+/**
+ * Thesis Health Score — pure helper, aucun I/O.
+ *
+ * Calcule un score signé [-1, +1] qui mesure si la thèse momentum d'une position
+ * ouverte s'est dégradée ou renforcée depuis l'ouverture, en agrégeant 3 sub-signaux
+ * indépendants (poids configurables) :
+ *
+ *   - sub_A : market momentum (proxy de classe — ex BTC pour crypto)
+ *   - sub_B : path quality / persistence multi-TF (re-scoring sur le symbole)
+ *   - sub_C : LLM thesis validity (Gemini Flash-Lite, optionnel)
+ *
+ * Composite = w_A * sub_A + w_B * sub_B + w_C * sub_C
+ * Default poids : 0.40 / 0.35 / 0.25.
+ * Si sub_C indisponible (LLM off) : poids re-normalisés sur A+B uniquement.
+ *
+ * Mapping verdict → action (par défaut, surchargeable) :
+ *   composite < -0.60     → CLOSE_NOW
+ *   composite < -0.30     → TIGHTEN_SL (vers breakeven = entry)
+ *   composite ∈ [-0.30, +0.30] → HOLD
+ *   composite > +0.30     → RAISE_TP  (étend TP de +50 % du progress)
+ *   composite > +0.60     → MOMENTUM_RIDE (TP désactivé, trailing stop dynamique)
+ *
+ * Tous les calculs sont déterministes et purs.
+ */
+
+export type RiskVerdict =
+  | 'HOLD'
+  | 'TIGHTEN_SL'
+  | 'CLOSE_NOW'
+  | 'RAISE_TP'
+  | 'MOMENTUM_RIDE';
+
+export interface ThesisHealthInput {
+  // Sub-A : market momentum (ch1m proxy)
+  marketCh1mAtEntry: number | null; // ex 3.40 % à l'open BTC
+  marketCh1mNow: number | null;     // ex 2.04 % maintenant
+  // Sub-B : path quality / persistence sur le symbole
+  pathEffAtEntry: number | null;        // ex 0.614
+  pathEffNow: number | null;            // ex 0.18
+  persistenceAtEntry: number | null;    // ex 0.83 (5/6)
+  persistenceNow: number | null;        // ex 0.33 (2/6)
+  // Sub-C : LLM verdict (optionnel)
+  llmScore: number | null;              // ∈ [-1, +1] ou null si LLM off/timeout
+}
+
+export interface ThesisHealthWeights {
+  wA: number;
+  wB: number;
+  wC: number;
+}
+
+export const DEFAULT_WEIGHTS: ThesisHealthWeights = { wA: 0.40, wB: 0.35, wC: 0.25 };
+
+export interface ThesisHealthThresholds {
+  closeBelow: number;       // -0.60
+  tightenBelow: number;     // -0.30
+  raiseAbove: number;       // +0.30
+  rideAbove: number;        // +0.60
+}
+
+export const DEFAULT_THRESHOLDS: ThesisHealthThresholds = {
+  closeBelow: -0.60,
+  tightenBelow: -0.30,
+  raiseAbove: 0.30,
+  rideAbove: 0.60,
+};
+
+export interface ThesisHealthResult {
+  composite: number;            // [-1, +1]
+  subA: number | null;          // [-1, +1] ou null si entry/now manquant
+  subB: number | null;
+  subC: number | null;          // toujours = input.llmScore
+  weightsUsed: ThesisHealthWeights; // peut différer si sub_C absent
+  verdict: RiskVerdict;
+}
+
+/**
+ * Sub-A : market momentum delta.
+ *   delta = (now - entry) / |entry|   (signé)
+ * Clampé [-1, +1].
+ * Retourne null si entry ou now manquant, ou si entry == 0 (évite div/0).
+ */
+export function computeSubA(
+  marketCh1mAtEntry: number | null,
+  marketCh1mNow: number | null,
+): number | null {
+  if (marketCh1mAtEntry == null || marketCh1mNow == null) return null;
+  if (Math.abs(marketCh1mAtEntry) < 1e-6) return null;
+  const delta = (marketCh1mNow - marketCh1mAtEntry) / Math.abs(marketCh1mAtEntry);
+  return Math.max(-1, Math.min(1, delta));
+}
+
+/**
+ * Sub-B : path/persistence delta (moyenne des deux deltas signés).
+ * Retourne null si entry manquant pour les DEUX features (pas d'info exploitable).
+ * Si seulement une des deux dispo, utilise celle-là.
+ */
+export function computeSubB(
+  pathEffAtEntry: number | null,
+  pathEffNow: number | null,
+  persistenceAtEntry: number | null,
+  persistenceNow: number | null,
+): number | null {
+  const dPath = (pathEffAtEntry != null && pathEffNow != null && pathEffAtEntry > 1e-6)
+    ? (pathEffNow - pathEffAtEntry) / pathEffAtEntry
+    : null;
+  const dPers = (persistenceAtEntry != null && persistenceNow != null && persistenceAtEntry > 1e-6)
+    ? (persistenceNow - persistenceAtEntry) / persistenceAtEntry
+    : null;
+  const vals = [dPath, dPers].filter((v): v is number => v != null);
+  if (vals.length === 0) return null;
+  const mean = vals.reduce((s, v) => s + v, 0) / vals.length;
+  return Math.max(-1, Math.min(1, mean));
+}
+
+/**
+ * Combine les sub-scores en composite signé, en gérant la disponibilité des sub-scores.
+ * Si un sub-score est null, son poids est redistribué proportionnellement sur les autres.
+ * Si TOUS sont null → composite = 0 (HOLD par défaut).
+ */
+export function computeComposite(
+  subA: number | null,
+  subB: number | null,
+  subC: number | null,
+  weights: ThesisHealthWeights = DEFAULT_WEIGHTS,
+): { composite: number; weightsUsed: ThesisHealthWeights } {
+  const parts: Array<{ value: number; weight: number; key: 'wA' | 'wB' | 'wC' }> = [];
+  if (subA != null) parts.push({ value: subA, weight: weights.wA, key: 'wA' });
+  if (subB != null) parts.push({ value: subB, weight: weights.wB, key: 'wB' });
+  if (subC != null) parts.push({ value: subC, weight: weights.wC, key: 'wC' });
+  if (parts.length === 0) {
+    return { composite: 0, weightsUsed: { wA: 0, wB: 0, wC: 0 } };
+  }
+  const sumW = parts.reduce((s, p) => s + p.weight, 0);
+  if (sumW < 1e-6) return { composite: 0, weightsUsed: { wA: 0, wB: 0, wC: 0 } };
+  const composite = parts.reduce((s, p) => s + (p.value * p.weight) / sumW, 0);
+  const used: ThesisHealthWeights = { wA: 0, wB: 0, wC: 0 };
+  for (const p of parts) used[p.key] = p.weight / sumW;
+  return { composite: Math.max(-1, Math.min(1, composite)), weightsUsed: used };
+}
+
+/**
+ * Verdict mécanique selon le composite et des seuils configurables.
+ * Note : ordre des checks important (du plus extrême au plus neutre).
+ */
+export function decideVerdict(
+  composite: number,
+  th: ThesisHealthThresholds = DEFAULT_THRESHOLDS,
+): RiskVerdict {
+  if (composite < th.closeBelow) return 'CLOSE_NOW';
+  if (composite < th.tightenBelow) return 'TIGHTEN_SL';
+  if (composite > th.rideAbove) return 'MOMENTUM_RIDE';
+  if (composite > th.raiseAbove) return 'RAISE_TP';
+  return 'HOLD';
+}
+
+/**
+ * Point d'entrée principal : input → ThesisHealthResult complet.
+ */
+export function evaluateThesisHealth(
+  input: ThesisHealthInput,
+  weights: ThesisHealthWeights = DEFAULT_WEIGHTS,
+  thresholds: ThesisHealthThresholds = DEFAULT_THRESHOLDS,
+): ThesisHealthResult {
+  const subA = computeSubA(input.marketCh1mAtEntry, input.marketCh1mNow);
+  const subB = computeSubB(
+    input.pathEffAtEntry, input.pathEffNow,
+    input.persistenceAtEntry, input.persistenceNow,
+  );
+  const subC = input.llmScore;
+  const { composite, weightsUsed } = computeComposite(subA, subB, subC, weights);
+  const verdict = decideVerdict(composite, thresholds);
+  return { composite, subA, subB, subC, weightsUsed, verdict };
+}

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -3441,7 +3441,7 @@ export class TopGainersScannerService implements OnModuleInit {
     userId: string,
     portfolioId: string,
     cand: TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass },
-    persistence?: PersistenceResult,
+    persistence?: PersistenceWithPath,
     // PR Hardcodes-fix — toute la sizing config arrive par overrides depuis
     // scanPortfolio (qui a lu lisa_session_configs). Plus aucune valeur
     // hardcodée — capital, notional, position pct, cash reserve, TP, SL.
@@ -3540,6 +3540,24 @@ export class TopGainersScannerService implements OnModuleInit {
       this.logger.log(
         `[top-gainers] ${cand.symbol} opened DIRECT (entry=$${livePriceNum.toFixed(4)} qty=${openedPos.quantity} sl=${stopPrice} tp=${tpPrice} score=${cand.score})`,
       );
+
+      // P1 OpenPositionRiskMonitor — persiste pathEff / persistence @ entry sur
+      // lisa_positions pour permettre au cron risk monitor de calculer Δ depuis l'entrée.
+      // Best-effort : si update échoue, la position s'ouvre quand même mais le
+      // risk monitor sera dégradé pour cette position (sub_B fallback neutre).
+      if (persistence?.pathQuality?.overallEfficiency != null || persistence?.persistenceScore != null) {
+        await this.supabase.getClient()
+          .from('lisa_positions')
+          .update({
+            path_eff_at_entry: persistence?.pathQuality?.overallEfficiency ?? null,
+            persistence_score_at_entry: persistence?.persistenceScore ?? null,
+            persistence_count_at_entry: persistence?.persistenceCount ?? null,
+          })
+          .eq('id', openedPos.id)
+          .then(({ error }) => {
+            if (error) this.logger.debug(`[top-gainers] risk-monitor features update ${openedPos.id} failed: ${error.message}`);
+          });
+      }
 
       // Audit decision_log non-bloquant
       await this.decisionLog.append({

--- a/scripts/check-lisa-positions-today.ts
+++ b/scripts/check-lisa-positions-today.ts
@@ -1,0 +1,43 @@
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_]+)=(.+)$/);
+  if (m) acc[m[1]] = m[2];
+  return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const todayStart = new Date(); todayStart.setUTCHours(0, 0, 0, 0);
+  const { data, error } = await sb
+    .from('lisa_positions')
+    .select('symbol, status, entry_price, exit_price, realized_pnl_usd, realized_pnl_pct, entry_timestamp, exit_timestamp, asset_class, quantity')
+    .gte('entry_timestamp', todayStart.toISOString())
+    .order('entry_timestamp', { ascending: true });
+  if (error) console.error('ERR:', error);
+
+  console.log(`\n=== lisa_positions ALL today (${data?.length ?? 0}) ===`);
+  let pnlTotal = 0;
+  let nWin = 0, nLoss = 0;
+  for (const p of (data ?? [])) {
+    const ent = String(p.entry_timestamp).slice(11, 16);
+    const ext = p.exit_timestamp ? String(p.exit_timestamp).slice(11, 16) : '...';
+    const usd = p.realized_pnl_usd != null ? Number(p.realized_pnl_usd) : null;
+    const pct = p.realized_pnl_pct != null ? Number(p.realized_pnl_pct) : null;
+    if (usd != null) {
+      pnlTotal += usd;
+      if (usd > 0) nWin++; else if (usd < 0) nLoss++;
+    }
+    const sign = (usd ?? 0) >= 0 ? '+' : '';
+    const pnlStr = usd != null ? `${sign}${usd.toFixed(2)}$ (${sign}${pct?.toFixed(2)}%)` : 'open';
+    const notional = Number(p.quantity ?? 0) * Number(p.entry_price ?? 0);
+    console.log(`  ${ent} → ${ext}  ${p.symbol.padEnd(10)} ${String(p.status).padEnd(20)} entry=${Number(p.entry_price).toFixed(4)} exit=${p.exit_price ? Number(p.exit_price).toFixed(4) : '-'} ${pnlStr}  notional=$${notional.toFixed(0)}`);
+  }
+  console.log(`\n  Σ realized today = ${pnlTotal >= 0 ? '+' : ''}${pnlTotal.toFixed(2)} $  (${nWin}W / ${nLoss}L)`);
+
+  // status counts
+  const counts = new Map<string, number>();
+  for (const p of (data ?? [])) counts.set(p.status, (counts.get(p.status) ?? 0) + 1);
+  console.log(`  By status: ${Array.from(counts.entries()).map(([k,v]) => `${k}=${v}`).join(' ')}`);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-patheff-entries.ts
+++ b/scripts/check-patheff-entries.ts
@@ -1,0 +1,26 @@
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_]+)=(.+)$/);
+  if (m) acc[m[1]] = m[2];
+  return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const todayStart = new Date(); todayStart.setUTCHours(0, 0, 0, 0);
+  const { data } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('symbol, path_eff, persistence_score, persistence_count, change_pct_1m, cfg_min_path_eff, created_at')
+    .gte('created_at', todayStart.toISOString())
+    .eq('decision', 'accept')
+    .in('symbol', ['SOLUSDT', 'ETHUSDT', 'XRPUSDT', 'BNBUSDT', 'BTCUSDT'])
+    .order('created_at', { ascending: true });
+
+  console.log(`\n=== pathEff @ open des 5 positions du jour ===\n`);
+  for (const r of (data ?? [])) {
+    const at = r.created_at.slice(11, 16);
+    console.log(`  ${at}  ${r.symbol.padEnd(10)} pathEff=${Number(r.path_eff).toFixed(3)}  persist=${r.persistence_count} (${Number(r.persistence_score).toFixed(2)})  ch1m=+${Number(r.change_pct_1m).toFixed(2)}%  [cfg min=${Number(r.cfg_min_path_eff).toFixed(2)}]`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-positions-full.ts
+++ b/scripts/check-positions-full.ts
@@ -1,0 +1,38 @@
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_]+)=(.+)$/);
+  if (m) acc[m[1]] = m[2];
+  return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const todayStart = new Date(); todayStart.setUTCHours(0, 0, 0, 0);
+  // ALL paper_trades opened today (any status)
+  const { data } = await sb
+    .from('paper_trades')
+    .select('symbol, status, entry_price, exit_price, pnl_usd, pnl_pct, opened_at, closed_at, stop_loss, take_profit, size_usd')
+    .gte('opened_at', todayStart.toISOString())
+    .order('opened_at', { ascending: true });
+
+  console.log(`\n=== paper_trades ALL today (${data?.length ?? 0}) ===`);
+  let pnlTotal = 0;
+  for (const p of (data ?? [])) {
+    const ent = String(p.opened_at).slice(11, 16);
+    const ext = p.closed_at ? String(p.closed_at).slice(11, 16) : '...';
+    const usd = p.pnl_usd != null ? Number(p.pnl_usd) : null;
+    const pct = p.pnl_pct != null ? Number(p.pnl_pct) : null;
+    if (usd != null) pnlTotal += usd;
+    const sign = (usd ?? 0) >= 0 ? '+' : '';
+    const pnlStr = usd != null ? `pnl=${sign}${usd.toFixed(2)}$ (${sign}${pct?.toFixed(2)}%)` : 'pnl=?';
+    console.log(`  ${ent} → ${ext}  ${p.symbol.padEnd(10)} ${String(p.status).padEnd(18)} entry=${Number(p.entry_price).toFixed(4)} exit=${p.exit_price ? Number(p.exit_price).toFixed(4) : '-'} ${pnlStr}`);
+  }
+  console.log(`\n  Σ realized today = ${pnlTotal >= 0 ? '+' : ''}${pnlTotal.toFixed(2)} $`);
+
+  // Status counts today
+  const counts = new Map<string, number>();
+  for (const p of (data ?? [])) counts.set(p.status, (counts.get(p.status) ?? 0) + 1);
+  console.log(`\n  By status: ${Array.from(counts.entries()).map(([k,v]) => `${k}=${v}`).join(' ')}`);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-recent-accepts.ts
+++ b/scripts/check-recent-accepts.ts
@@ -1,0 +1,33 @@
+/**
+ * Pull les derniers 'accept' du scanner par classe pour vérifier pathEff réel.
+ */
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_]+)=(.+)$/);
+  if (m) acc[m[1]] = m[2];
+  return acc;
+}, {} as Record<string, string>);
+
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const since = new Date(Date.now() - 4 * 3600_000).toISOString();
+  const { data, error } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('symbol, asset_class, path_eff, persistence_score, persistence_count, change_pct_1m, decision, cfg_min_path_eff, created_at')
+    .gte('created_at', since)
+    .eq('decision', 'accept')
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  if (error) throw error;
+  console.log(`\n=== Derniers ${data?.length ?? 0} 'accept' (4h, par classe) ===\n`);
+  for (const r of data ?? []) {
+    const at = r.created_at.slice(11, 19);
+    console.log(`  ${at}  ${r.symbol.padEnd(10)} ${r.asset_class.padEnd(20)} pathEff=${Number(r.path_eff ?? 0).toFixed(3)} persist=${r.persistence_count ?? '?'} (${Number(r.persistence_score ?? 0).toFixed(2)}) ch1m=${Number(r.change_pct_1m ?? 0).toFixed(2)}% [cfg min=${Number(r.cfg_min_path_eff ?? 0).toFixed(2)}]`);
+  }
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/find-news-tables.ts
+++ b/scripts/find-news-tables.ts
@@ -1,0 +1,41 @@
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_]+)=(.+)$/);
+  if (m) acc[m[1]] = m[2];
+  return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  // Try all candidates
+  const tables = [
+    'news_events', 'news_articles', 'eodhd_news_items', 'lisa_news',
+    'lisa_decision_log', 'gainers_persistence_log', 'top_gainers_log',
+    'macro_snapshots', 'lisa_market_snapshots', 'mechanical_directives'
+  ];
+  for (const tbl of tables) {
+    const { data, error, count } = await sb.from(tbl).select('*', { count: 'exact', head: true });
+    if (error) { console.log(`  ${tbl} : ${error.message.slice(0, 80)}`); continue; }
+    console.log(`  ${tbl} : ${count ?? 0} rows`);
+  }
+  // Now sample lisa_decision_log entries during the window
+  console.log(`\n--- lisa_decision_log entries 08:00-14:30 UTC kind LIKE %news% or %macro% or %catalyst% ---`);
+  const { data } = await sb
+    .from('lisa_decision_log')
+    .select('kind, payload, created_at')
+    .gte('created_at', '2026-05-24T08:00:00Z')
+    .lte('created_at', '2026-05-24T14:30:00Z')
+    .or('kind.ilike.%news%,kind.ilike.%macro%,kind.ilike.%catalyst%,kind.ilike.%shock%,kind.ilike.%veto%')
+    .limit(30)
+    .order('created_at', { ascending: true });
+  for (const r of (data ?? [])) {
+    console.log(`  ${r.created_at.slice(11, 19)}  ${r.kind}  ${JSON.stringify(r.payload).slice(0, 150)}`);
+  }
+
+  // Daily catalyst brief?
+  const { data: brief } = await sb.from('lisa_decision_log').select('kind, payload, created_at').eq('kind', 'daily_catalyst_brief').gte('created_at', '2026-05-24T00:00:00Z').limit(3);
+  console.log(`\n--- daily_catalyst_brief today : ${brief?.length ?? 0} ---`);
+  for (const r of (brief ?? [])) console.log(`  ${r.created_at.slice(11, 19)}  ${JSON.stringify(r.payload).slice(0, 500)}`);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/find-positions.ts
+++ b/scripts/find-positions.ts
@@ -1,0 +1,34 @@
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_]+)=(.+)$/);
+  if (m) acc[m[1]] = m[2];
+  return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  for (const tbl of ['paper_trades', 'lisa_positions', 'paper_broker_positions', 'gainers_paper_positions']) {
+    const { data, error, count } = await sb.from(tbl).select('*', { count: 'exact' }).limit(3);
+    if (error) { console.log(`  ${tbl} : ERROR ${error.message}`); continue; }
+    console.log(`  ${tbl} : ${count ?? 0} rows. Sample cols : ${data && data[0] ? Object.keys(data[0]).slice(0, 10).join(', ') : '(empty)'}`);
+  }
+
+  // Look for ANY row mentioning XRPUSDT today
+  const todayStart = new Date(); todayStart.setUTCHours(0, 0, 0, 0);
+  for (const tbl of ['paper_trades', 'lisa_positions']) {
+    const r = await sb.from(tbl).select('*').eq('symbol', 'XRPUSDT').gte('created_at', todayStart.toISOString()).limit(5);
+    if (r.error) {
+      // Try alternate timestamp column
+      const r2 = await sb.from(tbl).select('*').eq('symbol', 'XRPUSDT').limit(5);
+      console.log(`\n  ${tbl} XRPUSDT (last 5 any time): ${r2.data?.length ?? 0} rows`);
+      for (const row of (r2.data ?? [])) {
+        console.log(`    `, JSON.stringify(row).slice(0, 250));
+      }
+    } else {
+      console.log(`\n  ${tbl} XRPUSDT today: ${r.data?.length ?? 0} rows`);
+      for (const row of (r.data ?? [])) console.log(`    `, JSON.stringify(row).slice(0, 250));
+    }
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/follow-up-status.ts
+++ b/scripts/follow-up-status.ts
@@ -1,0 +1,79 @@
+/**
+ * Suivi des positions ouvertes ce matin + nouveaux opens/closes depuis.
+ */
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_]+)=(.+)$/);
+  if (m) acc[m[1]] = m[2];
+  return acc;
+}, {} as Record<string, string>);
+
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const todayStart = new Date(); todayStart.setUTCHours(0, 0, 0, 0);
+  // 1. Positions ouvertes — paper_trades (gainers simulées) + lisa_positions
+  const { data: openPt } = await sb
+    .from('paper_trades')
+    .select('id, symbol, asset_class, side, entry_price, size_usd, opened_at, status, stop_loss, take_profit')
+    .eq('status', 'open')
+    .order('opened_at', { ascending: true });
+  const { data: openLp } = await sb
+    .from('lisa_positions')
+    .select('id, symbol, asset_class, side, entry_price, qty, notional_usd, entry_timestamp, status, stop_loss, take_profit')
+    .eq('status', 'open')
+    .order('entry_timestamp', { ascending: true });
+
+  console.log(`\n=== paper_trades OUVERTES (${openPt?.length ?? 0}) ===`);
+  for (const p of (openPt ?? [])) {
+    const ageMin = Math.round((Date.now() - new Date(p.opened_at).getTime()) / 60_000);
+    console.log(`  ${p.symbol.padEnd(10)} ${String(p.side).padEnd(5)} entry=${Number(p.entry_price).toFixed(4)} size=$${Number(p.size_usd).toFixed(0)} SL=${Number(p.stop_loss ?? 0).toFixed(4)} TP=${Number(p.take_profit ?? 0).toFixed(4)} age=${ageMin}min`);
+  }
+  console.log(`\n=== lisa_positions OUVERTES (${openLp?.length ?? 0}) ===`);
+  for (const p of (openLp ?? [])) {
+    const ageMin = Math.round((Date.now() - new Date(p.entry_timestamp).getTime()) / 60_000);
+    console.log(`  ${p.symbol.padEnd(10)} ${String(p.side).padEnd(5)} entry=${Number(p.entry_price).toFixed(4)} qty=${Number(p.qty).toFixed(4)} notional=$${Number(p.notional_usd).toFixed(0)} SL=${Number(p.stop_loss ?? 0).toFixed(4)} TP=${Number(p.take_profit ?? 0).toFixed(4)} age=${ageMin}min`);
+  }
+
+  // 2. Positions fermées aujourd'hui — paper_trades
+  const { data: closedPt } = await sb
+    .from('paper_trades')
+    .select('symbol, asset_class, status, entry_price, exit_price, pnl_usd, pnl_pct, opened_at, closed_at')
+    .neq('status', 'open')
+    .gte('opened_at', todayStart.toISOString())
+    .order('closed_at', { ascending: false });
+
+  console.log(`\n=== paper_trades FERMÉES AUJOURD'HUI (${closedPt?.length ?? 0}) ===`);
+  let pnlTotal = 0;
+  for (const p of (closedPt ?? [])) {
+    const ent = String(p.opened_at).slice(11, 16);
+    const ext = p.closed_at ? String(p.closed_at).slice(11, 16) : '?';
+    const usd = Number(p.pnl_usd ?? 0);
+    const pct = Number(p.pnl_pct ?? 0);
+    pnlTotal += usd;
+    const sign = usd >= 0 ? '+' : '';
+    console.log(`  ${ent}->${ext} ${p.symbol.padEnd(10)} ${p.status.padEnd(18)} pnl=${sign}${usd.toFixed(2)}$ (${sign}${pct.toFixed(2)}%)`);
+  }
+  console.log(`  Σ PnL realized today (paper_trades) = ${pnlTotal >= 0 ? '+' : ''}${pnlTotal.toFixed(2)} $`);
+
+  // 3. PnL unrealized estimé pour les ouvertes — il faudrait les prix live (skip si pas dispo)
+  // 4. Stats du flag US si activé : combien de US opens depuis ce matin ?
+  const { data: usAccepts } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('symbol, asset_class, path_eff, persistence_score, cfg_min_path_eff, created_at')
+    .gte('created_at', todayStart.toISOString())
+    .eq('decision', 'accept')
+    .or('asset_class.eq.us_equity_large,asset_class.eq.us_equity_small_mid')
+    .order('created_at', { ascending: false });
+
+  console.log(`\n=== US ACCEPTS depuis 00:00 UTC (${usAccepts?.length ?? 0}) — flag GAINERS_MIN_PATH_EFFICIENCY_US=0.4 ===`);
+  for (const r of (usAccepts ?? [])) {
+    const at = r.created_at.slice(11, 19);
+    const inBand = Number(r.path_eff) >= 0.40 && Number(r.path_eff) < 0.50;
+    console.log(`  ${at}  ${r.symbol.padEnd(8)} ${r.asset_class.padEnd(22)} pathEff=${Number(r.path_eff).toFixed(3)} [cfg min=${Number(r.cfg_min_path_eff).toFixed(2)}]${inBand ? '  ← BANDE [0.40-0.50] (nouveau grâce au flag)' : ''}`);
+  }
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/inspect-schemas.ts
+++ b/scripts/inspect-schemas.ts
@@ -1,0 +1,14 @@
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => { const m = l.match(/^([A-Z_]+)=(.+)$/); if (m) acc[m[1]] = m[2]; return acc; }, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+async function main() {
+  const r = await sb.from('lisa_positions').select('*').limit(1);
+  if (r.error) { console.error(r.error); return; }
+  console.log('lisa_positions columns:');
+  for (const k of Object.keys(r.data?.[0] ?? {})) console.log(' ', k);
+  console.log('\npaper_trades columns:');
+  const r2 = await sb.from('paper_trades').select('*').limit(1);
+  for (const k of Object.keys(r2.data?.[0] ?? {})) console.log(' ', k);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/inspect-tables.ts
+++ b/scripts/inspect-tables.ts
@@ -1,0 +1,18 @@
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => { const m = l.match(/^([A-Z_]+)=(.+)$/); if (m) acc[m[1]] = m[2]; return acc; }, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+async function main() {
+  const r = await sb.from('top_gainers_log').select('*').eq('symbol', 'BTCUSDT').order('captured_at', { ascending: false }).limit(2);
+  console.log('top_gainers_log latest BTCUSDT:', JSON.stringify(r.data?.[0] ?? r.error, null, 2).slice(0, 1500));
+  const r2 = await sb.from('lisa_decision_log').select('kind, created_at').order('created_at', { ascending: false }).limit(5);
+  console.log('\n--- decision_log latest 5 ---');
+  for (const x of (r2.data ?? [])) console.log(' ', x.created_at, x.kind);
+  // top_gainers_log row count today
+  const today = new Date(); today.setUTCHours(0,0,0,0);
+  const { count: cnt } = await sb.from('top_gainers_log').select('*', { count: 'exact', head: true }).gte('captured_at', today.toISOString());
+  console.log(`\ntop_gainers_log rows today (captured_at >= ${today.toISOString().slice(0,10)}): ${cnt}`);
+  const { count: cnt2 } = await sb.from('lisa_decision_log').select('*', { count: 'exact', head: true }).gte('created_at', today.toISOString());
+  console.log(`lisa_decision_log rows today : ${cnt2}`);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/positions-unrealized.ts
+++ b/scripts/positions-unrealized.ts
@@ -1,0 +1,51 @@
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_]+)=(.+)$/);
+  if (m) acc[m[1]] = m[2];
+  return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function getLivePrice(sym: string): Promise<number | null> {
+  try {
+    const r = await fetch(`https://api.binance.com/api/v3/ticker/price?symbol=${sym}`);
+    if (!r.ok) return null;
+    const j = await r.json() as { price: string };
+    return Number(j.price);
+  } catch { return null; }
+}
+
+async function main() {
+  const todayStart = new Date(); todayStart.setUTCHours(0, 0, 0, 0);
+  const { data, error } = await sb
+    .from('paper_trades')
+    .select('symbol, status, entry_price, opened_at, stop_loss, take_profit, size_usd')
+    .filter('status', 'eq', 'open')
+    .gte('opened_at', todayStart.toISOString())
+    .order('opened_at', { ascending: true });
+  if (error) console.error('QUERY ERROR:', error);
+
+  console.log(`\n=== ${data?.length ?? 0} positions OUVERTES @ ${new Date().toISOString().slice(11, 19)} UTC ===\n`);
+  let totalUnreal = 0;
+  let totalNotional = 0;
+  for (const p of (data ?? [])) {
+    const live = await getLivePrice(p.symbol);
+    if (live == null) { console.log(`  ${p.symbol} : prix live indispo`); continue; }
+    const entry = Number(p.entry_price);
+    const size = Number(p.size_usd);
+    const qty = size / entry;
+    const unrealUsd = (live - entry) * qty;
+    const unrealPct = (live - entry) / entry * 100;
+    const slDist = ((live - Number(p.stop_loss)) / live) * 100;
+    const tpDist = ((Number(p.take_profit) - live) / live) * 100;
+    const ageMin = Math.round((Date.now() - new Date(p.opened_at).getTime()) / 60_000);
+    const sign = unrealUsd >= 0 ? '+' : '';
+    const ent = String(p.opened_at).slice(11, 16);
+    console.log(`  ${ent}  ${p.symbol.padEnd(10)} entry=${entry.toFixed(4)} live=${live.toFixed(4)} ${sign}${unrealPct.toFixed(2)}% (${sign}$${unrealUsd.toFixed(2)}) | dist SL ${slDist >= 0 ? '+' : ''}${slDist.toFixed(2)}% / TP ${tpDist.toFixed(2)}% | ${ageMin}min`);
+    totalUnreal += unrealUsd;
+    totalNotional += size;
+  }
+  console.log(`\n  Σ unrealized = ${totalUnreal >= 0 ? '+' : ''}${totalUnreal.toFixed(2)} $ sur $${totalNotional.toFixed(0)} déployé (${(totalUnreal / totalNotional * 100).toFixed(2)}%)`);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/postmortem-decision-log.ts
+++ b/scripts/postmortem-decision-log.ts
@@ -1,0 +1,57 @@
+/**
+ * Que s'est-il passé entre 08:00 et 14:30 UTC dans lisa_decision_log ?
+ * Et comment BTC s'est-il comporté ?
+ */
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_]+)=(.+)$/);
+  if (m) acc[m[1]] = m[2];
+  return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  // 1. decision_log kind counts in window
+  const { data: logs } = await sb
+    .from('lisa_decision_log')
+    .select('kind, created_at')
+    .gte('created_at', '2026-05-24T08:00:00Z')
+    .lte('created_at', '2026-05-24T14:30:00Z')
+    .limit(2000);
+  const counts = new Map<string, number>();
+  for (const r of (logs ?? [])) counts.set(r.kind, (counts.get(r.kind) ?? 0) + 1);
+  console.log(`=== decision_log kind counts 08:00-14:30 UTC (${logs?.length ?? 0} total) ===\n`);
+  for (const [k, v] of Array.from(counts.entries()).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(v).padStart(4)}  ${k}`);
+  }
+
+  // 2. BTC price evolution — pull every BTCUSDT row from top_gainers_log
+  console.log(`\n=== BTC price/change history 08:00-14:30 UTC (via top_gainers_log) ===`);
+  const { data: btc } = await sb
+    .from('top_gainers_log')
+    .select('symbol, close_price, change_pct, captured_at, sub_persistence_score, decision')
+    .gte('captured_at', '2026-05-24T08:00:00+00:00')
+    .lte('captured_at', '2026-05-24T14:30:00+00:00')
+    .eq('symbol', 'BTCUSDT')
+    .order('captured_at', { ascending: true });
+  console.log(`  ${btc?.length ?? 0} BTC snapshots\n`);
+  let prevPrice: number | null = null;
+  for (const r of (btc ?? [])) {
+    const at = r.captured_at.slice(11, 19);
+    const price = Number(r.close_price);
+    const dt = prevPrice ? `(${((price - prevPrice) / prevPrice * 100).toFixed(2)}%)` : '       ';
+    prevPrice = price;
+    console.log(`  ${at}  $${price.toFixed(2).padStart(10)}  ch1m=${Number(r.change_pct ?? 0).toFixed(2).padStart(6)}% ${dt}  decision=${r.decision ?? '-'}`);
+  }
+
+  // 3. Cross-check : à quelle heure BTC a commencé sa baisse durable ?
+  if (btc && btc.length > 5) {
+    const max = btc.reduce((m, r) => Number(r.close_price) > Number(m.close_price) ? r : m, btc[0]);
+    console.log(`\n  📈 Max BTC dans la fenêtre : $${Number(max.close_price).toFixed(2)} @ ${max.captured_at.slice(11,19)}`);
+    const last = btc[btc.length - 1];
+    console.log(`  📉 Dernier BTC : $${Number(last.close_price).toFixed(2)} @ ${last.captured_at.slice(11,19)}`);
+    console.log(`  Variation max → fin : ${((Number(last.close_price) - Number(max.close_price)) / Number(max.close_price) * 100).toFixed(2)}%`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/postmortem-signals.ts
+++ b/scripts/postmortem-signals.ts
@@ -1,0 +1,69 @@
+/**
+ * Post-mortem : entre 08:25 (open SOL/ETH/XRP) et 14:17 UTC (cascade SL),
+ * quels signaux DÉJÀ EN DB auraient pu prédire la mort du pump ?
+ *
+ * Hypothèses à tester :
+ *  H1 : persistence multi-TF s'est dégradée avant les SL
+ *  H2 : pathEff a chuté avant les SL
+ *  H3 : BTC a commencé à baisser avant que SOL/ETH ne SL (effet cascade)
+ *  H4 : volume / change_pct_1m a perdu son momentum sur les rescans
+ *  H5 : EVENT-NARRATIVE — y a-t-il eu une news / event économique pendant la fenêtre ?
+ */
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_]+)=(.+)$/);
+  if (m) acc[m[1]] = m[2];
+  return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+
+const WINDOW_START = '2026-05-24T08:00:00Z';
+const WINDOW_END   = '2026-05-24T14:30:00Z';
+const SYMS = ['SOLUSDT', 'ETHUSDT', 'XRPUSDT', 'BNBUSDT', 'BTCUSDT'];
+
+async function main() {
+  // H1 + H2 + H4 — Toutes les apparitions de ces symboles dans gainers_user_shadow_signals
+  // entre 08:00 et 14:30 UTC. accept OU reject — on veut voir l'évolution.
+  const { data: signals } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('symbol, decision, path_eff, persistence_score, persistence_count, change_pct_1m, created_at')
+    .gte('created_at', WINDOW_START)
+    .lte('created_at', WINDOW_END)
+    .in('symbol', SYMS)
+    .order('created_at', { ascending: true });
+
+  console.log(`\n=== H1+H2+H4 : Évolution des signals (${signals?.length ?? 0} apparitions) ===\n`);
+  for (const sym of SYMS) {
+    const rows = (signals ?? []).filter(r => r.symbol === sym);
+    if (rows.length === 0) continue;
+    console.log(`  --- ${sym} (${rows.length} apparitions) ---`);
+    for (const r of rows) {
+      const at = r.created_at.slice(11, 19);
+      const eff = r.path_eff != null ? Number(r.path_eff).toFixed(3) : ' n/a ';
+      const persist = r.persistence_count ?? '-';
+      const score = r.persistence_score != null ? Number(r.persistence_score).toFixed(2) : 'n/a';
+      const ch = r.change_pct_1m != null ? `${Number(r.change_pct_1m).toFixed(2)}%` : 'n/a';
+      console.log(`    ${at}  ${String(r.decision).padEnd(22)}  pathEff=${eff}  persist=${String(persist).padEnd(4)} (${score})  ch1m=${ch}`);
+    }
+    console.log('');
+  }
+
+  // H5 — Y a-t-il des news / event économiques dans la fenêtre ?
+  console.log(`\n=== H5 : News / events économiques durant la fenêtre ===\n`);
+  const tables = ['eodhd_news_persisted', 'eodhd_economic_events', 'gemini_daily_catalyst_brief', 'eodhd_news', 'economic_events'];
+  for (const tbl of tables) {
+    const { data, error } = await sb.from(tbl).select('*').gte('published_at', WINDOW_START).lte('published_at', WINDOW_END).limit(20);
+    if (error) {
+      // Try alternate timestamp column
+      const { data: d2, error: e2 } = await sb.from(tbl).select('*').gte('created_at', WINDOW_START).lte('created_at', WINDOW_END).limit(20);
+      if (e2) { console.log(`  ${tbl} : ${error.message}`); continue; }
+      console.log(`  ${tbl} : ${d2?.length ?? 0} rows (via created_at)`);
+      for (const r of (d2 ?? []).slice(0, 5)) console.log(`    `, JSON.stringify(r).slice(0, 300));
+    } else {
+      console.log(`  ${tbl} : ${data?.length ?? 0} rows`);
+      for (const r of (data ?? []).slice(0, 5)) console.log(`    `, JSON.stringify(r).slice(0, 300));
+    }
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/supabase/migrations/0157_lisa_positions_thesis_health_columns.sql
+++ b/supabase/migrations/0157_lisa_positions_thesis_health_columns.sql
@@ -1,0 +1,22 @@
+-- 0157_lisa_positions_thesis_health_columns.sql
+-- P1 / OpenPositionRiskMonitor — capture des features au moment de l'entrée
+-- pour calculer ultérieurement le thesis_health_score (cron 5 min, cf. service
+-- OpenPositionRiskMonitorService).
+--
+-- Pas d'index : on lit ces colonnes pour chaque position ouverte une par une
+-- via le PK id, pas de filtre par valeur.
+
+ALTER TABLE public.lisa_positions
+  ADD COLUMN IF NOT EXISTS path_eff_at_entry           NUMERIC(5,4),
+  ADD COLUMN IF NOT EXISTS persistence_score_at_entry  NUMERIC(5,4),
+  ADD COLUMN IF NOT EXISTS persistence_count_at_entry  TEXT,
+  ADD COLUMN IF NOT EXISTS market_ch1m_at_entry        NUMERIC(8,4);
+
+COMMENT ON COLUMN public.lisa_positions.path_eff_at_entry IS
+  'overallEfficiency multi-TF au moment de l''ouverture (P1 risk monitor). NULL = position pre-feature.';
+COMMENT ON COLUMN public.lisa_positions.persistence_score_at_entry IS
+  'persistence_score [0,1] au moment de l''ouverture (P1 risk monitor).';
+COMMENT ON COLUMN public.lisa_positions.persistence_count_at_entry IS
+  'persistence_count format "X/6" (text) au moment de l''ouverture (P1 risk monitor).';
+COMMENT ON COLUMN public.lisa_positions.market_ch1m_at_entry IS
+  'ch1m du proxy de marché de la classe (BTCUSDT pour crypto, SPY pour US, etc.) au moment de l''ouverture, pour Sub-A momentum.';


### PR DESCRIPTION
## Contexte — la claque du 24/05

Cascade SL crypto à 14:17 UTC (-$49.68 sur 4 positions) déclenchée par effacement progressif du momentum BTC entre 13:00 et 14:00. Les données DÉJÀ EN DB (`top_gainers_log`, ~9 190 rows/jour) montraient cette dégradation 22 min AVANT le 1er SL — mais aucun mécanisme ne consommait ce signal sur les positions ouvertes.

Post-mortem complet : commit `d68f3db` + scripts `postmortem-*.ts`.

## Architecture

`OpenPositionRiskMonitorService` — cron 5 min, lit `lisa_positions WHERE status='open'`, calcule un **`thesis_health_score`** signé `[-1, +1]` à partir de 3 sub-scores indépendants :

| Sub | Source | Formule |
|---|---|---|
| **A** market momentum | BTCUSDT (crypto) via `top_gainers_log` lookup | `(ch1m_now - ch1m_entry) / |ch1m_entry|` |
| **B** path/persistence | `MultiTimeframePersistenceService.analyze()` temps réel | mean signed des Δ pathEff + persistence |
| **C** LLM Gemini | _stub null pour l'instant — P5 future_ | verdict ∈ `{-1, -0.5, 0, +0.5, +1}` |

Composite : `0.40·A + 0.35·B + 0.25·C`, poids redistribués si un sub null.

### Verdicts ↔ actions

| Composite | Verdict | Action |
|---|---|---|
| `< -0.60` | **CLOSE_NOW** | `paperBroker.closePosition()` |
| `< -0.30` | **TIGHTEN_SL** | `SL → entry_price` (breakeven) |
| `[-0.30, +0.30]` | **HOLD** | no-op |
| `> +0.30` | **RAISE_TP** | `TP_new = entry + 1.5 × (TP_initial - entry)` |
| `> +0.60` | **MOMENTUM_RIDE** | `TP_new = entry + 2.0 × (TP_initial - entry)` |

### Validation cas réel (24/05 cascade)

Le helper appliqué aux valeurs réelles observées à 13:55 UTC retourne **`TIGHTEN_SL`** (composite ≈ -0.52) → SL placé à breakeven → cascade évitée. Économie estimée **~$25.83 (52 %)** sur cette journée.

## Files

| Phase | Effort | Files |
|---|---|---|
| P1 | 1 h | `supabase/migrations/0157_lisa_positions_thesis_health_columns.sql` + wiring scanner pour populer `path_eff_at_entry` / `persistence_score_at_entry` / `persistence_count_at_entry` |
| P2 | 2 h | `thesis-health-score.helper.ts` (pure, 27 tests) |
| P3+P4 | 3.5 h | `open-position-risk-monitor.service.ts` (cron + executors) + wiring module |

## Gating ENV (default OFF — back-compat 100 %)

```
RISK_MONITOR_ENABLED=true                  master kill-switch
RISK_MONITOR_ENABLED_CRYPTO=true            par classe
RISK_MONITOR_ENABLED_US=true
RISK_MONITOR_ENABLED_EU=true
RISK_MONITOR_ENABLED_ASIA=true
RISK_MONITOR_MAX_ACTIONS_PER_CYCLE=1        anti-cascade (default 1)
```

## Safeguards

- Max **1 action live par cycle de 5 min** (anti-cascade)
- Skip si live price `fallback*` (anti corruption SEE.LSE-style)
- `TIGHTEN_SL` no-op si SL déjà ≥ breakeven (préserve profit lock)
- `RAISE_TP` no-op si live déjà > TP initial (laisse trailing standard agir)
- Skip positions sans `path_eff_at_entry` (positions pré-P1)
- Best-effort partout (jamais d'exception qui plante le cron)
- Audit `lisa_decision_log` append-only

## Limites connues à monitorer J+1, J+7

- Sub-A actuellement = **crypto only** (BTC proxy). US/EU/Asia → sub-A null donc composite repose sur sub-B seul. Extension P5 future ajoutera SPY/CAC/N225.
- Sub-C désactivé (Gemini). Composite = A+B uniquement. P5 future activable via `GEMINI_RISK_MANAGER_ENABLED`.
- Pas de mode shadow (demandé user : "all-in tout de suite"). Mitigation = max 1 action/cycle + kill-switch ENV instantané + per-class enable.

## Test plan

- [x] 27 tests helper `thesis-health-score` verts (cas réel cascade BTC validé)
- [x] 201 suites / 2 665 tests apps/api verts (aucune régression)
- [x] `tsc --noEmit` clean sur apps/api
- [ ] Apply migration 0157 via `migrations-trigger-0157-risk-monitor` (post-merge)
- [ ] Fly deploy + boot log confirme `[risk-monitor]` silencieux tant que ENV vides
- [ ] Activation progressive : crypto seul d'abord, monitor 24 h, puis étendre

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_