### PR TITLE
feat(risk-monitor P5): Gemini Sub-C — thesis verdict signed via LLM Router

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/gemini-thesis-verdict.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/gemini-thesis-verdict.spec.ts
@@ -1,0 +1,111 @@
+import {
+  buildGeminiVerdictUserPrompt,
+  parseGeminiVerdict,
+} from '../gemini-thesis-verdict.helper';
+
+describe('buildGeminiVerdictUserPrompt', () => {
+  it('inclut toutes les features quand dispos', () => {
+    const p = buildGeminiVerdictUserPrompt({
+      symbol: 'BTCUSDT',
+      assetClass: 'crypto_major',
+      openedAt: '2026-05-24T11:08:00Z',
+      ageMinutes: 187,
+      entryPrice: 77188,
+      livePrice: 76381,
+      unrealPnlPct: -1.05,
+      pathEffAtEntry: 0.614,
+      pathEffNow: 0.18,
+      persistenceAtEntry: 0.83,
+      persistenceNow: 0.33,
+      marketCh1mAtEntry: 3.40,
+      marketCh1mNow: 1.46,
+      tpDistancePct: 4.0,
+      slDistancePct: -0.5,
+    });
+    expect(p).toContain('BTCUSDT');
+    expect(p).toContain('crypto_major');
+    expect(p).toContain('Entry: $77188');
+    expect(p).toContain('PathEff: 0.614 → 0.180');
+    expect(p).toContain('Persistence: 0.83 → 0.33');
+    expect(p).toContain('3.40% → 1.46%');
+    expect(p).toContain('TP: 4.00%');
+    expect(p).toContain('SL: -0.50%');
+  });
+
+  it('omet gracefully les features null', () => {
+    const p = buildGeminiVerdictUserPrompt({
+      symbol: 'AAPL',
+      assetClass: 'us_equity_large',
+      openedAt: '2026-05-24T15:00:00Z',
+      ageMinutes: 30,
+      entryPrice: 200,
+      livePrice: 198,
+      unrealPnlPct: -1,
+      pathEffAtEntry: null,
+      pathEffNow: null,
+      persistenceAtEntry: null,
+      persistenceNow: null,
+      marketCh1mAtEntry: null,
+      marketCh1mNow: null,
+      tpDistancePct: null,
+      slDistancePct: null,
+    });
+    expect(p).not.toContain('PathEff');
+    expect(p).not.toContain('Persistence');
+    expect(p).not.toContain('Market proxy');
+    expect(p).toContain('AAPL');
+  });
+});
+
+describe('parseGeminiVerdict', () => {
+  it('parse réponse JSON propre', () => {
+    const r = parseGeminiVerdict('{"score": -0.5, "rationale": "Momentum BTC perdu, tighten recommandé"}');
+    expect(r).not.toBeNull();
+    expect(r!.score).toBe(-0.5);
+    expect(r!.rationale).toBe('Momentum BTC perdu, tighten recommandé');
+  });
+
+  it('clamp score hors range', () => {
+    expect(parseGeminiVerdict('{"score": -2.5, "rationale": "x"}')!.score).toBe(-1);
+    expect(parseGeminiVerdict('{"score": 5, "rationale": "x"}')!.score).toBe(1);
+  });
+
+  it('extrait JSON entouré de markdown / texte', () => {
+    const r = parseGeminiVerdict('```json\n{"score": 0.7, "rationale": "Strong"}\n```\nExplication...');
+    expect(r).not.toBeNull();
+    expect(r!.score).toBe(0.7);
+  });
+
+  it('coupe rationale à 200 chars', () => {
+    const long = 'A'.repeat(300);
+    const r = parseGeminiVerdict(`{"score": 0, "rationale": "${long}"}`);
+    expect(r!.rationale.length).toBe(200);
+  });
+
+  it('null si pas de JSON', () => {
+    expect(parseGeminiVerdict('Hello, here is my answer: bearish')).toBeNull();
+  });
+
+  it('null si score absent', () => {
+    expect(parseGeminiVerdict('{"rationale": "no score"}')).toBeNull();
+  });
+
+  it('null si score NaN', () => {
+    expect(parseGeminiVerdict('{"score": "abc", "rationale": "x"}')).toBeNull();
+  });
+
+  it('null si content vide', () => {
+    expect(parseGeminiVerdict('')).toBeNull();
+    expect(parseGeminiVerdict('   ')).toBeNull();
+  });
+
+  it('null si JSON incomplet', () => {
+    expect(parseGeminiVerdict('{"score": 0.5, "rationale"')).toBeNull();
+  });
+
+  it('rationale optionnel → string vide ok', () => {
+    const r = parseGeminiVerdict('{"score": 0.3}');
+    expect(r).not.toBeNull();
+    expect(r!.rationale).toBe('');
+  });
+});

--- a/apps/api/src/modules/lisa/services/gemini-thesis-verdict.helper.ts
+++ b/apps/api/src/modules/lisa/services/gemini-thesis-verdict.helper.ts
@@ -1,0 +1,113 @@
+/**
+ * Gemini Thesis Verdict — pure helper, no I/O.
+ *
+ * Construit le prompt + parse la réponse pour le Sub-C du thesis_health_score.
+ *
+ * Le LLM doit retourner un score continu signé ∈ [-1, +1] :
+ *   -1.0 : thèse complètement cassée (close_now nécessaire)
+ *   -0.5 : dégradation modérée (tighten recommandé)
+ *    0.0 : neutre (rien à signaler)
+ *   +0.5 : thèse confirmée + force légère (raise_tp envisageable)
+ *   +1.0 : forte conviction de continuation (momentum_ride)
+ *
+ * Format JSON strict imposé pour parsing déterministe.
+ */
+
+export interface GeminiVerdictInput {
+  symbol: string;
+  assetClass: string;
+  openedAt: string; // ISO
+  ageMinutes: number;
+  entryPrice: number;
+  livePrice: number;
+  unrealPnlPct: number;
+  pathEffAtEntry: number | null;
+  pathEffNow: number | null;
+  persistenceAtEntry: number | null;
+  persistenceNow: number | null;
+  marketCh1mAtEntry: number | null;
+  marketCh1mNow: number | null;
+  tpDistancePct: number | null;
+  slDistancePct: number | null;
+}
+
+export interface GeminiVerdictParsed {
+  score: number;                // ∈ [-1, +1] clampé
+  rationale: string;            // 1 ligne, ≤ 200 chars
+  raw: string;                  // raw text pour debug
+}
+
+export const GEMINI_VERDICT_SYSTEM_PROMPT = `Tu es un risk manager quantitatif pour un scanner momentum crypto/equity.
+On te donne le contexte d'une position OUVERTE et tu dois évaluer si la thèse de momentum à l'entrée tient toujours.
+
+Réponds STRICTEMENT en JSON sur une seule ligne, sans markdown :
+{"score": <float dans [-1, +1]>, "rationale": "<1 ligne, max 180 chars>"}
+
+Échelle :
+ -1.0 = thèse cassée, fermer maintenant (catalyseur disparu, momentum inversé)
+ -0.5 = dégradation modérée (momentum perdu, mais SL pas atteint — tighten suggéré)
+  0.0 = neutre, indéterminé (tenir)
+ +0.5 = thèse confirmée + légère force supplémentaire
+ +1.0 = très forte conviction de continuation, momentum accéléré
+
+Ne propose JAMAIS d'action explicite (le système décide en aval). Juste un score numérique.`;
+
+export function buildGeminiVerdictUserPrompt(input: GeminiVerdictInput): string {
+  const lines: string[] = [];
+  lines.push(`Symbol: ${input.symbol}`);
+  lines.push(`Asset class: ${input.assetClass}`);
+  lines.push(`Opened: ${input.openedAt} (age ${input.ageMinutes} min)`);
+  lines.push(`Entry: $${input.entryPrice.toFixed(4)} / Live: $${input.livePrice.toFixed(4)} (unrealized ${input.unrealPnlPct.toFixed(2)}%)`);
+  if (input.pathEffAtEntry != null && input.pathEffNow != null) {
+    lines.push(`PathEff: ${input.pathEffAtEntry.toFixed(3)} → ${input.pathEffNow.toFixed(3)}`);
+  }
+  if (input.persistenceAtEntry != null && input.persistenceNow != null) {
+    lines.push(`Persistence: ${input.persistenceAtEntry.toFixed(2)} → ${input.persistenceNow.toFixed(2)}`);
+  }
+  if (input.marketCh1mAtEntry != null && input.marketCh1mNow != null) {
+    lines.push(`Market proxy ch1m: ${input.marketCh1mAtEntry.toFixed(2)}% → ${input.marketCh1mNow.toFixed(2)}%`);
+  }
+  if (input.tpDistancePct != null) lines.push(`Distance to TP: ${input.tpDistancePct.toFixed(2)}%`);
+  if (input.slDistancePct != null) lines.push(`Distance to SL: ${input.slDistancePct.toFixed(2)}%`);
+  lines.push('');
+  lines.push('La thèse de momentum à l\'entrée tient-elle toujours ? Réponds en JSON {"score":..., "rationale":"..."}.');
+  return lines.join('\n');
+}
+
+/**
+ * Parse la réponse Gemini. Robust : extrait le premier objet JSON valide
+ * trouvé, clamp le score à [-1, +1], coupe rationale à 200 chars.
+ * Retourne null si parsing impossible (caller traite comme sub-C = null).
+ */
+export function parseGeminiVerdict(content: string): GeminiVerdictParsed | null {
+  if (!content || typeof content !== 'string') return null;
+  // Extract JSON: cherche le 1er {...} balancé
+  const trimmed = content.trim();
+  let start = trimmed.indexOf('{');
+  if (start < 0) return null;
+  let depth = 0;
+  let end = -1;
+  for (let i = start; i < trimmed.length; i++) {
+    if (trimmed[i] === '{') depth++;
+    else if (trimmed[i] === '}') {
+      depth--;
+      if (depth === 0) { end = i; break; }
+    }
+  }
+  if (end < 0) return null;
+  const json = trimmed.slice(start, end + 1);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+  const scoreRaw = obj.score;
+  if (typeof scoreRaw !== 'number' || !Number.isFinite(scoreRaw)) return null;
+  const score = Math.max(-1, Math.min(1, scoreRaw));
+  const rationaleRaw = typeof obj.rationale === 'string' ? obj.rationale : '';
+  const rationale = rationaleRaw.slice(0, 200);
+  return { score, rationale, raw: content.slice(0, 500) };
+}

--- a/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
+++ b/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
@@ -31,11 +31,17 @@ import { SupabaseService } from '../../supabase/supabase.service';
 import { MultiTimeframePersistenceService } from './multi-tf-persistence.service';
 import { LisaService } from './lisa.service';
 import { DecisionLogService } from './decision-log.service';
+import { ScannerLlmRouterService } from './scanner-llm-router.service';
 import {
   evaluateThesisHealth,
   type RiskVerdict,
   type ThesisHealthResult,
 } from './thesis-health-score.helper';
+import {
+  buildGeminiVerdictUserPrompt,
+  parseGeminiVerdict,
+  GEMINI_VERDICT_SYSTEM_PROMPT,
+} from './gemini-thesis-verdict.helper';
 
 interface OpenPositionRow {
   id: string;
@@ -66,6 +72,7 @@ export class OpenPositionRiskMonitorService {
   private enabled = false;
   private perClass: PerClassEnabled = { crypto: false, us: false, eu: false, asia: false };
   private maxActionsPerCycle = 1;
+  private geminiEnabled = false;
 
   constructor(
     private readonly config: ConfigService,
@@ -73,6 +80,7 @@ export class OpenPositionRiskMonitorService {
     private readonly lisa: LisaService,
     private readonly mtfPersistence: MultiTimeframePersistenceService,
     private readonly decisionLog: DecisionLogService,
+    private readonly llmRouter: ScannerLlmRouterService,
   ) {}
 
   onModuleInit(): void {
@@ -85,9 +93,12 @@ export class OpenPositionRiskMonitorService {
     };
     const maxRaw = Number.parseInt(this.config.get<string>('RISK_MONITOR_MAX_ACTIONS_PER_CYCLE') ?? '1', 10);
     this.maxActionsPerCycle = Number.isFinite(maxRaw) && maxRaw >= 0 && maxRaw <= 20 ? maxRaw : 1;
+    // P5 — Gemini Sub-C : nécessite RISK_MONITOR_GEMINI_ENABLED=true ET router activé
+    this.geminiEnabled = (this.config.get<string>('RISK_MONITOR_GEMINI_ENABLED') ?? 'false').toLowerCase() === 'true'
+      && this.llmRouter.isEnabled();
     if (this.enabled) {
       const cls = Object.entries(this.perClass).filter(([, v]) => v).map(([k]) => k).join(',') || 'none';
-      this.logger.log(`[risk-monitor] ENABLED — classes=${cls} maxActions/cycle=${this.maxActionsPerCycle}`);
+      this.logger.log(`[risk-monitor] ENABLED — classes=${cls} maxActions/cycle=${this.maxActionsPerCycle} gemini=${this.geminiEnabled}`);
     }
   }
 
@@ -177,6 +188,17 @@ export class OpenPositionRiskMonitorService {
       this.logger.debug(`[risk-monitor] mtfPersistence ${pos.symbol}: ${String(e).slice(0, 150)}`);
     }
 
+    // Sub-C : Gemini Flash-Lite (P5). Désactivé par défaut, opt-in via env.
+    // Coût ~$0.0002/call, donc 12 calls/h × N positions ≈ marginal.
+    const llmScore = this.geminiEnabled
+      ? await this.computeGeminiScore(pos, {
+          marketAtEntry,
+          marketNow,
+          pathEffNow,
+          persistenceNow,
+        })
+      : null;
+
     return evaluateThesisHealth({
       marketCh1mAtEntry: marketAtEntry,
       marketCh1mNow: marketNow,
@@ -184,8 +206,70 @@ export class OpenPositionRiskMonitorService {
       pathEffNow,
       persistenceAtEntry: pos.persistence_score_at_entry,
       persistenceNow,
-      llmScore: null, // P5 ajoutera Gemini
+      llmScore,
     });
+  }
+
+  /**
+   * P5 — Sub-C Gemini. Construit le prompt avec le contexte enrichi, appelle
+   * le router (timeout 4s, 1 retry), parse le JSON verdict. Best-effort :
+   * tout échec → return null → poids re-normalisé sur A+B.
+   */
+  private async computeGeminiScore(
+    pos: OpenPositionRow,
+    ctx: { marketAtEntry: number | null; marketNow: number | null; pathEffNow: number | null; persistenceNow: number | null },
+  ): Promise<number | null> {
+    try {
+      const livePrice = ctx.marketNow == null ? Number(pos.entry_price) : null;
+      const live = await this.lisa.getLivePrice(pos.symbol);
+      const livePx = Number(live?.price ?? 0);
+      if (livePx <= 0 || (typeof live?.source === 'string' && live.source.startsWith('fallback'))) {
+        return null;
+      }
+      const entry = Number(pos.entry_price);
+      const unrealPct = entry > 0 ? ((livePx - entry) / entry) * 100 : 0;
+      const ageMin = Math.round((Date.now() - new Date(pos.entry_timestamp).getTime()) / 60_000);
+      const tpDistPct = pos.take_profit_price != null
+        ? ((Number(pos.take_profit_price) - livePx) / livePx) * 100
+        : null;
+      const slDistPct = pos.stop_loss_price != null
+        ? ((Number(pos.stop_loss_price) - livePx) / livePx) * 100
+        : null;
+      const userPrompt = buildGeminiVerdictUserPrompt({
+        symbol: pos.symbol,
+        assetClass: pos.asset_class,
+        openedAt: pos.entry_timestamp,
+        ageMinutes: ageMin,
+        entryPrice: entry,
+        livePrice: livePx,
+        unrealPnlPct: unrealPct,
+        pathEffAtEntry: pos.path_eff_at_entry,
+        pathEffNow: ctx.pathEffNow,
+        persistenceAtEntry: pos.persistence_score_at_entry,
+        persistenceNow: ctx.persistenceNow,
+        marketCh1mAtEntry: ctx.marketAtEntry,
+        marketCh1mNow: ctx.marketNow,
+        tpDistancePct: tpDistPct,
+        slDistancePct: slDistPct,
+      });
+      const resp = await this.llmRouter.call({
+        system: GEMINI_VERDICT_SYSTEM_PROMPT,
+        user: userPrompt,
+        temperature: 0.2,
+        maxTokens: 120,
+        timeoutMs: 4000,
+      });
+      const parsed = parseGeminiVerdict(resp.content);
+      if (!parsed) {
+        this.logger.debug(`[risk-monitor] Gemini ${pos.symbol} parse failed: ${resp.content.slice(0, 100)}`);
+        return null;
+      }
+      this.logger.debug(`[risk-monitor] Gemini ${pos.symbol} score=${parsed.score.toFixed(2)} (${parsed.rationale})`);
+      return parsed.score;
+    } catch (e) {
+      this.logger.debug(`[risk-monitor] Gemini ${pos.symbol} exception: ${String(e).slice(0, 150)}`);
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
## Contexte

Suite de PR #411 (risk-monitor P1-P4). Branche le Sub-C LLM dans le score composite.

## Changements

- `gemini-thesis-verdict.helper.ts` (new, pure, 12 tests) :
  - `GEMINI_VERDICT_SYSTEM_PROMPT` : échelle -1..+1 explicite, JSON strict 1 ligne
  - `buildGeminiVerdictUserPrompt(input)` : contexte enrichi (entry/live/pathEff Δ/persistence Δ/market Δ/TP-SL distance)
  - `parseGeminiVerdict(content)` : extract JSON robuste (markdown, texte autour), clamp [-1,+1], rationale ≤ 200 chars
- `open-position-risk-monitor.service.ts` : injecte `ScannerLlmRouterService`, ajoute `computeGeminiScore()` appelé depuis `evaluatePosition()`

## Gating

```
RISK_MONITOR_GEMINI_ENABLED=true   # default false
+ ScannerLlmRouterService.isEnabled() === true
```

Si désactivé → `llmScore = null` → helper P2 redistribue poids sur Sub-A + Sub-B (poids 0.40+0.35 → normalisé à 0.533+0.467).

## Safeguards

- Skip si live price `fallback*` (anti corruption)
- Timeout LLM 4 s, 1 retry router-side
- Parse échec → return null (best-effort silencieux)
- Toute exception swallowed → return null

## Coût

Flash-Lite ~$0.0002/call × 12 cron/h × N opens. Pour 5 opens : ~$0.012/h = **~$0.30/jour**. Marginal vs gain attendu.

## Test plan

- [x] 12 tests parser/builder verts
- [x] 202 suites / 2 677 tests apps/api verts
- [x] `tsc --noEmit` clean
- [ ] Activer sur prod après PR #411 mergé : `fly secrets set RISK_MONITOR_GEMINI_ENABLED=true`

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_