### PR TITLE
fix(risk-monitor): couverture étendue à toutes les positions et toutes les classes

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, Logger, NotFoundException, Inject, forwardRef } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger, NotFoundException, Inject, forwardRef, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHmac, randomUUID } from 'node:crypto';
 import Decimal from 'decimal.js';
@@ -43,6 +43,7 @@ import { LisaPerformanceAnalyticsService } from './lisa-performance-analytics.se
 import { EodhdTechnicalService } from './eodhd-technical.service';
 import { EodhdIntradayService } from './eodhd-intraday.service';
 import { IntradayProviderRouter } from './intraday-provider-router.service';
+import { MultiTimeframePersistenceService } from './multi-tf-persistence.service';
 import { BinanceMarketService } from './binance-market.service';
 import { EodhdMacroService } from './eodhd-macro.service';
 import { EodhdScreenerService } from './eodhd-screener.service';
@@ -143,6 +144,10 @@ export class LisaService {
     private readonly redditService: RedditService,
     // PR #353 — Router intraday dual-call EODHD + TD pour summarizePositions.
     private readonly intradayRouter: IntradayProviderRouter,
+    // Risk-monitor extension : capture pathEff/persistence @ entry pour positions
+    // ouvertes via le pipeline LLM (en plus du scanner). @Optional pour ne pas casser
+    // les tests existants qui instancient LisaService avec un sous-ensemble de deps.
+    @Optional() private readonly mtfPersistence?: MultiTimeframePersistenceService,
   ) {
     const anthropicKey = this.config.get<string>('ANTHROPIC_API_KEY');
     if (anthropicKey) {
@@ -2149,6 +2154,14 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
             if (error) this.logger.warn(`Failed to persist autonomy_rules for ${pos.id}: ${error.message}`);
           });
 
+        // Risk-monitor extension : capture pathEff/persistence/market_ch1m @ entry
+        // pour positions ouvertes via le pipeline LLM (en plus du scanner gainers).
+        // Best-effort : si mtfPersistence indisponible ou échec, le risk-monitor sera
+        // dégradé pour cette position (Sub-B/A null → Sub-C carry).
+        if (this.mtfPersistence) {
+          void this.captureRiskMonitorFeaturesAtEntry(pos.id, String(expression.symbol), Number(quote.price));
+        }
+
         await this.logDecision(portfolioId, 'position_opened', {
           summary: `Opened ${expression.symbol}: ${alloc.pctCapital}% (${alloc.amountUsd} USD) at ${quote.price} stop=${stopLossPrice}`,
           rationale: String(thesis.summary),
@@ -2687,6 +2700,66 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
   }
 
   /** Public price fetch — used by MechanicalTradingService (no Claude cost). */
+  /**
+   * Risk-monitor extension : capture pathEff + persistence + market_ch1m @ open
+   * pour une position venant d'être créée. Best-effort silencieux.
+   * - pathEff/persistence via mtfPersistence.analyze
+   * - market_ch1m via lookup du symbole dans top_gainers_log (snapshot le plus proche
+   *   de l'entry, capture toutes classes uniformément)
+   */
+  private async captureRiskMonitorFeaturesAtEntry(
+    positionId: string,
+    symbol: string,
+    livePrice: number,
+  ): Promise<void> {
+    try {
+      const update: Record<string, unknown> = {};
+      // mtfPersistence — récupère pathEff + persistence multi-TF temps réel
+      if (this.mtfPersistence && livePrice > 0) {
+        try {
+          const analyzed = await this.mtfPersistence.analyze({ symbol, currentPrice: livePrice });
+          if (analyzed) {
+            if (analyzed.pathQuality?.overallEfficiency != null) {
+              update.path_eff_at_entry = analyzed.pathQuality.overallEfficiency;
+            }
+            if (analyzed.persistenceScore != null) {
+              update.persistence_score_at_entry = analyzed.persistenceScore;
+            }
+            if (analyzed.persistenceCount) {
+              update.persistence_count_at_entry = analyzed.persistenceCount;
+            }
+          }
+        } catch (e) {
+          this.logger.debug(`[risk-monitor-capture] mtfPersistence ${symbol}: ${String(e).slice(0, 120)}`);
+        }
+      }
+      // market_ch1m : lookup top_gainers_log au plus proche de maintenant (proxy entry)
+      try {
+        const { data } = await this.supabase.getClient()
+          .from('top_gainers_log')
+          .select('change_pct')
+          .eq('symbol', symbol)
+          .order('captured_at', { ascending: false })
+          .limit(1);
+        if (data?.[0]?.change_pct != null) {
+          update.market_ch1m_at_entry = Number(data[0].change_pct);
+        }
+      } catch (e) {
+        this.logger.debug(`[risk-monitor-capture] top_gainers_log ${symbol}: ${String(e).slice(0, 120)}`);
+      }
+      if (Object.keys(update).length === 0) return;
+      const { error } = await this.supabase.getClient()
+        .from('lisa_positions')
+        .update(update)
+        .eq('id', positionId);
+      if (error) {
+        this.logger.debug(`[risk-monitor-capture] update ${positionId}: ${error.message}`);
+      }
+    } catch (e) {
+      this.logger.debug(`[risk-monitor-capture] exception ${symbol}: ${String(e).slice(0, 150)}`);
+    }
+  }
+
   async getLivePrice(symbol: string): Promise<{ symbol: string; price: string; asOf: string; source: string }> {
     return this.fetchLivePrice(symbol);
   }

--- a/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
+++ b/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
@@ -273,32 +273,38 @@ export class OpenPositionRiskMonitorService {
   }
 
   /**
-   * Sub-A — fetch market proxy ch1m at_entry vs now.
-   * Crypto : BTCUSDT depuis top_gainers_log (très fréquent, ~6 captures/min).
-   * US/EU/Asia : null pour l'instant (extension P5 future).
+   * Sub-A — momentum delta du SYMBOLE LUI-MÊME (toutes classes : crypto, US, EU, Asia).
+   *
+   * Approche directe : compare le ch1m du symbole à l'open vs maintenant via top_gainers_log
+   * (le scanner capture ~6 snapshots/min pour TOUS les symboles qui apparaissent dans
+   * les classements top movers, donc couvre les positions actives quel que soit l'asset class).
+   *
+   * Avantages vs proxy de classe :
+   *   - Pas d'hypothèse de corrélation (AAPL ne suit pas toujours SPY 1:1)
+   *   - Unique source pour toutes les classes
+   *   - Aucune dépendance externe (data déjà capturée par scanner)
+   *
+   * Si le symbole n'a aucune capture dans top_gainers_log (rare : LLM thèse sur small-cap
+   * non-scannée), Sub-A retourne null et le composite repose sur B+C.
    */
   private async computeMarketMomentum(pos: OpenPositionRow): Promise<{ atEntry: number | null; now: number | null }> {
-    if (!pos.asset_class.startsWith('crypto')) {
-      return { atEntry: pos.market_ch1m_at_entry ?? null, now: null };
-    }
-    const proxy = 'BTCUSDT';
-    // ch1m @ entry : prends la valeur stockée si dispo, sinon lookup au plus proche
+    // ch1m @ entry : valeur stockée si dispo (capturée à l'open), sinon lookup top_gainers_log
     let atEntry = pos.market_ch1m_at_entry;
     if (atEntry == null) {
       const { data } = await this.supabase.getClient()
         .from('top_gainers_log')
         .select('change_pct, captured_at')
-        .eq('symbol', proxy)
+        .eq('symbol', pos.symbol)
         .lte('captured_at', pos.entry_timestamp)
         .order('captured_at', { ascending: false })
         .limit(1);
       atEntry = data?.[0]?.change_pct != null ? Number(data[0].change_pct) : null;
     }
-    // ch1m now : dernier snapshot disponible
+    // ch1m now : dernier snapshot du symbole
     const { data: latest } = await this.supabase.getClient()
       .from('top_gainers_log')
       .select('change_pct, captured_at')
-      .eq('symbol', proxy)
+      .eq('symbol', pos.symbol)
       .order('captured_at', { ascending: false })
       .limit(1);
     const now = latest?.[0]?.change_pct != null ? Number(latest[0].change_pct) : null;

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -3541,18 +3541,28 @@ export class TopGainersScannerService implements OnModuleInit {
         `[top-gainers] ${cand.symbol} opened DIRECT (entry=$${livePriceNum.toFixed(4)} qty=${openedPos.quantity} sl=${stopPrice} tp=${tpPrice} score=${cand.score})`,
       );
 
-      // P1 OpenPositionRiskMonitor — persiste pathEff / persistence @ entry sur
-      // lisa_positions pour permettre au cron risk monitor de calculer Δ depuis l'entrée.
-      // Best-effort : si update échoue, la position s'ouvre quand même mais le
-      // risk monitor sera dégradé pour cette position (sub_B fallback neutre).
-      if (persistence?.pathQuality?.overallEfficiency != null || persistence?.persistenceScore != null) {
+      // P1 OpenPositionRiskMonitor — persiste pathEff / persistence / market_ch1m
+      // @ entry sur lisa_positions pour permettre au cron risk monitor de calculer
+      // Δ depuis l'entrée. Best-effort : si update échoue, la position s'ouvre
+      // quand même mais le risk monitor sera dégradé pour cette position.
+      const riskFeatures: Record<string, unknown> = {};
+      if (persistence?.pathQuality?.overallEfficiency != null) {
+        riskFeatures.path_eff_at_entry = persistence.pathQuality.overallEfficiency;
+      }
+      if (persistence?.persistenceScore != null) {
+        riskFeatures.persistence_score_at_entry = persistence.persistenceScore;
+      }
+      if (persistence?.persistenceCount) {
+        riskFeatures.persistence_count_at_entry = persistence.persistenceCount;
+      }
+      // Sub-A : ch1m du symbole lui-même (= candidate.changePct au moment de l'open)
+      if (typeof cand.changePct === 'number' && Number.isFinite(cand.changePct)) {
+        riskFeatures.market_ch1m_at_entry = cand.changePct;
+      }
+      if (Object.keys(riskFeatures).length > 0) {
         await this.supabase.getClient()
           .from('lisa_positions')
-          .update({
-            path_eff_at_entry: persistence?.pathQuality?.overallEfficiency ?? null,
-            persistence_score_at_entry: persistence?.persistenceScore ?? null,
-            persistence_count_at_entry: persistence?.persistenceCount ?? null,
-          })
+          .update(riskFeatures)
           .eq('id', openedPos.id)
           .then(({ error }) => {
             if (error) this.logger.debug(`[top-gainers] risk-monitor features update ${openedPos.id} failed: ${error.message}`);


### PR DESCRIPTION
## Contexte

Réponse à la frustration utilisateur — la version mergée des PR #411/#412 n'avait pas une couverture complète :
- Sub-A était hardcodé sur **BTC proxy crypto only** (US/EU/Asia → Sub-A null)
- Capture des features @ entry uniquement dans **le scanner gainers**, pas dans le pipeline LLM Lisa → les positions narratives (thèses LLM) n'avaient ni Sub-A ni Sub-B

## Correctifs

### 1. Sub-A universal (per-symbol, pas proxy de classe)

`computeMarketMomentum()` utilise désormais le ch1m du **symbole lui-même** via `top_gainers_log` (le scanner capture ~6 snapshots/min pour tous les symboles top movers). Couvre crypto + US + EU + Asia uniformément.

Avantages vs proxy de classe :
- Pas d'hypothèse de corrélation (AAPL ≠ SPY 1:1 en intraday)
- Source unique pour toutes les classes
- Aucune dépendance externe (data déjà capturée)

### 2. Capture features dans le pipeline LLM Lisa

Nouvelle méthode `captureRiskMonitorFeaturesAtEntry()` dans `lisa.service.ts`, appelée best-effort après `paperBroker.openPosition()`. Inject `@Optional()` `MultiTimeframePersistenceService` (back-compat tests).

### 3. Scanner populate aussi `market_ch1m_at_entry`

`market_ch1m_at_entry = candidate.changePct` — déjà connu au moment de l'open, gratuit.

## Couverture finale

| Origine | Asset class | Sub-A | Sub-B | Sub-C |
|---|---|---|---|---|
| Scanner gainers | crypto / us / eu / asia | ✅ | ✅ | ✅ |
| Lisa LLM pipeline | crypto / us / eu / asia | ✅ | ✅ | ✅ |
| Symbole jamais scanné (rare) | toute classe | null → fallback B+C | ✅ | ✅ |

## Test plan

- [x] 202 suites / 2 677 tests verts (apps/api)
- [x] `tsc --noEmit` clean
- [ ] Activer en prod (secrets déjà set après PR #412)
- [ ] Vérifier dans logs Fly : `[risk-monitor]` actions sur positions Lisa LLM ET scanner

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_