### PR TITLE
fix(risk-monitor): kind audit dédié + variable morte (2 bugs vérification)

### DIFF
--- a/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
+++ b/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
@@ -220,7 +220,6 @@ export class OpenPositionRiskMonitorService {
     ctx: { marketAtEntry: number | null; marketNow: number | null; pathEffNow: number | null; persistenceNow: number | null },
   ): Promise<number | null> {
     try {
-      const livePrice = ctx.marketNow == null ? Number(pos.entry_price) : null;
       const live = await this.lisa.getLivePrice(pos.symbol);
       const livePx = Number(live?.price ?? 0);
       if (livePx <= 0 || (typeof live?.source === 'string' && live.source.startsWith('fallback'))) {
@@ -421,7 +420,7 @@ export class OpenPositionRiskMonitorService {
   ): Promise<void> {
     await this.decisionLog.append({
       portfolioId: pos.portfolio_id,
-      kind: 'position_opened', // P3 fallback : kind validé par CHECK constraint, on encode l'info dans summary
+      kind: 'risk_monitor_action', // ajouté par migration 0158
       summary: `[RISK_MONITOR] ${verdict} ${pos.symbol} composite=${composite.toFixed(3)}`,
       rationale: `OpenPositionRiskMonitorService verdict mécanique sur thesis_health_score signé.`,
       payload: {

--- a/supabase/migrations/0158_lisa_decision_log_kind_risk_monitor.sql
+++ b/supabase/migrations/0158_lisa_decision_log_kind_risk_monitor.sql
@@ -1,0 +1,49 @@
+-- 0158_lisa_decision_log_kind_risk_monitor.sql
+-- Bug #2 fix : OpenPositionRiskMonitorService.auditAction utilisait
+-- 'position_opened' par défaut (kind autorisé) faute de kind dédié, ce qui
+-- polluait les analytics "dernières positions ouvertes".
+--
+-- Ajoute 'risk_monitor_action' à la liste autorisée. Le service ré-utilise
+-- ce kind pour tout audit (CLOSE_NOW, TIGHTEN_SL, RAISE_TP, MOMENTUM_RIDE).
+-- Le verdict détaillé est encodé dans payload.verdict.
+--
+-- Idempotent : DROP IF EXISTS + recréation avec liste complète.
+
+ALTER TABLE public.lisa_decision_log
+  DROP CONSTRAINT IF EXISTS lisa_decision_log_kind_check;
+
+ALTER TABLE public.lisa_decision_log
+  ADD CONSTRAINT lisa_decision_log_kind_check
+  CHECK (kind IN (
+    -- Original 0043
+    'proposal_generated', 'proposal_approved', 'proposal_rejected',
+    'position_opened', 'position_closed', 'position_resized',
+    'thesis_invalidated', 'risk_limit_breached', 'kill_switch_triggered',
+    'autopilot_cycle_started', 'autopilot_cycle_completed',
+    'market_regime_changed', 'analog_matched', 'user_override',
+    -- Autopilot extensions
+    'autopilot_cycle_completed_error', 'proposal_cooldown_active',
+    'autopilot_paused', 'autopilot_resumed', 'autopilot_disabled',
+    'autopilot_auto_approve_expired',
+    -- Mechanical agent
+    'mechanical_open', 'mechanical_close_stop', 'mechanical_close_target',
+    'mechanical_close_invalidated', 'mechanical_skip', 'mechanical_override_applied',
+    -- Hedge
+    'hedge_recommendation',
+    -- P5-EXEC visibility
+    'position_skipped_duplicate_symbol', 'position_skipped_insufficient_cash',
+    'position_skipped_fallback_price', 'proposal_capped_by_max_positions',
+    -- P19β shadow
+    'gainer_shadow_466', 'gainer_shadow_566',
+    -- 0118 observabilité
+    'position_open_failed',
+    -- 0119 adaptive selectivity
+    'adaptive_status_changed',
+    'adaptive_adjustment_applied',
+    'adaptive_restore_applied',
+    'adaptive_kill_switch_triggered',
+    -- 0156 PR #398 — Daily catalyst brief Gemini
+    'daily_catalyst_brief',
+    -- 0158 — OpenPositionRiskMonitorService audit
+    'risk_monitor_action'
+  ));


### PR DESCRIPTION
## Summary

Fix 2 bugs détectés lors de la vérification post-déploiement du risk-monitor :

**Bug #1 (cosmétique)** — variable morte `livePrice` dans `computeGeminiScore` (jamais utilisée, remplacée par `livePx`).

**Bug #2 (fonctionnel)** — `auditAction()` utilisait `kind: 'position_opened'` par défaut faute de kind dédié dans le CHECK constraint. Conséquence : les analytics "dernières positions ouvertes" auraient été polluées par des entrées TIGHTEN_SL / CLOSE_NOW / RAISE_TP / MOMENTUM_RIDE (faux positifs).

Fix :
- Migration **0158** : ajoute `'risk_monitor_action'` à `lisa_decision_log_kind_check`
- Service : `kind: 'position_opened'` → `kind: 'risk_monitor_action'`

Le verdict détaillé (`payload.verdict`) reste inchangé, c'est juste le kind racine qui devient propre.

## Test plan

- [x] TypeScript compile clean
- [x] 39 tests helpers verts (thesis-health-score, gemini-thesis-verdict)
- [ ] Migration 0158 appliquée via `migrations-trigger-0158-risk-monitor-kind` post-merge
- [ ] Fly deploy auto sur push main

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_