### PR TITLE
feat(correlation-guard): Feature #1 — anti-cascade cross-positions

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -63,6 +63,7 @@ import { PersistenceProbabilityService } from './services/persistence-probabilit
 import { ScannerLlmRouterService } from './services/scanner-llm-router.service';
 import { DailyCatalystBriefService } from './services/daily-catalyst-brief.service';
 import { OpenPositionRiskMonitorService } from './services/open-position-risk-monitor.service';
+import { CorrelationGuardService } from './services/correlation-guard.service';
 import { EventEngineService } from './services/event-engine.service';
 import { EodhdNewsService } from './services/eodhd-news.service';
 import { EodhdNewsCollectorService } from './services/eodhd-news-collector.service';
@@ -182,6 +183,8 @@ import { IntradayProviderRouter } from './services/intraday-provider-router.serv
     MultiTimeframePersistenceService,
     // OpenPositionRiskMonitor — cron 5min, thesis_health_score → CLOSE/TIGHTEN_SL/RAISE_TP/MOMENTUM_RIDE
     OpenPositionRiskMonitorService,
+    // Feature #1 — Cross-position correlation guard (anti-cascade 24/05)
+    CorrelationGuardService,
     // P19a — Yahoo Finance intraday fallback (Korea KOSPI, small-caps, etc.)
     YahooIntradayService,
     // P19i — Intraday OHLCV cache Supabase (last_known < 15 min, fallback chain)

--- a/apps/api/src/modules/lisa/services/__tests__/correlation-guard.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/correlation-guard.spec.ts
@@ -1,0 +1,193 @@
+import {
+  computeLogReturns,
+  computePearsonCorrelation,
+  assessCorrelationRisk,
+  parseCorrelationGuardConfig,
+  DEFAULT_CORRELATION_GUARD_CONFIG,
+} from '../correlation-guard.helper';
+
+describe('computeLogReturns', () => {
+  it('série constante → returns ≈ 0', () => {
+    const r = computeLogReturns([100, 100, 100, 100]);
+    expect(r.length).toBe(3);
+    for (const v of r) expect(Math.abs(v)).toBeLessThan(1e-9);
+  });
+  it('croissance exponentielle 2× → returns constants ≈ ln(2)', () => {
+    const r = computeLogReturns([1, 2, 4, 8]);
+    for (const v of r) expect(v).toBeCloseTo(Math.log(2), 6);
+  });
+  it('série de 1 élément → array vide', () => {
+    expect(computeLogReturns([100])).toEqual([]);
+  });
+  it('skip valeurs invalides (0, négatif, NaN)', () => {
+    const r = computeLogReturns([100, 0, 100, NaN, 100]);
+    expect(r).toEqual([]);
+  });
+});
+
+describe('computePearsonCorrelation', () => {
+  it('series identiques → corr = 1', () => {
+    const a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+    const r = computePearsonCorrelation(a, a);
+    expect(r).toBeCloseTo(1, 5);
+  });
+  it('series anti-corrélées → corr = -1', () => {
+    const a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+    const b = a.map((v) => -v);
+    expect(computePearsonCorrelation(a, b)).toBeCloseTo(-1, 5);
+  });
+  it('series indépendantes → corr proche 0', () => {
+    // Series déterministe mais "random-like"
+    const a = [1, -1, 2, -2, 1, -1, 2, -2, 1, -1, 2];
+    const b = [1, 2, -1, -2, 2, 1, -2, -1, 2, 1, -2];
+    const r = computePearsonCorrelation(a, b);
+    expect(Math.abs(r!)).toBeLessThan(0.3);
+  });
+  it('tailles différentes → null', () => {
+    expect(computePearsonCorrelation([1, 2, 3], [1, 2])).toBeNull();
+  });
+  it('< 10 observations → null', () => {
+    expect(computePearsonCorrelation([1, 2, 3], [1, 2, 3])).toBeNull();
+  });
+  it('variance nulle → null (corr indéfinie)', () => {
+    const flat = Array(15).fill(5);
+    const linear = Array.from({ length: 15 }, (_, i) => i);
+    expect(computePearsonCorrelation(flat, linear)).toBeNull();
+  });
+  it('corr clampée dans [-1, +1]', () => {
+    // Arithmétique flottante peut donner 1.0000000001
+    const a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    const r = computePearsonCorrelation(a, a);
+    expect(r).toBeLessThanOrEqual(1);
+    expect(r).toBeGreaterThanOrEqual(-1);
+  });
+});
+
+describe('assessCorrelationRisk', () => {
+  // Génère une série prix avec random walk déterministe
+  const makePrices = (seed: number, n: number, drift = 0.001, vol = 0.02): number[] => {
+    const out: number[] = [100];
+    let s = seed;
+    for (let i = 1; i < n; i++) {
+      s = (s * 9301 + 49297) % 233280;
+      const noise = ((s / 233280) - 0.5) * 2 * vol;
+      out.push(out[i - 1] * (1 + drift + noise));
+    }
+    return out;
+  };
+
+  it('aucun open → autorise', () => {
+    const r = assessCorrelationRisk([100, 101, 102], []);
+    expect(r.reject).toBe(false);
+    expect(r.reason).toContain('no_open_positions');
+  });
+
+  it('candidat avec historique insuffisant → autorise (skip safe)', () => {
+    const r = assessCorrelationRisk([100, 101], [
+      { symbol: 'AAPL', prices: makePrices(1, 31) },
+    ]);
+    expect(r.reject).toBe(false);
+    expect(r.reason).toContain('candidate_insufficient_history');
+  });
+
+  it('toutes positions corrélées 1.0 (cas SOL/ETH/BTC/BNB du 24/05) → REJECT', () => {
+    const candidate = makePrices(42, 31);
+    // Positions ouvertes = même série + bruit minime (haute correlation)
+    const opens = [
+      { symbol: 'SOLUSDT', prices: candidate.map((p) => p * 1.001) },
+      { symbol: 'ETHUSDT', prices: candidate.map((p) => p * 0.999) },
+      { symbol: 'XRPUSDT', prices: candidate.map((p) => p * 1.002) },
+      { symbol: 'BTCUSDT', prices: candidate.map((p) => p * 0.998) },
+    ];
+    const r = assessCorrelationRisk(candidate, opens);
+    expect(r.reject).toBe(true);
+    expect(r.avgCorr!).toBeGreaterThan(0.95);
+    expect(r.maxCorr!).toBeGreaterThan(0.95);
+    expect(r.perPosition).toHaveLength(4);
+    expect(r.reason).toContain('above_threshold');
+  });
+
+  it('positions décorrélées → autorise', () => {
+    const candidate = makePrices(42, 31);
+    const opens = [
+      { symbol: 'INDEPENDENT1', prices: makePrices(7, 31, 0.002, 0.03) },
+      { symbol: 'INDEPENDENT2', prices: makePrices(13, 31, -0.001, 0.025) },
+    ];
+    const r = assessCorrelationRisk(candidate, opens);
+    expect(r.reject).toBe(false);
+    expect(r.avgCorr!).toBeLessThan(0.7);
+  });
+
+  it('mix : 1 corrélée + 1 indépendante → moyenne peut être OK ou KO selon seuil', () => {
+    const candidate = makePrices(42, 31);
+    const opens = [
+      { symbol: 'CORR', prices: candidate.map((p) => p * 1.001) }, // ~1.0
+      { symbol: 'INDEP', prices: makePrices(99, 31) },              // ~0
+    ];
+    const r = assessCorrelationRisk(candidate, opens);
+    // avg(|~1.0|, |~0|) = ~0.5 < threshold 0.7 → autorise
+    expect(r.reject).toBe(false);
+    expect(r.avgCorr!).toBeGreaterThan(0);
+    expect(r.avgCorr!).toBeLessThan(0.7);
+  });
+
+  it('threshold custom 0.30 (très strict) → reject même partial coupling', () => {
+    const candidate = makePrices(42, 31);
+    const opens = [
+      { symbol: 'CORR', prices: candidate.map((p) => p * 1.001) }, // ~1.0
+      { symbol: 'INDEP', prices: makePrices(99, 31) },              // ~0
+    ];
+    const r = assessCorrelationRisk(candidate, opens, { threshold: 0.30, minObservations: 10 });
+    expect(r.reject).toBe(true);
+  });
+
+  it('opens sans assez d\'historique → ignorées, autorise', () => {
+    const candidate = makePrices(42, 31);
+    const opens = [
+      { symbol: 'NEW1', prices: [100, 101] },
+      { symbol: 'NEW2', prices: [100, 100, 101] },
+    ];
+    const r = assessCorrelationRisk(candidate, opens);
+    expect(r.reject).toBe(false);
+    expect(r.reason).toContain('no_valid_correlations_computable');
+  });
+
+  it('corr négative absolue compte aussi (anti-cascade reverse)', () => {
+    const candidate = makePrices(42, 31);
+    // Position ouverte anti-corrélée → si crypto crash, hedge crash aussi
+    const reversedReturns = candidate.map((p) => 200 / p);
+    const opens = [{ symbol: 'INVERSE_ETF', prices: reversedReturns }];
+    const r = assessCorrelationRisk(candidate, opens, { threshold: 0.70, minObservations: 10 });
+    expect(r.perPosition[0].corr).not.toBeNull();
+    // |corr| pris en compte, donc une forte anti-corr → reject aussi
+    expect(Math.abs(r.perPosition[0].corr!)).toBeGreaterThan(0.9);
+    expect(r.reject).toBe(true);
+  });
+});
+
+describe('parseCorrelationGuardConfig', () => {
+  it('env vide → defaults', () => {
+    const cfg = parseCorrelationGuardConfig({});
+    expect(cfg.threshold).toBe(DEFAULT_CORRELATION_GUARD_CONFIG.threshold);
+    expect(cfg.minObservations).toBe(DEFAULT_CORRELATION_GUARD_CONFIG.minObservations);
+  });
+  it('threshold custom valid', () => {
+    const cfg = parseCorrelationGuardConfig({ CORRELATION_GUARD_THRESHOLD: '0.5' });
+    expect(cfg.threshold).toBe(0.5);
+  });
+  it('threshold hors range → default', () => {
+    expect(parseCorrelationGuardConfig({ CORRELATION_GUARD_THRESHOLD: '1.5' }).threshold).toBe(0.70);
+    expect(parseCorrelationGuardConfig({ CORRELATION_GUARD_THRESHOLD: '0' }).threshold).toBe(0.70);
+  });
+  it('minObs custom valid', () => {
+    expect(parseCorrelationGuardConfig({ CORRELATION_GUARD_MIN_OBS: '20' }).minObservations).toBe(20);
+  });
+  it('NaN inputs → defaults', () => {
+    const cfg = parseCorrelationGuardConfig({
+      CORRELATION_GUARD_THRESHOLD: 'abc',
+      CORRELATION_GUARD_MIN_OBS: 'xyz',
+    });
+    expect(cfg.threshold).toBe(0.70);
+    expect(cfg.minObservations).toBe(10);
+  });
+});

--- a/apps/api/src/modules/lisa/services/correlation-guard.helper.ts
+++ b/apps/api/src/modules/lisa/services/correlation-guard.helper.ts
@@ -1,0 +1,159 @@
+/**
+ * Cross-position correlation guard — pure helper, no I/O.
+ *
+ * Évite la cascade de SL groupés (incident 24/05 : 4 SL crypto en 3 min sur
+ * SOL/ETH/XRP/BTC/BNB tous corrélés). Avant d'ouvrir une nouvelle position,
+ * on calcule la corrélation rolling 30j entre le candidat et les positions
+ * déjà ouvertes. Si trop concentré, on refuse.
+ *
+ * Méthode : Pearson sur log-returns daily 30j. Seuil défaut 0.70 (= moyen-fort
+ * coupling). Skip si < 10 observations (pas assez fiable).
+ */
+
+/**
+ * Compute log returns from a price series.
+ *   returns[i] = ln(prices[i+1] / prices[i])
+ * Retourne array de taille N-1. Si prices contient ≤ 1 valeur → array vide.
+ */
+export function computeLogReturns(prices: number[]): number[] {
+  const out: number[] = [];
+  for (let i = 1; i < prices.length; i++) {
+    const p0 = prices[i - 1];
+    const p1 = prices[i];
+    if (p0 > 0 && p1 > 0 && Number.isFinite(p0) && Number.isFinite(p1)) {
+      out.push(Math.log(p1 / p0));
+    }
+  }
+  return out;
+}
+
+/**
+ * Pearson correlation coefficient sur 2 series de returns alignées.
+ * Retourne null si :
+ *  - series de tailles différentes
+ *  - moins de 10 observations (insuffisant)
+ *  - variance nulle (constante) sur une des deux series → corrélation indéfinie
+ */
+export function computePearsonCorrelation(a: number[], b: number[]): number | null {
+  if (a.length !== b.length) return null;
+  if (a.length < 10) return null;
+  const n = a.length;
+  const meanA = a.reduce((s, v) => s + v, 0) / n;
+  const meanB = b.reduce((s, v) => s + v, 0) / n;
+  let num = 0, denA = 0, denB = 0;
+  for (let i = 0; i < n; i++) {
+    const dA = a[i] - meanA;
+    const dB = b[i] - meanB;
+    num += dA * dB;
+    denA += dA * dA;
+    denB += dB * dB;
+  }
+  if (denA < 1e-12 || denB < 1e-12) return null;
+  const r = num / Math.sqrt(denA * denB);
+  return Math.max(-1, Math.min(1, r));
+}
+
+export interface OpenPositionPrices {
+  symbol: string;
+  prices: number[];        // 30 daily closes (les plus récents en dernier)
+}
+
+export interface CorrelationGuardConfig {
+  threshold: number;       // ex 0.70 = au-dessus = trop corrélé
+  minObservations: number; // ex 10 (= 10 jours de returns)
+}
+
+export const DEFAULT_CORRELATION_GUARD_CONFIG: CorrelationGuardConfig = {
+  threshold: 0.70,
+  minObservations: 10,
+};
+
+export interface CorrelationAssessment {
+  reject: boolean;
+  reason: string;
+  avgCorr: number | null;
+  maxCorr: number | null;
+  perPosition: Array<{ symbol: string; corr: number | null }>;
+}
+
+/**
+ * Évalue si l'ouverture d'une nouvelle position serait trop corrélée aux
+ * positions déjà ouvertes. Logique :
+ *  1. Aucun open → autoriser (rien à comparer)
+ *  2. Pour chaque open, compute Pearson(candidate_returns, open_returns)
+ *  3. avg(|corr|) > threshold → REFUSER (corrélation peut être négative aussi
+ *     mais elle expose à des cascades reverse — on prend l'absolue valeur)
+ *  4. Sinon → autoriser
+ *
+ * Note : on filtre les corr=null (pas assez de data) avant la moyenne.
+ * Si toutes sont null → autoriser par défaut (pas d'info pour refuser).
+ */
+export function assessCorrelationRisk(
+  candidatePrices: number[],
+  openPositions: OpenPositionPrices[],
+  cfg: CorrelationGuardConfig = DEFAULT_CORRELATION_GUARD_CONFIG,
+): CorrelationAssessment {
+  if (openPositions.length === 0) {
+    return { reject: false, reason: 'no_open_positions', avgCorr: null, maxCorr: null, perPosition: [] };
+  }
+  const candReturns = computeLogReturns(candidatePrices);
+  if (candReturns.length < cfg.minObservations) {
+    return {
+      reject: false,
+      reason: `candidate_insufficient_history (${candReturns.length}/${cfg.minObservations} returns)`,
+      avgCorr: null, maxCorr: null, perPosition: [],
+    };
+  }
+  const perPosition: Array<{ symbol: string; corr: number | null }> = [];
+  for (const op of openPositions) {
+    const opReturns = computeLogReturns(op.prices);
+    if (opReturns.length < cfg.minObservations) {
+      perPosition.push({ symbol: op.symbol, corr: null });
+      continue;
+    }
+    // Aligne les longueurs sur le min des deux
+    const n = Math.min(candReturns.length, opReturns.length);
+    const a = candReturns.slice(-n);
+    const b = opReturns.slice(-n);
+    const corr = computePearsonCorrelation(a, b);
+    perPosition.push({ symbol: op.symbol, corr });
+  }
+  const validCorrs = perPosition
+    .map((p) => p.corr)
+    .filter((c): c is number => c != null)
+    .map((c) => Math.abs(c));
+  if (validCorrs.length === 0) {
+    return {
+      reject: false,
+      reason: 'no_valid_correlations_computable',
+      avgCorr: null, maxCorr: null, perPosition,
+    };
+  }
+  const avgCorr = validCorrs.reduce((s, c) => s + c, 0) / validCorrs.length;
+  const maxCorr = Math.max(...validCorrs);
+  const reject = avgCorr > cfg.threshold;
+  return {
+    reject,
+    reason: reject
+      ? `avg_correlation_${avgCorr.toFixed(2)}_above_threshold_${cfg.threshold.toFixed(2)}`
+      : `avg_correlation_${avgCorr.toFixed(2)}_below_threshold_${cfg.threshold.toFixed(2)}`,
+    avgCorr,
+    maxCorr,
+    perPosition,
+  };
+}
+
+/**
+ * Parse config from env vars.
+ */
+export function parseCorrelationGuardConfig(env: {
+  CORRELATION_GUARD_THRESHOLD?: string | undefined;
+  CORRELATION_GUARD_MIN_OBS?: string | undefined;
+}): CorrelationGuardConfig {
+  const thRaw = Number.parseFloat(env.CORRELATION_GUARD_THRESHOLD ?? '');
+  const minRaw = Number.parseInt(env.CORRELATION_GUARD_MIN_OBS ?? '', 10);
+  return {
+    threshold: Number.isFinite(thRaw) && thRaw > 0 && thRaw <= 1 ? thRaw : DEFAULT_CORRELATION_GUARD_CONFIG.threshold,
+    minObservations: Number.isFinite(minRaw) && minRaw >= 5 && minRaw <= 60 ? minRaw : DEFAULT_CORRELATION_GUARD_CONFIG.minObservations,
+  };
+}

--- a/apps/api/src/modules/lisa/services/correlation-guard.service.ts
+++ b/apps/api/src/modules/lisa/services/correlation-guard.service.ts
@@ -1,0 +1,136 @@
+/**
+ * Cross-position correlation guard — service avec fetch + cache.
+ *
+ * Récupère 30 daily closes par symbole (cache 10 min mémoire) :
+ *   - Crypto : BinanceMarketService.getKlines(sym, '1d', 30)
+ *   - Equities : ohlcv_cache_daily (cron OhlcvCacheService 21:30 UTC)
+ *
+ * Délègue ensuite au pure helper assessCorrelationRisk pour le verdict.
+ *
+ * Default OFF (env-gated). Best-effort : tout échec fetch → skip pas reject
+ * (on n'introduit pas un nouveau motif de blocage d'open par bug fetch).
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { BinanceMarketService } from './binance-market.service';
+import {
+  assessCorrelationRisk,
+  parseCorrelationGuardConfig,
+  type CorrelationGuardConfig,
+  type CorrelationAssessment,
+  type OpenPositionPrices,
+} from './correlation-guard.helper';
+
+interface CachedSeries {
+  prices: number[];
+  asOf: number;
+}
+
+@Injectable()
+export class CorrelationGuardService {
+  private readonly logger = new Logger(CorrelationGuardService.name);
+  private enabled = false;
+  private cfg: CorrelationGuardConfig = { threshold: 0.70, minObservations: 10 };
+  private cache = new Map<string, CachedSeries>();
+  private readonly CACHE_TTL_MS = 10 * 60_000;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+    private readonly binanceMarket: BinanceMarketService,
+  ) {}
+
+  onModuleInit(): void {
+    this.enabled = (this.config.get<string>('CORRELATION_GUARD_ENABLED') ?? 'false').toLowerCase() === 'true';
+    this.cfg = parseCorrelationGuardConfig({
+      CORRELATION_GUARD_THRESHOLD: this.config.get<string>('CORRELATION_GUARD_THRESHOLD'),
+      CORRELATION_GUARD_MIN_OBS: this.config.get<string>('CORRELATION_GUARD_MIN_OBS'),
+    });
+    if (this.enabled) {
+      this.logger.log(`[correlation-guard] ENABLED — threshold=${this.cfg.threshold.toFixed(2)} minObs=${this.cfg.minObservations}`);
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /**
+   * Évalue si l'ouverture d'une nouvelle position serait trop corrélée aux
+   * positions déjà ouvertes. Retourne assessment ; le caller décide.
+   *
+   * Best-effort : tout échec fetch → return { reject: false, reason: 'fetch_error' }.
+   */
+  async assessNewPosition(
+    candidate: { symbol: string; assetClass: string },
+    openPositions: Array<{ symbol: string; assetClass: string }>,
+  ): Promise<CorrelationAssessment> {
+    if (!this.enabled) {
+      return { reject: false, reason: 'guard_disabled', avgCorr: null, maxCorr: null, perPosition: [] };
+    }
+    if (openPositions.length === 0) {
+      return { reject: false, reason: 'no_open_positions', avgCorr: null, maxCorr: null, perPosition: [] };
+    }
+    try {
+      const candidatePrices = await this.fetchDailyCloses(candidate.symbol, candidate.assetClass);
+      if (candidatePrices.length < this.cfg.minObservations + 1) {
+        return {
+          reject: false,
+          reason: `candidate_insufficient_data (${candidatePrices.length} prices)`,
+          avgCorr: null, maxCorr: null, perPosition: [],
+        };
+      }
+      const openPrices: OpenPositionPrices[] = [];
+      for (const op of openPositions) {
+        const prices = await this.fetchDailyCloses(op.symbol, op.assetClass);
+        if (prices.length >= this.cfg.minObservations + 1) {
+          openPrices.push({ symbol: op.symbol, prices });
+        }
+      }
+      return assessCorrelationRisk(candidatePrices, openPrices, this.cfg);
+    } catch (e) {
+      this.logger.warn(`[correlation-guard] exception ${candidate.symbol}: ${String(e).slice(0, 150)}`);
+      return { reject: false, reason: 'fetch_exception', avgCorr: null, maxCorr: null, perPosition: [] };
+    }
+  }
+
+  /**
+   * Fetch ~30 daily closes pour un symbole, source-aware.
+   * Crypto → Binance API (cache interne service 2min)
+   * Equities → ohlcv_cache_daily (cron daily 21:30 UTC, max 60 bars/ticker)
+   * Cache local additionnel 10min pour limiter les appels redondants sur le même cycle.
+   */
+  private async fetchDailyCloses(symbol: string, assetClass: string): Promise<number[]> {
+    const cacheKey = `${symbol}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && Date.now() - cached.asOf < this.CACHE_TTL_MS) {
+      return cached.prices;
+    }
+    let prices: number[] = [];
+    try {
+      if (assetClass.startsWith('crypto')) {
+        const candles = await this.binanceMarket.getKlines(symbol, '1d', 30);
+        prices = (candles ?? []).map((c) => c.close).filter((p) => Number.isFinite(p) && p > 0);
+      } else {
+        // Equities → ohlcv_cache_daily, dernières 30 bars
+        const { data } = await this.supabase.getClient()
+          .from('ohlcv_cache_daily')
+          .select('close, bar_date')
+          .eq('ticker', symbol)
+          .order('bar_date', { ascending: false })
+          .limit(30);
+        // Ordre ASC pour respecter la convention "récent en dernier" du helper
+        prices = ((data ?? []) as Array<{ close: number }>)
+          .map((r) => Number(r.close))
+          .filter((p) => Number.isFinite(p) && p > 0)
+          .reverse();
+      }
+    } catch (e) {
+      this.logger.debug(`[correlation-guard] fetch ${symbol} (${assetClass}) failed: ${String(e).slice(0, 100)}`);
+    }
+    this.cache.set(cacheKey, { prices, asOf: Date.now() });
+    return prices;
+  }
+}

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -71,6 +71,7 @@ import {
   formatFilterLog,
 } from '@smartvest/ai-analyst';
 import { TickerBlacklistService } from './ticker-blacklist.service';
+import { CorrelationGuardService } from './correlation-guard.service';
 import {
   EARLY_RETURN_REASONS,
   type EarlyReturnReason,
@@ -651,6 +652,12 @@ export class TopGainersScannerService implements OnModuleInit {
      * no-op silencieux. Append en fin pour ne pas casser les tests existants.
      */
     @Optional() private readonly symbolAtrCache?: SymbolAtrCacheService,
+    /**
+     * Feature #1 — Cross-position correlation guard (post-incident 24/05 cascade).
+     * @Optional pour back-compat tests existants (specs scanner). Quand undefined
+     * ou guard disabled (env flag), aucun effet → back-compat 100 %.
+     */
+    @Optional() private readonly correlationGuard?: CorrelationGuardService,
   ) {}
 
   /**
@@ -3517,6 +3524,35 @@ export class TopGainersScannerService implements OnModuleInit {
       // Compute stop/TP prices from pcts (long only par scanner)
       const stopPrice = (livePriceNum * (1 - effectiveSl / 100)).toFixed(8);
       const tpPrice = (livePriceNum * (1 + effectiveTp / 100)).toFixed(8);
+
+      // Feature #1 — Cross-position correlation guard (post 24/05 cascade).
+      // Refuse l'ouverture si la position serait trop corrélée aux opens
+      // actuels (avg |Pearson 30j| > seuil). Best-effort : skip si guard
+      // disabled, no_open_positions, ou erreur fetch.
+      if (this.correlationGuard?.isEnabled()) {
+        try {
+          const { data: openRows } = await this.supabase.getClient()
+            .from('lisa_positions')
+            .select('symbol, asset_class')
+            .eq('portfolio_id', portfolioId)
+            .eq('status', 'open');
+          const opens = ((openRows ?? []) as Array<{ symbol: string; asset_class: string }>)
+            .filter((r) => r.symbol !== cand.symbol);
+          const assessment = await this.correlationGuard.assessNewPosition(
+            { symbol: cand.symbol, assetClass: String(cand.assetClass) },
+            opens.map((o) => ({ symbol: o.symbol, assetClass: o.asset_class })),
+          );
+          if (assessment.reject) {
+            this.logger.log(
+              `[correlation-guard] ${cand.symbol} REJECTED — ${assessment.reason} ` +
+              `(avg=${assessment.avgCorr?.toFixed(2)} max=${assessment.maxCorr?.toFixed(2)} on ${assessment.perPosition.length} opens)`,
+            );
+            return null;
+          }
+        } catch (e) {
+          this.logger.debug(`[correlation-guard] ${cand.symbol} exception (skip guard): ${String(e).slice(0, 120)}`);
+        }
+      }
 
       const openedPos = await this.lisa.getPaperBroker().openPositionDirect({
         portfolioId,


### PR DESCRIPTION
## Contexte — réponse directe au 24/05

Incident du jour : **cascade de 4 SL crypto en 3 minutes** (SOL/ETH/XRP/BTC/BNB, -$49.68 réalisé). Tous corrélés à BTC. Le scanner ne savait pas qu'il ouvrait 5 versions du même pari.

Feature #1 de la roadmap "IA au cœur" : avant chaque ouverture, vérifier que le candidat n'est pas une 5e copie de ce qu'on a déjà.

## Architecture

- **`correlation-guard.helper.ts`** (pure, 24 tests) :
  - `computeLogReturns(prices)` → log-returns
  - `computePearsonCorrelation(a, b)` → Pearson clampé [-1,+1], null si insuffisant
  - `assessCorrelationRisk(candidate, opens, cfg)` → `{reject, avgCorr, maxCorr, perPosition[]}`
- **`correlation-guard.service.ts`** : fetch 30 daily closes (Binance crypto / `ohlcv_cache_daily` equities), cache 10min, délégation au helper
- **Wiring** : `top-gainers-scanner.openTopGainerPosition` — gate avant `openPositionDirect`

## Méthode

1. Lit positions ouvertes du portfolio
2. Fetch 30 daily closes par symbole (Binance ou cache DB)
3. Calcule `Pearson(returns_candidate, returns_open)` pour chaque open
4. `avg(|corr|) > threshold` → REJECT + log

Pris en valeur absolue : un anti-corrélé fort (inverse ETF) compterait aussi comme risque cascade reverse.

## Gating ENV (default OFF — back-compat 100%)

```
CORRELATION_GUARD_ENABLED=true       # master
CORRELATION_GUARD_THRESHOLD=0.70     # ajustable, 0..1
CORRELATION_GUARD_MIN_OBS=10         # minimum observations
```

## Safeguards (no régression possible)

- Default disabled
- Best-effort : tout fetch error → skip guard (jamais blocage par bug)
- `@Optional()` injection (back-compat 12 specs scanner existants)
- minObs 10 : skip si historique insuffisant (= autorise par défaut, pas reject)
- Test cas réel 24/05 validé : 4 cryptos corr 1.0 → REJECT confirmé

## Test plan

- [x] 24 tests helper verts (Pearson, returns, assess, parse)
- [x] **203 suites / 2 701 tests apps/api verts** (aucune régression)
- [x] `tsc --noEmit` clean
- [ ] Activer en prod après merge : `fly secrets set CORRELATION_GUARD_ENABLED=true`
- [ ] Vérifier sur prochaine session crypto que des opens en cluster sont refusés avec log `[correlation-guard] REJECTED`

## Coût récurrent

Cache 10 min + ~5 opens max × 30 daily candles = ~150 fetches/h max. Binance gratuit pour crypto, `ohlcv_cache_daily` déjà populé pour equities. **$0 coût additionnel**.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_