### PR TITLE
feat(conviction-sizing): Feature #2 — sizing calibré sur la conviction d'entrée

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/thesis-health-score.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/thesis-health-score.spec.ts
@@ -4,8 +4,48 @@ import {
   computeComposite,
   decideVerdict,
   evaluateThesisHealth,
+  decideSizingMultiplier,
+  parseConvictionSizingConfig,
+  computeEntryConvictionScore,
   DEFAULT_WEIGHTS,
+  DEFAULT_CONVICTION_SIZING,
 } from '../thesis-health-score.helper';
+
+describe('computeEntryConvictionScore', () => {
+  it('A+ setup (pathEff 0.85, persist 0.83, ch1m 4.5%) → score positif élevé', () => {
+    const s = computeEntryConvictionScore({ pathEff: 0.85, persistence: 0.83, ch1mPct: 4.5 });
+    // pathEff norm = (0.85-0.55)/0.30 = 1.0
+    // persist norm = (0.83-0.50)/0.30 = 1.1 clamp 1.0
+    // ch1m norm = 4.5/5 = 0.9
+    // avg = (1.0 + 1.0 + 0.9) / 3 = 0.967
+    expect(s).toBeCloseTo(0.967, 2);
+  });
+  it('Setup moyen (pathEff 0.55, persist 0.50, ch1m 3.0) → ~0', () => {
+    const s = computeEntryConvictionScore({ pathEff: 0.55, persistence: 0.50, ch1mPct: 3.0 });
+    // pathEff norm = 0, persist norm = 0, ch1m norm = 3/5 = 0.6
+    // avg = 0.2
+    expect(s).toBeCloseTo(0.2, 2);
+  });
+  it('Setup faible (pathEff 0.30, persist 0.20, ch1m 1.0) → score négatif', () => {
+    const s = computeEntryConvictionScore({ pathEff: 0.30, persistence: 0.20, ch1mPct: 1.0 });
+    expect(s).toBeLessThan(-0.3);
+  });
+  it('Toutes features null → 0', () => {
+    expect(computeEntryConvictionScore({ pathEff: null, persistence: null, ch1mPct: null })).toBe(0);
+  });
+  it('Partial (seulement ch1m) → utilise les dispos', () => {
+    const s = computeEntryConvictionScore({ pathEff: null, persistence: null, ch1mPct: 5.0 });
+    expect(s).toBeCloseTo(1.0, 2);
+  });
+  it('Cas réel SOLUSDT 24/05 (pathEff 0.560, persist 0.83, ch1m 4.83%) → score positif', () => {
+    const s = computeEntryConvictionScore({ pathEff: 0.560, persistence: 0.83, ch1mPct: 4.83 });
+    // pathEff norm = (0.56-0.55)/0.30 = 0.033
+    // persist norm = 1.1 clamp 1.0
+    // ch1m norm = 4.83/5 = 0.966
+    // avg = 0.666 → A+ tier (selon DEFAULT_CONVICTION_SIZING highThreshold 0.60)
+    expect(s).toBeGreaterThan(0.6);
+  });
+});
 
 describe('computeSubA — market momentum delta', () => {
   it('momentum perdu 40 % → -0.40 (cas réel BTC 24/5)', () => {
@@ -174,5 +214,93 @@ describe('evaluateThesisHealth — bout-en-bout (cas réel BTC 24/5)', () => {
     });
     expect(r.composite).toBe(0);
     expect(r.verdict).toBe('HOLD');
+  });
+});
+
+describe('decideSizingMultiplier — sizing calibré conviction', () => {
+  it('composite < 0 → 0 (SKIP) par défaut', () => {
+    expect(decideSizingMultiplier(-0.5)).toBe(0);
+    expect(decideSizingMultiplier(-0.01)).toBe(0);
+  });
+  it('composite ∈ [0, 0.30) → multLow 0.7', () => {
+    expect(decideSizingMultiplier(0)).toBe(0.7);
+    expect(decideSizingMultiplier(0.15)).toBe(0.7);
+    expect(decideSizingMultiplier(0.299)).toBe(0.7);
+  });
+  it('composite ∈ [0.30, 0.60] → 1.0 (standard)', () => {
+    expect(decideSizingMultiplier(0.30)).toBe(1.0);
+    expect(decideSizingMultiplier(0.45)).toBe(1.0);
+    expect(decideSizingMultiplier(0.60)).toBe(1.0);
+  });
+  it('composite > 0.60 → multHigh 1.5', () => {
+    expect(decideSizingMultiplier(0.601)).toBe(1.5);
+    expect(decideSizingMultiplier(0.75)).toBe(1.5);
+    expect(decideSizingMultiplier(1.0)).toBe(1.5);
+  });
+  it('null / NaN → 1.0 (fallback sizing standard, back-compat safe)', () => {
+    expect(decideSizingMultiplier(null)).toBe(1.0);
+    expect(decideSizingMultiplier(NaN)).toBe(1.0);
+  });
+  it('skipIfNegative=false → composite négatif applique multLow', () => {
+    const cfg = { ...DEFAULT_CONVICTION_SIZING, skipIfNegative: false };
+    expect(decideSizingMultiplier(-0.5, cfg)).toBe(cfg.multLow);
+  });
+  it('config custom : multHigh 2.0', () => {
+    const cfg = { ...DEFAULT_CONVICTION_SIZING, multHigh: 2.0 };
+    expect(decideSizingMultiplier(0.8, cfg)).toBe(2.0);
+  });
+  it('maxMultiplier clamp : pas plus haut que cap', () => {
+    const cfg = { ...DEFAULT_CONVICTION_SIZING, multHigh: 5.0, maxMultiplier: 2.0 };
+    expect(decideSizingMultiplier(0.8, cfg)).toBe(2.0);
+  });
+  it('cas réel : composite +0.7 (A+ setup) → 1.5× sizing', () => {
+    expect(decideSizingMultiplier(0.7)).toBe(1.5);
+  });
+  it('cas réel : composite +0.15 (conviction moyenne) → 0.7× sizing', () => {
+    expect(decideSizingMultiplier(0.15)).toBe(0.7);
+  });
+  it('cas réel : composite -0.5 (thèse déjà cassée à entry) → SKIP', () => {
+    expect(decideSizingMultiplier(-0.5)).toBe(0);
+  });
+});
+
+describe('parseConvictionSizingConfig', () => {
+  it('env vide → enabled false, defaults', () => {
+    const r = parseConvictionSizingConfig({});
+    expect(r.enabled).toBe(false);
+    expect(r.cfg.multLow).toBe(0.7);
+    expect(r.cfg.multHigh).toBe(1.5);
+  });
+  it('CONVICTION_SIZING_ENABLED=true', () => {
+    expect(parseConvictionSizingConfig({ CONVICTION_SIZING_ENABLED: 'true' }).enabled).toBe(true);
+  });
+  it('overrides custom', () => {
+    const r = parseConvictionSizingConfig({
+      CONVICTION_SIZING_ENABLED: 'true',
+      CONVICTION_SIZING_MULT_LOW: '0.5',
+      CONVICTION_SIZING_MULT_HIGH: '2.0',
+      CONVICTION_SIZING_LOW_THRESHOLD: '0.20',
+      CONVICTION_SIZING_HIGH_THRESHOLD: '0.70',
+      CONVICTION_SIZING_SKIP_IF_NEGATIVE: 'false',
+    });
+    expect(r.cfg.multLow).toBe(0.5);
+    expect(r.cfg.multHigh).toBe(2.0);
+    expect(r.cfg.lowThreshold).toBe(0.20);
+    expect(r.cfg.highThreshold).toBe(0.70);
+    expect(r.cfg.skipIfNegative).toBe(false);
+  });
+  it('valeurs hors range → defaults', () => {
+    const r = parseConvictionSizingConfig({
+      CONVICTION_SIZING_MULT_LOW: '-1',
+      CONVICTION_SIZING_MULT_HIGH: '10',
+    });
+    expect(r.cfg.multLow).toBe(0.7);  // -1 < 0 → default 0.7
+    expect(r.cfg.multHigh).toBe(1.5); // 10 > 3 → default 1.5
+  });
+  it('NaN inputs → defaults', () => {
+    const r = parseConvictionSizingConfig({
+      CONVICTION_SIZING_MULT_LOW: 'abc',
+    });
+    expect(r.cfg.multLow).toBe(0.7);
   });
 });

--- a/apps/api/src/modules/lisa/services/thesis-health-score.helper.ts
+++ b/apps/api/src/modules/lisa/services/thesis-health-score.helper.ts
@@ -154,6 +154,123 @@ export function decideVerdict(
   return 'HOLD';
 }
 
+// =============================================================================
+// Feature #2 — Sizing calibré sur la conviction d'entrée
+// =============================================================================
+
+export interface ConvictionSizingConfig {
+  /** Si true, mult=0 (SKIP) quand composite < 0. Default true. */
+  skipIfNegative: boolean;
+  /** Multiplier pour composite ∈ [0, lowThreshold]. Default 0.7. */
+  multLow: number;
+  /** Multiplier pour composite ∈ [highThreshold, 1.0]. Default 1.5. */
+  multHigh: number;
+  /** Seuil bas : sub-mult appliqué en-dessous. Default 0.30. */
+  lowThreshold: number;
+  /** Seuil haut : sub-mult appliqué au-dessus. Default 0.60. */
+  highThreshold: number;
+  /** Cap dur du multiplicateur final. Sécurité. Default 2.0. */
+  maxMultiplier: number;
+}
+
+export const DEFAULT_CONVICTION_SIZING: ConvictionSizingConfig = {
+  skipIfNegative: true,
+  multLow: 0.7,
+  multHigh: 1.5,
+  lowThreshold: 0.30,
+  highThreshold: 0.60,
+  maxMultiplier: 2.0,
+};
+
+export interface EntryConvictionInput {
+  /** pathEff @ open ∈ [0, 1] ; ~0.50 = neutre, > 0.70 = clean trend */
+  pathEff: number | null;
+  /** persistenceScore @ open ∈ [0, 1] ; 4/6 = 0.67 = standard threshold */
+  persistence: number | null;
+  /** ch1m % @ open (ex 4.5 % de pump) ; > 5 % = très fort */
+  ch1mPct: number | null;
+}
+
+/**
+ * Compute un "conviction score" ∈ [-1, +1] basé sur la qualité du setup au moment
+ * de l'ouverture (pas un delta — c'est le score brut du candidat).
+ *
+ * Normalisation :
+ *   pathEff      : (v - 0.55) / 0.30  clampé [-1, +1]   (0.55 = neutre)
+ *   persistence  : (v - 0.50) / 0.30  clampé [-1, +1]
+ *   ch1m         : min(v / 5.0, 1.0)  (5 % = strong, plus = clamp)
+ *
+ * Moyenne des features dispos. Si TOUTES null → 0 (sizing standard).
+ */
+export function computeEntryConvictionScore(input: EntryConvictionInput): number {
+  const parts: number[] = [];
+  if (input.pathEff != null && Number.isFinite(input.pathEff)) {
+    parts.push(Math.max(-1, Math.min(1, (input.pathEff - 0.55) / 0.30)));
+  }
+  if (input.persistence != null && Number.isFinite(input.persistence)) {
+    parts.push(Math.max(-1, Math.min(1, (input.persistence - 0.50) / 0.30)));
+  }
+  if (input.ch1mPct != null && Number.isFinite(input.ch1mPct)) {
+    parts.push(Math.max(-1, Math.min(1, input.ch1mPct / 5.0)));
+  }
+  if (parts.length === 0) return 0;
+  return parts.reduce((s, v) => s + v, 0) / parts.length;
+}
+
+/**
+ * Décide le multiplicateur de sizing selon le composite d'entrée.
+ *   composite < 0 (si skipIfNegative=true)    → 0 (SKIP open)
+ *   composite ∈ [0, lowThreshold]              → multLow (default 0.7)
+ *   composite ∈ [lowThreshold, highThreshold]  → 1.0 (sizing standard)
+ *   composite > highThreshold                  → multHigh (default 1.5)
+ * Toujours clampé ∈ [0, maxMultiplier].
+ *
+ * Si composite est NaN/null (cas où on n'a pas pu le calculer), retourne 1.0
+ * (sizing standard) — back-compat safe.
+ */
+export function decideSizingMultiplier(
+  composite: number | null,
+  cfg: ConvictionSizingConfig = DEFAULT_CONVICTION_SIZING,
+): number {
+  if (composite == null || !Number.isFinite(composite)) return 1.0;
+  if (composite < 0) return cfg.skipIfNegative ? 0 : cfg.multLow;
+  let mult: number;
+  if (composite < cfg.lowThreshold) mult = cfg.multLow;
+  else if (composite > cfg.highThreshold) mult = cfg.multHigh;
+  else mult = 1.0;
+  return Math.max(0, Math.min(cfg.maxMultiplier, mult));
+}
+
+/**
+ * Parse config depuis env vars.
+ */
+export function parseConvictionSizingConfig(env: {
+  CONVICTION_SIZING_ENABLED?: string | undefined;
+  CONVICTION_SIZING_MULT_LOW?: string | undefined;
+  CONVICTION_SIZING_MULT_HIGH?: string | undefined;
+  CONVICTION_SIZING_LOW_THRESHOLD?: string | undefined;
+  CONVICTION_SIZING_HIGH_THRESHOLD?: string | undefined;
+  CONVICTION_SIZING_SKIP_IF_NEGATIVE?: string | undefined;
+  CONVICTION_SIZING_MAX_MULTIPLIER?: string | undefined;
+}): { enabled: boolean; cfg: ConvictionSizingConfig } {
+  const enabled = (env.CONVICTION_SIZING_ENABLED ?? 'false').toLowerCase() === 'true';
+  const parseFloat01 = (raw: string | undefined, def: number, min: number, max: number): number => {
+    const n = Number.parseFloat(raw ?? '');
+    return Number.isFinite(n) && n >= min && n <= max ? n : def;
+  };
+  return {
+    enabled,
+    cfg: {
+      skipIfNegative: (env.CONVICTION_SIZING_SKIP_IF_NEGATIVE ?? 'true').toLowerCase() !== 'false',
+      multLow: parseFloat01(env.CONVICTION_SIZING_MULT_LOW, DEFAULT_CONVICTION_SIZING.multLow, 0, 2),
+      multHigh: parseFloat01(env.CONVICTION_SIZING_MULT_HIGH, DEFAULT_CONVICTION_SIZING.multHigh, 0, 3),
+      lowThreshold: parseFloat01(env.CONVICTION_SIZING_LOW_THRESHOLD, DEFAULT_CONVICTION_SIZING.lowThreshold, 0, 1),
+      highThreshold: parseFloat01(env.CONVICTION_SIZING_HIGH_THRESHOLD, DEFAULT_CONVICTION_SIZING.highThreshold, 0, 1),
+      maxMultiplier: parseFloat01(env.CONVICTION_SIZING_MAX_MULTIPLIER, DEFAULT_CONVICTION_SIZING.maxMultiplier, 0.5, 5),
+    },
+  };
+}
+
 /**
  * Point d'entrée principal : input → ThesisHealthResult complet.
  */

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -87,6 +87,12 @@ import {
 import { TickerBlacklistService } from './ticker-blacklist.service';
 import { CorrelationGuardService } from './correlation-guard.service';
 import {
+  computeEntryConvictionScore,
+  decideSizingMultiplier,
+  parseConvictionSizingConfig,
+  type ConvictionSizingConfig,
+} from './thesis-health-score.helper';
+import {
   EARLY_RETURN_REASONS,
   type EarlyReturnReason,
   type GainersScannerStatus,
@@ -423,6 +429,13 @@ export class TopGainersScannerService implements OnModuleInit {
   private readonly stagflationHedgeGuard: StagflationHedgeGuardConfig;
 
   /**
+   * Feature #2 — Sizing calibré sur la conviction. Default OFF.
+   * Parsed once au constructor. Si enabled, calcule conviction score @ entry
+   * et scale notional par mult ∈ {0, 0.7, 1.0, 1.5}.
+   */
+  private convictionSizing!: { enabled: boolean; cfg: ConvictionSizingConfig };
+
+  /**
    * Data-driven gates per-class (audit 23-24/05). Default toutes envs vides = OFF.
    * S'ajoute aux gates existants (additif, OR logique).
    */
@@ -723,6 +736,23 @@ export class TopGainersScannerService implements OnModuleInit {
     if (this.tickerSizeMult.multipliers.size > 0) {
       this.logger.log(
         `[ticker-size-mult] ENABLED — ${this.tickerSizeMult.multipliers.size} tickers boostés/réduits`,
+      );
+    }
+
+    // Feature #2 — Conviction-calibrated sizing. Default OFF (back-compat).
+    this.convictionSizing = parseConvictionSizingConfig({
+      CONVICTION_SIZING_ENABLED: this.config.get<string>('CONVICTION_SIZING_ENABLED'),
+      CONVICTION_SIZING_MULT_LOW: this.config.get<string>('CONVICTION_SIZING_MULT_LOW'),
+      CONVICTION_SIZING_MULT_HIGH: this.config.get<string>('CONVICTION_SIZING_MULT_HIGH'),
+      CONVICTION_SIZING_LOW_THRESHOLD: this.config.get<string>('CONVICTION_SIZING_LOW_THRESHOLD'),
+      CONVICTION_SIZING_HIGH_THRESHOLD: this.config.get<string>('CONVICTION_SIZING_HIGH_THRESHOLD'),
+      CONVICTION_SIZING_SKIP_IF_NEGATIVE: this.config.get<string>('CONVICTION_SIZING_SKIP_IF_NEGATIVE'),
+      CONVICTION_SIZING_MAX_MULTIPLIER: this.config.get<string>('CONVICTION_SIZING_MAX_MULTIPLIER'),
+    });
+    if (this.convictionSizing.enabled) {
+      const { multLow, multHigh, lowThreshold, highThreshold, skipIfNegative } = this.convictionSizing.cfg;
+      this.logger.log(
+        `[conviction-sizing] ENABLED — mult ${multLow}/${multHigh} thresholds ${lowThreshold}/${highThreshold} skipNeg=${skipIfNegative}`,
       );
     }
   }
@@ -3583,12 +3613,38 @@ export class TopGainersScannerService implements OnModuleInit {
     // Ticker size multiplier data-driven (audit 23/05).
     // Default 1.0 (no-op) si symbole pas dans la config. Cap [0.1, 3.0] côté helper.
     const sizeMult = getTickerSizeMultiplier(cand.symbol, this.tickerSizeMult);
-    const effectiveNotional = Math.round(baseNotional * sizeMult * 100) / 100;
+    const tickerScaledNotional = baseNotional * sizeMult;
     if (sizeMult !== 1.0) {
       this.logger.log(
-        `[top-gainers] ${cand.symbol} size-mult ×${sizeMult} → notional $${baseNotional.toFixed(2)} → $${effectiveNotional.toFixed(2)}`,
+        `[top-gainers] ${cand.symbol} ticker-size-mult ×${sizeMult} → notional $${baseNotional.toFixed(2)} → $${tickerScaledNotional.toFixed(2)}`,
       );
     }
+
+    // Feature #2 — Conviction-calibrated sizing. Default OFF (mult = 1.0).
+    // Score @ entry basé sur (pathEff, persistence, ch1m) du candidat.
+    // Si enabled et composite < 0 (skipIfNegative=true par défaut) → mult=0 → SKIP open.
+    let convictionMult = 1.0;
+    let convictionScore = 0;
+    if (this.convictionSizing.enabled) {
+      convictionScore = computeEntryConvictionScore({
+        pathEff: persistence?.pathQuality?.overallEfficiency ?? null,
+        persistence: persistence?.persistenceScore ?? null,
+        ch1mPct: typeof cand.changePct === 'number' && Number.isFinite(cand.changePct) ? cand.changePct : null,
+      });
+      convictionMult = decideSizingMultiplier(convictionScore, this.convictionSizing.cfg);
+      if (convictionMult === 0) {
+        this.logger.log(
+          `[conviction-sizing] ${cand.symbol} SKIP open — score ${convictionScore.toFixed(3)} < 0 (thèse déjà cassée à l'entry)`,
+        );
+        return null;
+      }
+      if (convictionMult !== 1.0) {
+        this.logger.log(
+          `[conviction-sizing] ${cand.symbol} score=${convictionScore.toFixed(3)} → mult ×${convictionMult.toFixed(2)}`,
+        );
+      }
+    }
+    const effectiveNotional = Math.round(tickerScaledNotional * convictionMult * 100) / 100;
 
     // PR #250 — DÉCOUPLAGE COMPLET du pipeline LLM Lisa.
     //


### PR DESCRIPTION
## Contexte

Feature #2 de la roadmap "IA au cœur" : la machine investit MOINS sur les setups moyens et PLUS sur les A+ — comme un trader humain.

Aujourd'hui, chaque position prend ~$787 fixe, peu importe la qualité du signal. Un pathEff 0.55 (juste au-dessus du seuil) reçoit le même sizing qu'un pathEff 0.85 (très clean). Cette feature corrige ça.

## Architecture (pure addition, zéro refactor)

- **`thesis-health-score.helper.ts` (étendu)** :
  - `computeEntryConvictionScore({pathEff, persistence, ch1mPct})` → score ∈ [-1, +1]
  - `decideSizingMultiplier(score, cfg)` → multiplicateur clampé
  - `parseConvictionSizingConfig(env)` → config
- **`top-gainers-scanner.service.ts`** : avant `openPositionDirect`, calcule score + applique mult au notional

## Mapping verdict → sizing

| Score @ entry | Mult | Logique |
|---|---|---|
| `< 0` | **0 (SKIP)** | Thèse déjà cassée à l'entry, argent jeté |
| `[0, 0.30)` | 0.7 | Conviction moyenne, on engage moins |
| `[0.30, 0.60]` | 1.0 | Standard (default) |
| `> 0.60` | 1.5 | A+ setup, on charge |

Normalisation des features :
- `pathEff_norm = (v - 0.55) / 0.30` clampé
- `persistence_norm = (v - 0.50) / 0.30` clampé
- `ch1m_norm = min(v / 5.0, 1.0)`

## Gating ENV (default OFF, back-compat 100%)

```
CONVICTION_SIZING_ENABLED=true
CONVICTION_SIZING_MULT_LOW=0.7
CONVICTION_SIZING_MULT_HIGH=1.5
CONVICTION_SIZING_LOW_THRESHOLD=0.30
CONVICTION_SIZING_HIGH_THRESHOLD=0.60
CONVICTION_SIZING_SKIP_IF_NEGATIVE=true
CONVICTION_SIZING_MAX_MULTIPLIER=2.0  # cap dur
```

## Test plan

- [x] 49 tests helper verts (validation cas réel 24/05 inclus)
- [x] **211 suites / 2 819 tests apps/api verts** (aucune régression)
- [x] `tsc --noEmit` clean
- [ ] Activer en prod : `fly secrets set CONVICTION_SIZING_ENABLED=true`
- [ ] Vérifier logs `[conviction-sizing]` au prochain scanner cycle

## Safeguards

- Default OFF (mult=1.0 fallback)
- Score null/NaN → mult=1.0 (back-compat safe)
- Cap dur `maxMultiplier=2.0` (sécurité anti-explosion sizing)
- SKIP si score < 0 (configurable, default true)
- Aucun changement de structure DB ou flow scanner

## Effet attendu

Sur 30j de trades à profil mixed :
- ~20 % des opens en zone "score < 0" → évités = ~$15-20 perte évitée/jour
- ~30 % des opens en A+ tier → sizing ×1.5 → +$25-40 gain/jour si stratégie WR ~50%

Net estimé : **+$30-50/jour** sur le système actuel.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_