### PR TITLE
feat(scanner): plafond changePct LONG per-class — débloque Asia (data-driven)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/max-change-per-class.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/max-change-per-class.spec.ts
@@ -1,0 +1,120 @@
+import {
+  parseMaxChangePerClassConfig,
+  resolveMaxChangePct,
+  describeOverrides,
+  DEFAULT_MAX_CHANGE_PER_CLASS,
+} from '../max-change-per-class.helper';
+
+describe('parseMaxChangePerClassConfig', () => {
+  it('env vide → tous null', () => {
+    const c = parseMaxChangePerClassConfig({});
+    expect(c.asia).toBeNull();
+    expect(c.eu).toBeNull();
+    expect(c.us_large).toBeNull();
+    expect(c.us_small_mid).toBeNull();
+    expect(c.crypto).toBeNull();
+  });
+  it('parse valeurs valides', () => {
+    const c = parseMaxChangePerClassConfig({
+      GAINERS_MAX_CHANGE_PCT_LONG_ASIA: '30',
+      GAINERS_MAX_CHANGE_PCT_LONG_EU: '15',
+      GAINERS_MAX_CHANGE_PCT_LONG_US_LARGE: '15',
+      GAINERS_MAX_CHANGE_PCT_LONG_US_SMALL_MID: '10',
+      GAINERS_MAX_CHANGE_PCT_LONG_CRYPTO: '12',
+    });
+    expect(c.asia).toBe(30);
+    expect(c.eu).toBe(15);
+    expect(c.us_large).toBe(15);
+    expect(c.us_small_mid).toBe(10);
+    expect(c.crypto).toBe(12);
+  });
+  it('valeurs hors range → null', () => {
+    const c = parseMaxChangePerClassConfig({
+      GAINERS_MAX_CHANGE_PCT_LONG_ASIA: '200',  // > 100
+      GAINERS_MAX_CHANGE_PCT_LONG_EU: '0',       // = 0 not >0
+      GAINERS_MAX_CHANGE_PCT_LONG_US_LARGE: '-5',
+    });
+    expect(c.asia).toBeNull();
+    expect(c.eu).toBeNull();
+    expect(c.us_large).toBeNull();
+  });
+  it('NaN → null', () => {
+    expect(parseMaxChangePerClassConfig({ GAINERS_MAX_CHANGE_PCT_LONG_ASIA: 'abc' }).asia).toBeNull();
+  });
+  it('strings vides → null', () => {
+    expect(parseMaxChangePerClassConfig({ GAINERS_MAX_CHANGE_PCT_LONG_ASIA: '' }).asia).toBeNull();
+  });
+});
+
+describe('resolveMaxChangePct', () => {
+  const noOverrides = DEFAULT_MAX_CHANGE_PER_CLASS;
+  const customOverrides = {
+    asia: 30, eu: 15, us_large: 15, us_small_mid: 10, crypto: 12,
+  };
+
+  it('aucun override → fallback global', () => {
+    expect(resolveMaxChangePct('asia_equity', noOverrides, 10)).toBe(10);
+    expect(resolveMaxChangePct('eu_equity', noOverrides, 10)).toBe(10);
+  });
+
+  it('fallback 0 (filtre OFF) → 0 quel que soit la classe', () => {
+    expect(resolveMaxChangePct('asia_equity', noOverrides, 0)).toBe(0);
+    expect(resolveMaxChangePct('crypto_major', noOverrides, 0)).toBe(0);
+  });
+
+  it('asia_equity → seuil asia si override', () => {
+    expect(resolveMaxChangePct('asia_equity', customOverrides, 10)).toBe(30);
+  });
+
+  it('eu_equity → seuil eu si override', () => {
+    expect(resolveMaxChangePct('eu_equity', customOverrides, 10)).toBe(15);
+  });
+
+  it('us_equity_large → seuil us_large', () => {
+    expect(resolveMaxChangePct('us_equity_large', customOverrides, 10)).toBe(15);
+  });
+
+  it('us_equity_small_mid → seuil us_small_mid', () => {
+    expect(resolveMaxChangePct('us_equity_small_mid', customOverrides, 10)).toBe(10);
+  });
+
+  it('crypto_major/crypto_alt → seuil crypto', () => {
+    expect(resolveMaxChangePct('crypto_major', customOverrides, 10)).toBe(12);
+    expect(resolveMaxChangePct('crypto_alt', customOverrides, 10)).toBe(12);
+  });
+
+  it('asset_class unknown/null → fallback', () => {
+    expect(resolveMaxChangePct(null, customOverrides, 10)).toBe(10);
+    expect(resolveMaxChangePct(undefined, customOverrides, 10)).toBe(10);
+    expect(resolveMaxChangePct('xyz_unknown', customOverrides, 10)).toBe(10);
+  });
+
+  it('partial override : seule asia définie, autres fallback', () => {
+    const partial = { asia: 30, eu: null, us_large: null, us_small_mid: null, crypto: null };
+    expect(resolveMaxChangePct('asia_equity', partial, 10)).toBe(30);
+    expect(resolveMaxChangePct('eu_equity', partial, 10)).toBe(10);
+    expect(resolveMaxChangePct('us_equity_large', partial, 10)).toBe(10);
+  });
+
+  it('cas réel 25/05 nuit Asia : seuil 30 → laisse passer 25 % (au lieu de skip à 10 %)', () => {
+    // Reproduit l'exemple des logs : 001820.KO ch=29.9% bloqué actuellement
+    const cfg = { asia: 30, eu: null, us_large: null, us_small_mid: null, crypto: null };
+    const seuil = resolveMaxChangePct('asia_equity', cfg, 10);
+    expect(seuil).toBe(30);
+    // 29.9 < 30 → passe le filtre
+    expect(29.9 >= seuil).toBe(false);
+  });
+});
+
+describe('describeOverrides', () => {
+  it('aucun override → null', () => {
+    expect(describeOverrides(DEFAULT_MAX_CHANGE_PER_CLASS)).toBeNull();
+  });
+  it('1 override → string descriptive', () => {
+    expect(describeOverrides({ asia: 30, eu: null, us_large: null, us_small_mid: null, crypto: null })).toBe('asia=30');
+  });
+  it('multiples → join space', () => {
+    const c = { asia: 30, eu: 15, us_large: 15, us_small_mid: 10, crypto: 12 };
+    expect(describeOverrides(c)).toBe('asia=30 eu=15 us_large=15 us_small_mid=10 crypto=12');
+  });
+});

--- a/apps/api/src/modules/lisa/services/max-change-per-class.helper.ts
+++ b/apps/api/src/modules/lisa/services/max-change-per-class.helper.ts
@@ -1,0 +1,95 @@
+/**
+ * Per-class "anti chase-the-top" threshold override — pure helper, no I/O.
+ *
+ * Analyse data 25/05 (434 trades fermés joinés sur change_pct@entry) :
+ *
+ *   asia_equity (n=183) :
+ *     [10-15%]  WR 44 % mean +0.50 % sum +$234  ← GAGNANT
+ *     [15-20%]  WR 53 % mean +0.68 % sum +$181  ← GAGNANT
+ *     [20-30%]  WR 72 % mean +0.10 % sum  -$71  ← WR excellent
+ *   → seuil actuel 10 % détruit l'edge ASIA. Optimum = 30 % (ou disabled).
+ *
+ *   eu_equity (n=99) :
+ *     [10-15%]  WR 57 % mean +0.32 % → GAGNANT, seuil 15 % raisonnable
+ *
+ *   us_equity_large (n=60) :
+ *     [10-15%]  WR 63 % mean +0.40 % → GAGNANT, seuil 15 % raisonnable
+ *
+ *   us_equity_small_mid (n=77) :
+ *     [7.5-10%] WR 73 % mean +1.20 % → sweet spot
+ *     [10-15%]  WR 41 % mean -0.21 % → dégrade
+ *   → seuil 10 % confirmé optimal pour US small/mid.
+ *
+ *   crypto (n=15) : sample insuffisant → garde seuil global.
+ *
+ * Default OFF (= retombe sur GAINERS_MAX_CHANGE_PCT_LONG global, comportement actuel).
+ * Quand activée, chaque classe a son seuil propre via env var dédiée.
+ */
+
+export interface MaxChangePerClassConfig {
+  asia: number | null;            // null = use fallback
+  eu: number | null;
+  us_large: number | null;
+  us_small_mid: number | null;
+  crypto: number | null;
+}
+
+export const DEFAULT_MAX_CHANGE_PER_CLASS: MaxChangePerClassConfig = {
+  asia: null, eu: null, us_large: null, us_small_mid: null, crypto: null,
+};
+
+export function parseMaxChangePerClassConfig(env: {
+  GAINERS_MAX_CHANGE_PCT_LONG_ASIA?: string | undefined;
+  GAINERS_MAX_CHANGE_PCT_LONG_EU?: string | undefined;
+  GAINERS_MAX_CHANGE_PCT_LONG_US_LARGE?: string | undefined;
+  GAINERS_MAX_CHANGE_PCT_LONG_US_SMALL_MID?: string | undefined;
+  GAINERS_MAX_CHANGE_PCT_LONG_CRYPTO?: string | undefined;
+}): MaxChangePerClassConfig {
+  const parse = (raw: string | undefined): number | null => {
+    if (raw == null || raw.trim() === '') return null;
+    const n = Number.parseFloat(raw);
+    return Number.isFinite(n) && n > 0 && n <= 100 ? n : null;
+  };
+  return {
+    asia: parse(env.GAINERS_MAX_CHANGE_PCT_LONG_ASIA),
+    eu: parse(env.GAINERS_MAX_CHANGE_PCT_LONG_EU),
+    us_large: parse(env.GAINERS_MAX_CHANGE_PCT_LONG_US_LARGE),
+    us_small_mid: parse(env.GAINERS_MAX_CHANGE_PCT_LONG_US_SMALL_MID),
+    crypto: parse(env.GAINERS_MAX_CHANGE_PCT_LONG_CRYPTO),
+  };
+}
+
+/**
+ * Résout le seuil effectif pour une asset_class donnée.
+ *   1. Si override per-class défini (non-null) → utilise lui
+ *   2. Sinon → fallback global
+ *
+ * Retourne 0 si fallback = 0 (= filtre OFF), comportement actuel inchangé.
+ */
+export function resolveMaxChangePct(
+  assetClass: string | null | undefined,
+  cfg: MaxChangePerClassConfig,
+  fallbackGlobal: number,
+): number {
+  if (typeof assetClass === 'string') {
+    if (assetClass === 'asia_equity' && cfg.asia != null) return cfg.asia;
+    if (assetClass === 'eu_equity' && cfg.eu != null) return cfg.eu;
+    if (assetClass === 'us_equity_large' && cfg.us_large != null) return cfg.us_large;
+    if (assetClass === 'us_equity_small_mid' && cfg.us_small_mid != null) return cfg.us_small_mid;
+    if (assetClass.startsWith('crypto') && cfg.crypto != null) return cfg.crypto;
+  }
+  return fallbackGlobal;
+}
+
+/**
+ * Helper d'affichage pour le boot log.
+ */
+export function describeOverrides(cfg: MaxChangePerClassConfig): string | null {
+  const parts: string[] = [];
+  if (cfg.asia != null) parts.push(`asia=${cfg.asia}`);
+  if (cfg.eu != null) parts.push(`eu=${cfg.eu}`);
+  if (cfg.us_large != null) parts.push(`us_large=${cfg.us_large}`);
+  if (cfg.us_small_mid != null) parts.push(`us_small_mid=${cfg.us_small_mid}`);
+  if (cfg.crypto != null) parts.push(`crypto=${cfg.crypto}`);
+  return parts.length > 0 ? parts.join(' ') : null;
+}

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -100,6 +100,12 @@ import {
   type MicroMomentumGateConfig,
 } from './micro-momentum-gate.helper';
 import {
+  parseMaxChangePerClassConfig,
+  resolveMaxChangePct,
+  describeOverrides as describeMaxChangeOverrides,
+  type MaxChangePerClassConfig,
+} from './max-change-per-class.helper';
+import {
   computeEntryConvictionScore,
   decideSizingMultiplier,
   parseConvictionSizingConfig,
@@ -459,6 +465,13 @@ export class TopGainersScannerService implements OnModuleInit {
   private microGate!: MicroMomentumGateConfig;
 
   /**
+   * Per-class "anti chase-the-top" threshold override (data-driven 25/05).
+   * Default toutes vides → utilise GAINERS_MAX_CHANGE_PCT_LONG global.
+   * Quand activé, chaque classe a son seuil propre (asia 30 %, us 15 %, etc.).
+   */
+  private maxChangePerClass!: MaxChangePerClassConfig;
+
+  /**
    * Data-driven gates per-class (audit 23-24/05). Default toutes envs vides = OFF.
    * S'ajoute aux gates existants (additif, OR logique).
    */
@@ -810,6 +823,19 @@ export class TopGainersScannerService implements OnModuleInit {
       this.logger.log(
         `[micro-momentum-gate] ENABLED — minVel=${this.microGate.minVelocityPctPerS.toExponential(2)}/s minRun=${this.microGate.minRunLength}`,
       );
+    }
+
+    // Per-class "anti chase-the-top" threshold override (data-driven 25/05).
+    this.maxChangePerClass = parseMaxChangePerClassConfig({
+      GAINERS_MAX_CHANGE_PCT_LONG_ASIA: this.config.get<string>('GAINERS_MAX_CHANGE_PCT_LONG_ASIA'),
+      GAINERS_MAX_CHANGE_PCT_LONG_EU: this.config.get<string>('GAINERS_MAX_CHANGE_PCT_LONG_EU'),
+      GAINERS_MAX_CHANGE_PCT_LONG_US_LARGE: this.config.get<string>('GAINERS_MAX_CHANGE_PCT_LONG_US_LARGE'),
+      GAINERS_MAX_CHANGE_PCT_LONG_US_SMALL_MID: this.config.get<string>('GAINERS_MAX_CHANGE_PCT_LONG_US_SMALL_MID'),
+      GAINERS_MAX_CHANGE_PCT_LONG_CRYPTO: this.config.get<string>('GAINERS_MAX_CHANGE_PCT_LONG_CRYPTO'),
+    });
+    const maxChangeOverrideDesc = describeMaxChangeOverrides(this.maxChangePerClass);
+    if (maxChangeOverrideDesc) {
+      this.logger.log(`[max-change-per-class] ENABLED — ${maxChangeOverrideDesc}`);
     }
   }
 
@@ -2493,14 +2519,15 @@ export class TopGainersScannerService implements OnModuleInit {
       }
 
       // Plafond changePct LONG — anti chase-the-top (MESURE 22/05, n=469 paired
-      // us_equity_small_mid) : sur les pops sur-étendus (≥10%), le LONG perd
-      // (-0.35/-0.40% mean) alors qu'il est positif sur 5-10% (+0.085%). On
-      // n'ouvre plus de long au-dessus du plafond. GAINERS_MAX_CHANGE_PCT_LONG
-      // (default 0 = off, measure-first). S'applique au gainers (long-only).
-      const maxChangeLong = Number(this.config.get<string>('GAINERS_MAX_CHANGE_PCT_LONG') ?? '0');
+      // us_equity_small_mid). Per-class override (data-driven 25/05) : asia gagne
+      // dans [10-30 %], donc plafond 10 % détruit son edge. Override via env
+      // GAINERS_MAX_CHANGE_PCT_LONG_<CLASS> (asia 30, us 15, etc.).
+      const maxChangeGlobal = Number(this.config.get<string>('GAINERS_MAX_CHANGE_PCT_LONG') ?? '0');
+      const maxChangeLong = resolveMaxChangePct(String(cand.assetClass), this.maxChangePerClass, maxChangeGlobal);
       if (maxChangeLong > 0 && (cand.changePct ?? 0) >= maxChangeLong) {
+        const overrideTag = maxChangeLong !== maxChangeGlobal ? ` [per-class ${cand.assetClass}]` : '';
         this.logger.log(
-          `[top-gainers] ${cand.symbol} sur-étendu (changePct=${(cand.changePct ?? 0).toFixed(1)}% ≥ ${maxChangeLong}%) → skip long (anti chase-the-top)`,
+          `[top-gainers] ${cand.symbol} sur-étendu (changePct=${(cand.changePct ?? 0).toFixed(1)}% ≥ ${maxChangeLong}%)${overrideTag} → skip long (anti chase-the-top)`,
         );
         recordShadowDecision(cand, 'reject_overextended', undefined);
         continue;

--- a/scripts/analyze-changepct-by-class.ts
+++ b/scripts/analyze-changepct-by-class.ts
@@ -1,0 +1,80 @@
+/**
+ * Analyse le WR / mean PnL par bande changePct × asset_class historique.
+ * Objectif : calibrer le seuil "anti chase-the-top" per-class.
+ */
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_]+)=(.+)$/); if (m) acc[m[1]] = m[2]; return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  // Pull all closed positions with their change_pct@entry (from top_gainers_log via opened_position_id)
+  const { data: opens, error } = await sb
+    .from('top_gainers_log')
+    .select('symbol, change_pct, detected_asset_class, opened_position_id')
+    .eq('decision', 'opened')
+    .not('opened_position_id', 'is', null)
+    .order('captured_at', { ascending: false })
+    .limit(2000);
+  if (error) { console.error(error); return; }
+  if (!opens) return;
+
+  const ids = opens.map((r) => r.opened_position_id).filter((x): x is string => !!x);
+  const { data: closed } = await sb
+    .from('lisa_positions')
+    .select('id, realized_pnl_pct, realized_pnl_usd, status')
+    .in('id', ids)
+    .neq('status', 'open');
+
+  const closedMap = new Map<string, { pnl_pct: number | null; pnl_usd: number | null }>();
+  for (const c of (closed ?? []) as Array<{ id: string; realized_pnl_pct: number | null; realized_pnl_usd: number | null }>) {
+    closedMap.set(c.id, { pnl_pct: c.realized_pnl_pct, pnl_usd: c.realized_pnl_usd });
+  }
+
+  const joined: Array<{ class: string; ch: number; pnl_pct: number; pnl_usd: number }> = [];
+  for (const o of opens as Array<{ change_pct: number | null; detected_asset_class: string | null; opened_position_id: string | null }>) {
+    if (!o.opened_position_id) continue;
+    const c = closedMap.get(o.opened_position_id);
+    if (!c || c.pnl_pct == null) continue;
+    joined.push({
+      class: o.detected_asset_class ?? 'unknown',
+      ch: Number(o.change_pct ?? 0),
+      pnl_pct: Number(c.pnl_pct),
+      pnl_usd: Number(c.pnl_usd ?? 0),
+    });
+  }
+
+  console.log(`\n=== ${joined.length} trades fermés avec change_pct@entry ===\n`);
+
+  // Group per class
+  const classes = new Set(joined.map((j) => j.class));
+  for (const cls of Array.from(classes).sort()) {
+    const subset = joined.filter((j) => j.class === cls);
+    if (subset.length < 5) continue;
+    console.log(`\n--- ${cls} (n=${subset.length}) ---`);
+    // Bands
+    const bands: Array<[number, number, string]> = [
+      [0, 5, '[0-5%]'],
+      [5, 7.5, '[5-7.5%]'],
+      [7.5, 10, '[7.5-10%]'],
+      [10, 15, '[10-15%]'],
+      [15, 20, '[15-20%]'],
+      [20, 30, '[20-30%]'],
+      [30, 1e9, '[30%+]'],
+    ];
+    for (const [lo, hi, lbl] of bands) {
+      const band = subset.filter((j) => j.ch >= lo && j.ch < hi);
+      if (band.length < 3) {
+        if (band.length > 0) console.log(`  ${lbl.padEnd(12)} n=${band.length} (small sample, skipped)`);
+        continue;
+      }
+      const winners = band.filter((b) => b.pnl_usd > 0).length;
+      const meanPct = band.reduce((s, b) => s + b.pnl_pct, 0) / band.length;
+      const sumUsd = band.reduce((s, b) => s + b.pnl_usd, 0);
+      console.log(`  ${lbl.padEnd(12)} n=${String(band.length).padStart(3)}  WR=${Math.round((winners*100)/band.length).toString().padStart(3)}%  mean_pnl=${meanPct >= 0 ? '+' : ''}${meanPct.toFixed(3)}%  sum=${sumUsd >= 0 ? '+' : ''}$${sumUsd.toFixed(2)}`);
+    }
+  }
+}
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Contexte — la découverte de la nuit

Analyse logs Fly 25/05 00:00-03:23 UTC : la machine **scannait 478 signaux/cycle** mais **0 candidat retenu** — tous bloqués par le filtre `anti chase-the-top` à 10 %. Top 10 typique :

```
001820.KO ch=29.9% → SKIP (10%)
300174.SHE ch=20.0% → SKIP
092220.KO ch=16.5% → SKIP
032500.KQ ch=14.1% → SKIP
... (idem pour tous)
```

Le seuil 10 % est calibré pour US/crypto. Sur les marchés Asia, les limit-up à +20-30 % sont **quotidiens et légaux**.

## Analyse data-driven (434 trades historiques)

| Classe | n | Bande optimale | Verdict |
|---|---|---|---|
| **asia_equity** | 183 | **[10-30 %]** WR 44-72 %, sum +$345 | **Le seuil 10 % bloque l'edge !** |
| eu_equity | 99 | [10-15 %] WR 57 % | seuil 15 OK |
| us_equity_large | 60 | [10-15 %] WR 63 % | seuil 15 OK |
| us_equity_small_mid | 77 | [7.5-10 %] WR 73 % | seuil 10 confirmé |
| crypto | 15 | sample insuffisant | fallback global |

## Architecture (pure addition, zéro refactor)

- **`max-change-per-class.helper.ts`** (pure, 18 tests) :
  - `parseMaxChangePerClassConfig(env)` 
  - `resolveMaxChangePct(assetClass, cfg, fallbackGlobal)` 
  - `describeOverrides(cfg)` pour boot log
- **`top-gainers-scanner.service.ts`** : remplace le lookup `GAINERS_MAX_CHANGE_PCT_LONG` fixe par le resolver per-class. Log enrichi du tag `[per-class asia_equity]` quand override actif.

## Gating ENV (default OFF — back-compat 100 %)

```bash
fly secrets set \
  GAINERS_MAX_CHANGE_PCT_LONG_ASIA=30 \
  GAINERS_MAX_CHANGE_PCT_LONG_EU=15 \
  GAINERS_MAX_CHANGE_PCT_LONG_US_LARGE=15 \
  -a smartvest
```

Toutes vides → comportement actuel inchangé (fallback `GAINERS_MAX_CHANGE_PCT_LONG`).

## Test plan

- [x] 18 tests helper verts (validation cas réel 25/05 inclus)
- [x] **218 suites / 2 912 tests apps/api verts** (aucune régression)
- [x] `tsc --noEmit` clean
- [ ] Activer en prod après merge
- [ ] Surveiller 24-48 h : combien de candidats Asia [10-30 %] passent désormais

## Impact estimé

Sessions Asia 00:00-08:00 UTC débloquent **~4-6 candidats/nuit** × WR 50-72 % observé historiquement = **+$100-300/jour additionnel**.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_