### PR TITLE
feat(scanner): hour gate per-class peut override le global (débloque asia@6-8h)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/data-driven-gates.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/data-driven-gates.spec.ts
@@ -2,6 +2,7 @@ import {
   parseHoursCsv,
   parsePerClassHourBlacklist,
   shouldSkipByPerClassHourGate,
+  hasPerClassOverride,
   parseTickerSizeMultCsv,
   getTickerSizeMultiplier,
 } from '../data-driven-gates.helper';
@@ -155,5 +156,33 @@ describe('getTickerSizeMultiplier', () => {
   it('non-match → 1.0 (no-op default)', () => {
     expect(getTickerSizeMultiplier('AAPL.US', cfg)).toBe(1.0);
     expect(getTickerSizeMultiplier('UNKNOWN', cfg)).toBe(1.0);
+  });
+});
+
+describe('hasPerClassOverride', () => {
+  it('blacklist vide → false (pas d\'override)', () => {
+    const cfg = parsePerClassHourBlacklist({});
+    expect(hasPerClassOverride('asia_equity', cfg)).toBe(false);
+    expect(hasPerClassOverride('eu_equity', cfg)).toBe(false);
+  });
+
+  it('asia blacklist non-vide → true pour asia_equity', () => {
+    const cfg = parsePerClassHourBlacklist({ GAINERS_HOUR_BLACKLIST_ASIA_UTC: '0,1,2' });
+    expect(hasPerClassOverride('asia_equity', cfg)).toBe(true);
+    expect(hasPerClassOverride('eu_equity', cfg)).toBe(false);
+  });
+
+  it('asset_class inconnu → false', () => {
+    const cfg = parsePerClassHourBlacklist({ GAINERS_HOUR_BLACKLIST_ASIA_UTC: '0,1' });
+    expect(hasPerClassOverride('xyz_unknown', cfg)).toBe(false);
+  });
+
+  it('cas réel : Asia override [0..5] permet de lever global 8h pour asia', () => {
+    const cfg = parsePerClassHourBlacklist({ GAINERS_HOUR_BLACKLIST_ASIA_UTC: '0,1,2,3,4,5' });
+    expect(hasPerClassOverride('asia_equity', cfg)).toBe(true);
+    // L'heure 8 n'est PAS dans la blacklist asia → ne skip pas
+    expect(shouldSkipByPerClassHourGate('asia_equity', 8, cfg)).toBe(false);
+    // L'heure 3 EST dans la blacklist asia → skip
+    expect(shouldSkipByPerClassHourGate('asia_equity', 3, cfg)).toBe(true);
   });
 });

--- a/apps/api/src/modules/lisa/services/data-driven-gates.helper.ts
+++ b/apps/api/src/modules/lisa/services/data-driven-gates.helper.ts
@@ -96,6 +96,24 @@ export function shouldSkipByPerClassHourGate(
 }
 
 /**
+ * Returns true si une override per-class est définie pour cette classe (i.e.
+ * sa blacklist contient ≥ 1 heure). Utilisé par le scanner pour décider de
+ * "remplacer" le gate global par le per-class quand mode override est actif.
+ *
+ * Ex : si Asia override = [0,1,2,3,4,5], le scanner ignorera le global
+ * GAINERS_LONG_HOUR_BLACKLIST_UTC pour les candidats Asia (et utilisera
+ * uniquement le per-class). Permet d'autoriser asia@8h même si global blacklist 8h.
+ */
+export function hasPerClassOverride(
+  assetClass: string,
+  config: PerClassHourBlacklistConfig,
+): boolean {
+  const cls = assetClass as keyof PerClassHourBlacklistConfig;
+  const blacklist = config[cls];
+  return Boolean(blacklist && blacklist.size > 0);
+}
+
+/**
  * Parse "TICKER:MULT,TICKER:MULT" → Map<symbol_uppercase, multiplier>.
  * Pure, testable.
  *

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -47,6 +47,7 @@ import {
 import {
   parsePerClassHourBlacklist,
   shouldSkipByPerClassHourGate,
+  hasPerClassOverride,
   parseTickerSizeMultCsv,
   getTickerSizeMultiplier,
   type PerClassHourBlacklistConfig,
@@ -2546,7 +2547,15 @@ export class TopGainersScannerService implements OnModuleInit {
       const blacklistRaw = (this.config.get<string>('GAINERS_LONG_HOUR_BLACKLIST_UTC') ?? '').trim();
       const cryptoGated = (this.config.get<string>('GAINERS_LONG_HOUR_GATE_CRYPTO') ?? 'false').toLowerCase() === 'true';
       const isCryptoCandHourGate = cand.assetClass === 'crypto_major' || cand.assetClass === 'crypto_alt';
-      const gateApplies = (whitelistRaw.length > 0 || blacklistRaw.length > 0) && (cryptoGated || !isCryptoCandHourGate);
+      // Per-class override mode (analyse 25/05) : si activé ET la classe a une
+      // blacklist per-class non-vide, on SKIP le gate global pour cette classe.
+      // Permet par ex. d'autoriser asia@8h même si global blacklist 8h.
+      const perClassOverridesGlobal =
+        (this.config.get<string>('GAINERS_HOUR_GATE_PER_CLASS_OVERRIDES_GLOBAL') ?? 'false').toLowerCase() === 'true';
+      const classHasOverride = perClassOverridesGlobal && hasPerClassOverride(String(cand.assetClass), this.perClassHourGate);
+      const gateApplies = !classHasOverride
+        && (whitelistRaw.length > 0 || blacklistRaw.length > 0)
+        && (cryptoGated || !isCryptoCandHourGate);
       if (gateApplies) {
         const hourUtc = nowUtc.getUTCHours();
         // ⚠️ Number('') === 0 en JS → filtrer les tokens vides AVANT le map.

--- a/scripts/analyze-hours-by-class.ts
+++ b/scripts/analyze-hours-by-class.ts
@@ -1,0 +1,68 @@
+/**
+ * Analyse WR / sum PnL par heure UTC × asset_class historique.
+ * Objectif : valider/raffiner le hour blacklist actuel ({0,1,2,3,4,8,19,22,23}).
+ */
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_]+)=(.+)$/); if (m) acc[m[1]] = m[2]; return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const { data: opens } = await sb
+    .from('top_gainers_log')
+    .select('symbol, detected_asset_class, opened_position_id, captured_at')
+    .eq('decision', 'opened')
+    .not('opened_position_id', 'is', null)
+    .order('captured_at', { ascending: false })
+    .limit(2000);
+  if (!opens) return;
+
+  const ids = (opens as Array<{ opened_position_id: string | null }>).map((r) => r.opened_position_id).filter((x): x is string => !!x);
+  const { data: closed } = await sb
+    .from('lisa_positions')
+    .select('id, realized_pnl_pct, realized_pnl_usd, status, entry_timestamp')
+    .in('id', ids)
+    .neq('status', 'open');
+  const closedMap = new Map<string, { pnl_pct: number; pnl_usd: number; ts: string }>();
+  for (const c of (closed ?? []) as Array<{ id: string; realized_pnl_pct: number | null; realized_pnl_usd: number | null; entry_timestamp: string }>) {
+    if (c.realized_pnl_usd != null && c.entry_timestamp) {
+      closedMap.set(c.id, { pnl_pct: Number(c.realized_pnl_pct ?? 0), pnl_usd: Number(c.realized_pnl_usd), ts: c.entry_timestamp });
+    }
+  }
+
+  const joined: Array<{ class: string; hour: number; pnl_pct: number; pnl_usd: number }> = [];
+  for (const o of opens as Array<{ detected_asset_class: string | null; opened_position_id: string | null }>) {
+    if (!o.opened_position_id) continue;
+    const c = closedMap.get(o.opened_position_id);
+    if (!c) continue;
+    const h = Number.parseInt(c.ts.slice(11, 13), 10);
+    if (!Number.isFinite(h)) continue;
+    joined.push({ class: o.detected_asset_class ?? 'unknown', hour: h, pnl_pct: c.pnl_pct, pnl_usd: c.pnl_usd });
+  }
+
+  console.log(`\n=== ${joined.length} trades fermés avec entry_hour_utc ===\n`);
+
+  const classes = ['asia_equity', 'eu_equity', 'us_equity_large', 'us_equity_small_mid', 'crypto_major'];
+  for (const cls of classes) {
+    const sub = joined.filter((j) => j.class === cls);
+    if (sub.length < 10) {
+      console.log(`\n--- ${cls} (n=${sub.length}) → skip ---`);
+      continue;
+    }
+    console.log(`\n--- ${cls} (n=${sub.length}) ---`);
+    console.log('Hour | n   | WR%  | mean_pnl%  | sum_$');
+    for (let h = 0; h < 24; h++) {
+      const band = sub.filter((j) => j.hour === h);
+      if (band.length < 3) continue;
+      const winners = band.filter((b) => b.pnl_usd > 0).length;
+      const meanPct = band.reduce((s, b) => s + b.pnl_pct, 0) / band.length;
+      const sumUsd = band.reduce((s, b) => s + b.pnl_usd, 0);
+      const wr = Math.round((winners * 100) / band.length);
+      const flag = sumUsd >= 0 && wr >= 50 ? ' ✅' : sumUsd <= -20 ? ' ❌' : '';
+      console.log(`${String(h).padStart(2)}h  | ${String(band.length).padStart(3)} | ${String(wr).padStart(3)}% | ${(meanPct >= 0 ? '+' : '')}${meanPct.toFixed(3)}%  | ${sumUsd >= 0 ? '+' : ''}$${sumUsd.toFixed(2)}${flag}`);
+    }
+  }
+}
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Contexte

Suite de PR #420. La blacklist horaire per-class est **additive** au global — impossible de lever une heure du global pour une classe spécifique. Résultat : si `asia@8h` est dans le global blacklist, on bloque même les pumps Asia (qui historiquement gagnent à cette heure : sum +$316).

## Mécanique

Nouveau flag `GAINERS_HOUR_GATE_PER_CLASS_OVERRIDES_GLOBAL` :

| Mode | Comportement |
|---|---|
| `OFF` (default) | Global + per-class **additif** (comportement actuel) |
| `ON` | Per-class **remplace** global pour classes overridées. Global reste actif pour classes sans override. |

## Activation recommandée (data-driven 25/05)

```bash
fly secrets set \
  GAINERS_HOUR_GATE_PER_CLASS_OVERRIDES_GLOBAL=true \
  GAINERS_HOUR_BLACKLIST_ASIA_UTC=0,1,2,3,4,5 \
  GAINERS_HOUR_BLACKLIST_EU_UTC=8,9 \
  GAINERS_HOUR_BLACKLIST_US_UTC=14,17,18 \
  -a smartvest
```

Effets :
- **Asia** : autorise 6h-23h (sauf 0-5h). Débloque sweet spot 6h-8h (+$316 historique).
- **EU** : autorise toutes heures sauf 8h-9h (où sum=-$1730).
- **US** : autorise toutes heures sauf 14h, 17h, 18h (où WR < 40 %).

## Architecture

- `data-driven-gates.helper.ts` : nouvelle fonction `hasPerClassOverride(assetClass, cfg)` — pure, testée
- `top-gainers-scanner.service.ts` : lit le flag global override + skip le gate global si classe a override

## Test plan

- [x] 29 tests `data-driven-gates` verts (4 nouveaux dont cas réel asia@8h)
- [x] **218 suites / 2 916 tests apps/api verts** (aucune régression)
- [x] `tsc --noEmit` clean

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_