### PR TITLE
fix(migration-0162): drop CONCURRENTLY from CREATE UNIQUE INDEX

### DIFF
--- a/supabase/migrations/0162_unique_open_position_per_symbol.sql
+++ b/supabase/migrations/0162_unique_open_position_per_symbol.sql
@@ -15,7 +15,9 @@
 --   instead of an exception, consistent with the cap-reached behaviour):
 --   Before INSERT, check whether the symbol is already open; if so return NULL.
 
-CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_lisa_positions_unique_open_symbol
+-- CONCURRENTLY omitted: migration runner wraps SQL in a transaction block,
+-- and CREATE INDEX CONCURRENTLY cannot run inside a transaction (error 25001).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_lisa_positions_unique_open_symbol
   ON lisa_positions (portfolio_id, symbol)
   WHERE status = 'open';
 


### PR DESCRIPTION
Hotfix for migration 0162 which failed with:
`ERROR: 25001: CREATE INDEX CONCURRENTLY cannot run inside a transaction block`

The migration runner wraps each SQL file in a transaction; `CONCURRENTLY` is incompatible. Removing it — the brief write lock on `lisa_positions` is acceptable given the small row count.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_