### PR TITLE
hotfix(URGENT): disable OpportunityScout — bootstrap crash NestJS DI (clean from main)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -117,7 +117,10 @@ import { TwelveDataService } from './services/twelve-data.service';
 import { IntradayProviderRouter } from './services/intraday-provider-router.service';
 // R&D batch — services env-gated OFF par défaut (audit 23/05 propositions sérieuses)
 import { GeminiRiskManagerService } from './services/research/gemini-risk-manager.service';
-import { GeminiOpportunityScoutService } from './services/research/gemini-opportunity-scout.service';
+// HOTFIX 25/05 11:50 UTC — désactivé : injecte PaperBrokerService qui n'est
+// PAS @Injectable() (PaperBrokerDeps manual) → crash bootstrap NestJS → API
+// down → erreurs CORS front. Re-enable après refactor via MechanicalTradingService.
+// import { GeminiOpportunityScoutService } from './services/research/gemini-opportunity-scout.service';
 import { CryptoFundingFadeService } from './services/research/crypto-funding-fade.service';
 import { EventNarrativeInterpreterService } from './services/research/event-narrative-interpreter.service';
 import { HourlyEdgeAnalyzerService } from './services/research/hourly-edge-analyzer.service';
@@ -269,7 +272,7 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     IntradayProviderRouter,
     // R&D batch (23/05 propositions sérieuses, ENV-gated OFF par défaut)
     GeminiRiskManagerService,
-    GeminiOpportunityScoutService,
+    // GeminiOpportunityScoutService, // HOTFIX 25/05 — voir commentaire import
     CryptoFundingFadeService,
     EventNarrativeInterpreterService,
     HourlyEdgeAnalyzerService,


### PR DESCRIPTION
## 🚨 URGENT — API down depuis ~11:30 UTC, prod CORS errors

**(PR #432 fermée — conflits car branchée depuis feature; ce PR est propre depuis main)**

## Symptôme

Tous endpoints `smartvest.fly.dev/*` → erreur CORS depuis Vercel. C'est en réalité que **NestJS crash au bootstrap** → serveur HTTP ne répond pas → navigateur affiche "no Access-Control-Allow-Origin".

0 entries `lisa_decision_log` depuis 25+ min — autopilot/scanner ne tournent plus.

## Cause racine

`GeminiOpportunityScoutService` (introduit PR #430) injectait `PaperBrokerService` via constructor DI NestJS. Mais `PaperBrokerService` n'est **pas** `@Injectable()` — c'est instancié manuellement avec `PaperBrokerDeps` (interface). Au boot, le container DI throws → process exit → Fly restart loop.

## Hotfix

Commente `import` + `provider` du Scout dans `lisa.module.ts`. Le fichier `gemini-opportunity-scout.service.ts` reste en place pour refactor.

## Suite (PR ultérieure)

Refactor pour passer par `MechanicalTradingService.openForOpportunityScout` (pattern identique à `closeForRiskManager` déjà fait pour V2 RiskManager).

## Test plan

- [ ] CI typecheck vert (déjà validé localement)
- [ ] Merge immédiat
- [ ] Fly redeploy + 3 min : API endpoints répondent + decision_log reprend
- [ ] V2 RiskManager + macro news Gemini + EU liquidity fix : tous préservés (non touchés par ce hotfix)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_