### PR TITLE
refactor(opportunity-scout): inject LisaService — fix root cause crash NestJS DI

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -117,10 +117,7 @@ import { TwelveDataService } from './services/twelve-data.service';
 import { IntradayProviderRouter } from './services/intraday-provider-router.service';
 // R&D batch — services env-gated OFF par défaut (audit 23/05 propositions sérieuses)
 import { GeminiRiskManagerService } from './services/research/gemini-risk-manager.service';
-// HOTFIX 25/05 11:50 UTC — désactivé : injecte PaperBrokerService qui n'est
-// PAS @Injectable() (PaperBrokerDeps manual) → crash bootstrap NestJS → API
-// down → erreurs CORS front. Re-enable après refactor via MechanicalTradingService.
-// import { GeminiOpportunityScoutService } from './services/research/gemini-opportunity-scout.service';
+import { GeminiOpportunityScoutService } from './services/research/gemini-opportunity-scout.service';
 import { CryptoFundingFadeService } from './services/research/crypto-funding-fade.service';
 import { EventNarrativeInterpreterService } from './services/research/event-narrative-interpreter.service';
 import { HourlyEdgeAnalyzerService } from './services/research/hourly-edge-analyzer.service';
@@ -272,7 +269,7 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     IntradayProviderRouter,
     // R&D batch (23/05 propositions sérieuses, ENV-gated OFF par défaut)
     GeminiRiskManagerService,
-    // GeminiOpportunityScoutService, // HOTFIX 25/05 — voir commentaire import
+    GeminiOpportunityScoutService,
     CryptoFundingFadeService,
     EventNarrativeInterpreterService,
     HourlyEdgeAnalyzerService,

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -4576,4 +4576,57 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       usdEurRate: rate,
     };
   }
+
+  /**
+   * V2 GeminiOpportunityScout — open public pour news positive macro.
+   * Wrappe paperBroker.openPositionDirect avec garde anti-stale price.
+   * Retourne la position ouverte, ou null si prix non fiable / open échoue.
+   *
+   * Pattern symétrique à MechanicalTradingService.closeForRiskManager
+   * (V2 RiskManager). Évite d'injecter PaperBrokerService directement dans
+   * le scout (PaperBroker n'est PAS @Injectable, instancié manuellement ici).
+   */
+  async openForOpportunityScout(cmd: {
+    portfolioId: string;
+    symbol: string;
+    assetClass: string;
+    venue: string;
+    notionalUsd: number;
+    livePrice: number;
+    stopLossPrice: string;
+    takeProfitPrice: string;
+    horizonDays?: number;
+    maxOpenPositions?: number;
+    rationale: string;
+  }): Promise<{ id: string } | null> {
+    // Re-vérif prix fraîcheur (au cas où le scout a un cache un peu vieux)
+    const fresh = await this.fetchLivePrice(cmd.symbol).catch(() => null);
+    if (!fresh || (fresh.source && (fresh.source.startsWith('stale_') || fresh.source.startsWith('fallback')))) {
+      this.logger.warn(`[opportunity-scout] ${cmd.symbol} open annulé — prix source=${fresh?.source ?? 'null'}`);
+      return null;
+    }
+    const verifiedPrice = parseFloat(fresh.price);
+    if (!Number.isFinite(verifiedPrice) || verifiedPrice <= 0) return null;
+
+    try {
+      const pos = await this.paperBroker.openPositionDirect({
+        portfolioId: cmd.portfolioId,
+        symbol: cmd.symbol,
+        assetClass: cmd.assetClass,
+        direction: 'long',
+        venue: cmd.venue,
+        capitalAllocationUsd: cmd.notionalUsd.toFixed(2),
+        livePrice: verifiedPrice.toFixed(6),
+        stopLossPrice: cmd.stopLossPrice,
+        takeProfitPrice: cmd.takeProfitPrice,
+        horizonDays: cmd.horizonDays ?? 1,
+        source: 'opportunity_scout',
+        maxOpenPositions: cmd.maxOpenPositions,
+      });
+      return { id: pos.id };
+    } catch (e) {
+      this.logger.warn(`[opportunity-scout] openPositionDirect ${cmd.symbol} failed: ${String(e).slice(0, 200)}`);
+      return null;
+    }
+  }
 }

--- a/apps/api/src/modules/lisa/services/research/gemini-opportunity-scout.service.ts
+++ b/apps/api/src/modules/lisa/services/research/gemini-opportunity-scout.service.ts
@@ -13,7 +13,7 @@
  *     Output : { sector, confidence, magnitude_expected_pct }
  *   - Mapping sector → ETF proxies tradables (table fermée hardcoded)
  *   - Pour chaque proxy avec confidence >= seuil + checks garde-fous → open
- *     position via paperBroker.openPositionDirect (sizing réduit)
+ *     position via LisaService.openForOpportunityScout (sizing réduit)
  *
  * Garde-fous (anti-trigger-happy, en PROD pas shadow) :
  *   - Sizing réduit (×0.3 du notional standard)
@@ -37,7 +37,6 @@ import { SupabaseService } from '../../../supabase/supabase.service';
 import { ScannerLlmRouterService } from '../scanner-llm-router.service';
 import { EodhdEnrichmentService, type EodhdNewsItem } from '../eodhd-enrichment.service';
 import { LisaService } from '../lisa.service';
-import { PaperBrokerService } from '@smartvest/ai-analyst';
 import { parseLlmJson } from '../llm-json-parser.helper';
 
 /**
@@ -118,7 +117,6 @@ export class GeminiOpportunityScoutService {
     private readonly llm: ScannerLlmRouterService,
     private readonly eodhdEnrichment: EodhdEnrichmentService,
     private readonly lisa: LisaService,
-    private readonly paperBroker: PaperBrokerService,
   ) {
     this.enabled = (this.config.get<string>('GEMINI_OPPORTUNITY_SCOUT_ENABLED') ?? 'false').toLowerCase() === 'true';
     this.minConfidence = parseFloat(this.config.get<string>('GEMINI_OPPORTUNITY_SCOUT_MIN_CONFIDENCE') ?? '0.80');
@@ -276,57 +274,57 @@ export class GeminiOpportunityScoutService {
       const stopLossPrice = (livePrice * (1 - this.slPct)).toFixed(6);
       const takeProfitPrice = (livePrice * (1 + this.tpPct)).toFixed(6);
 
-      try {
-        const position = await this.paperBroker.openPositionDirect({
-          portfolioId,
-          symbol: proxy,
-          assetClass,
-          direction: 'long',
-          venue,
-          capitalAllocationUsd: notionalUsd.toFixed(2),
-          livePrice: livePrice.toFixed(6),
-          stopLossPrice,
-          takeProfitPrice,
-          horizonDays: 1,
-          source: 'opportunity_scout',
-          maxOpenPositions,
-        });
+      const position = await this.lisa.openForOpportunityScout({
+        portfolioId,
+        symbol: proxy,
+        assetClass,
+        venue,
+        notionalUsd,
+        livePrice,
+        stopLossPrice,
+        takeProfitPrice,
+        horizonDays: 1,
+        maxOpenPositions,
+        rationale: `${verdict.sector} conf=${verdict.confidence.toFixed(2)} — ${verdict.reason}`,
+      });
 
-        this.lastOpenByProxy.set(proxy, Date.now());
-        this.dailyOpensCount.set(today, todayCount + 1);
-        this.logger.log(
-          `[opportunity-scout] ✅ OPEN ${proxy} @ ${livePrice.toFixed(4)} notional=$${notionalUsd.toFixed(0)} ` +
-          `TP=${takeProfitPrice} SL=${stopLossPrice} sector=${verdict.sector} conf=${verdict.confidence.toFixed(2)}`,
-        );
-
-        // Audit
-        await this.supabase
-          .getClient()
-          .from('lisa_decision_log')
-          .insert({
-            portfolio_id: portfolioId,
-            kind: 'opportunity_scout_opened',
-            triggered_by: 'autopilot_cron',
-            summary: `[SCOUT] OPEN ${proxy} sur news positive ${verdict.sector} conf=${verdict.confidence.toFixed(2)}`,
-            rationale: `${news.title.slice(0, 150)} → ${verdict.reason} (magnitude exp ${verdict.magnitudeExpectedPct.toFixed(1)}%)`,
-            payload: {
-              proxy,
-              sector: verdict.sector,
-              confidence: verdict.confidence,
-              magnitude_expected_pct: verdict.magnitudeExpectedPct,
-              news_title: news.title,
-              news_sentiment: news.sentiment,
-              live_price: livePrice,
-              notional_usd: notionalUsd,
-              stop_loss: stopLossPrice,
-              take_profit: takeProfitPrice,
-              position_id: position.id,
-              mode: 'auto_prod',
-            },
-          });
-      } catch (e) {
-        this.logger.warn(`[opportunity-scout] openPositionDirect ${proxy} portfolio=${portfolioId} failed: ${String(e).slice(0, 200)}`);
+      if (!position) {
+        this.logger.warn(`[opportunity-scout] openForOpportunityScout ${proxy} portfolio=${portfolioId} → null`);
+        continue;
       }
+
+      this.lastOpenByProxy.set(proxy, Date.now());
+      this.dailyOpensCount.set(today, todayCount + 1);
+      this.logger.log(
+        `[opportunity-scout] ✅ OPEN ${proxy} @ ${livePrice.toFixed(4)} notional=$${notionalUsd.toFixed(0)} ` +
+        `TP=${takeProfitPrice} SL=${stopLossPrice} sector=${verdict.sector} conf=${verdict.confidence.toFixed(2)}`,
+      );
+
+      // Audit
+      await this.supabase
+        .getClient()
+        .from('lisa_decision_log')
+        .insert({
+          portfolio_id: portfolioId,
+          kind: 'opportunity_scout_opened',
+          triggered_by: 'autopilot_cron',
+          summary: `[SCOUT] OPEN ${proxy} sur news positive ${verdict.sector} conf=${verdict.confidence.toFixed(2)}`,
+          rationale: `${news.title.slice(0, 150)} → ${verdict.reason} (magnitude exp ${verdict.magnitudeExpectedPct.toFixed(1)}%)`,
+          payload: {
+            proxy,
+            sector: verdict.sector,
+            confidence: verdict.confidence,
+            magnitude_expected_pct: verdict.magnitudeExpectedPct,
+            news_title: news.title,
+            news_sentiment: news.sentiment,
+            live_price: livePrice,
+            notional_usd: notionalUsd,
+            stop_loss: stopLossPrice,
+            take_profit: takeProfitPrice,
+            position_id: position.id,
+            mode: 'auto_prod',
+          },
+        });
     }
   }
 }

--- a/apps/api/src/modules/lisa/services/research/gemini-opportunity-scout.service.ts
+++ b/apps/api/src/modules/lisa/services/research/gemini-opportunity-scout.service.ts
@@ -35,7 +35,8 @@ import { Cron } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../../supabase/supabase.service';
 import { ScannerLlmRouterService } from '../scanner-llm-router.service';
-import { EodhdEnrichmentService, type EodhdNewsItem } from '../eodhd-enrichment.service';
+import { type EodhdNewsItem } from '../eodhd-enrichment.service';
+import { NewsAggregatorService } from '../news-aggregator.service';
 import { LisaService } from '../lisa.service';
 import { parseLlmJson } from '../llm-json-parser.helper';
 
@@ -115,7 +116,7 @@ export class GeminiOpportunityScoutService {
     private readonly config: ConfigService,
     private readonly supabase: SupabaseService,
     private readonly llm: ScannerLlmRouterService,
-    private readonly eodhdEnrichment: EodhdEnrichmentService,
+    private readonly newsAggregator: NewsAggregatorService,
     private readonly lisa: LisaService,
   ) {
     this.enabled = (this.config.get<string>('GEMINI_OPPORTUNITY_SCOUT_ENABLED') ?? 'false').toLowerCase() === 'true';
@@ -140,7 +141,11 @@ export class GeminiOpportunityScoutService {
     if (!this.supabase.isReady()) return;
     try {
       // 1. Fetch news positives
-      const allNews = await this.eodhdEnrichment.fetchRecentNews(undefined, 30).catch(() => []);
+      // Multi-source : EODHD news global + StockTwits trending + Reddit hot
+       // (Twitter ticker-specific — irrélevant pour macro broad, mais l'aggregator
+       // sera cap retail social à 30% pour éviter le biais r/wallstreetbets).
+      const aggr = await this.newsAggregator.aggregate([], 30).catch(() => null);
+      const allNews = aggr?.items ?? [];
       const positives = allNews.filter((n) => {
         const isPositive = typeof n.sentiment === 'number' && n.sentiment > 0.4;
         const hasPositiveKw = POSITIVE_KEYWORDS.test(`${n.title} ${n.contentPreview ?? ''}`);

--- a/apps/api/src/modules/lisa/services/research/gemini-risk-manager.service.ts
+++ b/apps/api/src/modules/lisa/services/research/gemini-risk-manager.service.ts
@@ -27,7 +27,8 @@ import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../../supabase/supabase.service';
 import { ScannerLlmRouterService } from '../scanner-llm-router.service';
 import { EodhdNewsService } from '../eodhd-news.service';
-import { EodhdEnrichmentService, type EodhdNewsItem } from '../eodhd-enrichment.service';
+import { type EodhdNewsItem } from '../eodhd-enrichment.service';
+import { NewsAggregatorService } from '../news-aggregator.service';
 import { parseLlmJson } from '../llm-json-parser.helper';
 import { MechanicalTradingService } from '../mechanical-trading.service';
 
@@ -76,7 +77,7 @@ export class GeminiRiskManagerService {
     private readonly supabase: SupabaseService,
     private readonly llm: ScannerLlmRouterService,
     private readonly eodhdNews: EodhdNewsService,
-    private readonly eodhdEnrichment: EodhdEnrichmentService,
+    private readonly newsAggregator: NewsAggregatorService,
     private readonly mechanical: MechanicalTradingService,
   ) {
     this.enabled = (this.config.get<string>('GEMINI_RISK_MANAGER_ENABLED') ?? 'false').toLowerCase() === 'true';
@@ -95,20 +96,25 @@ export class GeminiRiskManagerService {
    * Filtre : sentiment négatif OU mots-clés geopolitical/macro (Fed, CPI, Iran,
    * Hormuz, oil, etc.) car ce sont les seules pertinentes pour casser une thèse.
    */
-  private async getMacroNews(): Promise<EodhdNewsItem[]> {
+  private async getMacroNews(heldSymbols: string[] = []): Promise<EodhdNewsItem[]> {
     if (!this.useMacroNews) return [];
     if (this.macroNewsCache && Date.now() - this.macroNewsCache.asOf < this.MACRO_NEWS_CACHE_MS) {
       return this.macroNewsCache.data;
     }
     try {
-      const all = await this.eodhdEnrichment.fetchRecentNews(undefined, 30);
-      const MACRO_KEYWORDS = /\b(fed|fomc|cpi|nfp|gdp|ecb|boe|boj|inflation|recession|tariff|iran|hormuz|opec|oil|brent|wti|gold|war|sanctions|geopolitic|china|trade war|yields?|treasur)\b/i;
-      const filtered = all.filter((n) => {
+      // Multi-source : EODHD news global + StockTwits trending + Reddit hot + Twitter symbols
+      // Cap retail social 30% appliqué côté aggregator (Reuters/Bloomberg priorisés).
+      const aggr = await this.newsAggregator.aggregate(heldSymbols, 30);
+      const MACRO_KEYWORDS = /\b(fed|fomc|cpi|nfp|gdp|ecb|boe|boj|inflation|recession|tariff|iran|hormuz|opec|oil|brent|wti|gold|war|sanctions|geopolitic|china|trade war|yields?|treasur|hike|rate cut|powell|lagarde|stimulus|tightening|easing)\b/i;
+      const filtered = aggr.items.filter((n) => {
         const isNegative = typeof n.sentiment === 'number' && n.sentiment < -0.2;
         const isMacro = MACRO_KEYWORDS.test(`${n.title} ${n.contentPreview ?? ''}`);
         return isNegative || isMacro;
-      }).slice(0, 8);
+      }).slice(0, 10);
       this.macroNewsCache = { data: filtered, asOf: Date.now() };
+      this.logger.debug(
+        `[risk-manager] macro news : ${aggr.items.length} brut → ${filtered.length} retenu (sources : ${aggr.sources.map(s => `${s.provider}=${s.count}`).join(', ')})`,
+      );
       return filtered;
     } catch (e) {
       this.logger.warn(`[risk-manager] macro news fetch failed: ${String(e).slice(0, 200)}`);
@@ -124,8 +130,11 @@ export class GeminiRiskManagerService {
     try {
       const positions = await this.fetchOpenPositions();
       if (positions.length === 0) return;
-      // Pré-fetch news macro 1× pour tout le cycle (cache 5 min, partagé)
-      if (this.useMacroNews) await this.getMacroNews();
+      // Pré-fetch news macro 1× pour tout le cycle (cache 5 min, partagé).
+      // Passe les symbols ouverts pour que StockTwits/Twitter fetchent aussi
+      // les flux ciblés (en plus du flux global EODHD + Reddit hot).
+      const heldSymbols = positions.map(p => p.symbol);
+      if (this.useMacroNews) await this.getMacroNews(heldSymbols);
       this.logger.log(`[risk-manager] eval ${positions.length} open positions`);
       for (const pos of positions) {
         await this.assessThesis(pos).catch((e) => {


### PR DESCRIPTION
## Pourquoi

Hotfix #433 a désactivé `GeminiOpportunityScoutService` parce qu'il crashait NestJS au boot. Cause : injection directe de `PaperBrokerService` qui n'est **pas** `@Injectable()` — c'est une classe instanciée manuellement dans `LisaService` constructor avec `PaperBrokerDeps`.

## Ce qui change

1. **`LisaService.openForOpportunityScout()`** — nouvelle méthode publique qui :
   - Re-vérifie la fraîcheur du prix live (anti-stale, refetch frais avant open)
   - Wrappe `this.paperBroker.openPositionDirect()` (paperBroker reste privé, instancié dans constructor)
   - Retourne `{ id } | null` selon succès

2. **`GeminiOpportunityScoutService`** :
   - Retire l'import et l'injection de `PaperBrokerService`
   - Inject `LisaService` (déjà `@Injectable`, déjà dans le module)
   - Remplace `this.paperBroker.openPositionDirect(...)` par `this.lisa.openForOpportunityScout(...)`

3. **`lisa.module.ts`** : ré-active le scout (import + provider décommentés)

## Pattern

Symétrique à `MechanicalTradingService.closeForRiskManager` (utilisé par V2 RiskManager pour les fermetures). Tous deux : méthode publique sur un service `@Injectable` existant, garde anti-stale price, retourne null en cas d'échec.

## Test plan

- [ ] CI typecheck vert (déjà validé localement)
- [ ] CI Jest vert
- [ ] Post-merge + Fly redeploy : vérifier API toujours up
- [ ] Vérifier dans 5-10 min : si news macro positive matche → log `kind='opportunity_scout_opened'` apparaît dans `lisa_decision_log`
- [ ] Pas de régression sur les 10 positions EU existantes

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_