### PR TITLE
fix(composite-score): convertir changePct1m absolu→fractionnaire pour le scorer

### DIFF
--- a/apps/api/src/modules/lisa/services/shadow-mapping.helper.ts
+++ b/apps/api/src/modules/lisa/services/shadow-mapping.helper.ts
@@ -96,7 +96,12 @@ export function mapTopGainerToCandidateRaw(
     medianDailyVolUsd20d: isCrypto ? candidate.avgVol50d : candidate.avgVol50d * candidate.close,
     marketCapUsd: candidate.marketCap,
     atrDailyRelative: null,
-    changePct1m: candidate.changePct,
+    // BUG FIX 25/05 — composite-scorer attend FRACTIONNAIRE (0.15 = 15%, cf.
+    // tests + momentumNormalizationCeiling=0.25). Le TopGainerCandidate stocke
+    // changePct en ABSOLU (15 = 15%, cf. logs `.toFixed(1)%` ligne 1188 scanner).
+    // Sans /100 : momentum saturé pour tout candidat ≥ 0.25% → composite_score
+    // figé à 0.800 pour tout EU/asia/us → ranking inutile, boost ×1.25 systématique.
+    changePct1m: candidate.changePct / 100,
     persistenceScore: null,
     persistenceCount: null,
     ema50Daily: null,

--- a/scripts/close-eu-pairs.ts
+++ b/scripts/close-eu-pairs.ts
@@ -1,0 +1,45 @@
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_][A-Z0-9_]*)=(.+)$/); if (m) acc[m[1]] = m[2]; return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+const TARGETS = ['NANO.PA', 'AMS.SW'];
+(async () => {
+  const { data: pos } = await sb.from('lisa_positions')
+    .select('id, symbol, direction, entry_price, entry_notional_usd, quantity')
+    .in('symbol', TARGETS).eq('status', 'open');
+  if (!pos || pos.length === 0) { console.log('No matching open positions'); return; }
+  console.log(`Found ${pos.length} positions to close:`);
+  for (const p of pos as any[]) console.log(`  ${p.symbol.padEnd(10)} ${p.direction.padEnd(6)} entry=${p.entry_price} notional=$${p.entry_notional_usd}`);
+
+  const now = new Date().toISOString();
+  const ids = (pos as any[]).map(p => p.id);
+  // Close at entry_price (break-even, no PnL) since live price unreliable.
+  // status='closed_invalidated' → paper-broker traite comme "no trade happened" (refund entry fees).
+  const { error } = await sb.from('lisa_positions')
+    .update({
+      status: 'closed_invalidated',
+      exit_price: null,  // will be filled by paper-broker if needed
+      exit_timestamp: now,
+      exit_reason: '[MANUAL_CLOSE] cap libération avant US open — TwelveData stale + EODHD quota HARD BLOCK',
+      realized_pnl_usd: 0,
+      realized_pnl_pct: 0,
+      updated_at: now,
+    })
+    .in('id', ids);
+  if (error) { console.error('UPDATE failed:', error); process.exit(1); }
+
+  // Audit log
+  const portfolioId = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+  for (const p of pos as any[]) {
+    await sb.from('lisa_decision_log').insert({
+      portfolio_id: portfolioId, kind: 'position_closed',
+      summary: `[MANUAL_CLOSE] ${p.symbol} ${p.direction.toUpperCase()} fermé manuellement (cap libération avant US open)`,
+      rationale: `Cap maxOpenPositions=14 saturé à 10/14 (5 paires EU). TwelveData stale 3j + EODHD quota HARD BLOCK → close break-even pour libérer 4 slots avant US 14:30 UTC.`,
+      payload: { position_id: p.id, symbol: p.symbol, direction: p.direction, entry_price: p.entry_price, source: 'manual_close_pre_us' },
+      triggered_by: 'user_manual',
+    });
+  }
+  console.log(`\n✅ Closed ${pos.length} positions. Cap : 10 → ${10-pos.length}/14 (slots libres : 4 → ${14-(10-pos.length)})`);
+})();


### PR DESCRIPTION
## Bug détecté (audit 25/05)

Tous candidats EU et US_large avaient **composite_score=0.800 figé**. Ranking inutile, top scoring incorrect.

## Cause racine

Discordance d'unité dans la codebase :
- **TopGainerCandidate.changePct** stocké en ABSOLU (15 = 15%)
- **GainersCandidateRaw.changePct1m** consommé en FRACTIONNAIRE par composite-scorer :
  - `momentumNormalizationCeiling = 0.25` (25%)
  - `momentumComponent = clamp01(changePct1m / 0.25)`
  - Tests utilisent tous fractionnaire (0.02, 0.15, 0.20...)

**Sans /100** : `changePct1m=15` absolu → `momentumComponent = clamp01(15/0.25) = 1.0` → momentum saturé pour TOUT candidat ≥ 0.25%. Combiné à boost ×1.25 systématique → composite_score figé à 0.800 (eu_equity: `0.55*1.0 + 0.25*1.0 + 0.20*0 = 0.80`).

## Fix

Division `/100` dans le mapper `shadow-mapping.helper.ts` ligne 99 (1 ligne).

**Impact analytics nul** : la DB `gainers_user_shadow_signals.change_pct_1m` reste en absolu (alimentée par `candInner.changePct` direct dans le scanner, pas via le mapper).

## Test plan

- [x] CI typecheck vert (local OK)
- [x] CI Jest vert (68/68 tests shadow-mapping + bloc1)
- [ ] Post-deploy : observer scores composite des prochains shadow signals — doit varier (pas figé à 0.800)
- [ ] Top scoring redevient discriminant

## Bonus

Script `close-eu-pairs.ts` utilisé pour libérer 4 slots avant US open (NANO.PA + AMS.SW closed manuellement).

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_