### PR TITLE
fix(open): bloque openPositionDirect sur source=stale_*/fallback_ (P19-staleness-OPEN)

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -4622,6 +4622,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         horizonDays: cmd.horizonDays ?? 1,
         source: 'opportunity_scout',
         maxOpenPositions: cmd.maxOpenPositions,
+        livePriceSource: fresh.source,
       });
       return { id: pos.id };
     } catch (e) {

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -3834,9 +3834,12 @@ export class TopGainersScannerService implements OnModuleInit {
         this.logger.warn(`[top-gainers] ${cand.symbol}: invalid live price ${quote.price} → skip`);
         return null;
       }
-      // Reject sur source fallback explicite (price corrupted)
-      if (typeof quote.source === 'string' && quote.source.startsWith('fallback')) {
-        this.logger.warn(`[top-gainers] ${cand.symbol}: fallback source ${quote.source} → skip`);
+      // Reject sur source fallback OU stale (price unreliable)
+      // P19-staleness-OPEN (25/05) : étend le check au stale_* (TwelveData
+      // LSE/Euronext/SIX figé vendredi → prix de 3j → on ne doit JAMAIS
+      // ouvrir sur ce prix, même si le ticker semble être un top gainer).
+      if (typeof quote.source === 'string' && (quote.source.startsWith('fallback') || quote.source.startsWith('stale_'))) {
+        this.logger.warn(`[top-gainers] ${cand.symbol}: unreliable source ${quote.source} → skip open (cycle suivant)`);
         return null;
       }
       const candCloseNum = Number(cand.close);
@@ -3923,6 +3926,9 @@ export class TopGainersScannerService implements OnModuleInit {
           horizonDays: 1,
           source: 'scanner_top_gainers',
           maxOpenPositions: overrides?.maxOpenPositions,
+          // P19-staleness-OPEN — double-check côté paper-broker au cas où
+          // le check scanner amont serait bypassé sur certains paths futurs.
+          livePriceSource: quote.source,
         });
 
         // Audit log + features capture pour CETTE direction (best-effort)

--- a/packages/ai-analyst/src/simulation/paper-broker.service.ts
+++ b/packages/ai-analyst/src/simulation/paper-broker.service.ts
@@ -348,6 +348,15 @@ export class PaperBrokerService {
     const now = new Date().toISOString();
     const livePrice = new Decimal(cmd.livePrice);
     const notional = new Decimal(cmd.capitalAllocationUsd);
+    // P19-staleness-OPEN (25/05) — refuse l'open si le quote est stale ou fallback.
+    // Sinon le scanner ouvre des paires LONG/SHORT sur un prix figé vendredi
+    // (incident TwelveData LSE/Euronext/SIX 25/05). Le check sur close existait
+    // déjà via R5 sanity, mais pas sur l'open — oversight critique.
+    if (cmd.livePriceSource && (cmd.livePriceSource.startsWith('stale_') || cmd.livePriceSource.startsWith('fallback'))) {
+      throw new Error(
+        `openPositionDirect rejected: live price source=${cmd.livePriceSource} (stale/fallback). symbol=${cmd.symbol} price=${cmd.livePrice}. No open on non-live quote.`,
+      );
+    }
     if (livePrice.isZero() || livePrice.isNegative()) {
       throw new Error(`Invalid live price: ${cmd.livePrice}`);
     }

--- a/packages/ai-analyst/src/simulation/types.ts
+++ b/packages/ai-analyst/src/simulation/types.ts
@@ -146,6 +146,14 @@ export const OpenPositionDirectCommand = z.object({
    * Absent → INSERT direct, comportement legacy inchangé.
    */
   maxOpenPositions: z.number().int().positive().optional(),
+  /**
+   * P19-staleness-OPEN (25/05) — source du quote utilisé pour `livePrice`.
+   * Si fourni et commence par `stale_` ou `fallback_`, l'open est REJETÉ
+   * avec un throw. Évite d'ouvrir une position sur un prix figé vendredi
+   * (incident TwelveData LSE/Euronext/SIX 25/05). Optionnel pour back-compat
+   * tests existants ; en prod toujours fourni par le scanner.
+   */
+  livePriceSource: z.string().optional(),
 });
 export type OpenPositionDirectCommand = z.infer<typeof OpenPositionDirectCommand>;
 

--- a/scripts/bump-cooldown.ts
+++ b/scripts/bump-cooldown.ts
@@ -1,0 +1,19 @@
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_][A-Z0-9_]*)=(.+)$/); if (m) acc[m[1]] = m[2]; return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+const PID = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+(async () => {
+  const { data: b } = await sb.from('lisa_session_configs')
+    .select('gainers_cooldown_minutes, gainers_post_sl_cooldown_min').eq('portfolio_id', PID).single();
+  console.log('BEFORE: gainers_cooldown_minutes =', (b as any)?.gainers_cooldown_minutes, '· post_sl =', (b as any)?.gainers_post_sl_cooldown_min);
+  const { error } = await sb.from('lisa_session_configs')
+    .update({ gainers_cooldown_minutes: 60, updated_at: new Date().toISOString() })
+    .eq('portfolio_id', PID);
+  if (error) { console.error(error); process.exit(1); }
+  const { data: a } = await sb.from('lisa_session_configs')
+    .select('gainers_cooldown_minutes').eq('portfolio_id', PID).single();
+  console.log(`AFTER : gainers_cooldown_minutes = ${(a as any)?.gainers_cooldown_minutes}\n✅ cooldown 5→60 min`);
+})();


### PR DESCRIPTION
## 🚨 Bug critique 25/05 ~15:26 UTC

Scanner a **réouvert NANO.PA paire LONG+SHORT 12 min après mon close manuel**, au prix figé vendredi (`stale_twelvedata` age=282390s = 3.27 jours).

```
[live-price] NANO.PA STALE quote tagged (source=twelvedata → stale_twelvedata, age=282381s)
[top-gainers] NANO.PA opened DIRECT (entry=$36.4600 plan=long+short ...)
```

Le système SAVAIT que le prix était stale, et l'a quand même ouvert. **Énorme trou de sécurité** : positions ouvertes sur prix de 3 jours.

## Cause racine

- Check anti-stale existait sur `closePosition` (R5 sanity, PR #429)
- **Oversight sur `openPositionDirect`** — aucun guard équivalent
- Scanner amont avait check `'fallback_'` mais **pas `'stale_*'`**

## Fix (defense in depth)

| Niveau | Fichier | Change |
|---|---|---|
| 1 | `types.ts` | `OpenPositionDirectCommand.livePriceSource` (optional) ajouté |
| 2 | `paper-broker.openPositionDirect` | throw si `livePriceSource` startsWith `stale_` ou `fallback` |
| 3 | `top-gainers-scanner` | Check étendu `fallback_` → `fallback_ OR stale_*` + propagation `quote.source` |
| 4 | `LisaService.openForOpportunityScout` | Propagation `livePriceSource` au scout V2 |

## Bonus

Script `bump-cooldown.ts` utilisé pour passer `gainers_cooldown_minutes` 5→60 min (palliatif manuel le temps du deploy — empêche re-open immédiat après close manual/TP/invalidated).

## Test plan

- [ ] CI typecheck vert (déjà OK local)
- [ ] CI Jest vert
- [ ] Merge urgent (US open dans ~50 min à 16:30 Paris)
- [ ] Post-deploy : logs Fly doivent montrer `openPositionDirect rejected: live price source=stale_twelvedata` au lieu de l'open
- [ ] User réactive kill-switch après deploy confirmé

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_