### PR TITLE
test(paper-broker): R5 anti-stale OPEN — 5 specs symétriques aux closes

### DIFF
--- a/packages/ai-analyst/src/simulation/__tests__/paper-broker-staleness-r5.spec.ts
+++ b/packages/ai-analyst/src/simulation/__tests__/paper-broker-staleness-r5.spec.ts
@@ -146,3 +146,70 @@ describe('PaperBrokerService.closePosition — P19-staleness R5 reject', () => {
     }
   });
 });
+
+/**
+ * P19-staleness-OPEN (25/05) — fix(open) bd266478 :
+ * openPositionDirect doit rejeter les opens sur source stale ou fallback.
+ * Symétrique du check close R5 ci-dessus. Sans ce guard, le scanner ouvrait
+ * NANO.PA paire LONG/SHORT au prix figé vendredi (age=282381s = 3.27j).
+ */
+describe('PaperBrokerService.openPositionDirect — P19-staleness-OPEN reject', () => {
+  function makeBroker() {
+    return new PaperBrokerService({
+      supabase: makeSupabaseMock({ id: 'new-pos' }),
+      fetchLivePrice: async () => ({ price: '36.46', source: 'twelvedata' }) as unknown as { price: string; source: string },
+    } as unknown as ConstructorParameters<typeof PaperBrokerService>[0]);
+  }
+
+  const baseOpenCmd = {
+    portfolioId: '58439d86-3f20-4a60-82a4-307f3f252bc2',
+    symbol: 'NANO.PA',
+    assetClass: 'eu_equity',
+    direction: 'long' as const,
+    venue: 'PA',
+    capitalAllocationUsd: '394.00',
+    livePrice: '36.46',
+    stopLossPrice: '35.81',
+    takeProfitPrice: '37.65',
+    horizonDays: 1,
+    source: 'scanner_top_gainers',
+  };
+
+  it('reject open avec livePriceSource=stale_twelvedata (incident 25/05 NANO.PA)', async () => {
+    const broker = makeBroker();
+    await expect(
+      broker.openPositionDirect({ ...baseOpenCmd, livePriceSource: 'stale_twelvedata' }),
+    ).rejects.toThrow(/stale\/fallback/);
+  });
+
+  it('reject open avec livePriceSource=stale_eodhd', async () => {
+    const broker = makeBroker();
+    await expect(
+      broker.openPositionDirect({ ...baseOpenCmd, livePriceSource: 'stale_eodhd' }),
+    ).rejects.toThrow(/stale\/fallback/);
+  });
+
+  it('reject open avec livePriceSource=fallback_unknown', async () => {
+    const broker = makeBroker();
+    await expect(
+      broker.openPositionDirect({ ...baseOpenCmd, livePriceSource: 'fallback_unknown' }),
+    ).rejects.toThrow(/stale\/fallback/);
+  });
+
+  it('reject open avec livePriceSource=fallback_quota_cap', async () => {
+    const broker = makeBroker();
+    await expect(
+      broker.openPositionDirect({ ...baseOpenCmd, livePriceSource: 'fallback_quota_cap' }),
+    ).rejects.toThrow(/stale\/fallback/);
+  });
+
+  it('back-compat : open SANS livePriceSource ne déclenche pas le guard (legacy callers)', async () => {
+    const broker = makeBroker();
+    // Note : peut échouer ailleurs (mock supabase incomplet), mais PAS sur le guard.
+    try {
+      await broker.openPositionDirect(baseOpenCmd);
+    } catch (e) {
+      expect(String(e)).not.toMatch(/stale\/fallback/);
+    }
+  });
+});

--- a/scripts/check-gemini-verdicts-today.ts
+++ b/scripts/check-gemini-verdicts-today.ts
@@ -1,0 +1,83 @@
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_][A-Z0-9_]*)=(.+)$/); if (m) acc[m[1]] = m[2]; return acc;
+}, {} as Record<string, string>);
+const sb = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!);
+const since = new Date(); since.setUTCHours(0, 0, 0, 0);
+
+(async () => {
+  console.log(`\n=== AUDIT GEMINI V2 RISK MANAGER — ${new Date().toISOString().slice(0,19)} UTC ===\n`);
+
+  // 1. Tous les verdicts risk_manager_thesis_broken aujourd'hui
+  const { data: rm } = await sb.from('lisa_decision_log')
+    .select('timestamp, summary, payload')
+    .eq('kind', 'risk_manager_thesis_broken')
+    .gte('timestamp', since.toISOString())
+    .order('timestamp', { ascending: false })
+    .limit(100);
+
+  if (!rm || rm.length === 0) {
+    console.log('0 entries risk_manager_thesis_broken aujourd\'hui.');
+    console.log('Possibles raisons :');
+    console.log('  - V2 RM ne détecte aucune thèse cassée (toutes "valid" ou "unclear")');
+    console.log('  - V2 RM ne tourne pas (flag GEMINI_RISK_MANAGER_ENABLED off ?)');
+    console.log('  - Migration 0164 pas appliquée (CHECK constraint rejette toujours ?)');
+    return;
+  }
+
+  console.log(`Total verdicts (broken conf>=0.7) : ${rm.length}\n`);
+
+  let autoClosed = 0;
+  let shadow = 0;
+  const bySymbol: Record<string, { count: number; closes: number; maxConf: number; reasons: string[] }> = {};
+  for (const r of rm as any[]) {
+    const isAutoClose = r.payload?.auto_closed === true;
+    if (isAutoClose) autoClosed++; else shadow++;
+    const sym = r.payload?.symbol ?? '?';
+    if (!bySymbol[sym]) bySymbol[sym] = { count: 0, closes: 0, maxConf: 0, reasons: [] };
+    bySymbol[sym].count++;
+    if (isAutoClose) bySymbol[sym].closes++;
+    const conf = Number(r.payload?.confidence ?? 0);
+    if (conf > bySymbol[sym].maxConf) bySymbol[sym].maxConf = conf;
+    const reason = r.payload?.reason ?? '?';
+    if (!bySymbol[sym].reasons.includes(reason)) bySymbol[sym].reasons.push(reason);
+  }
+  console.log(`  Auto-closed : ${autoClosed}  ·  Shadow log only : ${shadow}\n`);
+  console.log('Par symbol (top 10) :');
+  for (const [sym, s] of Object.entries(bySymbol).sort((a,b) => b[1].count - a[1].count).slice(0, 10)) {
+    console.log(`  ${sym.padEnd(15)} count=${s.count} closes=${s.closes} maxConf=${s.maxConf.toFixed(2)} reasons=${s.reasons.slice(0, 2).join(' | ').slice(0, 100)}`);
+  }
+
+  // 2. Compte risk_monitor_action aujourd'hui (Open Position Risk Monitor avec verdicts HOLD)
+  const { data: rmon } = await sb.from('lisa_decision_log')
+    .select('timestamp, summary, payload')
+    .eq('kind', 'risk_monitor_action')
+    .gte('timestamp', since.toISOString())
+    .order('timestamp', { ascending: false })
+    .limit(50);
+  console.log(`\nrisk_monitor_action (Open Position Risk Monitor) aujourd'hui : ${rmon?.length ?? 0}`);
+  if (rmon && rmon.length > 0) {
+    const verdictCount: Record<string, number> = {};
+    for (const r of rmon as any[]) {
+      const v = r.payload?.verdict ?? r.payload?.action ?? 'unknown';
+      verdictCount[v] = (verdictCount[v] ?? 0) + 1;
+    }
+    for (const [v, n] of Object.entries(verdictCount).sort((a,b) => b[1] - a[1])) {
+      console.log(`  ${String(n).padStart(5)}  ${v}`);
+    }
+  }
+
+  // 3. opportunity_scout_opened aujourd'hui
+  const { data: scout } = await sb.from('lisa_decision_log')
+    .select('timestamp, summary, payload')
+    .eq('kind', 'opportunity_scout_opened')
+    .gte('timestamp', since.toISOString())
+    .order('timestamp', { ascending: false });
+  console.log(`\nopportunity_scout_opened aujourd'hui : ${scout?.length ?? 0}`);
+  if (scout && scout.length > 0) {
+    for (const s of scout as any[]) {
+      console.log(`  ${s.timestamp.slice(11,19)} ${s.payload?.proxy} sector=${s.payload?.sector} conf=${s.payload?.confidence}`);
+    }
+  }
+})();

--- a/scripts/td-probe-holdings.ts
+++ b/scripts/td-probe-holdings.ts
@@ -1,0 +1,37 @@
+import * as fs from 'fs';
+const env = fs.readFileSync('.env', 'utf8').split('\n').reduce((acc, l) => {
+  const m = l.match(/^([A-Z_][A-Z0-9_]*)=(.+)$/); if (m) acc[m[1]] = m[2]; return acc;
+}, {} as Record<string, string>);
+const KEY = env.TWELVEDATA_API_KEY;
+if (!KEY) { console.log('⚠️ TWELVEDATA_API_KEY absent .env local — probe impossible (mais ça marche sur Fly).'); process.exit(0); }
+
+const symbols = [
+  { td: 'RMV:LSE', name: 'RMV.LSE Rightmove' },
+  { td: 'EZJ:LSE', name: 'EZJ.LSE easyJet' },
+  { td: 'AJB:LSE', name: 'AJB.LSE AJ Bell' },
+  { td: 'BOY:LSE', name: 'BOY.LSE Bodycote' },
+  { td: 'NANO:Euronext', name: 'NANO.PA Nanobiotix' },
+  { td: 'AMS:SIX', name: 'AMS.SW ams-OSRAM' },
+  { td: 'AAPL', name: 'AAPL US (control)' },
+];
+
+(async () => {
+  console.log(`\n=== TwelveData /quote probe — ${new Date().toISOString()} ===\n`);
+  for (const s of symbols) {
+    try {
+      const url = `https://api.twelvedata.com/quote?symbol=${encodeURIComponent(s.td)}&apikey=${KEY}`;
+      const res = await fetch(url);
+      const d = await res.json() as any;
+      const ts = d.timestamp ? new Date(Number(d.timestamp) * 1000).toISOString() : 'n/a';
+      const ageH = d.timestamp ? ((Date.now() - Number(d.timestamp) * 1000) / 3_600_000).toFixed(1) : 'n/a';
+      const close = d.close ?? 'n/a';
+      const datetime = d.datetime ?? 'n/a';
+      const isOpen = d.is_market_open;
+      const exchange = d.exchange ?? 'n/a';
+      const status = d.status === 'error' ? `ERROR: ${d.message ?? '?'}` : 'ok';
+      console.log(`${s.name.padEnd(28)} close=${String(close).padStart(10)} datetime=${datetime.padStart(20)} ts_age=${ageH}h marketOpen=${isOpen} ex=${exchange} ${status}`);
+    } catch (e) {
+      console.log(`${s.name.padEnd(28)} ERROR ${String(e).slice(0, 100)}`);
+    }
+  }
+})();


### PR DESCRIPTION
## Pourquoi

Couvre `fix(open)` bd266478 (PR #438 mergée) contre régression future. Sans ces specs, un futur refactor pourrait re-introduire le bug "open sur prix figé vendredi" silencieusement.

## Specs ajoutées (`paper-broker-staleness-r5.spec.ts`)

5 nouveaux tests dans le bloc `describe('PaperBrokerService.openPositionDirect — P19-staleness-OPEN reject')` :
- reject open `livePriceSource=stale_twelvedata` (incident 25/05 NANO.PA)
- reject `stale_eodhd`
- reject `fallback_unknown`
- reject `fallback_quota_cap`
- **back-compat** : sans `livePriceSource`, pas de guard (legacy callers protégés)

**10/10 tests verts** (5 close R5 préexistants + 5 nouveaux open).

## Bonus scripts

- `td-probe-holdings.ts` : probe direct TwelveData `/quote` sur LSE/PA/SW holdings pour confirmer hypothèse data feed figé vendredi (utilisable post-deploy via admin endpoint si besoin)
- `check-gemini-verdicts-today.ts` : audit `risk_manager_thesis_broken` + `risk_monitor_action` + `opportunity_scout_opened` sur la journée

## Test plan

- [x] Tests locaux : 10/10 verts
- [ ] CI typecheck vert
- [ ] CI Jest vert

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_