### PR TITLE
feat(admin): endpoint /admin/td-probe — diagnostic TwelveData live vs EOD

### DIFF
--- a/apps/api/src/modules/admin/admin-td-probe.controller.ts
+++ b/apps/api/src/modules/admin/admin-td-probe.controller.ts
@@ -1,0 +1,110 @@
+/**
+ * P19-staleness-DIAGNOSTIC (25/05) — /admin/td-probe endpoint.
+ *
+ * Hit direct l'API TwelveData `/quote` pour les holdings ou symbols passés
+ * en query, retourne le timestamp + datetime du quote. Permet de confirmer
+ * si TwelveData renvoie un prix stale (vendredi figé) sur nos LSE/Euronext/SIX
+ * holdings — autrement dit, si notre plan TD couvre vraiment ces exchanges
+ * en intraday ou seulement EOD.
+ *
+ * Usage :
+ *   curl -H "x-admin-token: $ADMIN_TOKEN" \
+ *     "https://smartvest.fly.dev/admin/td-probe?symbols=RMV.LSE,EZJ.LSE,AJB.LSE,NANO.PA,AMS.SW,AAPL.US"
+ *
+ * Pour chaque symbol :
+ *   - Map vers format TD (RMV.LSE → RMV:LSE)
+ *   - Call /quote, log timestamp + datetime + age en secondes
+ *   - Compare à now : si age > 300s pendant les heures d'ouverture du marché
+ *     correspondant → confirme stale feed
+ */
+
+import { Controller, Get, Headers, HttpException, HttpStatus, Logger, Query } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Controller('admin/td-probe')
+export class AdminTdProbeController {
+  private readonly logger = new Logger(AdminTdProbeController.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  @Get()
+  async probe(
+    @Headers('x-admin-token') providedToken: string | undefined,
+    @Query('symbols') symbols?: string,
+  ): Promise<unknown> {
+    this.assertAdmin(providedToken);
+    const apiKey = this.config.get<string>('TWELVEDATA_API_KEY');
+    if (!apiKey) {
+      throw new HttpException({ message: 'TWELVEDATA_API_KEY not configured', code: 'NO_KEY' }, 500);
+    }
+    const list = (symbols ?? 'RMV.LSE,EZJ.LSE,AJB.LSE,BOY.LSE,NANO.PA,AMS.SW,AAPL.US')
+      .split(',').map((s) => s.trim()).filter(Boolean);
+
+    const results: Array<Record<string, unknown>> = [];
+    const nowMs = Date.now();
+    for (const sym of list) {
+      const tdSym = toTdSymbol(sym);
+      try {
+        const url = `https://api.twelvedata.com/quote?symbol=${encodeURIComponent(tdSym)}&apikey=${apiKey}`;
+        const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+        const d = (await res.json()) as Record<string, unknown>;
+        const ts = typeof d.timestamp === 'string' || typeof d.timestamp === 'number' ? Number(d.timestamp) : null;
+        const lastQuoteAt = typeof d.last_quote_at === 'string' || typeof d.last_quote_at === 'number' ? Number(d.last_quote_at) : null;
+        const ageS = ts ? Math.floor(nowMs / 1000 - ts) : null;
+        const lastQuoteAgeS = lastQuoteAt ? Math.floor(nowMs / 1000 - lastQuoteAt) : null;
+        results.push({
+          symbol: sym, td_symbol: tdSym,
+          status: d.status ?? 'ok',
+          message: d.message ?? null,
+          close: d.close ?? null,
+          datetime: d.datetime ?? null,
+          timestamp: ts,
+          age_sec: ageS,
+          age_hours: ageS ? Math.round(ageS / 360) / 10 : null,
+          last_quote_at: lastQuoteAt,
+          last_quote_age_sec: lastQuoteAgeS,
+          last_quote_age_hours: lastQuoteAgeS ? Math.round(lastQuoteAgeS / 360) / 10 : null,
+          is_market_open: d.is_market_open ?? null,
+          exchange: d.exchange ?? null,
+          stale_verdict: ts && ageS && ageS > 600 ? `STALE (${Math.floor(ageS / 3600)}h${Math.floor((ageS % 3600) / 60)}min old)` : 'fresh-ish',
+        });
+      } catch (e) {
+        results.push({ symbol: sym, td_symbol: tdSym, error: String(e).slice(0, 200) });
+      }
+    }
+    return {
+      now_iso: new Date(nowMs).toISOString(),
+      probed: list.length,
+      results,
+    };
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException({ message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' }, HttpStatus.FORBIDDEN);
+    }
+    if (providedToken !== expected) {
+      throw new HttpException({ message: 'Invalid admin token', code: 'ADMIN_FORBIDDEN' }, HttpStatus.FORBIDDEN);
+    }
+  }
+}
+
+/**
+ * Mapping SmartVest ticker → TwelveData symbol.
+ *  - .LSE  → :LSE
+ *  - .PA   → :Euronext
+ *  - .SW   → :SIX
+ *  - .XETRA → :XETR
+ *  - .US ou rien → unchanged
+ */
+function toTdSymbol(sym: string): string {
+  const upper = sym.toUpperCase();
+  if (upper.endsWith('.LSE')) return `${upper.slice(0, -4)}:LSE`;
+  if (upper.endsWith('.PA')) return `${upper.slice(0, -3)}:Euronext`;
+  if (upper.endsWith('.AS')) return `${upper.slice(0, -3)}:Euronext`;
+  if (upper.endsWith('.SW')) return `${upper.slice(0, -3)}:SIX`;
+  if (upper.endsWith('.XETRA')) return `${upper.slice(0, -6)}:XETR`;
+  if (upper.endsWith('.US')) return upper.slice(0, -3);
+  return upper;
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -24,6 +24,7 @@ import { AdminMigrationsController } from './admin-migrations.controller';
 import { AdminSupabaseQueryController } from './admin-supabase-query.controller';
 import { AdminLogsController } from './admin-logs.controller';
 import { AdminEodhdStatusController } from './admin-eodhd-status.controller';
+import { AdminTdProbeController } from './admin-td-probe.controller';
 import { AdminGainersStatusController } from './admin-gainers-status.controller';
 import { AdminGainersBaselineController } from './admin-gainers-baseline.controller';
 import { AdminGainersMetricsController } from './admin-gainers-metrics.controller';
@@ -46,6 +47,7 @@ import { AdminResearchController } from './admin-research.controller';
     AdminSupabaseQueryController,
     AdminLogsController,
     AdminEodhdStatusController,
+    AdminTdProbeController,
     AdminGainersStatusController,
     AdminGainersBaselineController,
     AdminGainersMetricsController,


### PR DESCRIPTION
## Pourquoi

Pour diagnostiquer en autonomie si TD couvre l'intraday LIVE pour LSE/Euronext/SIX ou seulement EOD, sans dépendre d'une clé locale (la clé est uniquement en Fly secrets).

## Endpoint `GET /admin/td-probe`

Header requis : `x-admin-token: $ADMIN_TOKEN`
Query optionnelle : `?symbols=RMV.LSE,EZJ.LSE,AAPL.US` (default : holdings + AAPL)

Pour chaque symbol, retourne :
- `close`, `datetime`, `timestamp`, `age_sec`, `age_hours`
- `last_quote_at`, `last_quote_age_sec`, `last_quote_age_hours`
- `is_market_open`, `exchange`
- `stale_verdict` (`"STALE Xh Ymin old"` si age > 600s)

## Diagnostic déjà confirmé live 25/05 13:49 UTC (avec ta clé Pro 1597)

```
RMV.LSE last_quote_at = vendredi 22/05 15:29 UTC → 70h+ stale
EZJ.LSE last_quote_at = vendredi 22/05 15:29 UTC → 70h+ stale
AJB.LSE last_quote_at = vendredi 22/05 15:29 UTC → 70h+ stale
BOY.LSE last_quote_at = vendredi 22/05 15:29 UTC → 70h+ stale
NANO.PA last_quote_at = vendredi 22/05 15:35 UTC → 70h+ stale
AMS.SW  last_quote_at = vendredi 22/05 15:19 UTC → 70h+ stale
```

→ **Plan Pro 1597 ne couvre PAS le live LSE/Euronext/SIX intraday**, seulement EOD.

## Usage post-deploy

```bash
curl -H "x-admin-token: $ADMIN_TOKEN" \
  "https://smartvest.fly.dev/admin/td-probe?symbols=AAPL.US,RMV.LSE"
```

Permet de re-tester quand tu veux (ex: après upgrade plan TD ou après 14:30 UTC pour confirmer US live).

## Test plan

- [ ] CI typecheck vert
- [ ] CI Jest vert
- [ ] Post-deploy : curl endpoint + valide réponse JSON

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_