### PR TITLE
perf(gemini-v2-rm): cycle 5min → 60s + parallélisation Promise.all

### DIFF
--- a/apps/api/src/modules/lisa/services/research/gemini-risk-manager.service.ts
+++ b/apps/api/src/modules/lisa/services/research/gemini-risk-manager.service.ts
@@ -22,7 +22,7 @@
  */
 
 import { Injectable, Logger } from '@nestjs/common';
-import { Cron } from '@nestjs/schedule';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../../supabase/supabase.service';
 import { ScannerLlmRouterService } from '../scanner-llm-router.service';
@@ -157,8 +157,21 @@ export class GeminiRiskManagerService {
     }
   }
 
-  /** Cron toutes les 5 min — eval thèse pour chaque position open. */
-  @Cron('*/5 * * * *')
+  /**
+   * Cron toutes les minutes (P19-EXT 25/05) — eval thèse pour chaque position open.
+   *
+   * Passage 5min → 60s : réactivité news/prix sur positions ouvertes. Coût LLM
+   * marginal négligeable ($0.40 → $2/jour max). Bénéfice : détection thèse
+   * cassée jusqu'à 4 min plus tôt sur news chocs (Iran/Hormuz/Fed/profit
+   * warning). Garde-fou : cooldown re-entry 60min empêche le sur-trading même
+   * si Gemini oscille verdict.
+   *
+   * Parallélisation Promise.all pour latence cycle ≤ 5s (vs ~20s séquentiel).
+   *
+   * Évaluation positions cappée à 20 (cf. fetchOpenPositions limit). Si plus
+   * de 20 positions ouvertes simultanément, augmenter le cap.
+   */
+  @Cron(CronExpression.EVERY_MINUTE)
   async cronEvalOpenPositions(): Promise<void> {
     if (!this.enabled) return;
     if (!this.supabase.isReady()) return;
@@ -166,16 +179,22 @@ export class GeminiRiskManagerService {
       const positions = await this.fetchOpenPositions();
       if (positions.length === 0) return;
       // Pré-fetch news macro 1× pour tout le cycle (cache 5 min, partagé).
-      // Passe les symbols ouverts pour que StockTwits/Twitter fetchent aussi
-      // les flux ciblés (en plus du flux global EODHD + Reddit hot).
+      // Le cache 5min absorbe les cycles minute pour éviter de spammer
+      // EODHD/StockTwits/Reddit/Twitter — 1 fetch news / 5 min suffit.
       const heldSymbols = positions.map(p => p.symbol);
       if (this.useMacroNews) await this.getMacroNews(heldSymbols);
-      this.logger.log(`[risk-manager] eval ${positions.length} open positions`);
-      for (const pos of positions) {
-        await this.assessThesis(pos).catch((e) => {
-          this.logger.warn(`[risk-manager] ${pos.symbol} assessment failed: ${String(e).slice(0, 200)}`);
-        });
-      }
+      this.logger.log(`[risk-manager] eval ${positions.length} open positions (parallel)`);
+      // Parallélisation : tous les calls Gemini Flash-Lite en concurrent
+      // (~700-1500ms each → cycle ≤ 5s au lieu de ~20s séquentiel).
+      // Errors per-position isolées, n'arrêtent pas le batch.
+      await Promise.all(
+        positions.map((pos) =>
+          this.assessThesis(pos).catch((e) => {
+            this.logger.warn(`[risk-manager] ${pos.symbol} assessment failed: ${String(e).slice(0, 200)}`);
+            return null;
+          }),
+        ),
+      );
     } catch (e) {
       this.logger.warn(`[risk-manager] cron failed: ${String(e).slice(0, 200)}`);
     }


### PR DESCRIPTION
## Pourquoi

Accélérer la détection de thèses cassées par V2 RiskManager : passage de cycle 5min → 60s + parallélisation Promise.all pour rester sous le budget temps cycle.

## Trade-offs

| Metric | 5min actuel | 60s + parallèle | Verdict |
|---|---|---|---|
| LLM Gemini cost | $0.40/jour | $2/jour | ✅ négligeable vs budget $200 |
| TwelveData calls | 4k/jour | 20k/jour | ✅ avg 14/min, sous cap 1597/min |
| Latence cycle | ~20s séquentiel | ≤5s parallèle | ✅ rentre largement dans 60s |
| Détection thèse cassée | jusqu'à 5 min retard | jusqu'à 60s | 🎯 4 min gagnées par event |

## Bénéfice attendu

Faible volume d'events (audit aujourd'hui : 0 broken détectés), mais critique quand ça arrive. Sur news chocs (Iran/Hormuz/Fed/profit warning), 4 min plus tôt = différence entre sortir à -0.5% vs -1.5% sur position $570 ≈ **$3-10 économisés par event**. **Airbag**, faible coût marginal pour grand bénéfice ponctuel.

## Garde-fous existants

- ✅ Cooldown re-entry 60min — empêche sur-trading si Gemini oscille
- ✅ Anti-stale price OPEN/CLOSE (PR #438) — pas d'action sur prix fantôme
- ✅ Confidence min 0.80 auto-close — reste conservateur

## Hors scope

V2 Scout NON modifié, reste à 5min — news macro positives n'arrivent pas toutes les minutes, ROI marginal trop faible pour ×5 le cost.

## Test plan

- [x] Tests locaux 6/6 verts
- [ ] CI typecheck + Jest verts
- [ ] Post-deploy : observer logs `[risk-manager] eval N open positions (parallel)` toutes minutes

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_