### PR TITLE
feat(ai-analyst): T1-#2 SignalEnvelope with half-life decay

### DIFF
--- a/packages/ai-analyst/src/decisions/__tests__/signal-half-life.spec.ts
+++ b/packages/ai-analyst/src/decisions/__tests__/signal-half-life.spec.ts
@@ -1,0 +1,111 @@
+import {
+  buildSignal,
+  decayedConfidence,
+  HALF_LIFE_PRESETS,
+  isSignalFresh,
+  signalAgeMs,
+  signalDecayFactor,
+} from '../signal-half-life';
+
+describe('signal-half-life', () => {
+  const t0 = 1_700_000_000_000;
+
+  describe('signalDecayFactor', () => {
+    it('returns 1.0 at emission time', () => {
+      const sig = buildSignal('BUY', 'momentum', 'scanner', 'SCALP_1M', { emittedAt: t0 });
+      expect(signalDecayFactor(sig, t0)).toBe(1.0);
+    });
+
+    it('returns 0.75 at half of half-life', () => {
+      const sig = buildSignal('BUY', 'momentum', 'scanner', 'INTRADAY_5M', { emittedAt: t0 });
+      const halfHalfLife = HALF_LIFE_PRESETS.INTRADAY_5M / 2;
+      expect(signalDecayFactor(sig, t0 + halfHalfLife)).toBeCloseTo(0.75, 2);
+    });
+
+    it('returns 0.5 at exactly half-life', () => {
+      const sig = buildSignal('BUY', 'momentum', 'scanner', 'INTRADAY_5M', { emittedAt: t0 });
+      expect(signalDecayFactor(sig, t0 + HALF_LIFE_PRESETS.INTRADAY_5M)).toBeCloseTo(0.5, 2);
+    });
+
+    it('returns 0.25 at 2× half-life', () => {
+      const sig = buildSignal('BUY', 'momentum', 'scanner', 'INTRADAY_5M', { emittedAt: t0 });
+      expect(signalDecayFactor(sig, t0 + 2 * HALF_LIFE_PRESETS.INTRADAY_5M)).toBeCloseTo(0.25, 2);
+    });
+
+    it('returns 0 beyond hard expiry (3× half-life by default)', () => {
+      const sig = buildSignal('BUY', 'momentum', 'scanner', 'SCALP_1M', { emittedAt: t0 });
+      expect(signalDecayFactor(sig, t0 + 3 * HALF_LIFE_PRESETS.SCALP_1M)).toBe(0);
+      expect(signalDecayFactor(sig, t0 + 10 * HALF_LIFE_PRESETS.SCALP_1M)).toBe(0);
+    });
+
+    it('handles future emittedAt gracefully (clock skew)', () => {
+      const sig = buildSignal('BUY', 'momentum', 'scanner', 'SCALP_1M', { emittedAt: t0 + 1000 });
+      expect(signalDecayFactor(sig, t0)).toBe(1.0);
+    });
+  });
+
+  describe('isSignalFresh', () => {
+    it('uses 0.5 threshold by default', () => {
+      const sig = buildSignal('BUY', 'm', 's', 'INTRADAY_5M', { emittedAt: t0 });
+      expect(isSignalFresh(sig, { now: t0 + HALF_LIFE_PRESETS.INTRADAY_5M - 1 })).toBe(true);
+      expect(isSignalFresh(sig, { now: t0 + HALF_LIFE_PRESETS.INTRADAY_5M * 1.5 })).toBe(false);
+    });
+
+    it('respects custom strict threshold', () => {
+      const sig = buildSignal('BUY', 'm', 's', 'INTRADAY_5M', { emittedAt: t0 });
+      expect(isSignalFresh(sig, { now: t0 + 1000, minDecayFactor: 0.95 })).toBe(true);
+      expect(isSignalFresh(sig, { now: t0 + HALF_LIFE_PRESETS.INTRADAY_5M / 2, minDecayFactor: 0.95 })).toBe(false);
+    });
+  });
+
+  describe('decayedConfidence', () => {
+    it('multiplies base confidence by decay factor', () => {
+      const sig = buildSignal('BUY', 'm', 's', 'INTRADAY_5M', { confidence: 0.8, emittedAt: t0 });
+      expect(decayedConfidence(sig, t0)).toBeCloseTo(0.8, 2);
+      expect(decayedConfidence(sig, t0 + HALF_LIFE_PRESETS.INTRADAY_5M)).toBeCloseTo(0.4, 2);
+    });
+
+    it('returns undefined when base confidence missing', () => {
+      const sig = buildSignal('BUY', 'm', 's', 'INTRADAY_5M', { emittedAt: t0 });
+      expect(decayedConfidence(sig, t0)).toBeUndefined();
+    });
+
+    it('makes a fresh 0.7 outrank a stale 0.9 on scalping window', () => {
+      const fresh = buildSignal('BUY', 'a', 'sc1', 'SCALP_1M', { confidence: 0.7, emittedAt: t0 });
+      const stale = buildSignal('BUY', 'b', 'sc2', 'SCALP_1M', { confidence: 0.9, emittedAt: t0 - 40_000 });
+      const dFresh = decayedConfidence(fresh, t0)!;
+      const dStale = decayedConfidence(stale, t0)!;
+      expect(dFresh).toBeGreaterThan(dStale);
+    });
+  });
+
+  describe('signalAgeMs', () => {
+    it('returns 0 for future-emitted signal (no negative age)', () => {
+      const sig = buildSignal('BUY', 'm', 's', 'SCALP_1M', { emittedAt: t0 + 5000 });
+      expect(signalAgeMs(sig, t0)).toBe(0);
+    });
+
+    it('returns positive age for past-emitted signal', () => {
+      const sig = buildSignal('BUY', 'm', 's', 'SCALP_1M', { emittedAt: t0 - 12_345 });
+      expect(signalAgeMs(sig, t0)).toBe(12_345);
+    });
+  });
+
+  describe('buildSignal', () => {
+    it('wires ttlMs in context to match half-life preset', () => {
+      const sig = buildSignal('BUY', 'm', 's', 'SWING_1H', { emittedAt: t0 });
+      expect(sig.context.ttlMs).toBe(HALF_LIFE_PRESETS.SWING_1H);
+      expect(sig.halfLifeMs).toBe(HALF_LIFE_PRESETS.SWING_1H);
+    });
+
+    it('default hardExpiry = 3 × halfLife', () => {
+      const sig = buildSignal('BUY', 'm', 's', 'SCALP_1M', { emittedAt: t0 });
+      expect(sig.hardExpiryMs).toBe(3 * HALF_LIFE_PRESETS.SCALP_1M);
+    });
+
+    it('respects custom hardExpiry override', () => {
+      const sig = buildSignal('BUY', 'm', 's', 'SCALP_1M', { emittedAt: t0, hardExpiryMs: 200_000 });
+      expect(sig.hardExpiryMs).toBe(200_000);
+    });
+  });
+});

--- a/packages/ai-analyst/src/decisions/signal-half-life.ts
+++ b/packages/ai-analyst/src/decisions/signal-half-life.ts
@@ -1,0 +1,162 @@
+/**
+ * AXEES T1-#2 — Signal Half-Life metadata.
+ *
+ * Aujourd'hui un signal scanner (ex: "BUY NANO.PA at 0.85 momentum") est traité
+ * comme intemporel : si le mécanique le voit 3 minutes plus tard, il l'exécute
+ * comme s'il venait d'être émis. Sur du scalping 1m, c'est mortel — le momentum
+ * a déjà épuisé sa première vague.
+ *
+ * Vision AXEES :
+ *
+ *   "Chaque signal doit porter sa propre demi-vie. Un breakout 1m vaut 30s,
+ *    un setup swing 4h vaut 2h. Si le temps écoulé > half-life, le signal
+ *    est décay : confidence × decayFactor, ou rejeté si decayFactor < 0.3."
+ *
+ * Cette couche définit :
+ *   - SignalEnvelope : DecisionContext enrichi de TTL et emit-timestamp
+ *   - isSignalFresh / signalDecayFactor : helpers de décision en aval
+ *   - HALF_LIFE_PRESETS : valeurs typées par stratégie / horizon
+ *
+ * Back-compat : ADDITIVE. Les agents qui n'émettent pas de ttlMs sont
+ * considérés "fresh forever" (legacy behavior, no regression).
+ */
+
+import type { DecisionContext, TradingDecision } from './trading-decision';
+
+/**
+ * Presets de half-life en millisecondes, calibrés par horizon de stratégie.
+ *
+ * - SCALP_1M : breakout 1min crypto/gainers — décay rapide (45s)
+ * - INTRADAY_5M : top-gainers persistence multi-TF — décay moyen (3min)
+ * - INTRADAY_15M : Lisa cycle standard / harvest mode — décay confortable (10min)
+ * - SWING_1H : Lisa investment / mechanical guard — décay long (45min)
+ * - SWING_4H : thèses narrative / rebound-tp — décay très long (3h)
+ * - DAILY : analyse macro / régime — décay 24h
+ *
+ * Règle empirique : half-life ≈ 75% du cycle de réévaluation du caller.
+ * Au-delà de half-life, le signal vaut < 0.5 (linear decay).
+ */
+export const HALF_LIFE_PRESETS = {
+  SCALP_1M: 45_000,
+  INTRADAY_5M: 180_000,
+  INTRADAY_15M: 600_000,
+  SWING_1H: 2_700_000,
+  SWING_4H: 10_800_000,
+  DAILY: 86_400_000,
+} as const;
+
+export type HalfLifePreset = keyof typeof HALF_LIFE_PRESETS;
+
+/**
+ * Enveloppe sémantique d'un signal trading, avec décay temporel.
+ *
+ * Permet à un consumer aval (Debate Orchestrator, mécanique, audit) de
+ * raisonner sur la fraicheur d'un signal sans avoir à connaitre la stratégie
+ * émettrice.
+ */
+export interface SignalEnvelope {
+  context: DecisionContext;
+  /** Half-life en ms — au-delà, decayFactor < 0.5. */
+  halfLifeMs: number;
+  /** Timestamp d'émission (epoch ms). */
+  emittedAt: number;
+  /**
+   * TTL absolu en ms — au-delà, signal totalement rejeté (decayFactor=0).
+   * Default = 3 × halfLifeMs (decay résiduel <= 0.125 = négligeable).
+   */
+  hardExpiryMs?: number;
+}
+
+/**
+ * Construit une SignalEnvelope avec presets typés (DX friendly).
+ */
+export function buildSignal(
+  decision: TradingDecision,
+  reason: string,
+  triggeredBy: string,
+  preset: HalfLifePreset,
+  opts: {
+    confidence?: number;
+    emittedAt?: number;
+    metadata?: Record<string, unknown>;
+    hardExpiryMs?: number;
+  } = {},
+): SignalEnvelope {
+  const halfLifeMs = HALF_LIFE_PRESETS[preset];
+  const emittedAt = opts.emittedAt ?? Date.now();
+  const context: DecisionContext = {
+    decision,
+    reason,
+    triggeredBy,
+    ttlMs: halfLifeMs,
+    emittedAt,
+  };
+  if (opts.confidence !== undefined) context.confidence = opts.confidence;
+  if (opts.metadata !== undefined) context.metadata = opts.metadata;
+  return {
+    context,
+    halfLifeMs,
+    emittedAt,
+    hardExpiryMs: opts.hardExpiryMs ?? halfLifeMs * 3,
+  };
+}
+
+/**
+ * Calcule le facteur de décay temporel d'un signal.
+ *
+ * Modèle : linear decay sur [0, hardExpiryMs] avec point d'inflexion à
+ * halfLifeMs (decay = 0.5). Au-delà du hard expiry, decay = 0.
+ *
+ *   age = 0           → 1.0  (signal frais)
+ *   age = halfLife/2  → 0.75 (signal encore fort)
+ *   age = halfLife    → 0.5  (signal moyen — seuil de décision recommandé)
+ *   age = 2×halfLife  → 0.25 (signal faible)
+ *   age = 3×halfLife  → 0.0  (signal mort, à rejeter)
+ */
+export function signalDecayFactor(signal: SignalEnvelope, now: number = Date.now()): number {
+  const age = now - signal.emittedAt;
+  if (age <= 0) return 1.0;
+  const hardExpiry = signal.hardExpiryMs ?? signal.halfLifeMs * 3;
+  if (age >= hardExpiry) return 0;
+  if (age <= signal.halfLifeMs) {
+    return 1.0 - 0.5 * (age / signal.halfLifeMs);
+  }
+  const remaining = hardExpiry - age;
+  const decayWindow = hardExpiry - signal.halfLifeMs;
+  return 0.5 * (remaining / decayWindow);
+}
+
+/**
+ * Verdict simple : le signal est-il encore exploitable ?
+ * Seuil par défaut 0.5 (= half-life atteint) — caller peut être plus
+ * strict (0.7 = très frais) ou plus laxiste (0.3 = dernier wagon).
+ */
+export function isSignalFresh(
+  signal: SignalEnvelope,
+  opts: { minDecayFactor?: number; now?: number } = {},
+): boolean {
+  const min = opts.minDecayFactor ?? 0.5;
+  return signalDecayFactor(signal, opts.now) >= min;
+}
+
+/**
+ * Confidence ajustée par le décay temporel.
+ *
+ * Utile quand un consumer compare plusieurs signaux concurrents :
+ * un BUY confidence=0.8 émis il y a 30s vaut plus qu'un BUY
+ * confidence=0.9 émis il y a 4 minutes sur un preset SCALP_1M.
+ *
+ * Retourne undefined si le signal n'a pas de confidence base.
+ */
+export function decayedConfidence(signal: SignalEnvelope, now: number = Date.now()): number | undefined {
+  const base = signal.context.confidence;
+  if (typeof base !== 'number') return undefined;
+  return base * signalDecayFactor(signal, now);
+}
+
+/**
+ * Age du signal en ms (helper pour logs / metrics).
+ */
+export function signalAgeMs(signal: SignalEnvelope, now: number = Date.now()): number {
+  return Math.max(0, now - signal.emittedAt);
+}

--- a/packages/ai-analyst/src/index.ts
+++ b/packages/ai-analyst/src/index.ts
@@ -31,3 +31,4 @@ export * from './backtest/metrics';
 export * from './backtest/runner';
 export * from './scoring/continuous-score';
 export * from './decisions/trading-decision';
+export * from './decisions/signal-half-life';


### PR DESCRIPTION
## AXEES Quick Win T1-#2 — Signal Half-Life metadata

Deuxième des 4 quick wins T1.

### Problème

Un signal scanner (ex: "BUY NANO.PA momentum 0.85") est aujourd'hui traité comme intemporel. Le mécanique l'exécute 3 min plus tard comme s'il venait d'être émis → mortel sur du scalping où le momentum a déjà épuisé sa première vague.

### Solution

- `SignalEnvelope` enrichit `DecisionContext` (cf. PR #444) avec demi-vie temporelle
- 6 presets par horizon : SCALP_1M, INTRADAY_5M, INTRADAY_15M, SWING_1H, SWING_4H, DAILY
- `signalDecayFactor()` → linear decay :
  - âge=0 → 1.0
  - âge=halfLife → 0.5 (seuil recommandé)
  - âge=2× halfLife → 0.25
  - âge=3× halfLife → 0.0 (mort)
- `decayedConfidence()` permet à un consumer de comparer : un BUY conf=0.7 émis il y a 30s > un BUY conf=0.9 émis il y a 4 min sur SCALP_1M

### Tests

16/16 ✅ couvrant décay linéaire, hard expiry, clock skew, presets, seuils, fresh vs stale.

### Forward-compat

L'orchestrateur de débat T1-#1 agrégera les signaux en pondérant par `decayedConfidence()`. Le champ `ttlMs` existait déjà dans `DecisionContext` (cf. PR #444) — cette PR concrétise la mécanique.

### Suivi T1

- [x] #4 No-Trade semantic (PR #444)
- [x] #2 Signal half-life (cette PR)
- [ ] #1 Debate orchestrator
- [ ] #3 Strategy lifecycle formel

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_