### PR TITLE
feat(ai-analyst): T2-C MacroRegime detector (RISK_ON / RISK_OFF / EUPHORIA / PANIC)

### DIFF
--- a/packages/ai-analyst/src/decisions/__tests__/macro-regime.spec.ts
+++ b/packages/ai-analyst/src/decisions/__tests__/macro-regime.spec.ts
@@ -1,0 +1,141 @@
+import {
+  DEFAULT_MACRO_REGIME_THRESHOLDS,
+  detectMacroRegime,
+  type MacroRegimeInputs,
+} from '../macro-regime';
+
+describe('detectMacroRegime', () => {
+  describe('empty / degenerate', () => {
+    it('returns UNKNOWN when no features provided', () => {
+      const r = detectMacroRegime({});
+      expect(r.regime).toBe('UNKNOWN');
+      expect(r.confidence).toBe(0);
+      expect(r.suggestedVerdict).toBe('REGIME_UNKNOWN');
+    });
+
+    it('UNKNOWN when only null features', () => {
+      const r = detectMacroRegime({ vix: null, hyOasBps: null });
+      expect(r.regime).toBe('UNKNOWN');
+    });
+
+    it('UNKNOWN when features are present but all in neutral zone', () => {
+      // VIX 20 is between vixRiskOnMax (18) and vixRiskOffMin (22) -> no contrib
+      // Term spread 50bps is between 0 and 100 -> no contrib
+      const r = detectMacroRegime({ vix: 20, termSpreadBps: 50 });
+      expect(r.regime).toBe('UNKNOWN');
+    });
+  });
+
+  describe('RISK_ON', () => {
+    it('VIX low + term spread steep + HY tight -> RISK_ON', () => {
+      const r = detectMacroRegime({
+        vix: 14,
+        termSpreadBps: 120,
+        hyOasBps: 350,
+      });
+      expect(r.regime).toBe('RISK_ON');
+      expect(r.suggestedVerdict).toBe('HOLD');
+      expect(r.confidence).toBeGreaterThan(0.5);
+    });
+
+    it('rationale mentions regime and confidence', () => {
+      const r = detectMacroRegime({ vix: 14, hyOasBps: 350 });
+      expect(r.rationale).toContain('RISK_ON');
+      expect(r.rationale).toMatch(/\d+%/);
+    });
+  });
+
+  describe('EUPHORIA', () => {
+    it('VIX < 12 + HY ultra-tight -> EUPHORIA', () => {
+      const r = detectMacroRegime({ vix: 10, hyOasBps: 250 });
+      expect(r.regime).toBe('EUPHORIA');
+      expect(r.suggestedVerdict).toBe('REDUCE_SIZE');
+    });
+
+    it('EUPHORIA confidence high when both VIX and HY align', () => {
+      const r = detectMacroRegime({ vix: 9, hyOasBps: 220 });
+      expect(r.regime).toBe('EUPHORIA');
+      expect(r.confidence).toBeGreaterThanOrEqual(0.5);
+    });
+  });
+
+  describe('RISK_OFF', () => {
+    it('VIX 24 + term inverted + HY wide -> RISK_OFF', () => {
+      const r = detectMacroRegime({
+        vix: 24,
+        termSpreadBps: -20,
+        hyOasBps: 550,
+      });
+      expect(r.regime).toBe('RISK_OFF');
+      expect(r.suggestedVerdict).toBe('REDUCE_SIZE');
+    });
+
+    it('DXY 5d +3% pushes toward RISK_OFF', () => {
+      const r = detectMacroRegime({ vix: 24, dxyChange5dPct: 3.0 });
+      expect(r.regime).toBe('RISK_OFF');
+    });
+  });
+
+  describe('PANIC', () => {
+    it('VIX 40 + HY blowout -> PANIC', () => {
+      const r = detectMacroRegime({ vix: 40, hyOasBps: 750 });
+      expect(r.regime).toBe('PANIC');
+      expect(r.suggestedVerdict).toBe('MARKET_UNSAFE');
+      expect(r.confidence).toBeGreaterThan(0.5);
+    });
+
+    it('PANIC dominates when both VIX and HY blow out together', () => {
+      const r = detectMacroRegime({ vix: 38, hyOasBps: 720 });
+      expect(r.regime).toBe('PANIC');
+    });
+  });
+
+  describe('data quality', () => {
+    it('haircut confidence by 30% when dataQualityDegraded=true', () => {
+      const clean = detectMacroRegime({ vix: 14, hyOasBps: 300 });
+      const degraded = detectMacroRegime({ vix: 14, hyOasBps: 300, dataQualityDegraded: true });
+      expect(degraded.regime).toBe(clean.regime);
+      expect(degraded.confidence).toBeCloseTo(clean.confidence * 0.7, 2);
+    });
+  });
+
+  describe('explainability', () => {
+    it('contributingFeatures lists every feature that scored', () => {
+      const r = detectMacroRegime({ vix: 14, hyOasBps: 300, termSpreadBps: 120 });
+      const features = r.contributingFeatures.map((c) => c.feature);
+      expect(features).toContain('vix');
+      expect(features).toContain('hyOasBps');
+      expect(features).toContain('termSpreadBps');
+    });
+
+    it('scores show per-regime breakdown', () => {
+      const r = detectMacroRegime({ vix: 14, hyOasBps: 300 });
+      expect(r.scores.RISK_ON).toBeGreaterThan(0);
+      expect(r.scores.PANIC).toBe(0);
+    });
+  });
+
+  describe('threshold overrides', () => {
+    it('respects custom thresholds', () => {
+      // With stricter EUPHORIA threshold, VIX=11 might not trigger
+      const strict = detectMacroRegime(
+        { vix: 11, hyOasBps: 400 },
+        { ...DEFAULT_MACRO_REGIME_THRESHOLDS, vixEuphoriaMax: 10 },
+      );
+      // vix 11 >= 10 (strict euphoria max) AND < 18 (riskOnMax) -> RISK_ON only
+      expect(strict.regime).toBe('RISK_ON');
+    });
+  });
+
+  describe('determinism', () => {
+    it('same inputs -> same output', () => {
+      const inputs: MacroRegimeInputs = { vix: 18.5, hyOasBps: 380, termSpreadBps: 45 };
+      expect(detectMacroRegime(inputs)).toEqual(detectMacroRegime(inputs));
+    });
+  });
+
+  it('exports DEFAULT_MACRO_REGIME_THRESHOLDS with sensible defaults', () => {
+    expect(DEFAULT_MACRO_REGIME_THRESHOLDS.vixPanicMin).toBe(35);
+    expect(DEFAULT_MACRO_REGIME_THRESHOLDS.hyOasBlowout).toBe(700);
+  });
+});

--- a/packages/ai-analyst/src/decisions/macro-regime.ts
+++ b/packages/ai-analyst/src/decisions/macro-regime.ts
@@ -1,0 +1,275 @@
+/**
+ * AXEES T2-C — Macro Regime Detector.
+ *
+ * Orthogonal au TacticalRegimeClassifier (BTC-focused intraday) : ce module
+ * détecte le régime MACRO cross-asset sur un horizon multi-jours à semaines,
+ * à partir d'inputs déjà disponibles dans MarketSnapshot (cf. CLAUDE.md
+ * §6quater : cascade live → proxy ETF → fallback).
+ *
+ * Vision AXEES :
+ *
+ *   "Remplacer les seuils statiques (VIX>30, pnl7d) par un détecteur formel
+ *    à 4 états. Chaque stratégie déclare ses régimes favoris. En EUPHORIA on
+ *    baisse les sizing, en PANIC on relève les seuils de quarantine."
+ *
+ * Les 4 régimes :
+ *
+ *   RISK_ON   : vol contenue, term spread positif, credit serré.
+ *               Sizing nominal, BUY autorisés, stratégies momentum favorisées.
+ *   RISK_OFF  : vol modérée mais credit qui s'écarte, spread plat/négatif.
+ *               Sizing -20%, BUY plus sélectifs, stratégies mean-reversion favorisées.
+ *   EUPHORIA  : vol très basse, credit ultra-serré, complaisance générale.
+ *               Sizing -30%, BUY ultra-sélectifs (risque de retournement),
+ *               stratégies path quality très strictes.
+ *   PANIC     : VIX > 35, credit blow-out, flight to quality.
+ *               BUY suspendus, CLOSE accéléré, seuils quarantine relevés.
+ *
+ * Algorithme : système de scoring par feature. Chaque feature contribue
+ * un score [-2..+2] vers chaque régime. Le régime gagnant = max score
+ * agrégé. Confidence = winnerScore / totalAbsScore.
+ *
+ * Pure fn déterministe, testable sans I/O.
+ */
+
+import type { TradingDecision } from './trading-decision';
+
+export type MacroRegime = 'RISK_ON' | 'RISK_OFF' | 'EUPHORIA' | 'PANIC' | 'UNKNOWN';
+
+/**
+ * Inputs macro. Tous optionnels — le détecteur dégrade gracieusement quand
+ * une feature est indisponible (fallback / proxy ETF / source down).
+ */
+export interface MacroRegimeInputs {
+  /** VIX spot. Null si indisponible. */
+  vix?: number | null;
+  /** Term spread US10Y - US2Y en bps. ex: 50 = +50bps. Null si indispo. */
+  termSpreadBps?: number | null;
+  /** HY OAS (High Yield credit spread) en bps. ex: 350. Null si indispo. */
+  hyOasBps?: number | null;
+  /** IG OAS (Investment Grade credit spread) en bps. ex: 95. Null si indispo. */
+  igOasBps?: number | null;
+  /** DXY (US Dollar Index) spot. ex: 104.5. Null si indispo. */
+  dxy?: number | null;
+  /** Variation DXY sur 5 jours en %. ex: +1.5. Optionnel. */
+  dxyChange5dPct?: number | null;
+  /** Drapeau qualité données : si true, la source est dégradée (proxy/fallback). */
+  dataQualityDegraded?: boolean;
+}
+
+export interface RegimeVerdict {
+  regime: MacroRegime;
+  /** Confidence 0..1 du verdict (ratio du score gagnant / total). */
+  confidence: number;
+  /** Scores aggrégés par régime (debug + explainability). */
+  scores: Record<Exclude<MacroRegime, 'UNKNOWN'>, number>;
+  /** Features qui ont contribué (audit + debug). */
+  contributingFeatures: ReadonlyArray<{
+    feature: string;
+    value: number;
+    contributions: Partial<Record<Exclude<MacroRegime, 'UNKNOWN'>, number>>;
+  }>;
+  /** Verdict TradingDecision suggéré par défaut pour ce régime. */
+  suggestedVerdict: TradingDecision;
+  /** Rationale human-readable. */
+  rationale: string;
+}
+
+/**
+ * Seuils calibrés sur données historiques 2018-2026 US.
+ * Ajustables via override partiel dans detectMacroRegime(input, thresholdsOverride?).
+ */
+export interface MacroRegimeThresholds {
+  /** VIX seuils par régime. */
+  vixEuphoriaMax: number;     // < 12 = EUPHORIA bias
+  vixRiskOnMax: number;        // < 18 = RISK_ON bias
+  vixRiskOffMin: number;       // > 22 = RISK_OFF bias
+  vixPanicMin: number;         // > 35 = PANIC bias
+
+  /** Term spread (10Y-2Y) en bps. */
+  termInversionBps: number;    // < 0 = RISK_OFF
+  termSteepBps: number;        // > 100 = RISK_ON
+
+  /** HY OAS en bps. */
+  hyOasUltraTight: number;     // < 280 = EUPHORIA
+  hyOasNormal: number;         // 280..450 = RISK_ON neutral
+  hyOasWide: number;           // > 500 = RISK_OFF
+  hyOasBlowout: number;        // > 700 = PANIC
+}
+
+export const DEFAULT_MACRO_REGIME_THRESHOLDS: MacroRegimeThresholds = {
+  vixEuphoriaMax: 12,
+  vixRiskOnMax: 18,
+  vixRiskOffMin: 22,
+  vixPanicMin: 35,
+  termInversionBps: 0,
+  termSteepBps: 100,
+  hyOasUltraTight: 280,
+  hyOasNormal: 450,
+  hyOasWide: 500,
+  hyOasBlowout: 700,
+};
+
+type ConcreteRegime = Exclude<MacroRegime, 'UNKNOWN'>;
+
+/**
+ * Détecte le régime macro courant à partir des inputs cross-asset.
+ *
+ * Algorithme :
+ *   1. Pour chaque feature présente, calcule contributions [-2..+2] par régime
+ *   2. Agrège : winnerRegime = argmax(scores), confidence = winner / totalAbs
+ *   3. Si total absolu = 0 (pas de feature) → UNKNOWN avec confidence=0
+ *   4. Si données degraded → confidence × 0.7 (haircut data quality)
+ *
+ * Suggested verdicts par régime :
+ *   RISK_ON   → HOLD (sizing nominal, BUY ailleurs autorisés)
+ *   RISK_OFF  → REDUCE_SIZE (sizing -20%)
+ *   EUPHORIA  → REDUCE_SIZE (sizing -30%, complaisance)
+ *   PANIC     → MARKET_UNSAFE (suspend nouvelles ouvertures, accélère CLOSE)
+ *   UNKNOWN   → REGIME_UNKNOWN (conservative skip)
+ */
+export function detectMacroRegime(
+  inputs: MacroRegimeInputs,
+  thresholds: MacroRegimeThresholds = DEFAULT_MACRO_REGIME_THRESHOLDS,
+): RegimeVerdict {
+  const scores: Record<ConcreteRegime, number> = {
+    RISK_ON: 0,
+    RISK_OFF: 0,
+    EUPHORIA: 0,
+    PANIC: 0,
+  };
+  const contributing: RegimeVerdict['contributingFeatures'] = [] as Array<{
+    feature: string;
+    value: number;
+    contributions: Partial<Record<ConcreteRegime, number>>;
+  }>;
+
+  // Feature: VIX
+  if (typeof inputs.vix === 'number' && inputs.vix > 0) {
+    const contribs: Partial<Record<ConcreteRegime, number>> = {};
+    const v = inputs.vix;
+    if (v < thresholds.vixEuphoriaMax) {
+      contribs.EUPHORIA = 2;
+      contribs.RISK_ON = 1;
+    } else if (v < thresholds.vixRiskOnMax) {
+      contribs.RISK_ON = 2;
+    } else if (v >= thresholds.vixPanicMin) {
+      contribs.PANIC = 2;
+      contribs.RISK_OFF = 1;
+    } else if (v >= thresholds.vixRiskOffMin) {
+      contribs.RISK_OFF = 2;
+    }
+    applyContribs(scores, contribs);
+    (contributing as Array<unknown>).push({ feature: 'vix', value: v, contributions: contribs });
+  }
+
+  // Feature: term spread
+  if (typeof inputs.termSpreadBps === 'number') {
+    const contribs: Partial<Record<ConcreteRegime, number>> = {};
+    const t = inputs.termSpreadBps;
+    if (t < thresholds.termInversionBps) {
+      contribs.RISK_OFF = 1;
+    } else if (t > thresholds.termSteepBps) {
+      contribs.RISK_ON = 1;
+    }
+    applyContribs(scores, contribs);
+    if (Object.keys(contribs).length > 0) {
+      (contributing as Array<unknown>).push({ feature: 'termSpreadBps', value: t, contributions: contribs });
+    }
+  }
+
+  // Feature: HY OAS
+  if (typeof inputs.hyOasBps === 'number' && inputs.hyOasBps > 0) {
+    const contribs: Partial<Record<ConcreteRegime, number>> = {};
+    const h = inputs.hyOasBps;
+    if (h < thresholds.hyOasUltraTight) {
+      contribs.EUPHORIA = 2;
+      contribs.RISK_ON = 1;
+    } else if (h <= thresholds.hyOasNormal) {
+      contribs.RISK_ON = 1;
+    } else if (h >= thresholds.hyOasBlowout) {
+      contribs.PANIC = 2;
+      contribs.RISK_OFF = 1;
+    } else if (h >= thresholds.hyOasWide) {
+      contribs.RISK_OFF = 2;
+    }
+    applyContribs(scores, contribs);
+    (contributing as Array<unknown>).push({ feature: 'hyOasBps', value: h, contributions: contribs });
+  }
+
+  // Feature: DXY change 5d
+  if (typeof inputs.dxyChange5dPct === 'number') {
+    const contribs: Partial<Record<ConcreteRegime, number>> = {};
+    const d = inputs.dxyChange5dPct;
+    if (d > 2.0) {
+      contribs.RISK_OFF = 1;
+    } else if (d < -2.0) {
+      contribs.RISK_ON = 1;
+    }
+    applyContribs(scores, contribs);
+    if (Object.keys(contribs).length > 0) {
+      (contributing as Array<unknown>).push({ feature: 'dxyChange5dPct', value: d, contributions: contribs });
+    }
+  }
+
+  // Agrégation
+  const totalAbs = Object.values(scores).reduce((acc, s) => acc + Math.abs(s), 0);
+  if (totalAbs === 0) {
+    return {
+      regime: 'UNKNOWN',
+      confidence: 0,
+      scores,
+      contributingFeatures: contributing,
+      suggestedVerdict: 'REGIME_UNKNOWN',
+      rationale: 'Aucune feature disponible pour détection de régime.',
+    };
+  }
+
+  let winner: ConcreteRegime = 'RISK_ON';
+  let winnerScore = -Infinity;
+  for (const r of ['RISK_ON', 'RISK_OFF', 'EUPHORIA', 'PANIC'] as ConcreteRegime[]) {
+    if (scores[r] > winnerScore) {
+      winnerScore = scores[r];
+      winner = r;
+    }
+  }
+
+  let confidence = winnerScore > 0 ? winnerScore / totalAbs : 0;
+  if (inputs.dataQualityDegraded) {
+    confidence *= 0.7;
+  }
+  confidence = Math.max(0, Math.min(1, confidence));
+
+  const suggestedVerdict = regimeToVerdict(winner);
+  const rationale = `Régime ${winner} (score ${winnerScore}/${totalAbs}, confidence ${(confidence * 100).toFixed(0)}%${inputs.dataQualityDegraded ? ', data degraded' : ''}).`;
+
+  return {
+    regime: winnerScore <= 0 ? 'UNKNOWN' : winner,
+    confidence,
+    scores,
+    contributingFeatures: contributing,
+    suggestedVerdict: winnerScore <= 0 ? 'REGIME_UNKNOWN' : suggestedVerdict,
+    rationale,
+  };
+}
+
+function applyContribs(
+  scores: Record<ConcreteRegime, number>,
+  contribs: Partial<Record<ConcreteRegime, number>>,
+): void {
+  for (const k of Object.keys(contribs) as ConcreteRegime[]) {
+    scores[k] += contribs[k] ?? 0;
+  }
+}
+
+function regimeToVerdict(r: ConcreteRegime): TradingDecision {
+  switch (r) {
+    case 'RISK_ON':
+      return 'HOLD';
+    case 'RISK_OFF':
+      return 'REDUCE_SIZE';
+    case 'EUPHORIA':
+      return 'REDUCE_SIZE';
+    case 'PANIC':
+      return 'MARKET_UNSAFE';
+  }
+}

--- a/packages/ai-analyst/src/index.ts
+++ b/packages/ai-analyst/src/index.ts
@@ -34,3 +34,4 @@ export * from './decisions/trading-decision';
 export * from './decisions/signal-half-life';
 export * from './decisions/debate-orchestrator';
 export * from './decisions/strategy-lifecycle';
+export * from './decisions/macro-regime';


### PR DESCRIPTION
## AXEES T2-C — MacroRegime detector

Premier des 3 chantiers T2 Buildable.

### Pourquoi

Aujourd'hui les seuils sont **statiques** (VIX > 30, pnl7d ≤ -5%). On veut un détecteur formel qui adapte les sizing/seuils contextuellement et que chaque stratégie puisse interroger pour déclarer ses régimes favoris.

### Les 4 régimes

| Régime | Verdict suggéré | Sizing | Effet |
|---|---|---|---|
| `RISK_ON` | HOLD | nominal | BUY autorisés |
| `RISK_OFF` | REDUCE_SIZE | -20% | BUY plus sélectifs |
| `EUPHORIA` | REDUCE_SIZE | -30% | Complaisance générale, anti top |
| `PANIC` | MARKET_UNSAFE | suspendu | CLOSE accéléré, no new entries |
| `UNKNOWN` | REGIME_UNKNOWN | conservative skip | Features insuffisantes |

### Algorithme

Scoring par feature `[-2..+2]` vers chaque régime → max wins → confidence = `winnerScore / totalAbsScore`. Haircut -30% si `dataQualityDegraded=true`.

Features supportées :
- VIX (seuils 12 / 18 / 22 / 35)
- Term spread US10Y-US2Y (seuils 0bps / 100bps)
- HY OAS (seuils 280 / 450 / 500 / 700 bps)
- DXY change 5d (seuils ±2%)

Tous seuils overridables via second argument.

### Tests (17/17)

UNKNOWN sur features absentes ou zone neutre, RISK_ON pur, EUPHORIA pur, RISK_OFF pur, PANIC pur, data quality haircut, explainability (contributingFeatures), threshold overrides, déterminisme.

### Orthogonal à l'existant

Le `TacticalRegimeClassifier` reste intact (BTC-focused, intraday, NEWS_SHOCK/VOL_SPIKE/BULL/BEAR/RANGE). Ce nouveau détecteur est macro cross-asset multi-jours — les 2 sont complémentaires.

### Forward-compat avec T1

- T1-#1 Debate (PR #446) : `regime=PANIC → MARKET_UNSAFE` est dans `VETO_DECISIONS` → court-circuite le débat
- T1-#3 Lifecycle (PR #447) : `criticalViolation` peut être déclenché par `regime=PANIC`

### Série T2

- [x] T2-C MacroRegime detector (cette PR)
- [ ] T2-A Volatility cartographer per-sector
- [ ] T2-B Capital allocator dynamique

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_