### PR TITLE
feat(ai-analyst): T2-B Capital Allocator dynamique

### DIFF
--- a/packages/ai-analyst/src/decisions/__tests__/capital-allocator.spec.ts
+++ b/packages/ai-analyst/src/decisions/__tests__/capital-allocator.spec.ts
@@ -1,0 +1,163 @@
+import {
+  allocateCapital,
+  DEFAULT_ALLOCATION_RULES,
+  type StrategyAllocationInput,
+} from '../capital-allocator';
+import type { StrategyHealth, StrategyState } from '../strategy-lifecycle';
+
+function health(over: Partial<StrategyHealth> = {}): StrategyHealth {
+  return {
+    sampleSize: 100,
+    hitRate: 0.55,
+    sharpe: 1.0,
+    pnl7dPct: 0.01,
+    drawdownPct: 0.03,
+    ageDays: 30,
+    ...over,
+  };
+}
+
+function input(
+  id: string,
+  state: StrategyState,
+  base: number,
+  over: Partial<StrategyHealth> = {},
+): StrategyAllocationInput {
+  return { strategyId: id, state, health: health(over), baseAllocationPct: base };
+}
+
+describe('allocateCapital', () => {
+  describe('terminal states forced to 0', () => {
+    it('quarantine -> 0%', () => {
+      const r = allocateCapital([input('s1', 'quarantine', 0.20)]);
+      expect(r.verdicts[0].finalAllocationPct).toBe(0);
+      expect(r.zeroedStrategies).toContain('s1');
+    });
+
+    it('retired -> 0%', () => {
+      const r = allocateCapital([input('s2', 'retired', 0.20)]);
+      expect(r.verdicts[0].finalAllocationPct).toBe(0);
+      expect(r.zeroedStrategies).toContain('s2');
+    });
+  });
+
+  describe('monitoring cap', () => {
+    it('caps monitoring to 50% of base', () => {
+      const r = allocateCapital([input('s1', 'monitoring', 0.20)]);
+      expect(r.verdicts[0].finalAllocationPct).toBeCloseTo(0.10, 3);
+      expect(r.verdicts[0].reason).toContain('Monitoring');
+    });
+  });
+
+  describe('proposed cap', () => {
+    it('caps proposed to 10% of base (paper-mostly)', () => {
+      const r = allocateCapital([input('s1', 'proposed', 0.20)]);
+      expect(r.verdicts[0].finalAllocationPct).toBeCloseTo(0.02, 3);
+    });
+  });
+
+  describe('active performant boost', () => {
+    it('sharpe >= 1.5 ET pnl7d >= 0 -> 1.3x base', () => {
+      const r = allocateCapital([input('s1', 'active', 0.20, { sharpe: 2.0, pnl7dPct: 0.02 })]);
+      expect(r.verdicts[0].finalAllocationPct).toBeCloseTo(0.26, 3);
+      expect(r.verdicts[0].reason).toContain('performant');
+    });
+
+    it('boost capped by maxSingleAllocationPct', () => {
+      const r = allocateCapital([input('s1', 'active', 0.35, { sharpe: 2.0, pnl7dPct: 0.05 })]);
+      // 0.35 * 1.3 = 0.455 -> capped at 0.40
+      expect(r.verdicts[0].finalAllocationPct).toBeCloseTo(0.40, 3);
+      expect(r.verdicts[0].capped).toBe(true);
+    });
+  });
+
+  describe('active underperformer haircut', () => {
+    it('sharpe < 0.5 -> 0.7x base', () => {
+      const r = allocateCapital([input('s1', 'active', 0.20, { sharpe: 0.2 })]);
+      expect(r.verdicts[0].finalAllocationPct).toBeCloseTo(0.14, 3);
+      expect(r.verdicts[0].reason).toContain('sous-performant');
+    });
+
+    it('pnl7d < 0 -> 0.7x even with decent sharpe', () => {
+      const r = allocateCapital([input('s1', 'active', 0.20, { sharpe: 1.0, pnl7dPct: -0.01 })]);
+      expect(r.verdicts[0].finalAllocationPct).toBeCloseTo(0.14, 3);
+    });
+  });
+
+  describe('active nominal', () => {
+    it('sharpe 1.0 + pnl positif -> 1.0x base', () => {
+      const r = allocateCapital([input('s1', 'active', 0.15, { sharpe: 1.0, pnl7dPct: 0.005 })]);
+      expect(r.verdicts[0].finalAllocationPct).toBeCloseTo(0.15, 3);
+      expect(r.verdicts[0].appliedMultiplier).toBe(1.0);
+    });
+  });
+
+  describe('min plancher', () => {
+    it('active under min plancher -> 0%', () => {
+      const r = allocateCapital([input('s1', 'active', 0.03, { sharpe: 1.0 })]);
+      // 0.03 * 1.0 = 0.03 < 0.05 plancher
+      expect(r.verdicts[0].finalAllocationPct).toBe(0);
+      expect(r.zeroedStrategies).toContain('s1');
+    });
+  });
+
+  describe('rescale when sum > 100%', () => {
+    it('rescales proportionally', () => {
+      const inputs = [
+        input('s1', 'active', 0.40, { sharpe: 2.0, pnl7dPct: 0.05 }), // 0.40*1.3=0.52 cap 0.40
+        input('s2', 'active', 0.40, { sharpe: 2.0, pnl7dPct: 0.05 }), // 0.40
+        input('s3', 'active', 0.30, { sharpe: 1.0 }), // 0.30
+      ];
+      const r = allocateCapital(inputs);
+      // raw sum = 0.40 + 0.40 + 0.30 = 1.10 > 1.0
+      expect(r.rescaled).toBe(true);
+      expect(r.totalAllocated).toBeCloseTo(1.0, 3);
+    });
+
+    it('does not rescale when sum < 100%', () => {
+      const inputs = [
+        input('s1', 'active', 0.20, { sharpe: 1.0 }),
+        input('s2', 'active', 0.20, { sharpe: 1.0 }),
+      ];
+      const r = allocateCapital(inputs);
+      expect(r.rescaled).toBe(false);
+      expect(r.totalAllocated).toBeCloseTo(0.40, 3);
+      expect(r.residualCashPct).toBeCloseTo(0.60, 3);
+    });
+  });
+
+  describe('mixed states scenario', () => {
+    it('handles realistic mix correctly', () => {
+      const inputs = [
+        input('top-gainers', 'active', 0.30, { sharpe: 1.8, pnl7dPct: 0.03 }),
+        input('rebound-tp', 'monitoring', 0.20),
+        input('harvest', 'active', 0.20, { sharpe: 0.3 }),
+        input('experimental', 'proposed', 0.10),
+        input('legacy-bull', 'quarantine', 0.20),
+      ];
+      const r = allocateCapital(inputs);
+      // top-gainers: 0.30 * 1.3 = 0.39 (cap 0.40)
+      // rebound-tp: 0.20 * 0.5 = 0.10
+      // harvest: 0.20 * 0.7 = 0.14
+      // experimental: 0.10 * 0.1 = 0.01
+      // legacy-bull: 0
+      const total = 0.39 + 0.10 + 0.14 + 0.01;
+      expect(r.totalAllocated).toBeCloseTo(total, 2);
+      expect(r.zeroedStrategies).toContain('legacy-bull');
+      expect(r.rescaled).toBe(false);
+    });
+  });
+
+  describe('determinism', () => {
+    it('same inputs -> same output', () => {
+      const inputs = [input('s1', 'active', 0.20, { sharpe: 1.2 })];
+      expect(allocateCapital(inputs)).toEqual(allocateCapital(inputs));
+    });
+  });
+
+  it('exports DEFAULT_ALLOCATION_RULES with conservative caps', () => {
+    expect(DEFAULT_ALLOCATION_RULES.maxSingleAllocationPct).toBe(0.40);
+    expect(DEFAULT_ALLOCATION_RULES.performantMultiplier).toBe(1.3);
+    expect(DEFAULT_ALLOCATION_RULES.minActiveAllocationPct).toBe(0.05);
+  });
+});

--- a/packages/ai-analyst/src/decisions/capital-allocator.ts
+++ b/packages/ai-analyst/src/decisions/capital-allocator.ts
@@ -1,0 +1,246 @@
+/**
+ * AXEES T2-B — Capital Allocator dynamique.
+ *
+ * Vision AXEES :
+ *
+ *   "Le capital flotte entre stratégies selon leur StrategyHealth (T1-#3).
+ *    Une stratégie en monitoring est réduite à 50%, une stratégie active
+ *    avec sharpe > 1.5 est bumpée à 130%. Une stratégie en quarantine est
+ *    à 0%. On n'arrose plus une stratégie qui sous-performe, on dope celle
+ *    qui marche."
+ *
+ * Aujourd'hui chaque portfolio = 1 capital fixe partagé entre stratégies
+ * sans aucune pondération par performance. Une stratégie défaillante mange
+ * le même budget qu'une stratégie qui carbure.
+ *
+ * Cette couche définit :
+ *   - StrategyAllocationInput : stratégie + StrategyHealth + baseAllocationPct
+ *   - AllocationVerdict : pondération finale + reason + bornes appliquées
+ *   - allocateCapital(inputs, rules?) : pure fn déterministe
+ *
+ * Règles immuables :
+ *   1. Stratégies en `quarantine` ou `retired` -> 0% (jamais d'override).
+ *   2. Stratégies en `monitoring` -> max 50% de base allocation.
+ *   3. Stratégies en `proposed` -> max 10% de base (paper-only majoritaire).
+ *   4. Stratégies en `active` :
+ *      - sharpe >= 1.5 ET pnl7d >= 0 -> 1.3x base (boost performant)
+ *      - sharpe in [0.5, 1.5[ -> 1.0x base (nominal)
+ *      - sharpe < 0.5 OU pnl7d < 0 -> 0.7x base (sous-performant)
+ *   5. Somme conservée : si total > 100% capital, on rescale proportionnellement.
+ *   6. Borne plancher 5% par stratégie active (sinon trop fragmenté pour faire effet).
+ *
+ * Back-compat : ADDITIVE. Pas de wiring runtime — le caller (orchestrator
+ * portfolio, cron de rebalance) applique les verdicts.
+ */
+
+import type { StrategyHealth, StrategyState } from './strategy-lifecycle';
+
+export interface StrategyAllocationInput {
+  /** Identifiant unique de la stratégie. */
+  strategyId: string;
+  /** État du cycle de vie (cf. T1-#3 strategy-lifecycle). */
+  state: StrategyState;
+  /** Métriques de santé courantes. */
+  health: StrategyHealth;
+  /**
+   * Allocation de base en % du capital total (0..1). ex: 0.20 = 20% du capital.
+   * Le scaler applique multipliers/cap dessus.
+   */
+  baseAllocationPct: number;
+}
+
+export interface CapitalAllocationRules {
+  /** Plancher minimum pour une stratégie active (sinon trop fragmenté). */
+  minActiveAllocationPct: number;
+  /** Plafond max d'une seule stratégie (anti-concentration). */
+  maxSingleAllocationPct: number;
+  /** Multiplier sur baseAllocationPct pour stratégie active performante. */
+  performantMultiplier: number;
+  /** Multiplier sur baseAllocationPct pour stratégie active sous-performante. */
+  underperformerMultiplier: number;
+  /** Plafond pour stratégie en monitoring (fraction de baseAllocationPct). */
+  monitoringCap: number;
+  /** Plafond pour stratégie en proposed (paper-mostly). */
+  proposedCap: number;
+  /** Seuils sharpe pour classification active. */
+  performantSharpeMin: number;
+  underperformerSharpeMax: number;
+}
+
+export const DEFAULT_ALLOCATION_RULES: CapitalAllocationRules = {
+  minActiveAllocationPct: 0.05,
+  maxSingleAllocationPct: 0.40,
+  performantMultiplier: 1.3,
+  underperformerMultiplier: 0.7,
+  monitoringCap: 0.5,
+  proposedCap: 0.1,
+  performantSharpeMin: 1.5,
+  underperformerSharpeMax: 0.5,
+};
+
+export interface AllocationVerdict {
+  strategyId: string;
+  /** Allocation finale en fraction du capital (0..1). */
+  finalAllocationPct: number;
+  /** Allocation brute avant rescale (pour audit). */
+  rawAllocationPct: number;
+  /** Multiplier appliqué (1.0 = nominal). */
+  appliedMultiplier: number;
+  /** True si une borne (plancher, plafond, rescale) a été appliquée. */
+  capped: boolean;
+  reason: string;
+}
+
+export interface CapitalAllocationResult {
+  verdicts: ReadonlyArray<AllocationVerdict>;
+  /** Somme des allocations finales (devrait être <= 1.0). */
+  totalAllocated: number;
+  /** Cash résiduel non alloué (1.0 - totalAllocated). */
+  residualCashPct: number;
+  /** Stratégies forcées à 0% (quarantine/retired). */
+  zeroedStrategies: ReadonlyArray<string>;
+  /** True si rescale proportionnel a été appliqué. */
+  rescaled: boolean;
+}
+
+/**
+ * Calcule l'allocation par stratégie selon état + santé.
+ *
+ * Algorithme :
+ *   1. Pour chaque stratégie, calcule raw allocation selon state + health
+ *   2. Si state in {quarantine, retired} -> 0
+ *   3. Si state = monitoring -> min(base, base × monitoringCap)
+ *   4. Si state = proposed -> min(base, base × proposedCap)
+ *   5. Si state = active :
+ *      - performant -> base × performantMultiplier
+ *      - underperformer -> base × underperformerMultiplier
+ *      - autre -> base × 1.0
+ *   6. Borne haute : min(raw, maxSingleAllocationPct)
+ *   7. Borne basse : si state=active ET raw < minActiveAllocationPct -> 0
+ *   8. Rescale : si sum(raw) > 1.0, scale proportionnellement
+ *
+ * Pure fn déterministe.
+ */
+export function allocateCapital(
+  inputs: ReadonlyArray<StrategyAllocationInput>,
+  rules: CapitalAllocationRules = DEFAULT_ALLOCATION_RULES,
+): CapitalAllocationResult {
+  const zeroed: string[] = [];
+  const verdicts: Array<AllocationVerdict & { rawForRescale: number }> = [];
+
+  for (const inp of inputs) {
+    const v = computeSingle(inp, rules, zeroed);
+    verdicts.push({ ...v, rawForRescale: v.finalAllocationPct });
+  }
+
+  // Rescale si somme > 1.0
+  const rawSum = verdicts.reduce((acc, v) => acc + v.finalAllocationPct, 0);
+  let rescaled = false;
+  if (rawSum > 1.0) {
+    rescaled = true;
+    const scaleFactor = 1.0 / rawSum;
+    for (const v of verdicts) {
+      v.finalAllocationPct *= scaleFactor;
+      if (!v.capped) v.capped = true;
+      v.reason += ` Rescale x${scaleFactor.toFixed(3)} (somme initiale ${(rawSum * 100).toFixed(0)}% > 100%).`;
+    }
+  }
+
+  const totalAllocated = verdicts.reduce((acc, v) => acc + v.finalAllocationPct, 0);
+  const residualCashPct = Math.max(0, 1.0 - totalAllocated);
+
+  return {
+    verdicts: verdicts.map(({ rawForRescale: _ignored, ...v }) => v),
+    totalAllocated,
+    residualCashPct,
+    zeroedStrategies: zeroed,
+    rescaled,
+  };
+}
+
+function computeSingle(
+  inp: StrategyAllocationInput,
+  rules: CapitalAllocationRules,
+  zeroed: string[],
+): AllocationVerdict {
+  // 1. Quarantine / retired -> 0
+  if (inp.state === 'quarantine' || inp.state === 'retired') {
+    zeroed.push(inp.strategyId);
+    return {
+      strategyId: inp.strategyId,
+      finalAllocationPct: 0,
+      rawAllocationPct: 0,
+      appliedMultiplier: 0,
+      capped: true,
+      reason: `State=${inp.state} : allocation forcée à 0.`,
+    };
+  }
+
+  // 2. Monitoring -> cap
+  if (inp.state === 'monitoring') {
+    const raw = inp.baseAllocationPct * rules.monitoringCap;
+    const final = Math.min(raw, rules.maxSingleAllocationPct);
+    return {
+      strategyId: inp.strategyId,
+      finalAllocationPct: final,
+      rawAllocationPct: raw,
+      appliedMultiplier: rules.monitoringCap,
+      capped: final < raw || raw < inp.baseAllocationPct,
+      reason: `Monitoring : cap ${(rules.monitoringCap * 100).toFixed(0)}% (raw ${(raw * 100).toFixed(1)}%).`,
+    };
+  }
+
+  // 3. Proposed -> cap bas
+  if (inp.state === 'proposed') {
+    const raw = inp.baseAllocationPct * rules.proposedCap;
+    return {
+      strategyId: inp.strategyId,
+      finalAllocationPct: raw,
+      rawAllocationPct: raw,
+      appliedMultiplier: rules.proposedCap,
+      capped: true,
+      reason: `Proposed : cap ${(rules.proposedCap * 100).toFixed(0)}% (paper-mostly).`,
+    };
+  }
+
+  // 4. Active -> multiplier selon perf
+  const { sharpe, pnl7dPct } = inp.health;
+  let multiplier = 1.0;
+  let label = 'nominal';
+  if (typeof sharpe === 'number' && sharpe >= rules.performantSharpeMin && (pnl7dPct ?? 0) >= 0) {
+    multiplier = rules.performantMultiplier;
+    label = 'performant';
+  } else if (
+    (typeof sharpe === 'number' && sharpe < rules.underperformerSharpeMax) ||
+    (typeof pnl7dPct === 'number' && pnl7dPct < 0)
+  ) {
+    multiplier = rules.underperformerMultiplier;
+    label = 'sous-performant';
+  }
+
+  const raw = inp.baseAllocationPct * multiplier;
+
+  // 5. Borne basse : si trop petit, on zero
+  if (raw < rules.minActiveAllocationPct) {
+    zeroed.push(inp.strategyId);
+    return {
+      strategyId: inp.strategyId,
+      finalAllocationPct: 0,
+      rawAllocationPct: raw,
+      appliedMultiplier: multiplier,
+      capped: true,
+      reason: `Active ${label} : ${(raw * 100).toFixed(1)}% < plancher ${(rules.minActiveAllocationPct * 100).toFixed(0)}% -> 0.`,
+    };
+  }
+
+  // 6. Borne haute : cap maxSingle
+  const final = Math.min(raw, rules.maxSingleAllocationPct);
+  return {
+    strategyId: inp.strategyId,
+    finalAllocationPct: final,
+    rawAllocationPct: raw,
+    appliedMultiplier: multiplier,
+    capped: final < raw,
+    reason: `Active ${label} : multiplier ${multiplier} -> ${(final * 100).toFixed(1)}%.`,
+  };
+}

--- a/packages/ai-analyst/src/index.ts
+++ b/packages/ai-analyst/src/index.ts
@@ -36,3 +36,4 @@ export * from './decisions/debate-orchestrator';
 export * from './decisions/strategy-lifecycle';
 export * from './decisions/macro-regime';
 export * from './decisions/volatility-cartography';
+export * from './decisions/capital-allocator';


### PR DESCRIPTION
## AXEES T2-B — Capital Allocator dynamique

**Dernier des 3 chantiers T2 Buildable. Termine la série T2.**

### Pourquoi

Aujourd'hui chaque portfolio a un capital fixe partagé sans pondération. Une stratégie défaillante mange le même budget qu'une stratégie qui carbure. Le capital ne flotte pas.

Demain : on **dope** ce qui marche, on **affame** ce qui décroche.

### Règles immuables

| État | Allocation |
|---|---|
| `quarantine` / `retired` | **0%** (jamais d'override) |
| `monitoring` | max 50% × base |
| `proposed` | max 10% × base (paper-mostly) |
| `active` performant (sharpe ≥ 1.5 ET pnl7d ≥ 0) | **1.3× base** |
| `active` sous-performant (sharpe < 0.5 OU pnl7d < 0) | 0.7× base |
| `active` nominal | 1.0× base |

**Bornes** :
- Haut : 40% max par stratégie (anti-concentration)
- Bas : 5% min pour active (sinon trop fragmenté → 0%)
- Rescale proportionnel si somme > 100%

### Output

```ts
{
  verdicts: [{ strategyId, finalAllocationPct, rawAllocationPct,
               appliedMultiplier, capped, reason }],
  totalAllocated: 0.94,
  residualCashPct: 0.06,
  zeroedStrategies: ['legacy-bull'],
  rescaled: false
}
```

### Tests (15/15)

Terminal states, caps monitoring/proposed, boost performant + cap maxSingle, haircut sharpe/pnl, nominal, plancher, rescale > 100%, scenario mixte réaliste, déterminisme.

### Forward-compat

- **T1-#3 Lifecycle** : input direct `StrategyHealth + StrategyState`
- **T2-C MacroRegime** : possibilité future de boost macro (RISK_ON +10% global, PANIC -50%)
- **T2-A Volatility** : exclure capital des cellules excluded avant allocation

### Série T2 — COMPLÈTE

- [x] T2-C MacroRegime detector (PR #448 merged)
- [x] T2-A Volatility cartographer (PR #449 en review)
- [x] T2-B Capital allocator (cette PR)

### Bilan T1+T2

**7 building blocks déterministes, 130+ unit tests, 0 wiring runtime impact (additif strict).** La phase d'intégration (wiring scanner + mechanical + RiskEnforcer) suivra après validation des building blocks.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_