### PR TITLE
feat(ai-analyst): bridge legacy shadow signals → Debate Orchestrator

### DIFF
--- a/packages/ai-analyst/src/decisions/__tests__/shadow-to-debate-bridge.spec.ts
+++ b/packages/ai-analyst/src/decisions/__tests__/shadow-to-debate-bridge.spec.ts
@@ -1,0 +1,174 @@
+import { resolveDebate } from '../debate-orchestrator';
+import { HALF_LIFE_PRESETS, signalDecayFactor } from '../signal-half-life';
+import {
+  bridgeShadowBatch,
+  bridgeShadowToDebate,
+  type ShadowSignalRow,
+} from '../shadow-to-debate-bridge';
+
+describe('shadow-to-debate-bridge', () => {
+  const t0 = 1_700_000_000_000;
+
+  describe('bridgeShadowToDebate', () => {
+    it('maps "accept" -> BUY semantic decision', () => {
+      const row: ShadowSignalRow = { decision: 'accept', emittedAt: t0, confidence: 0.8 };
+      const inp = bridgeShadowToDebate(row);
+      expect(inp.signal.context.decision).toBe('BUY');
+      expect(inp.signal.context.confidence).toBe(0.8);
+    });
+
+    it('maps "reject_persistence" -> WAIT', () => {
+      const inp = bridgeShadowToDebate({ decision: 'reject_persistence', emittedAt: t0 });
+      expect(inp.signal.context.decision).toBe('WAIT');
+    });
+
+    it('maps "reject_overextended" -> CHASE_THE_TOP', () => {
+      const inp = bridgeShadowToDebate({ decision: 'reject_overextended', emittedAt: t0 });
+      expect(inp.signal.context.decision).toBe('CHASE_THE_TOP');
+    });
+
+    it('maps "reject_volatile_regime" -> MARKET_UNSAFE', () => {
+      const inp = bridgeShadowToDebate({ decision: 'reject_volatile_regime', emittedAt: t0 });
+      expect(inp.signal.context.decision).toBe('MARKET_UNSAFE');
+    });
+
+    it('maps unknown decision -> REGIME_UNKNOWN (safe fallback)', () => {
+      const inp = bridgeShadowToDebate({ decision: 'reject_unknown_future_code', emittedAt: t0 });
+      expect(inp.signal.context.decision).toBe('REGIME_UNKNOWN');
+    });
+
+    it('parses ISO string timestamp', () => {
+      const iso = new Date(t0).toISOString();
+      const inp = bridgeShadowToDebate({ decision: 'accept', emittedAt: iso, confidence: 0.7 });
+      expect(inp.signal.emittedAt).toBe(t0);
+    });
+
+    it('parses numeric epoch timestamp', () => {
+      const inp = bridgeShadowToDebate({ decision: 'accept', emittedAt: t0, confidence: 0.7 });
+      expect(inp.signal.emittedAt).toBe(t0);
+    });
+
+    it('uses INTRADAY_5M half-life by default', () => {
+      const inp = bridgeShadowToDebate({ decision: 'accept', emittedAt: t0, confidence: 0.7 });
+      expect(inp.signal.halfLifeMs).toBe(HALF_LIFE_PRESETS.INTRADAY_5M);
+    });
+
+    it('respects custom half-life preset', () => {
+      const inp = bridgeShadowToDebate(
+        { decision: 'accept', emittedAt: t0, confidence: 0.7 },
+        { halfLifePreset: 'SCALP_1M' },
+      );
+      expect(inp.signal.halfLifeMs).toBe(HALF_LIFE_PRESETS.SCALP_1M);
+    });
+
+    it('uses default agentId when row has none', () => {
+      const inp = bridgeShadowToDebate({ decision: 'accept', emittedAt: t0 });
+      expect(inp.agentId).toBe('scanner_gainers');
+    });
+
+    it('respects custom defaultAgentId', () => {
+      const inp = bridgeShadowToDebate(
+        { decision: 'accept', emittedAt: t0 },
+        { defaultAgentId: 'scanner_v2' },
+      );
+      expect(inp.agentId).toBe('scanner_v2');
+    });
+
+    it('row.agentId overrides defaultAgentId', () => {
+      const inp = bridgeShadowToDebate(
+        { decision: 'accept', emittedAt: t0, agentId: 'specific' },
+        { defaultAgentId: 'fallback' },
+      );
+      expect(inp.agentId).toBe('specific');
+    });
+
+    it('passes agentWeight through', () => {
+      const inp = bridgeShadowToDebate({ decision: 'accept', emittedAt: t0 }, { agentWeight: 2.5 });
+      expect(inp.agentWeight).toBe(2.5);
+    });
+
+    it('preserves reason from row', () => {
+      const inp = bridgeShadowToDebate({ decision: 'accept', emittedAt: t0, reason: 'high persistence' });
+      expect(inp.signal.context.reason).toBe('high persistence');
+    });
+
+    it('fallback reason mentions legacy decision', () => {
+      const inp = bridgeShadowToDebate({ decision: 'reject_cooldown', emittedAt: t0 });
+      expect(inp.signal.context.reason).toContain('reject_cooldown');
+    });
+
+    it('preserves metadata', () => {
+      const inp = bridgeShadowToDebate({
+        decision: 'accept',
+        emittedAt: t0,
+        metadata: { p_win: 0.78, persistence_score: 0.85 },
+      });
+      expect(inp.signal.context.metadata).toEqual({ p_win: 0.78, persistence_score: 0.85 });
+    });
+  });
+
+  describe('bridgeShadowBatch', () => {
+    it('maps an array of rows', () => {
+      const rows: ShadowSignalRow[] = [
+        { decision: 'accept', emittedAt: t0, confidence: 0.8 },
+        { decision: 'reject_persistence', emittedAt: t0 + 1000, confidence: 0.5 },
+      ];
+      const inputs = bridgeShadowBatch(rows);
+      expect(inputs).toHaveLength(2);
+      expect(inputs[0].signal.context.decision).toBe('BUY');
+      expect(inputs[1].signal.context.decision).toBe('WAIT');
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(bridgeShadowBatch([])).toHaveLength(0);
+    });
+  });
+
+  describe('end-to-end with resolveDebate', () => {
+    it('multiple accepts -> BUY consensus via debate', () => {
+      const rows: ShadowSignalRow[] = [
+        { decision: 'accept', emittedAt: t0, agentId: 'scanner_a', confidence: 0.8 },
+        { decision: 'accept', emittedAt: t0, agentId: 'scanner_b', confidence: 0.75 },
+      ];
+      const debate = resolveDebate(bridgeShadowBatch(rows), t0);
+      expect(debate.decision).toBe('BUY');
+      expect(debate.contributingAgents).toHaveLength(2);
+    });
+
+    it('reject_volatile_regime alone -> MARKET_UNSAFE veto via debate', () => {
+      const rows: ShadowSignalRow[] = [
+        { decision: 'reject_volatile_regime', emittedAt: t0, confidence: 0.9 },
+      ];
+      const debate = resolveDebate(bridgeShadowBatch(rows), t0);
+      expect(debate.decision).toBe('MARKET_UNSAFE');
+      expect(debate.vetoTriggered).toBe(true);
+    });
+
+    it('stale shadow signals are filtered out', () => {
+      const rows: ShadowSignalRow[] = [
+        { decision: 'accept', emittedAt: t0 - 800_000, confidence: 0.9 }, // stale on INTRADAY_5M
+      ];
+      const debate = resolveDebate(bridgeShadowBatch(rows), t0);
+      expect(debate.decision).toBe('WAIT');
+      expect(debate.staleAgents.length).toBeGreaterThan(0);
+    });
+
+    it('mix accept + reject_cooldown -> WAIT (no consensus, COOLDOWN_ACTIVE is not veto)', () => {
+      const rows: ShadowSignalRow[] = [
+        { decision: 'accept', emittedAt: t0, agentId: 'a', confidence: 0.8 },
+        { decision: 'reject_cooldown', emittedAt: t0, agentId: 'b', confidence: 0.8 },
+      ];
+      const debate = resolveDebate(bridgeShadowBatch(rows), t0);
+      // BUY 1 vs COOLDOWN_ACTIVE 1 -> tie, fallback WAIT
+      expect(debate.decision).toBe('WAIT');
+    });
+
+    it('shadow signal decay reflects half-life preset', () => {
+      const inp = bridgeShadowToDebate(
+        { decision: 'accept', emittedAt: t0 - HALF_LIFE_PRESETS.INTRADAY_5M, confidence: 0.9 },
+      );
+      // After exactly one half-life, decay factor should be 0.5
+      expect(signalDecayFactor(inp.signal, t0)).toBeCloseTo(0.5, 2);
+    });
+  });
+});

--- a/packages/ai-analyst/src/decisions/shadow-to-debate-bridge.ts
+++ b/packages/ai-analyst/src/decisions/shadow-to-debate-bridge.ts
@@ -1,0 +1,108 @@
+/**
+ * AXEES T1/T2 Bridge — Shadow signals -> Debate input.
+ *
+ * Aujourd'hui SmartVest stocke chaque décision de scanner gainers dans la
+ * table `gainers_user_shadow_signals` avec une colonne `decision` legacy
+ * (`accept`, `reject_persistence`, `reject_overextended`, etc.). T1-#4
+ * (PR #444) a livré un mapping `mapShadowDecisionToSemantic()` mais aucun
+ * consumer n'utilise ces verdicts sémantiques.
+ *
+ * Cette couche introduit la passerelle entre les données legacy déjà
+ * persistées et le nouveau framework de débat (T1-#1, T1-#2) sans toucher
+ * au code émetteur. Permet de :
+ *
+ *   1. Valider end-to-end T1+T2 sur des données réelles
+ *   2. Préparer le wiring runtime du Debate Orchestrator
+ *   3. Backfill historique sans migration DB destructive
+ *
+ * Pure fn déterministe — pas d'I/O DB. Le caller fournit les rows pré-fetchées.
+ */
+
+import type { DebateInput } from './debate-orchestrator';
+import { buildSignal, type HalfLifePreset } from './signal-half-life';
+import { mapShadowDecisionToSemantic } from './trading-decision';
+
+/**
+ * Row brute de `gainers_user_shadow_signals` (subset utile pour le bridge).
+ * Le caller fournit ce shape sans dépendance Supabase ici.
+ */
+export interface ShadowSignalRow {
+  /** Decision legacy ('accept', 'reject_persistence', ...). */
+  decision: string;
+  /** Timestamp d'émission ISO 8601 ou epoch ms. */
+  emittedAt: string | number;
+  /** Optionnel : score de confiance déjà calculé par le scanner. */
+  confidence?: number;
+  /** Optionnel : reason human-readable. */
+  reason?: string;
+  /** Optionnel : agentId pour distinguer plusieurs scanners. */
+  agentId?: string;
+  /** Optionnel : metadata libre. */
+  metadata?: Record<string, unknown>;
+}
+
+export interface BridgeOptions {
+  /** Preset de half-life à appliquer. Default INTRADAY_5M (scanner gainers cycle). */
+  halfLifePreset?: HalfLifePreset;
+  /** AgentId par défaut si la row n'en porte pas. */
+  defaultAgentId?: string;
+  /** Confidence par défaut si la row n'en porte pas. */
+  defaultConfidence?: number;
+  /** Poids relatif de l'agent dans le débat. Default 1.0. */
+  agentWeight?: number;
+}
+
+/**
+ * Convertit une row legacy en DebateInput prêt pour resolveDebate().
+ *
+ * Étapes :
+ *   1. Mappe `decision` legacy -> TradingDecision sémantique (via T1-#4)
+ *   2. Wrappe en SignalEnvelope avec half-life preset (via T1-#2)
+ *   3. Conserve confidence/reason/metadata si présent dans la row
+ *   4. Renvoie un DebateInput consommable par T1-#1
+ */
+export function bridgeShadowToDebate(
+  row: ShadowSignalRow,
+  opts: BridgeOptions = {},
+): DebateInput {
+  const semanticDecision = mapShadowDecisionToSemantic(row.decision);
+  const emittedAtMs = typeof row.emittedAt === 'number'
+    ? row.emittedAt
+    : Date.parse(row.emittedAt);
+
+  const buildOpts: {
+    confidence?: number;
+    emittedAt?: number;
+    metadata?: Record<string, unknown>;
+  } = { emittedAt: emittedAtMs };
+  const conf = row.confidence ?? opts.defaultConfidence;
+  if (conf !== undefined) buildOpts.confidence = conf;
+  if (row.metadata !== undefined) buildOpts.metadata = row.metadata;
+
+  const signal = buildSignal(
+    semanticDecision,
+    row.reason ?? `Legacy decision: ${row.decision}`,
+    row.agentId ?? opts.defaultAgentId ?? 'scanner_gainers',
+    opts.halfLifePreset ?? 'INTRADAY_5M',
+    buildOpts,
+  );
+
+  const inp: DebateInput = {
+    agentId: row.agentId ?? opts.defaultAgentId ?? 'scanner_gainers',
+    signal,
+  };
+  if (opts.agentWeight !== undefined) inp.agentWeight = opts.agentWeight;
+  return inp;
+}
+
+/**
+ * Batch helper : convertit plusieurs rows en une fois.
+ * Utile pour récupérer "tous les signaux des 15 dernières minutes sur SYMBOL"
+ * et les passer directement à resolveDebate().
+ */
+export function bridgeShadowBatch(
+  rows: ReadonlyArray<ShadowSignalRow>,
+  opts: BridgeOptions = {},
+): ReadonlyArray<DebateInput> {
+  return rows.map((r) => bridgeShadowToDebate(r, opts));
+}

--- a/packages/ai-analyst/src/index.ts
+++ b/packages/ai-analyst/src/index.ts
@@ -36,3 +36,4 @@ export * from './decisions/debate-orchestrator';
 export * from './decisions/strategy-lifecycle';
 export * from './decisions/macro-regime';
 export * from './decisions/volatility-cartography';
+export * from './decisions/shadow-to-debate-bridge';


### PR DESCRIPTION
## Bridge T1/T2 — Shadow signals → Debate input

### Pourquoi

T1 + T2 ont livré **7 building blocks déterministes** mais aucun caller existant ne les consomme. SmartVest stocke déjà chaque décision de scanner dans `gainers_user_shadow_signals` avec une colonne `decision` legacy (`accept`, `reject_persistence`, etc.).

Cette PR fournit la **passerelle** qui transforme ces données legacy en `DebateInput[]` consommable par `resolveDebate()` — **sans toucher au scanner ou aux émetteurs**.

### API

```ts
bridgeShadowToDebate(row, opts?) → DebateInput
bridgeShadowBatch(rows, opts?) → DebateInput[]
```

Étapes appliquées en chaîne :
1. `mapShadowDecisionToSemantic()` (T1-#4) sur le champ `decision`
2. `buildSignal()` (T1-#2) avec `halfLifePreset` configurable (default `INTRADAY_5M`)
3. Conservation `confidence` / `reason` / `metadata` si présents
4. Wrap en `DebateInput` consommable par `resolveDebate()` (T1-#1)

Pure fn déterministe — pas d'I/O Supabase. Le caller fournit les rows pré-fetchées.

### Bénéfices

- Validation end-to-end T1+T2 sur données réelles
- Backfill historique sans migration DB destructive
- Préparation du wiring runtime futur (juste injecter le service Supabase qui fetch, le bridge fait le reste)

### Tests (23/23)

Mapping de 5+ verdicts legacy, parsing ISO + epoch timestamps, half-life presets, agentId fallback, agentWeight, reason preservation, metadata, batch helper, **end-to-end avec resolveDebate** (BUY consensus, MARKET_UNSAFE veto, stales filtrés, tie → WAIT, decay aligné sur preset).

### Prochaine étape

Wiring runtime : cron qui fetch les shadow signals des 15 dernières minutes par symbol candidat et passe à `resolveDebate()` pour produire un verdict consolidé. Cette PR est l'adaptateur sans lequel ce wiring serait impossible sans toucher au scanner.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_