### PR TITLE
feat(lisa): wire Debate Gate into top-gainers scanner (shadow mode default)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/debate-gate.service.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/debate-gate.service.spec.ts
@@ -1,0 +1,208 @@
+import { ConfigService } from '@nestjs/config';
+import { DebateGateService, type CandidateScores } from '../services/debate-gate.service';
+
+function makeService(envValue: string | undefined = undefined): DebateGateService {
+  const config = {
+    get: (key: string) => (key === 'DEBATE_GATE_ENABLED' ? envValue : undefined),
+  } as unknown as ConfigService;
+  return new DebateGateService(config);
+}
+
+const t0 = 1_700_000_000_000;
+
+function scores(over: Partial<CandidateScores> = {}): CandidateScores {
+  return {
+    symbol: 'TEST.US',
+    persistenceScore: 0.8,
+    pathEfficiency: 0.75,
+    pWin: 0.6,
+    changePct: 5,
+    ...over,
+  };
+}
+
+describe('DebateGateService', () => {
+  describe('isActive flag', () => {
+    it('defaults to false (shadow mode) when env unset', () => {
+      expect(makeService(undefined).isActive()).toBe(false);
+    });
+
+    it('false when env != "true"', () => {
+      expect(makeService('1').isActive()).toBe(false);
+      expect(makeService('TRUE').isActive()).toBe(false);
+    });
+
+    it('true only when env === "true" exactly', () => {
+      expect(makeService('true').isActive()).toBe(true);
+    });
+  });
+
+  describe('shadow mode (default OFF)', () => {
+    it('allows everything in shadow mode, even if debate says no', () => {
+      const svc = makeService(undefined);
+      const r = svc.evaluateCandidate(scores({ persistenceScore: 0.1, pWin: 0.2, changePct: 50 }), t0);
+      expect(r.allow).toBe(true);
+      expect(r.shadowMode).toBe(true);
+    });
+
+    it('computes verdict even in shadow mode (for audit log)', () => {
+      const svc = makeService(undefined);
+      const r = svc.evaluateCandidate(scores({ persistenceScore: 0.1 }), t0);
+      expect(r.verdict.decision).toBeDefined();
+      expect(r.verdict.rationale).toBeDefined();
+    });
+  });
+
+  describe('active mode (gate ON)', () => {
+    it('allows BUY consensus', () => {
+      const svc = makeService('true');
+      const r = svc.evaluateCandidate(
+        scores({ persistenceScore: 0.85, pathEfficiency: 0.8, pWin: 0.65, changePct: 5 }),
+        t0,
+      );
+      expect(r.shadowMode).toBe(false);
+      expect(r.verdict.decision).toBe('BUY');
+      expect(r.allow).toBe(true);
+    });
+
+    it('blocks non-BUY consensus', () => {
+      const svc = makeService('true');
+      const r = svc.evaluateCandidate(
+        scores({ persistenceScore: 0.3, pathEfficiency: 0.3, pWin: 0.3, changePct: -2 }),
+        t0,
+      );
+      expect(r.allow).toBe(false);
+      expect(r.verdict.decision).not.toBe('BUY');
+    });
+
+    it('blocks CHASE_THE_TOP when momentum + path quality + ml all flag overextension', () => {
+      const svc = makeService('true');
+      const r = svc.evaluateCandidate(
+        scores({ persistenceScore: 0.4, pathEfficiency: 0.3, pWin: 0.4, changePct: 25 }),
+        t0,
+      );
+      expect(r.allow).toBe(false);
+      expect(['CHASE_THE_TOP', 'WAIT']).toContain(r.verdict.decision);
+    });
+
+    it('macro PANIC veto blocks the candidate', () => {
+      const svc = makeService('true');
+      const r = svc.evaluateCandidate(
+        scores({
+          persistenceScore: 0.85,
+          pathEfficiency: 0.8,
+          pWin: 0.7,
+          changePct: 5,
+          macroRegimeDecision: 'MARKET_UNSAFE',
+          macroRegimeConfidence: 0.9,
+        }),
+        t0,
+      );
+      expect(r.verdict.vetoTriggered).toBe(true);
+      expect(r.verdict.decision).toBe('MARKET_UNSAFE');
+      expect(r.allow).toBe(false);
+    });
+
+    it('volatility cell stress veto blocks candidate', () => {
+      const svc = makeService('true');
+      const r = svc.evaluateCandidate(
+        scores({
+          persistenceScore: 0.85,
+          pathEfficiency: 0.8,
+          pWin: 0.7,
+          changePct: 5,
+          cellDecision: 'MARKET_UNSAFE',
+          cellConfidence: 0.9,
+        }),
+        t0,
+      );
+      expect(r.allow).toBe(false);
+      expect(r.verdict.vetoTriggered).toBe(true);
+    });
+
+    it('strategy quarantine veto blocks candidate', () => {
+      const svc = makeService('true');
+      const r = svc.evaluateCandidate(
+        scores({
+          persistenceScore: 0.85,
+          pathEfficiency: 0.8,
+          pWin: 0.7,
+          changePct: 5,
+          strategySuggestedVerdict: 'QUARANTINE',
+        }),
+        t0,
+      );
+      expect(r.allow).toBe(false);
+      expect(r.verdict.vetoTriggered).toBe(true);
+    });
+  });
+
+  describe('agent count', () => {
+    it('includes persistence + momentum minimum (2 agents)', () => {
+      const svc = makeService('true');
+      const r = svc.evaluateCandidate(
+        { symbol: 'X', persistenceScore: 0.8, changePct: 5 },
+        t0,
+      );
+      expect(r.agentCount).toBe(2);
+    });
+
+    it('adds optional agents when scores provided', () => {
+      const svc = makeService('true');
+      const r = svc.evaluateCandidate(
+        scores({ macroRegimeDecision: 'HOLD', cellDecision: 'HOLD', strategySuggestedVerdict: 'HOLD' }),
+        t0,
+      );
+      // persistence + path + ml + momentum + macro + cell + strategy = 7
+      expect(r.agentCount).toBe(7);
+    });
+  });
+
+  describe('verdict mapping', () => {
+    const svc = makeService('true');
+
+    it('persistence 0.85 -> BUY signal', () => {
+      const inputs = svc.buildAgentInputs(scores({ persistenceScore: 0.85 }), t0);
+      const p = inputs.find((i) => i.agentId === 'persistence');
+      expect(p?.signal.context.decision).toBe('BUY');
+    });
+
+    it('persistence 0.3 -> WAIT signal', () => {
+      const inputs = svc.buildAgentInputs(scores({ persistenceScore: 0.3 }), t0);
+      const p = inputs.find((i) => i.agentId === 'persistence');
+      expect(p?.signal.context.decision).toBe('WAIT');
+    });
+
+    it('changePct 25 -> CHASE_THE_TOP signal', () => {
+      const inputs = svc.buildAgentInputs(scores({ changePct: 25 }), t0);
+      const m = inputs.find((i) => i.agentId === 'momentum');
+      expect(m?.signal.context.decision).toBe('CHASE_THE_TOP');
+    });
+
+    it('pWin 0.3 -> WAIT signal', () => {
+      const inputs = svc.buildAgentInputs(scores({ pWin: 0.3 }), t0);
+      const m = inputs.find((i) => i.agentId === 'ml_pwin');
+      expect(m?.signal.context.decision).toBe('WAIT');
+    });
+
+    it('pathEfficiency 0.2 -> CHASE_THE_TOP signal (choppy)', () => {
+      const inputs = svc.buildAgentInputs(scores({ pathEfficiency: 0.2 }), t0);
+      const p = inputs.find((i) => i.agentId === 'path_quality');
+      expect(p?.signal.context.decision).toBe('CHASE_THE_TOP');
+    });
+  });
+
+  describe('fail-open on error', () => {
+    it('returns allow=true if a downstream throws (no regression)', () => {
+      const svc = makeService('true');
+      // Force error by passing invalid number (NaN)
+      const r = svc.evaluateCandidate(
+        { symbol: 'X', persistenceScore: Number.NaN, changePct: Number.NaN },
+        t0,
+      );
+      // Even with weird inputs, service should not crash
+      expect(r).toBeDefined();
+      expect(typeof r.allow).toBe('boolean');
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -67,6 +67,7 @@ import { OpenPositionRiskMonitorService } from './services/open-position-risk-mo
 import { CorrelationGuardService } from './services/correlation-guard.service';
 import { DailyRetrospectiveService } from './services/daily-retrospective.service';
 import { AdaptiveCooldownService } from './services/adaptive-cooldown.service';
+import { DebateGateService } from './services/debate-gate.service';
 import { EarlyExitGuardService } from './services/early-exit-guard.service';
 import { FeatureABTuningService } from './services/feature-ab-tuning.service';
 import { EventEngineService } from './services/event-engine.service';
@@ -202,6 +203,8 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     DailyRetrospectiveService,
     // Feature #4 — Adaptive cooldown per symbol (weekly refresh)
     AdaptiveCooldownService,
+    // AXEES T1+T2 wiring — debate gate (default OFF / shadow mode).
+    DebateGateService,
     // Miracle #3 — Early exit guard via Gemini (T+5-15min on opens)
     EarlyExitGuardService,
     // Miracle #4 — Auto-tuning A/B (snapshot daily + analyze 14j window)

--- a/apps/api/src/modules/lisa/services/debate-gate.service.ts
+++ b/apps/api/src/modules/lisa/services/debate-gate.service.ts
@@ -1,0 +1,275 @@
+/**
+ * DebateGateService — wiring runtime des building blocks T1+T2.
+ *
+ * Intercepte la décision finale du scanner gainers (juste avant openPositionDirect)
+ * et soumet le candidat à un débat multi-agents avant d'autoriser l'ouverture.
+ *
+ * Architecture :
+ *   - Construit jusqu'à 6 SignalEnvelope synthétiques à partir des scores déjà
+ *     calculés par le scanner (persistence, path quality, p_win, momentum,
+ *     optionnel macro regime, optionnel volatility cell).
+ *   - Lance resolveDebate() (T1-#1) pour produire un ConsensusVerdict.
+ *   - Retourne allow + verdict + shadowMode pour permettre au caller de
+ *     décider (block ou shadow log).
+ *
+ * Sécurité opérationnelle :
+ *   - Feature flag DEBATE_GATE_ENABLED (env). Default `false` -> shadow only.
+ *     Le scanner conserve son comportement actuel ; le service logge ce qu'il
+ *     AURAIT décidé pour observabilité.
+ *   - Catch-all error -> shadowMode allow=true (no regression in case of bug).
+ *   - Pure logique, pas d'I/O Supabase ici. L'audit log est délégué au caller
+ *     pour traçabilité homogène avec lisa_decision_log existant.
+ *
+ * Rollback en 1 clic : `fly secrets set DEBATE_GATE_ENABLED=false` ou flip via
+ *   admin endpoint runtime (suit dans un PR dédié si besoin).
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  type ConsensusVerdict,
+  type DebateInput,
+  buildSignal,
+  resolveDebate,
+  type TradingDecision,
+} from '@smartvest/ai-analyst';
+
+export interface CandidateScores {
+  symbol: string;
+  /** Persistence score 0..1 (≥ 0.67 = strong). */
+  persistenceScore: number;
+  /** Path efficiency 0..1 (≥ 0.7 = smooth). Optional. */
+  pathEfficiency?: number;
+  /** Probability of win 0..1 (≥ 0.55 = bullish). Optional. */
+  pWin?: number;
+  /** Momentum (changePct) — negative = down, positive = up. */
+  changePct: number;
+  /** Pre-computed regime verdict (T2-C). Optional. */
+  macroRegimeDecision?: TradingDecision;
+  macroRegimeConfidence?: number;
+  /** Pre-computed volatility cell verdict (T2-A). Optional. */
+  cellDecision?: TradingDecision;
+  cellConfidence?: number;
+  /** Pre-computed strategy lifecycle suggestion (T1-#3). Optional. */
+  strategySuggestedVerdict?: TradingDecision;
+}
+
+export interface DebateGateResult {
+  /** True = autorise l'ouverture, false = block. */
+  allow: boolean;
+  /** Verdict du débat (pour audit / log). */
+  verdict: ConsensusVerdict;
+  /** True si feature flag OFF — verdict calculé mais allow toujours true. */
+  shadowMode: boolean;
+  /** Nombre d'agents participants. */
+  agentCount: number;
+  /** Erreur éventuelle pendant l'évaluation (fail-open). */
+  error?: string;
+}
+
+@Injectable()
+export class DebateGateService {
+  private readonly logger = new Logger(DebateGateService.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  /**
+   * True si le gate est actif (bloquant). False = shadow mode (log only).
+   */
+  isActive(): boolean {
+    return this.config.get<string>('DEBATE_GATE_ENABLED') === 'true';
+  }
+
+  /**
+   * Évalue un candidat. Pure fn sauf logger — pas d'I/O DB.
+   *
+   * Fail-safe : si une exception remonte, retourne `allow=true` (no regression).
+   * En shadow mode (default), `allow=true` même si le débat dit non.
+   */
+  evaluateCandidate(scores: CandidateScores, now: number = Date.now()): DebateGateResult {
+    const shadowMode = !this.isActive();
+    try {
+      const inputs = this.buildAgentInputs(scores, now);
+      const verdict = resolveDebate(inputs, now);
+      const debateAllows = verdict.decision === 'BUY';
+      const allow = shadowMode ? true : debateAllows;
+
+      if (shadowMode && !debateAllows) {
+        this.logger.log(
+          `[debate-gate SHADOW] ${scores.symbol} would have been blocked: ${verdict.decision} (${verdict.rationale})`,
+        );
+      } else if (!shadowMode && !debateAllows) {
+        this.logger.warn(
+          `[debate-gate ACTIVE] ${scores.symbol} blocked: ${verdict.decision} (${verdict.rationale})`,
+        );
+      }
+
+      return { allow, verdict, shadowMode, agentCount: inputs.length };
+    } catch (e) {
+      const errMsg = e instanceof Error ? e.message : String(e);
+      this.logger.error(`[debate-gate] eval error for ${scores.symbol} (fail-open): ${errMsg}`);
+      return {
+        allow: true,
+        verdict: this.failOpenVerdict(),
+        shadowMode,
+        agentCount: 0,
+        error: errMsg,
+      };
+    }
+  }
+
+  /**
+   * Construit jusqu'à 6 SignalEnvelope à partir des scores du candidat.
+   * Exposé pour testabilité.
+   */
+  buildAgentInputs(scores: CandidateScores, now: number = Date.now()): DebateInput[] {
+    const inputs: DebateInput[] = [];
+
+    // Agent 1 : persistence multi-TF (T1 existing logic)
+    const persistenceDecision = this.persistenceVerdict(scores.persistenceScore);
+    inputs.push({
+      agentId: 'persistence',
+      signal: buildSignal(
+        persistenceDecision,
+        `persistence_score=${scores.persistenceScore.toFixed(2)}`,
+        'persistence',
+        'INTRADAY_5M',
+        { confidence: scores.persistenceScore, emittedAt: now },
+      ),
+    });
+
+    // Agent 2 : path quality (optional)
+    if (typeof scores.pathEfficiency === 'number') {
+      const pathDecision = this.pathQualityVerdict(scores.pathEfficiency);
+      inputs.push({
+        agentId: 'path_quality',
+        signal: buildSignal(
+          pathDecision,
+          `path_eff=${scores.pathEfficiency.toFixed(2)}`,
+          'path_quality',
+          'INTRADAY_5M',
+          { confidence: scores.pathEfficiency, emittedAt: now },
+        ),
+      });
+    }
+
+    // Agent 3 : ML probability (optional)
+    if (typeof scores.pWin === 'number') {
+      const mlDecision = this.mlVerdict(scores.pWin);
+      inputs.push({
+        agentId: 'ml_pwin',
+        signal: buildSignal(
+          mlDecision,
+          `p_win=${scores.pWin.toFixed(2)}`,
+          'ml_pwin',
+          'INTRADAY_5M',
+          { confidence: scores.pWin, emittedAt: now },
+        ),
+      });
+    }
+
+    // Agent 4 : momentum (anti-chase-the-top)
+    const momentumDecision = this.momentumVerdict(scores.changePct);
+    inputs.push({
+      agentId: 'momentum',
+      signal: buildSignal(
+        momentumDecision,
+        `changePct=${scores.changePct.toFixed(2)}%`,
+        'momentum',
+        'INTRADAY_5M',
+        { confidence: this.momentumConfidence(scores.changePct), emittedAt: now },
+      ),
+    });
+
+    // Agent 5 : macro regime (T2-C, optional, agentWeight 1.5 — c'est un veto-friendly)
+    if (scores.macroRegimeDecision) {
+      inputs.push({
+        agentId: 'macro_regime',
+        agentWeight: 1.5,
+        signal: buildSignal(
+          scores.macroRegimeDecision,
+          `macro_regime`,
+          'macro_regime',
+          'INTRADAY_15M',
+          { confidence: scores.macroRegimeConfidence ?? 0.5, emittedAt: now },
+        ),
+      });
+    }
+
+    // Agent 6 : volatility cell (T2-A, optional, agentWeight 1.5)
+    if (scores.cellDecision) {
+      inputs.push({
+        agentId: 'vol_cell',
+        agentWeight: 1.5,
+        signal: buildSignal(
+          scores.cellDecision,
+          `vol_cell`,
+          'vol_cell',
+          'INTRADAY_15M',
+          { confidence: scores.cellConfidence ?? 0.5, emittedAt: now },
+        ),
+      });
+    }
+
+    // Agent 7 : strategy lifecycle (T1-#3, optional)
+    if (scores.strategySuggestedVerdict) {
+      inputs.push({
+        agentId: 'strategy_lifecycle',
+        signal: buildSignal(
+          scores.strategySuggestedVerdict,
+          `strategy_lifecycle`,
+          'strategy_lifecycle',
+          'DAILY',
+          { confidence: 0.6, emittedAt: now },
+        ),
+      });
+    }
+
+    return inputs;
+  }
+
+  private persistenceVerdict(score: number): TradingDecision {
+    if (score >= 0.67) return 'BUY';
+    if (score >= 0.5) return 'HOLD';
+    return 'WAIT';
+  }
+
+  private pathQualityVerdict(eff: number): TradingDecision {
+    if (eff >= 0.7) return 'BUY';
+    if (eff >= 0.4) return 'HOLD';
+    return 'CHASE_THE_TOP';
+  }
+
+  private mlVerdict(pWin: number): TradingDecision {
+    if (pWin >= 0.55) return 'BUY';
+    if (pWin >= 0.45) return 'HOLD';
+    return 'WAIT';
+  }
+
+  private momentumVerdict(changePct: number): TradingDecision {
+    if (changePct < 0) return 'WAIT';
+    if (changePct > 15) return 'CHASE_THE_TOP';
+    if (changePct >= 2) return 'BUY';
+    return 'HOLD';
+  }
+
+  private momentumConfidence(changePct: number): number {
+    const abs = Math.abs(changePct);
+    if (abs >= 5 && abs <= 15) return 0.8;
+    if (abs >= 2 && abs < 5) return 0.65;
+    return 0.4;
+  }
+
+  private failOpenVerdict(): ConsensusVerdict {
+    return {
+      decision: 'BUY',
+      confidence: 0,
+      consensusRatio: 0,
+      vetoTriggered: false,
+      contributingAgents: [],
+      dissentingAgents: [],
+      rationale: 'Fail-open: debate gate error, allowing candidate (no regression).',
+      staleAgents: [],
+    };
+  }
+}

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -89,6 +89,7 @@ import {
 import { TickerBlacklistService } from './ticker-blacklist.service';
 import { CorrelationGuardService } from './correlation-guard.service';
 import { AdaptiveCooldownService } from './adaptive-cooldown.service';
+import { DebateGateService } from './debate-gate.service';
 import { MicroMomentumProbeService } from './micro-momentum-probe.service';
 import {
   parseReverseMomentumConfig,
@@ -745,6 +746,11 @@ export class TopGainersScannerService implements OnModuleInit {
      * @Optional pour back-compat tests existants.
      */
     @Optional() private readonly adaptiveCooldown?: AdaptiveCooldownService,
+    /**
+     * AXEES T1+T2 — debate gate (default OFF, shadow log only).
+     * @Optional pour back-compat tests existants. Activable via DEBATE_GATE_ENABLED=true.
+     */
+    @Optional() private readonly debateGate?: DebateGateService,
     /**
      * Miracle #2 — Micro-momentum gate (vélocité 6s à l'entrée).
      * @Optional pour back-compat tests existants.
@@ -3919,6 +3925,33 @@ export class TopGainersScannerService implements OnModuleInit {
             continue;
           }
         }
+
+        // AXEES T1+T2 — Debate Gate (default OFF / shadow mode via DEBATE_GATE_ENABLED).
+        // Soumet le candidat à un débat multi-agents (persistence + path quality +
+        // momentum) avant l'ouverture. En shadow mode, logue seulement ; en mode actif,
+        // bloque si le consensus n'est pas BUY. Fail-open en cas d'erreur (no regression).
+        if (this.debateGate && item.direction === 'long' && persistence) {
+          try {
+            const gateScores: import('./debate-gate.service').CandidateScores = {
+              symbol: cand.symbol,
+              persistenceScore: persistence.persistenceScore,
+              changePct: cand.changePct,
+            };
+            const pathEff = persistence.pathQuality?.overallEfficiency;
+            if (typeof pathEff === 'number') gateScores.pathEfficiency = pathEff;
+            const gateResult = this.debateGate.evaluateCandidate(gateScores);
+            if (!gateResult.allow) {
+              this.logger.warn(
+                `[debate-gate] ${cand.symbol} BLOCKED — verdict=${gateResult.verdict.decision} consensus=${(gateResult.verdict.consensusRatio * 100).toFixed(0)}% agents=${gateResult.agentCount} (${gateResult.verdict.rationale})`,
+              );
+              continue;
+            }
+          } catch (e) {
+            // Fail-open : on ne casse jamais le scanner même si le gate plante.
+            this.logger.error(`[debate-gate] ${cand.symbol} eval threw (fail-open): ${String(e).slice(0, 120)}`);
+          }
+        }
+
         const { stopLoss, takeProfit } = computeSlTpForDirection(livePriceNum, effectiveSl, effectiveTp, item.direction);
         const stopPriceStr = stopLoss.toFixed(8);
         const tpPriceStr = takeProfit.toFixed(8);


### PR DESCRIPTION
## WIRING runtime — premier câblage des building blocks T1+T2

Transforme les 7 abstractions livrées (T1 #444/#445/#446/#447 + T2 #448/#449/#450) en **pression réelle sur les ouvertures de positions** du scanner gainers.

### Approche prudente

- **Feature flag `DEBATE_GATE_ENABLED`** (env). Default `false` → **shadow mode**. Le scanner conserve son comportement actuel ; le service logge ce qu'il **aurait** décidé.
- **Fail-open** : si le gate throw, on laisse passer (no regression).
- **`@Optional()` injection** : si le service n'est pas provisionné, le scanner fonctionne comme avant.
- **Rollback 1 clic** : `fly secrets set DEBATE_GATE_ENABLED=false`.

### DebateGateService (new)

`evaluateCandidate({ symbol, persistenceScore, pathEfficiency?, pWin?, changePct, macroRegimeDecision?, cellDecision?, strategySuggestedVerdict? })` construit jusqu'à **7 SignalEnvelope** (1 par dimension de scoring) et lance `resolveDebate()`.

| Agent | Mapping |
|---|---|
| `persistence` | ≥0.67→BUY, ≥0.5→HOLD, <0.5→WAIT |
| `path_quality` | ≥0.7→BUY, ≥0.4→HOLD, <0.4→CHASE_THE_TOP |
| `ml_pwin` | ≥0.55→BUY, ≥0.45→HOLD, <0.45→WAIT |
| `momentum` | [2,15]→BUY, >15→CHASE_THE_TOP, <0→WAIT |
| `macro_regime` (weight 1.5) | verdict T2-C passé tel quel |
| `vol_cell` (weight 1.5) | verdict T2-A passé tel quel |
| `strategy_lifecycle` | suggestedVerdict T1-#3 |

### Injection point

`top-gainers-scanner.service.ts` ~ligne 3927, **après** micro-momentum gate, **avant** `openPositionDirect`. Long-only.

### Tests (19/19)

- Feature flag (default off, env != 'true', exact 'true')
- Shadow mode (allow=true même si verdict ≠ BUY)
- Active mode (BUY consensus passe, non-BUY block)
- Vetoes : MARKET_UNSAFE macro / cell, QUARANTINE strategy
- Agent count 2..7
- Verdict mapping par dimension
- Fail-open sur erreur

### Validation manuelle recommandée

1. ✅ Tests typecheck + jest passent (auto-CI)
2. 🔍 Après deploy : vérifier logs `[debate-gate SHADOW]` apparaissent
3. 📊 Compter ratio "would have been blocked" / total candidats sur 24h
4. 🎯 Inspecter top causes de blocage avant d'activer
5. 🟢 `DEBATE_GATE_ENABLED=true` uniquement après calibration

### État T1+T2

- [x] T1-#4 No-Trade semantic (#444)
- [x] T1-#2 Signal half-life (#445)
- [x] T1-#1 Debate orchestrator (#446)
- [x] T1-#3 Strategy lifecycle (#447)
- [x] T2-C MacroRegime (#448)
- [x] T2-A Volatility cartographer (#449)
- [x] T2-B Capital allocator (#450)
- [x] **Wiring runtime** (cette PR) ← le truc qui rend tout utile

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_