### PR TITLE
chore(scripts): backtest debate gate on historical shadow signals

### DIFF
--- a/scripts/backtest-debate-gate.ts
+++ b/scripts/backtest-debate-gate.ts
@@ -33,7 +33,7 @@ function arg(name: string): string | undefined {
 }
 const hasFlag = (name: string) => args.includes(`--${name}`);
 
-const SUPABASE_URL = process.env.SUPABASE_URL || '';
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '';
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
 if (!SUPABASE_URL || !SUPABASE_KEY) {
   console.error('ERROR: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required.');

--- a/scripts/backtest-debate-gate.ts
+++ b/scripts/backtest-debate-gate.ts
@@ -1,0 +1,244 @@
+/**
+ * Backtest rétroactif du Debate Gate sur les rows historiques
+ * `gainers_user_shadow_signals` (Thu/Fri/lookback configurable).
+ *
+ * Pour chaque row 'accept' historique :
+ *   - On reconstruit les scores (persistenceScore, pathEff, changePct)
+ *   - On évalue via DebateGateService.evaluateCandidate (logique idem prod)
+ *   - On note ce que le gate AURAIT décidé (allow / block + verdict + reason)
+ *
+ * Permet de calibrer les seuils SANS attendre 24h de prod et SANS risquer
+ * de bloquer 100% des candidats.
+ *
+ * Usage :
+ *   pnpm tsx scripts/backtest-debate-gate.ts                  # last 4 days
+ *   pnpm tsx scripts/backtest-debate-gate.ts --days 7         # last 7 days
+ *   pnpm tsx scripts/backtest-debate-gate.ts --from 2026-05-21 --to 2026-05-23
+ *   pnpm tsx scripts/backtest-debate-gate.ts --only-accept    # only 'accept' rows
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import {
+  buildSignal,
+  resolveDebate,
+  type DebateInput,
+  type TradingDecision,
+} from '@smartvest/ai-analyst';
+
+const args = process.argv.slice(2);
+function arg(name: string): string | undefined {
+  const idx = args.indexOf(`--${name}`);
+  if (idx >= 0 && args[idx + 1]) return args[idx + 1];
+  return undefined;
+}
+const hasFlag = (name: string) => args.includes(`--${name}`);
+
+const SUPABASE_URL = process.env.SUPABASE_URL || '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('ERROR: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required.');
+  process.exit(1);
+}
+
+const days = Number(arg('days') ?? 4);
+const fromIso = arg('from');
+const toIso = arg('to');
+const onlyAccept = hasFlag('only-accept');
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+interface ShadowRow {
+  symbol: string;
+  decision: string;
+  change_pct_1m: number | null;
+  score: number | null;
+  path_eff: number | null;
+  persistence_score: number | null;
+  persistence_count: string | null;
+  is_asia: boolean;
+  created_at: string;
+}
+
+// Reproduit la logique de DebateGateService.buildAgentInputs + resolveDebate
+function evaluateRow(row: ShadowRow, now: number): {
+  finalDecision: TradingDecision;
+  consensus: number;
+  agentCount: number;
+  veto: boolean;
+  rationale: string;
+  agentsBucket: Record<string, TradingDecision>;
+} {
+  const inputs: DebateInput[] = [];
+  const agentsBucket: Record<string, TradingDecision> = {};
+
+  // Persistence agent
+  const ps = row.persistence_score ?? 0;
+  let persistenceDec: TradingDecision;
+  if (ps >= 0.67) persistenceDec = 'BUY';
+  else if (ps >= 0.5) persistenceDec = 'HOLD';
+  else persistenceDec = 'WAIT';
+  agentsBucket['persistence'] = persistenceDec;
+  inputs.push({
+    agentId: 'persistence',
+    signal: buildSignal(persistenceDec, `ps=${ps.toFixed(2)}`, 'persistence', 'INTRADAY_5M', {
+      confidence: ps,
+      emittedAt: now,
+    }),
+  });
+
+  // Path quality agent (if present)
+  if (typeof row.path_eff === 'number') {
+    const pe = row.path_eff;
+    let pathDec: TradingDecision;
+    if (pe >= 0.7) pathDec = 'BUY';
+    else if (pe >= 0.4) pathDec = 'HOLD';
+    else pathDec = 'CHASE_THE_TOP';
+    agentsBucket['path_quality'] = pathDec;
+    inputs.push({
+      agentId: 'path_quality',
+      signal: buildSignal(pathDec, `pe=${pe.toFixed(2)}`, 'path_quality', 'INTRADAY_5M', {
+        confidence: pe,
+        emittedAt: now,
+      }),
+    });
+  }
+
+  // Momentum agent
+  const cp = row.change_pct_1m ?? 0;
+  let momentumDec: TradingDecision;
+  if (cp < 0) momentumDec = 'WAIT';
+  else if (cp > 15) momentumDec = 'CHASE_THE_TOP';
+  else if (cp >= 2) momentumDec = 'BUY';
+  else momentumDec = 'HOLD';
+  agentsBucket['momentum'] = momentumDec;
+  const momConf = Math.abs(cp) >= 5 && Math.abs(cp) <= 15 ? 0.8 : Math.abs(cp) >= 2 && Math.abs(cp) < 5 ? 0.65 : 0.4;
+  inputs.push({
+    agentId: 'momentum',
+    signal: buildSignal(momentumDec, `cp=${cp.toFixed(2)}%`, 'momentum', 'INTRADAY_5M', {
+      confidence: momConf,
+      emittedAt: now,
+    }),
+  });
+
+  const verdict = resolveDebate(inputs, now);
+  return {
+    finalDecision: verdict.decision,
+    consensus: verdict.consensusRatio,
+    agentCount: inputs.length,
+    veto: verdict.vetoTriggered,
+    rationale: verdict.rationale,
+    agentsBucket,
+  };
+}
+
+async function main() {
+  const toDate = toIso ? new Date(toIso) : new Date();
+  const fromDate = fromIso ? new Date(fromIso) : new Date(toDate.getTime() - days * 86_400_000);
+  console.log(`\n📊 Backtest Debate Gate`);
+  console.log(`Window : ${fromDate.toISOString()} → ${toDate.toISOString()}`);
+  console.log(`Mode   : ${onlyAccept ? 'only "accept" rows' : 'all rows'}\n`);
+
+  let query = supabase
+    .from('gainers_user_shadow_signals')
+    .select('symbol, decision, change_pct_1m, score, path_eff, persistence_score, persistence_count, is_asia, created_at')
+    .gte('created_at', fromDate.toISOString())
+    .lte('created_at', toDate.toISOString())
+    .limit(10000);
+
+  if (onlyAccept) query = query.eq('decision', 'accept');
+
+  const { data, error } = await query;
+  if (error) {
+    console.error('Query error:', error.message);
+    process.exit(1);
+  }
+  const rows = (data ?? []) as ShadowRow[];
+  console.log(`Fetched ${rows.length} rows.\n`);
+
+  if (rows.length === 0) {
+    console.log('No data in window. Did the scanner run on these days ?');
+    process.exit(0);
+  }
+
+  // Stats globales
+  const byLegacy: Record<string, number> = {};
+  for (const r of rows) byLegacy[r.decision] = (byLegacy[r.decision] ?? 0) + 1;
+
+  // Re-évaluation via debate gate
+  const verdicts: Record<string, number> = {};
+  const blockedAccepts: Array<{ row: ShadowRow; eval: ReturnType<typeof evaluateRow> }> = [];
+  const passedAccepts: Array<{ row: ShadowRow; eval: ReturnType<typeof evaluateRow> }> = [];
+
+  for (const row of rows) {
+    const now = new Date(row.created_at).getTime();
+    const ev = evaluateRow(row, now);
+    verdicts[ev.finalDecision] = (verdicts[ev.finalDecision] ?? 0) + 1;
+
+    if (row.decision === 'accept') {
+      if (ev.finalDecision === 'BUY') passedAccepts.push({ row, eval: ev });
+      else blockedAccepts.push({ row, eval: ev });
+    }
+  }
+
+  // Report
+  console.log('═══════════════════════════════════════════════════════════');
+  console.log('📋 RÉPARTITION LEGACY DECISIONS (vraies décisions scanner)');
+  console.log('═══════════════════════════════════════════════════════════');
+  for (const [dec, count] of Object.entries(byLegacy).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${dec.padEnd(25)} ${count.toString().padStart(5)} (${((count / rows.length) * 100).toFixed(1)}%)`);
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════');
+  console.log('🤖 VERDICTS DEBATE GATE (re-évaluation TOUS les rows)');
+  console.log('═══════════════════════════════════════════════════════════');
+  for (const [dec, count] of Object.entries(verdicts).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${dec.padEnd(25)} ${count.toString().padStart(5)} (${((count / rows.length) * 100).toFixed(1)}%)`);
+  }
+
+  const acceptCount = (byLegacy['accept'] ?? 0);
+  console.log('\n═══════════════════════════════════════════════════════════');
+  console.log(`🎯 ANALYSE SUR ${acceptCount} ROWS "accept" (vrais trades)`);
+  console.log('═══════════════════════════════════════════════════════════');
+  console.log(`  Auraient été acceptés par le gate : ${passedAccepts.length} (${((passedAccepts.length / Math.max(1, acceptCount)) * 100).toFixed(1)}%)`);
+  console.log(`  Auraient été BLOQUÉS par le gate  : ${blockedAccepts.length} (${((blockedAccepts.length / Math.max(1, acceptCount)) * 100).toFixed(1)}%)`);
+
+  if (blockedAccepts.length > 0) {
+    console.log('\n  Top raisons de blocage :');
+    const reasons: Record<string, number> = {};
+    for (const b of blockedAccepts) {
+      reasons[b.eval.finalDecision] = (reasons[b.eval.finalDecision] ?? 0) + 1;
+    }
+    for (const [r, count] of Object.entries(reasons).sort((a, b) => b[1] - a[1])) {
+      console.log(`    ${r.padEnd(20)} ${count.toString().padStart(5)}`);
+    }
+
+    console.log('\n  Échantillon (10 premiers blocked-accepts) :');
+    for (const b of blockedAccepts.slice(0, 10)) {
+      const r = b.row;
+      const e = b.eval;
+      const agents = Object.entries(e.agentsBucket).map(([k, v]) => `${k}=${v}`).join(', ');
+      console.log(`    ${r.symbol.padEnd(15)} cp=${(r.change_pct_1m ?? 0).toFixed(1)}% ps=${(r.persistence_score ?? 0).toFixed(2)} pe=${(r.path_eff ?? 0).toFixed(2)} → ${e.finalDecision} (cons=${(e.consensus * 100).toFixed(0)}%) [${agents}]`);
+    }
+  }
+
+  // Verdict global
+  const blockRatio = blockedAccepts.length / Math.max(1, acceptCount);
+  console.log('\n═══════════════════════════════════════════════════════════');
+  console.log('💡 VERDICT CALIBRATION');
+  console.log('═══════════════════════════════════════════════════════════');
+  if (blockRatio < 0.10) {
+    console.log(`  ✅ blockRatio ${(blockRatio * 100).toFixed(0)}% : gate TROP LAXISTE, ne sert presque à rien`);
+    console.log(`     → Resserrer les seuils (persistence 0.75, momentum strict)`);
+  } else if (blockRatio > 0.60) {
+    console.log(`  ⚠️  blockRatio ${(blockRatio * 100).toFixed(0)}% : gate TROP STRICT, étrangle le scanner`);
+    console.log(`     → Relâcher (consensus 0.4, persistence 0.55) ou KEEP=false`);
+  } else {
+    console.log(`  ✅ blockRatio ${(blockRatio * 100).toFixed(0)}% : cible 20-40% — calibration RAISONNABLE`);
+    console.log(`     → Activer DEBATE_GATE_ENABLED=true en confiance`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/check-portfolios-status.ts
+++ b/scripts/check-portfolios-status.ts
@@ -1,0 +1,52 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+const sb = createClient(url, key);
+
+async function main() {
+  const { data: portfolios, error } = await sb
+    .from('portfolios')
+    .select('id, name, created_at')
+    .order('created_at', { ascending: false });
+  if (error) { console.error(error); process.exit(1); }
+
+  console.log(`\n=== ${portfolios?.length ?? 0} portfolios ===\n`);
+
+  const { data: configs } = await sb
+    .from('lisa_session_configs')
+    .select('portfolio_id, strategy_mode, autopilot_enabled, kill_switch_active, autopilot_paused_reason, capital_usd, profile, capital_discipline_mode')
+    .in('portfolio_id', (portfolios ?? []).map((p) => p.id));
+
+  const cfgByPid = new Map((configs ?? []).map((c) => [c.portfolio_id, c]));
+
+  for (const p of portfolios ?? []) {
+    const c = cfgByPid.get(p.id);
+    console.log(`✓  ${(p.name ?? '(unnamed)').padEnd(35)} (${p.id.slice(0, 8)})`);
+    if (!c) {
+      console.log(`    ⚠️  NO lisa_session_config row`);
+      continue;
+    }
+    console.log(`    strategy_mode      = ${c.strategy_mode ?? '(null)'}`);
+    console.log(`    autopilot_enabled  = ${c.autopilot_enabled}`);
+    console.log(`    autopilot_paused   = ${c.autopilot_paused_reason ?? '(no)'}`);
+    console.log(`    kill_switch_active = ${c.kill_switch_active}`);
+    console.log(`    capital_usd        = ${c.capital_usd}`);
+    console.log(`    profile            = ${c.profile}`);
+    console.log(`    discipline_mode    = ${c.capital_discipline_mode}`);
+    console.log('');
+  }
+
+  // Scanner predicate : strategy_mode='gainers' AND autopilot_enabled=true
+  const active = (configs ?? []).filter((c) =>
+    c.strategy_mode === 'gainers' && c.autopilot_enabled === true,
+  );
+  console.log(`=== Scanner predicate match (strategy_mode='gainers' AND autopilot=true) : ${active.length} ===`);
+  for (const a of active) console.log(`  ✓ ${a.portfolio_id}`);
+
+  // Env fallback
+  console.log(`\n=== Env fallback ===`);
+  console.log(`STRATEGY_MODE = ${process.env.STRATEGY_MODE ?? '(unset)'}`);
+}
+
+main();

--- a/scripts/check-position-tables.ts
+++ b/scripts/check-position-tables.ts
@@ -1,0 +1,38 @@
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL || '', process.env.SUPABASE_SERVICE_ROLE_KEY || '');
+const PID = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+async function main() {
+  // Try paper_trades
+  const { data: pt, error: ptErr } = await sb
+    .from('paper_trades')
+    .select('id, symbol, status, opened_at, closed_at, source, pnl_pct')
+    .eq('portfolio_id', PID)
+    .order('opened_at', { ascending: false })
+    .limit(15);
+  if (ptErr) console.log('paper_trades err:', ptErr.message);
+  else {
+    console.log(`=== paper_trades on Sim SmartVest : ${pt?.length ?? 0} ===`);
+    for (const p of pt ?? []) console.log(`  ${p.opened_at}  ${p.symbol.padEnd(15)} ${p.status}  source=${p.source}  pnl=${p.pnl_pct}`);
+  }
+
+  // Last decision_log for this portfolio around 12-13h UTC
+  const { data: log } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, kind, summary')
+    .eq('portfolio_id', PID)
+    .gte('timestamp', '2026-05-25T12:00:00Z')
+    .order('timestamp', { ascending: false })
+    .limit(30);
+  console.log(`\n=== decision_log last 30 since 12:00 UTC ===`);
+  for (const l of log ?? []) console.log(`  ${l.timestamp}  ${l.kind.padEnd(30)}  ${l.summary?.slice(0, 80)}`);
+
+  // Open positions on ALL portfolios via paper_trades
+  const { data: openAll } = await sb
+    .from('paper_trades')
+    .select('id, portfolio_id, symbol, opened_at')
+    .eq('status', 'open');
+  console.log(`\n=== ALL open paper_trades (across portfolios) : ${openAll?.length ?? 0} ===`);
+  for (const o of openAll ?? []) console.log(`  ${o.opened_at}  pid=${o.portfolio_id.slice(0,8)} ${o.symbol}`);
+}
+main();

--- a/scripts/check-scanner-recent-activity.ts
+++ b/scripts/check-scanner-recent-activity.ts
@@ -1,0 +1,53 @@
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL || '', process.env.SUPABASE_SERVICE_ROLE_KEY || '');
+
+async function main() {
+  // Last shadow signals (any) - prove scanner ran
+  const { data: lastSig } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('created_at, decision, symbol')
+    .order('created_at', { ascending: false })
+    .limit(5);
+
+  console.log('=== Last 5 shadow signals (any decision) ===');
+  for (const r of lastSig ?? []) {
+    console.log(`  ${r.created_at}  ${r.decision.padEnd(25)}  ${r.symbol}`);
+  }
+
+  // Last accept (proves scanner found a candidate)
+  const { data: lastAccept } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('created_at, symbol, change_pct_1m, persistence_score, path_eff')
+    .eq('decision', 'accept')
+    .order('created_at', { ascending: false })
+    .limit(5);
+
+  console.log('\n=== Last 5 ACCEPT decisions ===');
+  for (const r of lastAccept ?? []) {
+    console.log(`  ${r.created_at}  ${r.symbol.padEnd(15)} cp=${r.change_pct_1m} ps=${r.persistence_score} pe=${r.path_eff}`);
+  }
+
+  // Open positions on the active portfolio
+  const PID = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+  const { data: positions } = await sb
+    .from('lisa_positions')
+    .select('id, symbol, status, opened_at, closed_at, source, entry_price, exit_price, pnl_usd, pnl_pct')
+    .eq('portfolio_id', PID)
+    .order('opened_at', { ascending: false })
+    .limit(10);
+
+  console.log('\n=== Last 10 positions on Simulation SmartVest ===');
+  for (const p of positions ?? []) {
+    const status = p.status === 'open' ? '🟢 OPEN' : `🔴 CLOSED (${p.pnl_pct?.toFixed(2)}%)`;
+    console.log(`  ${p.opened_at}  ${p.symbol.padEnd(15)} ${status}  source=${p.source}`);
+  }
+
+  // Open positions count
+  const { count: openCount } = await sb
+    .from('lisa_positions')
+    .select('id', { count: 'exact', head: true })
+    .eq('portfolio_id', PID)
+    .eq('status', 'open');
+  console.log(`\n=== Open positions count : ${openCount ?? 0} ===`);
+}
+main();


### PR DESCRIPTION
## Backtest calibration Debate Gate sur données réelles Jeu/Ven

### Pourquoi

Le Debate Gate (PR #452/#453) est ACTIVE par défaut. Les seuils actuels sont **partiellement heuristiques** (cf. discussion sur la calibration). Risque : 0 trade ce soir/demain si trop strict.

Ce script permet de calibrer **avant** activation prod en réjouant la logique du gate sur les rows historiques `gainers_user_shadow_signals` (jeudi/vendredi 2026-05-21/22).

### Usage

```bash
# Default : 4 derniers jours (couvre Jeu/Ven + week-end)
pnpm tsx scripts/backtest-debate-gate.ts

# Window custom
pnpm tsx scripts/backtest-debate-gate.ts --from 2026-05-21 --to 2026-05-23

# Focus sur les vrais trades du scanner
pnpm tsx scripts/backtest-debate-gate.ts --only-accept
```

### Output

- Répartition decisions legacy (accept / reject_*)
- Verdicts re-évalués via Debate Gate (TOUS les rows)
- **Analyse sur rows `accept`** : passe vs bloqué + top raisons
- Échantillon 10 premiers `blocked-accepts`
- **Verdict calibration** : trop laxiste / cible / trop strict

### Cible empirique

| blockRatio | Diagnostic | Action |
|---|---|---|
| < 10% | Gate inutile | Resserrer seuils |
| 20-40% | ✅ Cible | Activer en confiance |
| > 60% | Gate étranglant | Relâcher OU `DEBATE_GATE_ENABLED=false` |

### Prochaine étape

Une fois mergé, à exécuter avec `SUPABASE_SERVICE_ROLE_KEY` configuré pour obtenir un verdict objectif avant l'ouverture Asia cette nuit.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_