### PR TITLE
chore(scripts): diag scripts for stale paper_trades vs lisa_positions

### DIFF
--- a/scripts/cross-check-lisa-vs-paper.ts
+++ b/scripts/cross-check-lisa-vs-paper.ts
@@ -1,0 +1,53 @@
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL || '', process.env.SUPABASE_SERVICE_ROLE_KEY || '');
+const PID = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+async function main() {
+  // Open in paper_trades
+  const { data: openPaper } = await sb
+    .from('paper_trades')
+    .select('*')
+    .eq('portfolio_id', PID)
+    .eq('status', 'open');
+  console.log(`paper_trades.status='open' : ${openPaper?.length ?? 0}`);
+
+  // Open in lisa_positions
+  const { data: openLisa } = await sb
+    .from('lisa_positions')
+    .select('id, symbol, status, opened_at, closed_at')
+    .eq('portfolio_id', PID)
+    .eq('status', 'open');
+  console.log(`lisa_positions.status='open' : ${openLisa?.length ?? 0}`);
+
+  // Sample lisa_positions for the 3 Korean symbols
+  const koreanSymbols = ['059120.KQ', '016360.KO', '021050.KO'];
+  console.log(`\n=== lisa_positions for stale paper_trades Korean symbols ===`);
+  for (const sym of koreanSymbols) {
+    const { data } = await sb
+      .from('lisa_positions')
+      .select('id, status, opened_at, closed_at, pnl_pct, entry_price, exit_price')
+      .eq('portfolio_id', PID)
+      .eq('symbol', sym)
+      .gte('opened_at', '2026-05-05')
+      .lte('opened_at', '2026-05-08')
+      .order('opened_at', { ascending: true });
+    console.log(`\n${sym} :`);
+    for (const p of data ?? []) {
+      const status = p.status === 'open' ? '🟢 OPEN' : `🔴 ${p.status} (pnl=${p.pnl_pct?.toFixed(2) ?? '?'}%)`;
+      console.log(`  opened=${p.opened_at?.slice(0,16)}  closed=${p.closed_at?.slice(0,16) ?? '(never)'}  ${status}`);
+    }
+  }
+
+  // lisa_positions status distribution
+  const { data: allLisa } = await sb
+    .from('lisa_positions')
+    .select('status')
+    .eq('portfolio_id', PID);
+  const byStatus: Record<string, number> = {};
+  for (const r of allLisa ?? []) byStatus[r.status] = (byStatus[r.status] ?? 0) + 1;
+  console.log(`\n=== lisa_positions status distribution (this portfolio) ===`);
+  for (const [s, n] of Object.entries(byStatus).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${s.padEnd(25)} ${n}`);
+  }
+}
+main();

--- a/scripts/investigate-stale-positions.ts
+++ b/scripts/investigate-stale-positions.ts
@@ -1,0 +1,73 @@
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL || '', process.env.SUPABASE_SERVICE_ROLE_KEY || '');
+const PID = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+async function main() {
+  // 1. All open positions, grouped by age
+  const { data: open } = await sb
+    .from('paper_trades')
+    .select('*')
+    .eq('portfolio_id', PID)
+    .eq('status', 'open')
+    .order('opened_at', { ascending: false });
+
+  const now = Date.now();
+  const stats = { lt1d: 0, lt7d: 0, lt30d: 0, gt30d: 0 };
+  const byAge: Record<string, number> = {};
+
+  for (const p of open ?? []) {
+    const age = (now - new Date(p.opened_at).getTime()) / 86_400_000;
+    if (age < 1) stats.lt1d++;
+    else if (age < 7) stats.lt7d++;
+    else if (age < 30) stats.lt30d++;
+    else stats.gt30d++;
+  }
+
+  console.log(`\n=== ${open?.length ?? 0} OPEN paper_trades on Sim SmartVest ===`);
+  console.log(`  < 1 day   : ${stats.lt1d}`);
+  console.log(`  < 7 days  : ${stats.lt7d}`);
+  console.log(`  < 30 days : ${stats.lt30d}`);
+  console.log(`  > 30 days : ${stats.gt30d}`);
+
+  // 2. Sample of oldest
+  console.log(`\n=== 15 OLDEST open positions ===`);
+  const oldest = (open ?? []).slice().sort((a, b) => +new Date(a.opened_at) - +new Date(b.opened_at)).slice(0, 15);
+  for (const p of oldest) {
+    const ageDays = ((now - new Date(p.opened_at).getTime()) / 86_400_000).toFixed(1);
+    console.log(`  ${p.opened_at.slice(0, 19)}  ${p.symbol.padEnd(15)} ${(p.asset_class ?? '?').padEnd(12)} dir=${p.direction} entry=${p.entry_price} SL=${p.stop_loss} TP=${p.take_profit} size=$${p.size_usd}  AGE=${ageDays}j`);
+  }
+
+  // 3. Group by asset class
+  const byClass: Record<string, number> = {};
+  for (const p of open ?? []) byClass[p.asset_class] = (byClass[p.asset_class] ?? 0) + 1;
+  console.log(`\n=== Open positions by asset_class ===`);
+  for (const [c, n] of Object.entries(byClass).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${c.padEnd(20)} ${n}`);
+  }
+
+  // 4. Check if there's a mechanical_directive or close attempt in decision_log
+  const sampleSymbol = oldest[0]?.symbol;
+  if (sampleSymbol) {
+    console.log(`\n=== decision_log for sample stale symbol ${sampleSymbol} (last 30 events) ===`);
+    const { data: logs } = await sb
+      .from('lisa_decision_log')
+      .select('timestamp, kind, summary, rationale')
+      .eq('portfolio_id', PID)
+      .or(`summary.ilike.%${sampleSymbol}%,rationale.ilike.%${sampleSymbol}%`)
+      .order('timestamp', { ascending: false })
+      .limit(30);
+    for (const l of logs ?? []) console.log(`  ${l.timestamp.slice(0, 19)}  ${l.kind.padEnd(30)}  ${l.summary?.slice(0, 70)}`);
+  }
+
+  // 5. Stop-loss / take-profit logs that should have fired
+  console.log(`\n=== Recent stop_triggered / take_profit_triggered / closed_invalidated ===`);
+  const { data: closeLogs } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, kind, summary')
+    .eq('portfolio_id', PID)
+    .in('kind', ['stop_triggered', 'take_profit_triggered', 'closed_invalidated', 'mechanical_close', 'sanity_bound'])
+    .order('timestamp', { ascending: false })
+    .limit(20);
+  for (const l of closeLogs ?? []) console.log(`  ${l.timestamp.slice(0, 19)}  ${l.kind.padEnd(30)}  ${l.summary?.slice(0, 70)}`);
+}
+main();

--- a/scripts/q-paper-trades.ts
+++ b/scripts/q-paper-trades.ts
@@ -1,0 +1,20 @@
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL || '', process.env.SUPABASE_SERVICE_ROLE_KEY || '');
+async function main() {
+  const { data, count } = await sb
+    .from('paper_trades')
+    .select('portfolio_id, status', { count: 'exact' })
+    .eq('status', 'open');
+  console.log('TOTAL open across all portfolios:', count);
+  const byPid: Record<string, number> = {};
+  for (const r of data ?? []) byPid[r.portfolio_id] = (byPid[r.portfolio_id] ?? 0) + 1;
+  for (const [pid, n] of Object.entries(byPid)) console.log(`  ${pid} : ${n}`);
+
+  const { data: all, count: allCount } = await sb.from('paper_trades').select('status', { count: 'exact' });
+  console.log('\nTotal rows:', allCount);
+  const byStatus: Record<string, number> = {};
+  for (const r of all ?? []) byStatus[r.status] = (byStatus[r.status] ?? 0) + 1;
+  console.log('Status distribution :');
+  for (const [s, n] of Object.entries(byStatus)) console.log(`  ${s ?? '(null)'} : ${n}`);
+}
+main();


### PR DESCRIPTION
## Diagnostic 92 paper_trades stale (sans toucher au code prod)

3 scripts read-only utilisés pour diagnostiquer le bug remonté pendant la session d'aujourd'hui :

### Découvertes

| Table | Open count | Status |
|---|---|---|
| `lisa_positions` (vraies) | **0** | ✅ toutes fermées : 196 invalidated + 195 stop + 98 target + 10 kill + 7 expired |
| `paper_trades` (mirror) | **92** | ⚠️ orphelins, jamais sync |

### Cause racine

`mechanical-trading.service.ts:2729-2742` update **uniquement** `lisa_positions`, jamais `paper_trades`. Le miroir n'est jamais synchronisé.

### Impact réel

- ✅ **Capital protégé** : les vraies positions ferment proprement (stop/target/invalidation)
- ⚠️ **ML dataset P9 pollué** : 92 "trades infinis" faussent les features de la logistic regression

**Non urgent**. Fix séparé via :
- Option A : mirror update dans `mechanical-trading.closePosition` après le `lisa_positions.update`
- Option B : appeler `PaperBrokerService.closePosition()` depuis la mécanique
- Option C : cron nightly de reconciliation

### Scripts

- `q-paper-trades.ts` : count + distribution status global
- `investigate-stale-positions.ts` : age + sample 15 oldest + decision_log
- `cross-check-lisa-vs-paper.ts` : compare les 2 tables pour prouver le désync

Gardés pour usage futur de diagnostic.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_