### PR TITLE
chore(scripts): live diag scripts utilisés soir 25/05

### DIFF
--- a/scripts/live-state.ts
+++ b/scripts/live-state.ts
@@ -1,0 +1,30 @@
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL || '', process.env.SUPABASE_SERVICE_ROLE_KEY || '');
+
+async function main() {
+  const since = new Date(Date.now() - 4 * 3600_000).toISOString();
+  const { data: shadow, count } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('decision', { count: 'exact', head: false })
+    .gte('created_at', since);
+  const byDecision: Record<string, number> = {};
+  for (const r of shadow ?? []) byDecision[r.decision] = (byDecision[r.decision] ?? 0) + 1;
+  console.log(`SHADOW SIGNALS (4h) : ${count}`);
+  for (const [d, n] of Object.entries(byDecision).sort((a, b) => b[1] - a[1])) console.log(`  ${d.padEnd(25)} ${n}`);
+
+  const { data: lastAccept } = await sb
+    .from('gainers_user_shadow_signals').select('symbol, created_at')
+    .eq('decision', 'accept').order('created_at', { ascending: false }).limit(3);
+  console.log('Last 3 accepts:');
+  for (const r of lastAccept ?? []) console.log(`  ${r.created_at}  ${r.symbol}`);
+
+  const { count: openCount } = await sb.from('paper_trades').select('*', { count: 'exact', head: true }).eq('status', 'open');
+  console.log(`\nPaper_trades OPEN now : ${openCount}`);
+
+  const { data: recentOpens } = await sb
+    .from('paper_trades').select('symbol, opened_at, asset_class')
+    .eq('status', 'open').order('opened_at', { ascending: false }).limit(5);
+  console.log('Last 5 opens:');
+  for (const r of recentOpens ?? []) console.log(`  ${r.opened_at}  ${r.symbol} (${r.asset_class})`);
+}
+main();

--- a/scripts/why-no-opens.ts
+++ b/scripts/why-no-opens.ts
@@ -1,0 +1,46 @@
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL || '', process.env.SUPABASE_SERVICE_ROLE_KEY || '');
+const PID = '58439d86-3f20-4a60-82a4-307f3f252bc2';
+
+async function main() {
+  const since = new Date(Date.now() - 4 * 3600_000).toISOString();
+  // lisa_positions opened in last 4h
+  const { data: lp } = await sb
+    .from('lisa_positions').select('id, symbol, opened_at, status, closed_at')
+    .eq('portfolio_id', PID)
+    .gte('opened_at', since)
+    .order('opened_at', { ascending: false });
+  console.log(`lisa_positions opened in 4h: ${lp?.length ?? 0}`);
+  for (const r of lp ?? []) console.log(`  ${r.opened_at}  ${r.symbol.padEnd(15)} status=${r.status} closed=${r.closed_at ?? '-'}`);
+
+  // decision_log for debate gate / scanner around TLO.TO
+  const { data: log } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, kind, summary')
+    .eq('portfolio_id', PID)
+    .gte('timestamp', since)
+    .ilike('summary', '%TLO%')
+    .order('timestamp', { ascending: false })
+    .limit(20);
+  console.log(`\ndecision_log mentions TLO (4h): ${log?.length ?? 0}`);
+  for (const r of log ?? []) console.log(`  ${r.timestamp}  ${r.kind.padEnd(28)}  ${r.summary?.slice(0, 80)}`);
+
+  // Any cycle skip reasons last 4h
+  const { data: skips } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, kind, summary')
+    .eq('portfolio_id', PID)
+    .gte('timestamp', since)
+    .in('kind', ['autopilot_cycle_completed', 'autopilot_paused', 'no_open_attempt', 'budget_cap_reached', 'position_cap_reached'])
+    .order('timestamp', { ascending: false })
+    .limit(10);
+  console.log(`\nrecent cycle events: ${skips?.length ?? 0}`);
+  for (const r of skips ?? []) console.log(`  ${r.timestamp}  ${r.kind.padEnd(28)}  ${r.summary?.slice(0, 80)}`);
+
+  // Total open paper_trades vs lisa_positions
+  const { count: ptOpen } = await sb.from('paper_trades').select('*', { count: 'exact', head: true }).eq('status', 'open').eq('portfolio_id', PID);
+  const { count: lpOpen } = await sb.from('lisa_positions').select('*', { count: 'exact', head: true }).eq('status', 'open').eq('portfolio_id', PID);
+  console.log(`\npaper_trades open : ${ptOpen}`);
+  console.log(`lisa_positions open : ${lpOpen}`);
+}
+main();


### PR DESCRIPTION
## Scripts diag prod soir 25/05

Deux scripts read-only utilisés pour diagnostiquer **"6 accepts / 0 opens"** détecté en prod le 25/05 vers 17h UTC.

### Diagnostic confirmé

Logs prod :
```
[top-gainers] NTAP.US (us_equity_large) hour 17h UTC blacklist par-classe → skip long
[top-gainers] TLO.TO (us_equity_small_mid) hour 17h UTC blacklist par-classe → skip long
... (16 candidats US tous skip au même cycle)
```

**Cause** : `GAINERS_HOUR_BLACKLIST_US_UTC` contient `17` (= 19h CEST). Tous les candidats US sont killed avant d'atteindre le debate gate ou openPositionDirect.

### Risque MAJEUR Asia

Si `GAINERS_HOUR_BLACKLIST_ASIA_UTC=0,1,2,3,4,5` est setté (vu dans transcripts antérieurs), cela correspond **exactement aux heures d'ouverture Nikkei (00-06 UTC) + Hang Seng (01:30-08 UTC)**. → 0 trade Asia garanti cette nuit.

### Fix par user via Fly CLI

```bash
fly secrets unset GAINERS_HOUR_BLACKLIST_ASIA_UTC \
                  GAINERS_HOUR_BLACKLIST_US_UTC \
                  GAINERS_HOUR_BLACKLIST_EU_UTC \
                  GAINERS_HOUR_BLACKLIST_CRYPTO_UTC \
                  -a smartvest
```

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_