### PR TITLE
feat(scanner): session 25/05 — Risk Manager V2, Opportunity Scout, EU fixes, audit scripts, staleness P19

### DIFF
--- a/apps/api/fly.toml
+++ b/apps/api/fly.toml
@@ -9,8 +9,35 @@ primary_region = "cdg"
 [env]
   NODE_ENV = "production"
   API_PORT = "3001"
+
+  # Gemini Risk Manager V2 — auto-close sur thèse cassée
   GEMINI_RISK_MANAGER_ENABLED = "true"
   GEMINI_RISK_MANAGER_AUTO_CLOSE_MIN_CONFIDENCE = "0.8"
+  GEMINI_RISK_MANAGER_USE_MACRO_NEWS = "true"
+
+  # Tier 1 — Production-grade features (activés 25/05/2026)
+  GAINERS_TRAILING_STOP_BREAKEVEN_ENABLED = "true"
+  GAINERS_TRAILING_TP_ENABLED = "true"
+  MICRO_MOMENTUM_GATE_ENABLED = "true"
+  EARLY_EXIT_GUARD_ENABLED = "true"
+  CORRELATION_GUARD_ENABLED = "true"
+  CONVICTION_SIZING_ENABLED = "true"
+  RISK_MONITOR_ENABLED = "true"
+  RISK_MONITOR_ENABLED_CRYPTO = "true"
+  RISK_MONITOR_ENABLED_US = "true"
+  RISK_MONITOR_ENABLED_EU = "true"
+  RISK_MONITOR_ENABLED_ASIA = "true"
+  RISK_MONITOR_GEMINI_ENABLED = "true"
+  EODHD_NEWS_PERSIST_ENABLED = "true"
+  EODHD_ECONOMIC_EVENTS_ENABLED = "true"
+  GEMINI_DAILY_BRIEF_ENABLED = "true"
+  SYMBOL_ATR_CACHE_REFRESH_ENABLED = "true"
+  DAILY_RETROSPECTIVE_ENABLED = "true"
+
+  # Tier 2 — Higher-risk features (sizing réduit côté code)
+  REVERSE_MOMENTUM_MODE = "both"
+  REVERSE_MOMENTUM_SHORT_RATIO = "0.5"
+  FEATURE_AB_TUNING_ENABLED = "true"
 
   # P19-V2 (25/05/2026) — Gemini Risk Manager V2 macro news.
   # Note : la plupart des feature flags vivent dans les Fly secrets (source de

--- a/apps/api/fly.toml
+++ b/apps/api/fly.toml
@@ -10,34 +10,12 @@ primary_region = "cdg"
   NODE_ENV = "production"
   API_PORT = "3001"
 
-  # Gemini Risk Manager V2 — auto-close sur thèse cassée
-  GEMINI_RISK_MANAGER_ENABLED = "true"
-  GEMINI_RISK_MANAGER_AUTO_CLOSE_MIN_CONFIDENCE = "0.8"
+  # P19-V2 (25/05/2026) — Gemini Risk Manager V2 macro news.
+  # Note : la plupart des feature flags vivent dans les Fly secrets (source de
+  # vérité). Ces 3 sont nouveaux et default-OFF dans le code, on les active ici
+  # pour démarrage immédiat. Fly secrets prennent la priorité si dupliqué.
   GEMINI_RISK_MANAGER_USE_MACRO_NEWS = "true"
-
-  # Tier 1 — Production-grade features (activés 25/05/2026)
-  GAINERS_TRAILING_STOP_BREAKEVEN_ENABLED = "true"
-  GAINERS_TRAILING_TP_ENABLED = "true"
-  MICRO_MOMENTUM_GATE_ENABLED = "true"
-  EARLY_EXIT_GUARD_ENABLED = "true"
-  CORRELATION_GUARD_ENABLED = "true"
-  CONVICTION_SIZING_ENABLED = "true"
-  RISK_MONITOR_ENABLED = "true"
-  RISK_MONITOR_ENABLED_CRYPTO = "true"
-  RISK_MONITOR_ENABLED_US = "true"
-  RISK_MONITOR_ENABLED_EU = "true"
-  RISK_MONITOR_ENABLED_ASIA = "true"
-  RISK_MONITOR_GEMINI_ENABLED = "true"
-  EODHD_NEWS_PERSIST_ENABLED = "true"
-  EODHD_ECONOMIC_EVENTS_ENABLED = "true"
-  GEMINI_DAILY_BRIEF_ENABLED = "true"
-  SYMBOL_ATR_CACHE_REFRESH_ENABLED = "true"
-  DAILY_RETROSPECTIVE_ENABLED = "true"
-
-  # Tier 2 — Higher-risk features (sizing réduit côté code)
-  REVERSE_MOMENTUM_MODE = "both"
-  REVERSE_MOMENTUM_SHORT_RATIO = "0.5"
-  FEATURE_AB_TUNING_ENABLED = "true"
+  GEMINI_RISK_MANAGER_AUTO_CLOSE_MIN_CONFIDENCE = "0.8"
 
   # P19-V2 (25/05/2026) — Gemini Risk Manager V2 macro news.
   # Note : la plupart des feature flags vivent dans les Fly secrets (source de

--- a/apps/api/fly.toml
+++ b/apps/api/fly.toml
@@ -9,6 +9,8 @@ primary_region = "cdg"
 [env]
   NODE_ENV = "production"
   API_PORT = "3001"
+  GEMINI_RISK_MANAGER_ENABLED = "true"
+  GEMINI_RISK_MANAGER_AUTO_CLOSE_MIN_CONFIDENCE = "0.8"
 
   # P19-V2 (25/05/2026) — Gemini Risk Manager V2 macro news.
   # Note : la plupart des feature flags vivent dans les Fly secrets (source de

--- a/supabase/migrations/0162_unique_open_position_per_symbol.sql
+++ b/supabase/migrations/0162_unique_open_position_per_symbol.sql
@@ -17,6 +17,8 @@
 
 -- CONCURRENTLY omitted: migration runner wraps SQL in a transaction block,
 -- and CREATE INDEX CONCURRENTLY cannot run inside a transaction (error 25001).
+-- Non-concurrent creation briefly locks writes on lisa_positions, acceptable
+-- here given the small row count (dozens, not millions).
 CREATE UNIQUE INDEX IF NOT EXISTS idx_lisa_positions_unique_open_symbol
   ON lisa_positions (portfolio_id, symbol)
   WHERE status = 'open';


### PR DESCRIPTION
## Résumé session 25/05

22 commits couvrant 4 axes majeurs :

### 1. Risk Manager V2 + Opportunity Scout
- `feat(risk-manager)`: auto-close sur thèse cassée via Gemini news LLM (sentiment ≤ -0.6, fraîcheur < 30min)
- `feat(opportunity-scout)`: symétrique du RM — news positive → auto-open PROD (gate conviction + path_eff)
- `fix(gemini)`: strip backtick fences before JSON.parse (évite crash scanner LLM calls)
- `fix(audit)`: decision_log par direction reverse-momentum + migration 0164 kinds Gemini V2

### 2. Corrections scanner EU / Asia / doublons
- `fix(scanner)`: EU session opens 07:00 UTC summer (Paris/XETRA CEST)
- `fix(scanner)`: prevent duplicate open positions for same symbol
- `fix(scanner)`: direction-aware same-symbol guard in try_open_position (#0163)
- `fix(scanner)`: per-class hour gate remplace TOUJOURS le global (supprime env OVERRIDES_GLOBAL)
- `fix(migration-0162)`: drop CONCURRENTLY — cannot run inside transaction block
- `feat(scanner)`: cycle scan → 5 minutes (cron + DB gainers_cycle_minutes)

### 3. Staleness P19 — prix froids rejetés
- `fix(live-price)`: tag stale TD/EODHD quotes + R5 rejects stale closes (P19-staleness)
- `test(intraday-router)`: update getLiveQuote assertions for new quoteTsMs field

### 4. Activation prod + audit scripts
- `feat(prod)`: activation Tier 1+2 features + fix EU liquidity + macro news Gemini
- `fix(shadow-sim)`: stop EODHD spam for Asian tickers, resolve TIME_LIMIT when past hold window
- `chore(scripts)`: audit-all-features, audit-eu-rejects, audit-positions-today, audit Asia no-opens, check-eodhd-calls

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_