### PR TITLE
fix(shadow-sizing): small portfolio = 40 positions × $262

### DIFF
--- a/apps/api/src/modules/lisa/services/market-close-report.service.ts
+++ b/apps/api/src/modules/lisa/services/market-close-report.service.ts
@@ -281,7 +281,7 @@ Les 5 portfolios bench :
 - "main" : portfolio principal (capital $10.5k, sizing 7.5%/pos, mode mixed)
 - "shadow_high" : 3 positions × $3500 (concentré)
 - "shadow_middle" : 15 positions × $700 (équilibré)
-- "shadow_small" : 20 positions × $525 (diversifié)
+- "shadow_small" : 40 positions × $262 (diversifié)
 - "trader_agent" : portfolio dédié $10k piloté par Gemini Pro autonome (cron 5min)
 
 Cible $200/jour total.

--- a/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
@@ -69,7 +69,7 @@ interface GeminiDecision {
 const SHADOW_SIZING_GEMINI_SYSTEM_PROMPT = `Tu es un agent IA de risk management pour 3 portfolios paper-trading "shadow sizing" qui benchmarkent l'effet du sizing sur la même watchlist :
 - "high" : 3 positions × ~$3500 (concentré)
 - "middle" : 15 positions × ~$700 (équilibré)
-- "small" : 20 positions × ~$525 (diversifié)
+- "small" : 40 positions × ~$262 (diversifié)
 
 Ton job : analyser les snapshots toutes les 30 min et décider d'UNE action concrète pour maximiser P&L net après fees, avec cible $200/jour.
 

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -199,7 +199,7 @@ const EU_EXCHANGES = ['LSE', 'XETRA', 'PA', 'SW', 'MI', 'MC', 'BME', 'AS', 'AMS'
 const SHADOW_PORTFOLIO_IDS = new Set<string>([
   'a0000001-0000-0000-0000-000000000001',  // shadow_high   : 3  pos × $3500
   'a0000002-0000-0000-0000-000000000002',  // shadow_middle : 15 pos × $700
-  'a0000003-0000-0000-0000-000000000003',  // shadow_small  : 20 pos × $525 (cap DB)
+  'a0000003-0000-0000-0000-000000000003',  // shadow_small  : 40 pos × $262
 ]);
 // Portfolios qui bypassent les hour-blacklists (LONG global + per-class).
 // Objectif : maximiser le nombre de signaux collectés sur la durée complète


### PR DESCRIPTION
## Summary

3 endroits hardcodaient encore l'ancienne config `20 × $525` pour le shadow small alors que la DB et le code TS sont déjà à `40 × $262`. Aligne les system prompts Gemini + commentaire annotation.

- `shadow-sizing-orchestrator.service.ts:72` — system prompt Gemini auto-tuner
- `market-close-report.service.ts:284` — system prompt Gemini daily wrap
- `top-gainers-scanner.service.ts:202` — commentaire annotation

Conséquence : Gemini raisonnait sur une fausse capacité (20 vs 40 max_open) → ses suggestions `raise_sizing` / `lower_sizing` étaient calibrées sur le mauvais référentiel.

## Test plan

- [x] `tsc -p apps/api --noEmit` OK
- [x] DB déjà à 40 (`lisa_session_configs.gainers_max_open_positions=40` pour a0000003)
- [ ] Post-deploy : prochain cycle shadow-sizing-orchestrator écrit la rationale Gemini avec la bonne valeur (40)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_