### PR TITLE
feat(trader-agent, shadow-sizing): Gemini 2.5 Pro + macro frais + wire close/scale_in/trail_stop

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -91,6 +91,10 @@ export class LisaService {
   private readonly riskEnforcer: RiskEnforcer;
   private readonly paperBroker: PaperBrokerService;
   private readonly riskMonitor: RiskMonitorService;
+  // Cache léger du dernier MarketSnapshot. Consommé par les services tiers
+  // (LiveTraderAgent, ShadowSizingOrchestrator) qui ont besoin d'un contexte
+  // macro frais sans payer le coût d'un re-fetch complet à chaque cycle.
+  private lastMarketSnapshotCache: { snap: MarketSnapshot; fetchedAt: number } | null = null;
 
   /**
    * P0-B — Cache last-known macro per indicator. Quand toutes les sources
@@ -4676,6 +4680,61 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     } catch (e) {
       this.logger.warn(`[opportunity-scout] openPositionDirect ${cmd.symbol} failed: ${String(e).slice(0, 200)}`);
       return null;
+    }
+  }
+
+  /**
+   * Snapshot macro cached. Re-fetch si plus vieux que maxAgeSec.
+   * Évite à des services tiers (LiveTraderAgent, ShadowSizingOrchestrator) de
+   * payer 15-20 calls API + 3s latency à chaque cycle 5min.
+   *
+   * Le cache n'est PAS partagé avec le pipeline Lisa principal (qui appelle
+   * fetchMarketSnapshot() directement pour garantir la fraîcheur d'un proposal).
+   */
+  async getRecentMarketSnapshot(maxAgeSec: number = 120): Promise<MarketSnapshot> {
+    const now = Date.now();
+    if (this.lastMarketSnapshotCache && (now - this.lastMarketSnapshotCache.fetchedAt) < maxAgeSec * 1000) {
+      return this.lastMarketSnapshotCache.snap;
+    }
+    const fresh = await this.fetchMarketSnapshot();
+    this.lastMarketSnapshotCache = { snap: fresh, fetchedAt: now };
+    return fresh;
+  }
+
+  /**
+   * Close une position par id via le paperBroker. Pattern symétrique à
+   * openForOpportunityScout. Utilisé par LiveTraderAgent quand Gemini propose
+   * un action_kind='close' sur un symbol qu'il détient.
+   *
+   * Le caller résout symbol → positionId via son state (positions ouvertes
+   * du portfolio). Sanity bound : refuse si livePrice diverge > 30% d'entry
+   * (anti-corruption cache, cf. règle "checkStopTarget [SANITY_BOUND]").
+   */
+  async closeForOpportunityScout(cmd: {
+    positionId: string;
+    livePrice: number;
+    livePriceSource?: string;
+    reason: 'closed_target' | 'closed_stop' | 'closed_invalidated' | 'closed_user' | 'closed_kill' | 'closed_expired';
+    rationale: string;
+  }): Promise<{ closed: boolean; error?: string }> {
+    // Refuse si source unreliable (fallback / stale)
+    if (cmd.livePriceSource && (cmd.livePriceSource.startsWith('stale_') || cmd.livePriceSource.startsWith('fallback'))) {
+      return { closed: false, error: `price source unreliable: ${cmd.livePriceSource}` };
+    }
+    if (!Number.isFinite(cmd.livePrice) || cmd.livePrice <= 0) {
+      return { closed: false, error: `invalid livePrice ${cmd.livePrice}` };
+    }
+    try {
+      await this.paperBroker.closePosition({
+        positionId: cmd.positionId,
+        reason: cmd.reason,
+        livePrice: cmd.livePrice.toFixed(6),
+        rationale: cmd.rationale.slice(0, 500),
+        ...(cmd.livePriceSource ? { livePriceSource: cmd.livePriceSource } : {}),
+      });
+      return { closed: true };
+    } catch (e) {
+      return { closed: false, error: String(e).slice(0, 200) };
     }
   }
 }

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -191,15 +191,16 @@ export class LiveTraderAgentService {
         },
       }, null, 2);
 
-      // 5. Call Gemini Pro
+      // 5. Call Gemini Pro (raisonnement multi-facteurs sur 20 candidats + macro + news + memory).
+      // Auto-fallback Flash Lite → Claude Opus si Pro indisponible (cf. ScannerLlmRouter.callWithPro).
       let response: { content: string; providerId: string; costUsd: number; latencyMs: number };
       try {
-        response = await this.llmRouter.call({
+        response = await this.llmRouter.callWithPro({
           system: systemPrompt,
           user: userPrompt,
           temperature: 0.3,
           maxTokens: 1000,
-          timeoutMs: 15_000,
+          timeoutMs: 20_000,
         });
       } catch (e) {
         this.logger.warn(`[trader-agent] LLM call failed: ${String(e).slice(0, 150)}`);
@@ -348,7 +349,8 @@ RÉPONSE JSON OBLIGATOIRE :
         market_close_reports_today: closeReports ?? [],
       }, null, 2);
 
-      const response = await this.llmRouter.call({
+      // Post-mortem = raisonnement sur 24h × 5 portfolios → Pro requis (qualité d'analyse).
+      const response = await this.llmRouter.callWithPro({
         system: postMortemPrompt,
         user: userPayload,
         temperature: 0.4,
@@ -455,12 +457,15 @@ RÉPONSE JSON OBLIGATOIRE :
   }
 
   private async fetchMacroContext(): Promise<object> {
-    // Best-effort : si LisaService expose un cache macro, l'utiliser
+    // Cache 2 min côté LisaService — partagé avec ShadowSizingOrchestrator pour
+    // éviter de re-fetch les 15-20 calls API EODHD/Yahoo à chaque cycle de 5 min.
     try {
-      const cached = (this.lisa as unknown as { lastMarketSnapshot?: object }).lastMarketSnapshot;
-      if (cached) return cached;
-    } catch { /* ignore */ }
-    return { note: 'macro_snapshot_unavailable_this_cycle' };
+      const snap = await this.lisa.getRecentMarketSnapshot(120);
+      return snap;
+    } catch (e) {
+      this.logger.warn(`[trader-agent] macro fetch failed: ${String(e).slice(0, 100)}`);
+      return { note: 'macro_snapshot_unavailable_this_cycle', error: String(e).slice(0, 100) };
+    }
   }
 
   private async fetchRecentNews(n: number): Promise<object[]> {
@@ -554,12 +559,145 @@ Garde ces lessons en tête en priorité pour ta décision actuelle.`;
     }
 
     if (decision.action_kind === 'close') {
-      // TODO future PR : close via paperBroker
-      return { applied: false, error: 'close action not yet wired (follow-up PR)' };
+      // Gemini fournit un symbol → on résout vers le positionId via state.openPositions.
+      if (!decision.symbol) return { applied: false, error: 'close requires symbol' };
+      const sym = decision.symbol.toUpperCase();
+      const match = state.openPositions.find((p) => p.symbol.toUpperCase() === sym);
+      if (!match) {
+        return { applied: false, error: `close: no open position for ${sym} on trader agent portfolio` };
+      }
+      // Need the position id (not exposed in state) — re-query.
+      const { data: row } = await this.supabase.getClient()
+        .from('lisa_positions')
+        .select('id')
+        .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID)
+        .eq('symbol', match.symbol)
+        .eq('status', 'open')
+        .order('entry_timestamp', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (!row?.id) return { applied: false, error: `close: position row not found for ${sym}` };
+
+      const livePriceData = await this.lisa.getLivePrice(decision.symbol).catch(() => null);
+      if (!livePriceData?.price) return { applied: false, error: 'close: no live price' };
+      const livePrice = Number(livePriceData.price);
+      if (!Number.isFinite(livePrice) || livePrice <= 0) return { applied: false, error: 'close: invalid live price' };
+
+      const res = await this.lisa.closeForOpportunityScout({
+        positionId: row.id,
+        livePrice,
+        ...(livePriceData.source ? { livePriceSource: String(livePriceData.source) } : {}),
+        reason: 'closed_user',
+        rationale: `[trader-agent] ${decision.thesis ?? 'gemini close decision'}`,
+      });
+      if (res.closed) return { applied: true, positionId: row.id };
+      return { applied: false, ...(res.error !== undefined ? { error: res.error } : {}) };
     }
 
-    if (decision.action_kind === 'open_pairs' || decision.action_kind === 'scale_in' || decision.action_kind === 'trail_stop') {
-      return { applied: false, error: `${decision.action_kind} not yet wired (follow-up PR)` };
+    if (decision.action_kind === 'scale_in') {
+      // Scale-in = nouvelle ligne open_directional sur un symbol DÉJÀ détenu,
+      // notional capé à +50% du sizing standard (cf. system prompt). Le paper-broker
+      // tracke 2 lignes distinctes — comportement attendu.
+      if (!decision.symbol || !decision.direction || !decision.notional_usd) {
+        return { applied: false, error: 'scale_in: missing symbol/direction/notional' };
+      }
+      const sym = decision.symbol.toUpperCase();
+      const hasOpen = state.openPositions.some((p) => p.symbol.toUpperCase() === sym);
+      if (!hasOpen) {
+        return { applied: false, error: `scale_in: no existing position on ${sym} (use open_directional)` };
+      }
+      if (state.openCount >= 5) return { applied: false, error: 'scale_in: max 5 open positions' };
+      const notional = Math.max(MIN_NOTIONAL_USD, Math.min(MAX_CONCENTRATION_USD * 1.5, decision.notional_usd));
+      const slPct = Math.max(0.5, Math.min(3, decision.stop_loss_pct ?? 1.2));
+      const tpPct = Math.max(0.8, Math.min(5, decision.take_profit_pct ?? 2.5));
+
+      const livePriceData = await this.lisa.getLivePrice(decision.symbol).catch(() => null);
+      if (!livePriceData?.price) return { applied: false, error: 'scale_in: no live price' };
+      const livePrice = Number(livePriceData.price);
+      if (!Number.isFinite(livePrice) || livePrice <= 0) return { applied: false, error: 'scale_in: invalid live price' };
+      if (livePriceData.source && (String(livePriceData.source).startsWith('stale_') || String(livePriceData.source).startsWith('fallback'))) {
+        return { applied: false, error: `scale_in: price source unreliable: ${livePriceData.source}` };
+      }
+
+      const sign = decision.direction === 'short' ? -1 : 1;
+      const stopLossPrice = (livePrice * (1 - sign * slPct / 100)).toFixed(6);
+      const takeProfitPrice = (livePrice * (1 + sign * tpPct / 100)).toFixed(6);
+
+      try {
+        const opened = await this.lisa.openForOpportunityScout({
+          portfolioId: TRADER_AGENT_PORTFOLIO_ID,
+          symbol: decision.symbol,
+          assetClass: 'unknown',
+          venue: 'paper',
+          notionalUsd: notional,
+          livePrice,
+          stopLossPrice,
+          takeProfitPrice,
+          horizonDays: Math.ceil((decision.horizon_minutes ?? 60) / (60 * 24)),
+          maxOpenPositions: 5,
+          rationale: `[trader-agent SCALE_IN] ${decision.thesis}`,
+        });
+        if (!opened) return { applied: false, error: 'scale_in: open returned null' };
+        return { applied: true, positionId: opened.id };
+      } catch (e) {
+        return { applied: false, error: String(e).slice(0, 200) };
+      }
+    }
+
+    if (decision.action_kind === 'trail_stop') {
+      // Trail stop = UPDATE stop_loss_price d'une position ouverte.
+      // Gemini fournit symbol + nouveau stop_loss_pct (% sous entry pour long).
+      // Garde-fou : le nouveau stop ne peut JAMAIS être plus permissif que l'ancien
+      // (sinon ce n'est pas un trail mais un loosening — refusé).
+      if (!decision.symbol) return { applied: false, error: 'trail_stop: requires symbol' };
+      const sym = decision.symbol.toUpperCase();
+      const match = state.openPositions.find((p) => p.symbol.toUpperCase() === sym);
+      if (!match) return { applied: false, error: `trail_stop: no open position for ${sym}` };
+
+      const { data: row } = await this.supabase.getClient()
+        .from('lisa_positions')
+        .select('id, stop_loss_price, entry_price, direction')
+        .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID)
+        .eq('symbol', match.symbol)
+        .eq('status', 'open')
+        .order('entry_timestamp', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (!row?.id) return { applied: false, error: `trail_stop: position row not found for ${sym}` };
+
+      const livePriceData = await this.lisa.getLivePrice(decision.symbol).catch(() => null);
+      if (!livePriceData?.price) return { applied: false, error: 'trail_stop: no live price' };
+      const livePrice = Number(livePriceData.price);
+      if (!Number.isFinite(livePrice) || livePrice <= 0) return { applied: false, error: 'trail_stop: invalid live price' };
+
+      const slPct = Math.max(0.1, Math.min(5, decision.stop_loss_pct ?? 1.2));
+      const isLong = String(row.direction) !== 'short';
+      const sign = isLong ? -1 : 1;
+      // Nouveau stop calculé depuis livePrice (trail = suit le marché)
+      const newStop = livePrice * (1 + sign * slPct / 100);
+      const oldStop = Number(row.stop_loss_price);
+
+      // Garde-fou : le nouveau stop doit être PLUS strict
+      // - long : newStop > oldStop (on remonte le stop)
+      // - short : newStop < oldStop (on descend le stop)
+      const stricter = isLong ? newStop > oldStop : newStop < oldStop;
+      if (!stricter) {
+        return { applied: false, error: `trail_stop: new stop ${newStop.toFixed(4)} not stricter than current ${oldStop.toFixed(4)} (${isLong ? 'long' : 'short'})` };
+      }
+
+      const { error } = await this.supabase.getClient()
+        .from('lisa_positions')
+        .update({ stop_loss_price: newStop.toFixed(6) })
+        .eq('id', row.id);
+      if (error) return { applied: false, error: `trail_stop: db update failed: ${error.message}` };
+      return { applied: true, positionId: row.id };
+    }
+
+    if (decision.action_kind === 'open_pairs') {
+      // Pair trade = 2 positions simultanées (long A + short B), market neutral.
+      // Hors-scope MVP : nécessite logique d'apariement + sizing partagé. À câbler
+      // dans un PR dédié quand le besoin se manifeste sur les décisions Gemini.
+      return { applied: false, error: 'open_pairs: not yet wired (rare action, follow-up PR)' };
     }
 
     return { applied: false, error: `unknown action: ${decision.action_kind}` };

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -341,6 +341,16 @@ export class LiveTraderAgentService {
         }
       }
 
+      // Macro snapshot frais — sert à corréler les outcomes (gagnant/perdant)
+      // au régime du jour. Cache 2 min côté LisaService (probablement déjà chaud).
+      let macroSnapshot: object;
+      try {
+        macroSnapshot = await this.lisa.getRecentMarketSnapshot(120);
+      } catch (e) {
+        this.logger.warn(`[trader-agent:post-mortem] macro fetch failed: ${String(e).slice(0, 100)}`);
+        macroSnapshot = { note: 'macro_snapshot_unavailable' };
+      }
+
       const postMortemPrompt = `Tu es un coach trader senior. Analyse la journée du Trader Agent (portfolio $10k Gemini Pro autonome) ET le comparatif des 5 portfolios paper (main + 3 shadows + trader_agent).
 
 OBJECTIF : générer 5 lessons concrètes pour DOPER l'apprentissage du Trader Agent. Les lessons doivent :
@@ -350,20 +360,55 @@ OBJECTIF : générer 5 lessons concrètes pour DOPER l'apprentissage du Trader A
 4. Référencer les market_close_reports (Asia/EU/US sessions) pour contextualiser
 5. Être actionable : "Quand le contexte est X, fais Y" (pas "il faut être prudent")
 
+LECTURE MACRO OBLIGATOIRE (input \`macro_snapshot_eod\`) :
+Tu DOIS conditionner chaque lesson au régime macro du jour. Une lesson "ouvrir
+short sur tech au open US" n'a aucune valeur si elle ne précise pas le contexte
+(VIX 28 vs VIX 14, US10Y > 4.5% vs < 4.0%, etc.). Sans condition macro, la
+lesson est rejetée comme "macro-blind".
+
+Grille de lecture :
+- VIX > 25 = stressé / VIX > 30 = panique
+- US10Y up > +10bps = pression rates
+- DXY spike + 10Y > 4.5% = flight from risk assets
+- HY OAS > 500bps = credit stress
+- Gold + DXY contraires = flight to safety
+- Brent +5% intraday = geopolitique
+- USDJPY < 145 = yen carry unwind risk
+
+Chaque \`lesson_text\` DOIT contenir une clause "Quand <CONDITION MACRO>, alors
+<ACTION>". Sinon Gemini rejette la lesson.
+
+PATTERNS CROSS-PORTFOLIO À CHERCHER :
+- "Trader Agent a passé X trades pendant Asia session alors que shadow_high
+  qui était cash a évité une perte de $Y (cf. macro VIX 22 + DXY spike)"
+- "Shadow_small a ouvert 8 positions avec sizing micro pendant US morning :
+  $Z gain net malgré fees 30%. Le Trader Agent aurait dû en faire 4 sur
+  les mêmes patterns avec sizing 2× pour battre les frais"
+- "Trader Agent a ouvert 1 position à 17:00 UTC pendant la blacklist hour US,
+  -$X. Shadow_middle (qui bypass blacklist) a ouvert mais avec sentiment news
+  +0.8 → +$Y. Conclusion : bypass OK SI confirmation news fraîche"
+
 RÉPONSE JSON OBLIGATOIRE :
 {
-  "summary": "1-2 phrases résumé journée trader_agent vs autres portfolios",
+  "summary": "1-2 phrases résumé journée trader_agent vs autres portfolios + régime macro dominant",
+  "macro_regime_today": "ex: VIX 22 (élevé), US10Y 4.45% (rates stress), DXY 103 (USD fort), HY OAS 380bps (calme corporate)",
   "trader_agent_daily_pnl_usd": <nombre net total>,
-  "winning_patterns": ["pattern 1 avec chiffres", "pattern 2", ...],
-  "losing_patterns": ["pattern 1 avec chiffres", "pattern 2", ...],
-  "cross_portfolio_insights": ["X a battu Y de $Z grâce à...", ...],
+  "winning_patterns": ["pattern + chiffres + condition macro"],
+  "losing_patterns": ["pattern + chiffres + condition macro"],
+  "cross_portfolio_insights": ["X a battu Y de $Z grâce à... (régime macro: ...)", ...],
   "new_lessons": [
-    {"lesson_kind": "winning_pattern|losing_pattern|risk_observation|market_regime_rule|sizing_rule|cross_portfolio_insight", "lesson_text": "Quand X, fais Y (référence: Z trades observés)", "confidence": 0.0-1.0}
+    {
+      "lesson_kind": "winning_pattern|losing_pattern|risk_observation|market_regime_rule|sizing_rule|cross_portfolio_insight",
+      "lesson_text": "Quand <condition macro>, alors <action> (référence: Z trades observés)",
+      "confidence": 0.0-1.0,
+      "macro_condition": "VIX>25|US10Y>4.5|DXY>103|GOLD+DXY-|BRENT+5%|HY_OAS>500|USDJPY<145|REGIME_CALME|REGIME_MIXED"
+    }
   ]
 }`;
 
       const userPayload = JSON.stringify({
         date: new Date().toISOString().slice(0, 10),
+        macro_snapshot_eod: macroSnapshot,
         trader_agent_decisions: decisions ?? [],
         trader_agent_positions: positions ?? [],
         cross_portfolio_daily_summary: dailyByPortfolio,
@@ -381,7 +426,7 @@ RÉPONSE JSON OBLIGATOIRE :
 
       const cleaned = response.content.trim().replace(/^```json\s*/i, '').replace(/```\s*$/, '').trim();
       const parsed = JSON.parse(cleaned);
-      const newLessons = parsed.new_lessons as Array<{ lesson_kind: string; lesson_text: string; confidence: number }>;
+      const newLessons = parsed.new_lessons as Array<{ lesson_kind: string; lesson_text: string; confidence: number; macro_condition?: string }>;
 
       if (!Array.isArray(newLessons) || newLessons.length === 0) {
         this.logger.warn('[trader-agent:post-mortem] no lessons returned');
@@ -389,17 +434,38 @@ RÉPONSE JSON OBLIGATOIRE :
       }
 
       const today = new Date().toISOString().slice(0, 10);
+      const macroRegime = parsed.macro_regime_today ?? null;
+      let persisted = 0;
+      let rejectedMacroBlind = 0;
       for (const l of newLessons) {
+        // Gate macro-condition : refuse les lessons qui n'ont pas de condition macro
+        // explicite (la grille interdit les lessons "macro-blind"). On accepte aussi
+        // les lessons qui contiennent "Quand" + un mot macro (VIX|DXY|10Y|HY|OAS|GOLD|BRENT|USDJPY|REGIME)
+        // dans le texte si macro_condition n'est pas fourni.
+        const hasExplicitMacroCondition = !!l.macro_condition && l.macro_condition.length > 0;
+        const hasInlineMacroClause = /quand\b.*\b(vix|dxy|10y|hy|oas|gold|brent|usdjpy|regime|us10y)\b/i.test(l.lesson_text);
+        if (!hasExplicitMacroCondition && !hasInlineMacroClause) {
+          this.logger.warn(`[trader-agent:post-mortem] reject macro-blind lesson: ${l.lesson_text.slice(0, 80)}`);
+          rejectedMacroBlind++;
+          continue;
+        }
         await this.supabase.getClient().from('trader_agent_memory').insert({
           portfolio_id: TRADER_AGENT_PORTFOLIO_ID,
           lesson_kind: l.lesson_kind,
           lesson_text: l.lesson_text,
           confidence: l.confidence,
           derived_from_date: today,
-          payload: { summary: parsed.summary, winning: parsed.winning_patterns, losing: parsed.losing_patterns },
+          payload: {
+            summary: parsed.summary,
+            macro_regime_today: macroRegime,
+            macro_condition: l.macro_condition ?? null,
+            winning: parsed.winning_patterns,
+            losing: parsed.losing_patterns,
+          },
         });
+        persisted++;
       }
-      this.logger.log(`[trader-agent:post-mortem] persisted ${newLessons.length} new lessons`);
+      this.logger.log(`[trader-agent:post-mortem] persisted ${persisted} lessons (${rejectedMacroBlind} rejected macro-blind)`);
     } catch (e) {
       this.logger.warn(`[trader-agent:post-mortem] failed: ${String(e).slice(0, 200)}`);
     }

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -98,6 +98,27 @@ RÉPONSE JSON OBLIGATOIRE (1 seul objet, pas de markdown) :
   "max_loss_usd": 18
 }
 
+CONTEXTE MACRO (input \`macro\` — snapshot LisaService) :
+- VIX > 30 = panique : refuse open_directional sauf setup A+ (conf ≥ 0.85)
+- VIX 20-30 = stressé : sizing -30%, privilégie close sur positions -EV
+- US10Y up > +10bps en intraday = pression rates : évite small caps + REITs
+- DXY spike + US10Y > 4.5% = flight from risk assets, prudence equities
+- Brent up > +5% intraday = risk geopolitique : prudence aero/airlines/EU
+- Gold up > +2% AVEC DXY down = flight to safety : refuse shorts risk-on
+- HY OAS > 500bps OU IG OAS > 150bps = credit stress, prudence cycliques
+- USDJPY breakdown < 145 = yen carry unwind, contagion risk-off (cf. août 2024)
+- Si \`macro.dataQuality.fallback\` contient ≥ 3 indicateurs → photo macro
+  dégradée, réduis ton sizing -30% ET ta confidence -0.05
+- Si \`macro.note = 'macro_snapshot_unavailable_this_cycle'\` → contexte aveugle,
+  refuse open_directional (uniquement close/trail_stop/hold autorisés)
+
+CONTEXTE NEWS (input \`news_recent\` — eodhd dernières 2h) :
+- Sentiment fort négatif (≤ -0.6) sur un ticker que tu DÉTIENS → propose close
+- Sentiment fort positif (≥ +0.7) sur un ticker dans candidates → bonus conviction
+- News macro vs news ticker : pondère la macro plus haut sur les décisions sizing
+- Évite d'ouvrir 5 minutes avant un événement \`macro.upcomingEvents\`
+  (FOMC, CPI, NFP) : volatilité non-directionnelle
+
 Sois rigoureux, conservateur, sceptique. Mieux vaut 5 holds qu'1 mauvais trade.`;
 
 @Injectable()

--- a/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
+++ b/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
@@ -32,26 +32,39 @@ export class ScannerLlmRouterService {
   private readonly logger = new Logger(ScannerLlmRouterService.name);
   private readonly enabled: boolean;
   private readonly router: MultiVendorLlmRouter | null;
+  // Router dédié aux raisonnements complexes (decisions trader agent, post-mortem,
+  // shadow sizing auto-correction). Chain : Gemini 2.5 Pro → Flash Lite → Claude Opus.
+  // Coût ~×125 vs flash-lite mais qualité de raisonnement multi-facteurs supérieure.
+  private readonly routerPro: MultiVendorLlmRouter | null;
 
   constructor(private readonly config: ConfigService) {
     this.enabled = (this.config.get<string>('SCANNER_LLM_ROUTER_ENABLED') ?? 'false').toLowerCase() === 'true';
 
     if (!this.enabled) {
       this.router = null;
-      this.logger.log('SCANNER_LLM_ROUTER_ENABLED=false — router inactive (legacy Claude path)');
+      this.routerPro = null;
+      this.logger.log('SCANNER_LLM_ROUTER_ENABLED=true — router inactive (legacy Claude path)');
       return;
     }
 
     // ADR-001 — Chain simplifiée : Gemini primary + Claude Opus fallback ultime.
-    // Suppression OpenAI + Mistral (était P17 fallback chain) : ne sont plus
-    // dans le contrat d'archi LLM. Réduit la surface providers à 2 (Google + Anthropic).
+    const geminiKey = this.config.get<string>('GEMINI_API_KEY');
     const anthropicKey = this.config.get<string>('ANTHROPIC_API_KEY');
     const claudeFallback = anthropicKey
       ? [new ClaudeProvider({ anthropic: new Anthropic({ apiKey: anthropicKey }) })]
       : [];
 
+    // Chain default (fast path scanner) : Flash Lite → Claude Opus
     const chain = [
-      new GeminiProvider({ apiKey: this.config.get<string>('GEMINI_API_KEY') }),
+      new GeminiProvider({ apiKey: geminiKey }),
+      ...claudeFallback,
+    ];
+
+    // Chain Pro (raisonnement) : Pro → Flash Lite → Claude Opus
+    // Si Pro fail (quota, timeout), on dégrade automatiquement.
+    const chainPro = [
+      new GeminiProvider({ apiKey: geminiKey, model: 'gemini-2.5-pro' }),
+      new GeminiProvider({ apiKey: geminiKey }),
       ...claudeFallback,
     ];
 
@@ -62,11 +75,20 @@ export class ScannerLlmRouterService {
         retryDelayMs: 1000,
         onCall: (m) => this.handleMetrics(m),
       });
+      // Timeout plus large pour Pro (raisonnement plus long, jusqu'à 15s observés).
+      this.routerPro = new MultiVendorLlmRouter(chainPro, {
+        timeoutMs: 20000,
+        retriesPerProvider: 1,
+        retryDelayMs: 1000,
+        onCall: (m) => this.handleMetrics(m),
+      });
       const active = this.router.getActiveProviders().map((p) => p.id).join(' → ');
-      this.logger.log(`SCANNER_LLM_ROUTER_ENABLED=true — chain: ${active}`);
+      const activePro = this.routerPro.getActiveProviders().map((p) => p.id).join(' → ');
+      this.logger.log(`SCANNER_LLM_ROUTER_ENABLED=true — fast chain: ${active} | pro chain: ${activePro}`);
     } catch (err) {
       this.logger.warn(`Router disabled — no provider configured: ${err instanceof Error ? err.message : err}`);
       this.router = null;
+      this.routerPro = null;
     }
   }
 
@@ -76,15 +98,34 @@ export class ScannerLlmRouterService {
   }
 
   /**
-   * Appel LLM via la chain. Ne lance jamais d'erreur de connectivité
-   * silencieuse — si tous les providers échouent, throw `AllProvidersFailedError`
-   * et le caller décide (fallback déterministe ou propagation).
+   * Appel LLM via la chain rapide (Flash Lite → Opus). Pour les tâches simples /
+   * volumineuses (scanner, screening, classification).
    */
   async call(params: LlmCallParams): Promise<{ content: string; providerId: string; costUsd: number; latencyMs: number; fallbackUsed: boolean }> {
     if (!this.router) {
       throw new Error('ScannerLlmRouterService.call() — router disabled (check SCANNER_LLM_ROUTER_ENABLED + GEMINI_API_KEY)');
     }
     const res = await this.router.call(params);
+    return {
+      content: res.content,
+      providerId: res.providerId,
+      costUsd: res.costUsd,
+      latencyMs: res.latencyMs,
+      fallbackUsed: res.fallbackUsed,
+    };
+  }
+
+  /**
+   * Appel LLM via la chain Pro (Gemini 2.5 Pro → Flash Lite → Opus).
+   * Pour les raisonnements multi-facteurs : décisions trader agent, post-mortem,
+   * auto-correction sizing. Coût ~×125 vs call() mais qualité supérieure.
+   * Auto-fallback sur Flash Lite si Pro indisponible (quota, timeout).
+   */
+  async callWithPro(params: LlmCallParams): Promise<{ content: string; providerId: string; costUsd: number; latencyMs: number; fallbackUsed: boolean }> {
+    if (!this.routerPro) {
+      throw new Error('ScannerLlmRouterService.callWithPro() — router disabled');
+    }
+    const res = await this.routerPro.call(params);
     return {
       content: res.content,
       providerId: res.providerId,

--- a/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
@@ -87,6 +87,17 @@ CONTRAINTES :
 - Privilégie kill > restart > tune > sizing en cas de doute (gestion du risque d'abord)
 - N'utilise PAS de connaissances externes — base tes décisions UNIQUEMENT sur les data fournies
 
+CONTEXTE MACRO (input \`macro\`) :
+- Pondère tes décisions selon le régime : VIX > 25 = risk-off, agressivité kill ↑ / raise_sizing ↓
+- DXY spike + US10Y > 4.5% = pressure sur risk assets, prudence
+- Si \`macro.dataQuality.fallback\` non vide → indicateurs dégradés, baisse ta confidence de 0.1
+
+CONTEXTE NEWS (input \`macro_news_digest\`, top 10 tier-1 dernières 2h) :
+- Sert UNIQUEMENT à contextualiser le régime narratif (pas à trader des tickers individuels)
+- Exemple : "5 news Fed pivot positifs + 2 news bank stress négatifs" → régime mixte, pas de raise_sizing
+- Si digest vide ou tous sentiment ~0 → marché calme, conditions normales
+- Ne cite pas les titres dans ta rationale (trop verbeux), mais réfère au régime narratif synthétisé
+
 RÉPONSE OBLIGATOIRE :
 Renvoie UN SEUL objet JSON minimal (pas de markdown, pas de \\\`\\\`\\\`json) avec cette shape exacte :
 {
@@ -545,6 +556,61 @@ export class ShadowSizingOrchestratorService {
   //   2. Capés par cycle (delta sizing ≤ 20%)
   //   3. Logués dans shadow_sizing_autotune_log (decision_kind='gemini_auto_apply')
   //
+  /**
+   * Macro news digest pour le contexte de raisonnement Gemini auto-tune.
+   *
+   * Filtre :
+   *  - dernières 2h (window de fraîcheur narratif)
+   *  - sources tier-1 uniquement (reuters, bloomberg, cnbc, marketwatch, wsj, ft)
+   *  - sentiment fort (|polarity| ≥ 0.5)
+   *  - dédupliqué par title (même article = plusieurs tickers dans la table)
+   *  - top 10 par |sentiment| × recency
+   *
+   * Best-effort : retourne `[]` si fail.
+   */
+  private async fetchMacroNewsDigest(): Promise<Array<{ title: string; sentiment: number; source: string; published_at: string; tags: string[] }>> {
+    const TIER_1_HOSTS = [
+      'reuters.com', 'bloomberg.com', 'cnbc.com', 'marketwatch.com',
+      'wsj.com', 'ft.com', 'nasdaq.com', 'finance.yahoo.com',
+    ];
+    const sinceIso = new Date(Date.now() - 2 * 60 * 60_000).toISOString();
+    try {
+      const { data } = await this.supabase.getClient()
+        .from('eodhd_news_articles')
+        .select('title, sentiment_polarity, source_url, published_at, tags')
+        .gte('published_at', sinceIso)
+        .order('published_at', { ascending: false })
+        .limit(150);  // fetch large pour dédup, filter ensuite
+      if (!data || data.length === 0) return [];
+
+      // Filter + extract host + dédup
+      const seenTitles = new Set<string>();
+      const out: Array<{ title: string; sentiment: number; source: string; published_at: string; tags: string[] }> = [];
+      for (const r of data) {
+        const title = String(r.title ?? '').trim();
+        if (!title || seenTitles.has(title)) continue;
+        const sent = Number(r.sentiment_polarity);
+        if (!Number.isFinite(sent) || Math.abs(sent) < 0.5) continue;
+        const host = (String(r.source_url ?? '').match(/\/\/([^/]+)/)?.[1] ?? '').toLowerCase();
+        if (!TIER_1_HOSTS.some((h) => host.includes(h))) continue;
+        seenTitles.add(title);
+        const tags = Array.isArray(r.tags) ? (r.tags as string[]).slice(0, 5) : [];
+        out.push({
+          title: title.slice(0, 140),
+          sentiment: Number(sent.toFixed(2)),
+          source: host,
+          published_at: String(r.published_at).slice(0, 16),
+          tags,
+        });
+        if (out.length >= 10) break;
+      }
+      return out;
+    } catch (e) {
+      this.logger.warn(`[shadow-sizing-gemini] news digest fetch failed: ${String(e).slice(0, 100)}`);
+      return [];
+    }
+  }
+
   // Gated par SHADOW_SIZING_GEMINI_ENABLED=true (default OFF — safe MVP).
   // Si false, la méthode no-op silencieusement.
   private async geminiDrivenAutoCorrection(snapshots: ProfileSnapshot[]): Promise<void> {
@@ -587,12 +653,18 @@ export class ShadowSizingOrchestratorService {
       macro = { note: 'macro_snapshot_unavailable_this_cycle' };
     }
 
+    // Macro news digest : 10 titres tier-1 sentiment fort, < 2h, dédupliqués.
+    // But : enrichir le contexte de raisonnement sizing avec le régime narratif
+    // sans noise (per-ticker news non pertinent à ce niveau méta).
+    const newsDigest = await this.fetchMacroNewsDigest();
+
     const systemPrompt = SHADOW_SIZING_GEMINI_SYSTEM_PROMPT;
     const userPrompt = JSON.stringify({
       current_time_utc: new Date().toISOString(),
       target_usd_per_day: DAILY_TARGET_USD,
       drawdown_kill_threshold_pct: DRAWDOWN_KILL_PCT,
       macro,
+      macro_news_digest: newsDigest,
       profiles: snapshots.map((s) => ({
         name: s.profileName,
         portfolio_id: s.portfolioId.slice(0, 8),

--- a/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
@@ -576,11 +576,23 @@ export class ShadowSizingOrchestratorService {
       recentDecisions[snap.profileName] = (decisions ?? []) as object[];
     }
 
+    // Macro context (cache 2 min côté LisaService — partagé avec LiveTraderAgent).
+    // Critique pour contextualiser les décisions kill/raise/lower (un drawdown en VIX 35
+    // ne se traite pas comme un drawdown en VIX 14).
+    let macro: object;
+    try {
+      macro = await this.lisa.getRecentMarketSnapshot(120);
+    } catch (e) {
+      this.logger.warn(`[shadow-sizing-gemini] macro fetch failed: ${String(e).slice(0, 100)}`);
+      macro = { note: 'macro_snapshot_unavailable_this_cycle' };
+    }
+
     const systemPrompt = SHADOW_SIZING_GEMINI_SYSTEM_PROMPT;
     const userPrompt = JSON.stringify({
       current_time_utc: new Date().toISOString(),
       target_usd_per_day: DAILY_TARGET_USD,
       drawdown_kill_threshold_pct: DRAWDOWN_KILL_PCT,
+      macro,
       profiles: snapshots.map((s) => ({
         name: s.profileName,
         portfolio_id: s.portfolioId.slice(0, 8),
@@ -600,14 +612,16 @@ export class ShadowSizingOrchestratorService {
       recent_decisions_per_profile: recentDecisions,
     }, null, 2);
 
+    // Gemini Pro pour le raisonnement sizing — qualité supérieure sur l'analyse
+    // comparative multi-profiles + macro. Auto-fallback Flash Lite si Pro down.
     let response: { content: string; providerId: string; costUsd: number; latencyMs: number };
     try {
-      response = await this.llmRouter.call({
+      response = await this.llmRouter.callWithPro({
         system: systemPrompt,
         user: userPrompt,
         temperature: 0.2,
         maxTokens: 800,
-        timeoutMs: 10_000,
+        timeoutMs: 20_000,
       });
     } catch (e) {
       this.logger.warn(`[shadow-sizing-gemini] LLM call failed: ${String(e).slice(0, 150)}`);

--- a/packages/ai-analyst/src/llm/providers/gemini-provider.ts
+++ b/packages/ai-analyst/src/llm/providers/gemini-provider.ts
@@ -1,14 +1,21 @@
 /**
- * P17 — Adapter Google GenAI (Gemini 2.5 Flash-Lite).
+ * P17 — Adapter Google GenAI (Gemini 2.5 Flash-Lite par défaut).
  * Provider PRIMAIRE de la chaîne fallback (bench P16 winner).
  *
- * Pricing avril 2026 : $0.10 input / $0.40 output par 1M tokens.
+ * Pricing avril 2026 (par 1M tokens) :
+ *   - gemini-2.5-flash-lite : $0.10 input / $0.40 output  (default, scanner fast path)
+ *   - gemini-2.5-flash      : $0.30 input / $2.50 output  (grounded search)
+ *   - gemini-2.5-pro        : $1.25 input / $10.00 output (raisonnement complexe, post-mortem, decisions trader)
  */
 
 import type { LlmCallParams, LlmCallResult, LlmProvider } from './types';
 
-const PRICE_INPUT_PER_M = 0.10;
-const PRICE_OUTPUT_PER_M = 0.40;
+const PRICE_INPUT_PER_M_FLASH_LITE = 0.10;
+const PRICE_OUTPUT_PER_M_FLASH_LITE = 0.40;
+const PRICE_INPUT_PER_M_FLASH = 0.30;
+const PRICE_OUTPUT_PER_M_FLASH = 2.50;
+const PRICE_INPUT_PER_M_PRO = 1.25;
+const PRICE_OUTPUT_PER_M_PRO = 10.00;
 
 export interface GeminiProviderConfig {
   apiKey: string | undefined;
@@ -16,13 +23,18 @@ export interface GeminiProviderConfig {
 }
 
 export class GeminiProvider implements LlmProvider {
-  readonly id = 'gemini-flash-lite';
+  readonly id: string;
   readonly model: string;
   private readonly apiKey: string | undefined;
 
   constructor(config: GeminiProviderConfig) {
     this.apiKey = config.apiKey;
     this.model = config.model ?? 'gemini-2.5-flash-lite';
+    // id dérivé du model pour distinguer les instances dans le router/logs.
+    if (this.model.includes('pro')) this.id = 'gemini-pro';
+    else if (this.model.includes('flash-lite')) this.id = 'gemini-flash-lite';
+    else if (this.model.includes('flash')) this.id = 'gemini-flash';
+    else this.id = `gemini-${this.model}`;
   }
 
   isConfigured(): boolean {
@@ -40,12 +52,7 @@ export class GeminiProvider implements LlmProvider {
     // coverage faible. Coût ajouté ~$35/1000 grounded queries.
     //
     // ⚠️ gemini-2.5-flash-lite NE SUPPORTE PAS googleSearch tool.
-    // Détecté 26/05 : latency 500-900ms (vs grounded = 1.5-3s attendus) →
-    // le tool est silencieusement ignoré par flash-lite. Override modèle vers
-    // gemini-2.5-flash quand grounding demandé. Coût marginal :
-    //   - flash-lite : $0.10 / $0.40 par 1M tokens (input/output)
-    //   - flash      : $0.30 / $2.50 par 1M tokens (3× input, 6× output)
-    // Pour RM V2 (~14 positions × cron 5min × ~500 tokens) ≈ +$2-5/jour.
+    // Override modèle vers flash quand grounding demandé.
     const grounded = !!params.enableSearchGrounding;
     const tools = grounded ? [{ googleSearch: {} as Record<string, never> }] : undefined;
     const effectiveModel = grounded && this.model.includes('flash-lite')
@@ -67,9 +74,19 @@ export class GeminiProvider implements LlmProvider {
 
     const inputTokens = res.usageMetadata?.promptTokenCount ?? 0;
     const outputTokens = res.usageMetadata?.candidatesTokenCount ?? 0;
-    // Pricing différencié si on a switch vers flash (×3 input, ×6 output)
-    const inputPrice = grounded ? 0.30 : PRICE_INPUT_PER_M;
-    const outputPrice = grounded ? 2.50 : PRICE_OUTPUT_PER_M;
+    // Pricing par effectiveModel (grounded override prioritaire)
+    const isPro = effectiveModel.includes('pro');
+    const isFlashFull = effectiveModel.includes('flash') && !effectiveModel.includes('flash-lite');
+    const inputPrice = isPro
+      ? PRICE_INPUT_PER_M_PRO
+      : isFlashFull
+        ? PRICE_INPUT_PER_M_FLASH
+        : PRICE_INPUT_PER_M_FLASH_LITE;
+    const outputPrice = isPro
+      ? PRICE_OUTPUT_PER_M_PRO
+      : isFlashFull
+        ? PRICE_OUTPUT_PER_M_FLASH
+        : PRICE_OUTPUT_PER_M_FLASH_LITE;
     const costUsd = (inputTokens * inputPrice + outputTokens * outputPrice) / 1_000_000;
 
     return {


### PR DESCRIPTION
## Summary

4 upgrades sur la qualité décisionnelle des deux agents Gemini autonomes.

### 1. Force Gemini 2.5 Pro
- `GeminiProvider` : id dynamique selon model (gemini-pro / gemini-flash / gemini-flash-lite) + pricing différencié ($1.25/$10 vs $0.10/$0.40 par 1M tokens)
- `ScannerLlmRouterService` : nouveau `routerPro` avec chaîne Pro → Flash Lite → Claude Opus (auto-fallback) + méthode `callWithPro()`
- `LiveTraderAgent` (cycle décision + post-mortem nightly) + `ShadowSizingOrchestrator.geminiDrivenAutoCorrection` : tous les appels LLM passent désormais par `callWithPro`

### 2. Macro snapshot frais (cache TTL 120s)
- `LisaService.getRecentMarketSnapshot(maxAgeSec)` : cache léger partagé
- `LiveTraderAgent.fetchMacroContext` lisait un champ inexistant (`lastMarketSnapshot`) → toujours undefined → fallback. Désormais lit le cache.
- `ShadowSizingOrchestrator` injecte macro dans le user prompt — critique pour pondérer un drawdown selon régime VIX

### 3. Wire close / scale_in / trail_stop dans LiveTraderAgent
- `LisaService.closeForOpportunityScout` : miroir de openForOpportunityScout (positionId + livePrice + reason + rationale)
- `applyDecision` :
  - `close` : résout symbol → positionId via state.openPositions + paperBroker
  - `scale_in` : nouvelle open_directional sur symbol déjà détenu, notional capé à 150% du sizing standard
  - `trail_stop` : UPDATE `lisa_positions.stop_loss_price` avec garde-fou "stricter only" (refuse loosening)
- `open_pairs` reste non câblé (rare, follow-up PR)

### Coûts estimés
- Pro Trader Agent : 288 cycles × ~1500 tokens × Pro pricing ≈ $1.5-3/jour (vs $0.06 en Flash Lite)
- Pro Shadow Sizing : 288 cycles × ~1000 tokens × Pro ≈ $0.5-1/jour
- Macro fetch : 1 fetch par 2min × 2 services = inchangé (cache partagé)

## Test plan

- [x] `tsc -p apps/api --noEmit` OK
- [x] `npm run build --workspace=@smartvest/ai-analyst` OK
- [ ] Post-deploy : vérifier `gemini_provider='gemini-pro'` dans nouvelles rows `trader_agent_decisions`
- [ ] Post-deploy : vérifier que `input_macro` n'est plus `{note:'unavailable'}` dans les nouvelles décisions
- [ ] Post-deploy : si Gemini propose un `close`/`scale_in`/`trail_stop`, vérifier `action_applied=true` dans la row correspondante

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_