### PR TITLE
fix(gemini-pro): auto-fallback Pro→Flash Lite + DB error log

### DIFF
--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -224,7 +224,19 @@ export class LiveTraderAgentService {
           timeoutMs: 20_000,
         });
       } catch (e) {
-        this.logger.warn(`[trader-agent] LLM call failed: ${String(e).slice(0, 150)}`);
+        const errMsg = `LLM call failed: ${String(e).slice(0, 200)}`;
+        this.logger.warn(`[trader-agent] ${errMsg}`);
+        // Persist le fail en DB pour visibilité sans accès Fly logs.
+        await this.logDecision({
+          cycleStartedAt, state,
+          candidates, macro, news, memory,
+          action: 'hold' as const,
+          actionKindOverride: 'skip_safety_bound',
+          notionalUsd: 0, confidence: 0,
+          thesis: `LLM unavailable: ${errMsg}`,
+          applied: false,
+          applyError: errMsg,
+        }).catch(() => null);
         return;
       }
 

--- a/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
+++ b/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
@@ -119,19 +119,41 @@ export class ScannerLlmRouterService {
    * Appel LLM via la chain Pro (Gemini 2.5 Pro → Flash Lite → Opus).
    * Pour les raisonnements multi-facteurs : décisions trader agent, post-mortem,
    * auto-correction sizing. Coût ~×125 vs call() mais qualité supérieure.
-   * Auto-fallback sur Flash Lite si Pro indisponible (quota, timeout).
+   *
+   * Stratégie défensive : si la chain Pro entière fail (AllProvidersFailedError
+   * ou exception non capturée), on retombe automatiquement sur la chain rapide
+   * call() (Flash Lite → Opus). Garantit qu'un consumer ne se retrouve JAMAIS
+   * silencieusement skipé à cause d'un quota/modèle Pro indisponible.
    */
   async callWithPro(params: LlmCallParams): Promise<{ content: string; providerId: string; costUsd: number; latencyMs: number; fallbackUsed: boolean }> {
-    if (!this.routerPro) {
-      throw new Error('ScannerLlmRouterService.callWithPro() — router disabled');
+    if (this.routerPro) {
+      try {
+        const res = await this.routerPro.call(params);
+        return {
+          content: res.content,
+          providerId: res.providerId,
+          costUsd: res.costUsd,
+          latencyMs: res.latencyMs,
+          fallbackUsed: res.fallbackUsed,
+        };
+      } catch (e) {
+        this.logger.warn(
+          `[scanner-llm] callWithPro routerPro failed → fallback to fast chain. err=${String(e).slice(0, 200)}`,
+        );
+        // tombe sur le fast path ci-dessous
+      }
     }
-    const res = await this.routerPro.call(params);
+    // Fallback : Flash Lite → Opus (la chain "call" classique).
+    if (!this.router) {
+      throw new Error('ScannerLlmRouterService.callWithPro() — both routerPro and router disabled');
+    }
+    const res = await this.router.call(params);
     return {
       content: res.content,
-      providerId: res.providerId,
+      providerId: `${res.providerId}-via-pro-fallback`,
       costUsd: res.costUsd,
       latencyMs: res.latencyMs,
-      fallbackUsed: res.fallbackUsed,
+      fallbackUsed: true,
     };
   }
 

--- a/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
@@ -696,7 +696,20 @@ export class ShadowSizingOrchestratorService {
         timeoutMs: 20_000,
       });
     } catch (e) {
-      this.logger.warn(`[shadow-sizing-gemini] LLM call failed: ${String(e).slice(0, 150)}`);
+      const errMsg = `LLM call failed: ${String(e).slice(0, 200)}`;
+      this.logger.warn(`[shadow-sizing-gemini] ${errMsg}`);
+      // Persist le fail en DB pour visibilité sans accès Fly logs.
+      await this.logAutoTune({
+        portfolioId: snapshots[0].portfolioId,
+        profileName: 'gemini_fail',
+        decisionKind: 'no_action',
+        triggerMetric: 'gemini_llm_error',
+        triggerValue: 0,
+        thresholdValue: 0,
+        actionApplied: false,
+        rationale: `🤖 Gemini call FAILED — ${errMsg}`,
+        payload: { error: errMsg },
+      }).catch(() => null);
       return;
     }
 


### PR DESCRIPTION
## Summary

PR #480 a forcé Gemini 2.5 Pro sur Trader Agent + Shadow Sizing via `callWithPro()`. Observation prod immédiate post-deploy : Trader Agent stoppe d'écrire (last row 03:20:01 UTC, puis silence total), Shadow Sizing Gemini block ne tourne plus non plus, **aucune trace `[trader-agent]` ni `[shadow-sizing-gemini]` dans Fly logs** (même pas le warn `LLM call failed`).

Le scanner principal Gainers continue de tourner normalement avec `call()` (Flash Lite) — donc le router fonctionne. Seul `callWithPro()` throw silencieusement. Hypothèse : `gemini-2.5-pro` pas accessible avec la clé `GEMINI_API_KEY` actuelle (quota / model API gating).

## Fix défensif en 3 niveaux

1. **`ScannerLlmRouterService.callWithPro`** : si `routerPro` fail (any throw), **fallback automatique sur `this.router`** (Flash Lite → Opus). Garantit que `callWithPro` ne throw JAMAIS si au moins un router est dispo. `providerId` taggé `-via-pro-fallback` pour audit.

2. **`LiveTraderAgent.runDecisionCycle`** : si `callWithPro` throw (cas extrême : les 2 routers down) → persiste une row `trader_agent_decisions` avec `action_kind='skip_safety_bound'` + `apply_error` complet. Plus de silence DB.

3. **`ShadowSizingOrchestrator.geminiDrivenAutoCorrection`** : si `callWithPro` throw → log row `shadow_sizing_autotune_log` avec `decision_kind='no_action'` + `trigger_metric='gemini_llm_error'` + `rationale` détaillé. Visibilité DB sans accès Fly logs.

Résultat attendu post-deploy : soit Gemini Pro est OK et tout marche, soit le fallback Flash Lite reprend automatiquement, soit on voit l'erreur exacte en DB pour debug.

## Test plan

- [x] `tsc -p apps/api --noEmit` OK
- [ ] Post-deploy : vérifier `trader_agent_decisions` reçoit des rows à nouveau (cron 5min)
- [ ] Vérifier `gemini_provider` dans les rows — soit `gemini-pro` (Pro OK), soit `gemini-flash-lite-via-pro-fallback` (Pro down, fallback OK)
- [ ] Si Pro est down, log dans Fly : `[scanner-llm] callWithPro routerPro failed → fallback to fast chain. err=...` donnera la cause exacte

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_