### PR TITLE
diag: logs inconditionnels Trader Agent + Shadow Sizing

### DIFF
--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -135,8 +135,13 @@ export class LiveTraderAgentService {
   ) {}
 
   onModuleInit(): void {
-    this.enabled = (this.config.get<string>('LIVE_TRADER_AGENT_ENABLED') ?? 'false')
-      .toLowerCase() === 'true';
+    const raw = this.config.get<string>('LIVE_TRADER_AGENT_ENABLED');
+    this.enabled = (raw ?? 'false').toLowerCase() === 'true';
+    // Log TOUJOURS (même si disabled) pour visibilité boot — sinon on ne sait
+    // pas si onModuleInit est appelé OU si le flag est mal lu.
+    this.logger.log(
+      `[trader-agent] onModuleInit fired — LIVE_TRADER_AGENT_ENABLED raw="${raw}" parsed_enabled=${this.enabled}`,
+    );
     if (this.enabled) {
       this.logger.log(
         `[trader-agent] ENABLED — portfolio=${TRADER_AGENT_PORTFOLIO_ID.slice(0, 8)} capital=$${TRADER_AGENT_CAPITAL_USD} cron */5min`,
@@ -149,6 +154,8 @@ export class LiveTraderAgentService {
    */
   @Cron('*/5 * * * *', { name: 'live-trader-agent-decision', timeZone: 'UTC' })
   async runDecisionCycle(): Promise<void> {
+    // Log inconditionnel chaque tick pour vérifier que le cron tire vraiment.
+    this.logger.log(`[trader-agent] cron tick @ ${new Date().toISOString()} enabled=${this.enabled} supabase=${this.supabase.isReady()} llmRouter=${this.llmRouter.isEnabled()}`);
     if (!this.enabled) return;
     if (!this.supabase.isReady()) return;
     if (!this.llmRouter.isEnabled()) {

--- a/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
@@ -145,11 +145,16 @@ export class ShadowSizingOrchestratorService {
   ) {}
 
   onModuleInit(): void {
-    this.enabled = (this.config.get<string>('SHADOW_SIZING_ORCHESTRATOR_ENABLED') ?? 'false')
-      .toLowerCase() === 'true';
+    const raw = this.config.get<string>('SHADOW_SIZING_ORCHESTRATOR_ENABLED');
+    const rawGem = this.config.get<string>('SHADOW_SIZING_GEMINI_ENABLED');
+    this.enabled = (raw ?? 'false').toLowerCase() === 'true';
+    // Log TOUJOURS pour visibilité boot.
+    this.logger.log(
+      `[shadow-sizing] onModuleInit fired — SHADOW_SIZING_ORCHESTRATOR_ENABLED raw="${raw}" parsed_enabled=${this.enabled} | SHADOW_SIZING_GEMINI_ENABLED raw="${rawGem}"`,
+    );
     if (this.enabled) {
       this.logger.log(
-        `[shadow-sizing] ENABLED — cron */30min, target=$${DAILY_TARGET_USD}/d, drawdown_kill=${DRAWDOWN_KILL_PCT}%`,
+        `[shadow-sizing] ENABLED — cron */5min, target=$${DAILY_TARGET_USD}/d, drawdown_kill=${DRAWDOWN_KILL_PCT}%`,
       );
     }
   }
@@ -161,6 +166,8 @@ export class ShadowSizingOrchestratorService {
    */
   @Cron('*/5 * * * *', { name: 'shadow-sizing-orchestrator', timeZone: 'UTC' })
   async runCycle(): Promise<void> {
+    // Log inconditionnel chaque tick.
+    this.logger.log(`[shadow-sizing] cron tick @ ${new Date().toISOString()} enabled=${this.enabled} supabase=${this.supabase.isReady()}`);
     if (!this.enabled) return;
     if (!this.supabase.isReady()) return;
 


### PR DESCRIPTION
## Diagnostic actif

Post PR #481/#482 : Trader Agent + Shadow Sizing toujours silencieux malgré tous les fixes. Les logs Fly ne révèlent rien parce que tous les `[trader-agent]` et `[shadow-sizing]` logs sont conditionnés par `enabled=true`.

## Fix

Logs **toujours visibles** :
- `onModuleInit` : print raw value du flag + parsed enabled
- `runCycle` / `runDecisionCycle` : print à chaque tick avec status enabled/supabase/llmRouter

## Diagnostic possible en 1 cycle (5min)

Au prochain boot + tick, on saura LITTÉRALEMENT :
1. Est-ce que `onModuleInit` est appelé ?
2. Quelle est la valeur RAW de `LIVE_TRADER_AGENT_ENABLED` et `SHADOW_SIZING_ORCHESTRATOR_ENABLED` ?
3. Est-ce que le cron tire ?
4. Quelle dépendance (enabled/supabase/llmRouter) bloque ?

## Test plan

- [x] `tsc -p apps/api --noEmit` OK
- [ ] Post-deploy : grep `fly logs` pour `\[trader-agent\] onModuleInit fired` et `\[shadow-sizing\] onModuleInit fired`
- [ ] Tick suivant : `\[trader-agent\] cron tick @ ...`

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_