### PR TITLE
diag: write boot sentinel rows to DB

### DIFF
--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -137,16 +137,33 @@ export class LiveTraderAgentService {
   onModuleInit(): void {
     const raw = this.config.get<string>('LIVE_TRADER_AGENT_ENABLED');
     this.enabled = (raw ?? 'false').toLowerCase() === 'true';
-    // Log TOUJOURS (même si disabled) pour visibilité boot — sinon on ne sait
-    // pas si onModuleInit est appelé OU si le flag est mal lu.
     this.logger.log(
       `[trader-agent] onModuleInit fired — LIVE_TRADER_AGENT_ENABLED raw="${raw}" parsed_enabled=${this.enabled}`,
     );
+    // PREUVE DB sentinel : écrit une row trader_agent_decisions au boot pour
+    // prouver que onModuleInit est appelé (sans dépendre des Fly logs).
+    // Tag distinctif via action_kind='hold' + thesis='[BOOT_SENTINEL]'.
+    this.writeBootSentinel(raw).catch(() => null);
     if (this.enabled) {
       this.logger.log(
         `[trader-agent] ENABLED — portfolio=${TRADER_AGENT_PORTFOLIO_ID.slice(0, 8)} capital=$${TRADER_AGENT_CAPITAL_USD} cron */5min`,
       );
     }
+  }
+
+  private async writeBootSentinel(rawFlag: string | undefined): Promise<void> {
+    if (!this.supabase.isReady()) return;
+    const now = new Date();
+    await this.supabase.getClient().from('trader_agent_decisions').insert({
+      portfolio_id: TRADER_AGENT_PORTFOLIO_ID,
+      cycle_started_at: now.toISOString(),
+      input_state: { boot_sentinel: true, raw_flag: rawFlag ?? 'undefined', parsed_enabled: this.enabled },
+      action_kind: 'hold',
+      thesis: `[BOOT_SENTINEL] onModuleInit fired @ ${now.toISOString()} — flag raw="${rawFlag}" parsed=${this.enabled}`,
+      confidence: 0,
+      action_applied: false,
+      apply_error: '[BOOT_SENTINEL] proof onModuleInit was called',
+    });
   }
 
   /**

--- a/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
@@ -148,15 +148,32 @@ export class ShadowSizingOrchestratorService {
     const raw = this.config.get<string>('SHADOW_SIZING_ORCHESTRATOR_ENABLED');
     const rawGem = this.config.get<string>('SHADOW_SIZING_GEMINI_ENABLED');
     this.enabled = (raw ?? 'false').toLowerCase() === 'true';
-    // Log TOUJOURS pour visibilité boot.
     this.logger.log(
       `[shadow-sizing] onModuleInit fired — SHADOW_SIZING_ORCHESTRATOR_ENABLED raw="${raw}" parsed_enabled=${this.enabled} | SHADOW_SIZING_GEMINI_ENABLED raw="${rawGem}"`,
     );
+    // PREUVE DB sentinel : écrit une row shadow_sizing_autotune_log au boot.
+    this.writeBootSentinel(raw, rawGem).catch(() => null);
     if (this.enabled) {
       this.logger.log(
         `[shadow-sizing] ENABLED — cron */5min, target=$${DAILY_TARGET_USD}/d, drawdown_kill=${DRAWDOWN_KILL_PCT}%`,
       );
     }
+  }
+
+  private async writeBootSentinel(raw: string | undefined, rawGem: string | undefined): Promise<void> {
+    if (!this.supabase.isReady()) return;
+    const now = new Date();
+    await this.supabase.getClient().from('shadow_sizing_autotune_log').insert({
+      portfolio_id: SHADOW_PORTFOLIOS[0].id,
+      profile_name: 'boot_sentinel',
+      decision_kind: 'no_action',
+      trigger_metric: 'boot_sentinel',
+      trigger_value: 0,
+      threshold_value: 0,
+      action_applied: false,
+      rationale: `[BOOT_SENTINEL] onModuleInit fired @ ${now.toISOString()} — ORCH raw="${raw}" parsed=${this.enabled} | GEM raw="${rawGem}"`,
+      payload: { boot_sentinel: true, raw_flag: raw, raw_gem: rawGem, parsed_enabled: this.enabled },
+    });
   }
 
   /**


### PR DESCRIPTION
## Diagnostic définitif sans logs Fly

Pousse une **preuve DB** : `onModuleInit` écrit une row sentinel dans `trader_agent_decisions` (tag `[BOOT_SENTINEL]`) et `shadow_sizing_autotune_log` (profile_name `boot_sentinel`).

Après deploy :
- Row présente → onModuleInit appelé, on saura la VRAIE valeur des flags
- Row absente → service jamais instancié = problème wiring NestJS (DI, dépendance circulaire, throw silencieux)

Pas de polling logs nécessaire — query directe Supabase suffit.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_