### PR TITLE
fix(trader-agent): Promise.allSettled pour éviter throw silencieux

### DIFF
--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -284,13 +284,25 @@ export class LiveTraderAgentService {
         return;
       }
 
-      // 3. Fetch candidates + macro + news + memory
-      const [candidates, macro, news, memory] = await Promise.all([
+      // 3. Fetch candidates + macro + news + memory — chaque fetch en allSettled
+      // pour qu'un échec individuel (DB query fail, API down) ne stoppe pas le
+      // cycle entier. Fallback aux valeurs vides en cas de fail.
+      const settled = await Promise.allSettled([
         this.fetchTopCandidates(20),
         this.fetchMacroContext(),
         this.fetchRecentNews(10),
         this.fetchActiveMemory(50),
       ]);
+      const candidates = settled[0].status === 'fulfilled' ? settled[0].value : [];
+      const macro = settled[1].status === 'fulfilled' ? settled[1].value : { note: 'macro_fetch_failed' };
+      const news = settled[2].status === 'fulfilled' ? settled[2].value : [];
+      const memory = settled[3].status === 'fulfilled' ? settled[3].value : [];
+      const fetchFailures = settled
+        .map((s, i) => s.status === 'rejected' ? `${['candidates','macro','news','memory'][i]}=${String(s.reason).slice(0,80)}` : null)
+        .filter((x) => x !== null);
+      if (fetchFailures.length > 0) {
+        this.logger.warn(`[trader-agent] fetch partial failures: ${fetchFailures.join(' | ')}`);
+      }
 
       // 4. Build system + user prompts
       const systemPrompt = this.buildSystemPrompt(memory);


### PR DESCRIPTION
## Fix le 2ème blocage : cycle complet plante post-CYCLE_TICK

PR #486 a fait tirer le cron (sentinels CYCLE_TICK écrits à 06:05:00 et 06:10:00 ✅). Mais le cycle complet ne s'exécute pas — uniquement le sentinel apparaît, jamais de décision Gemini.

Cause : `Promise.all([fetchTopCandidates, fetchMacroContext, fetchRecentNews, fetchActiveMemory])` — si un seul fetch throw (ex: DB query fail, EODHD weekend skip, etc.), le throw remonte au catch outer qui logue error et drop le cycle.

## Fix

`Promise.allSettled` + fallback par fetch. Le cycle continue avec contexte partiellement vide même si 1-2 fetches échouent. Log warn liste les fetches en échec pour audit.

## Test plan

- [x] `tsc -p apps/api --noEmit` OK
- [ ] Post-deploy : `trader_agent_decisions` reçoit une vraie décision (`[REAL]` row avec `gemini_provider` set, pas juste `[SENTINEL]`) au prochain tick `*/5`

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_