### PR TITLE
feat(scanner-postmortem): apprentissage Gemini Pro daily (Phase 2)

### DIFF
--- a/apps/api/src/modules/admin/admin-scanner-postmortem.controller.ts
+++ b/apps/api/src/modules/admin/admin-scanner-postmortem.controller.ts
@@ -1,0 +1,56 @@
+/**
+ * Endpoints admin pour MainScannerPostMortemService.
+ *
+ * GET  /admin/scanner-postmortem/status         — lessons actives + flag enabled
+ * POST /admin/scanner-postmortem/run            — déclenche un post-mortem ad-hoc (utile pour tester sans attendre 02:30 UTC)
+ *   body: { windowHours?: number, default 24 }
+ *
+ * Auth : header x-admin-token aligné sur AdminTraderAgentController.
+ */
+
+import { Body, Controller, Get, Headers, HttpException, HttpStatus, Logger, Post } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { MainScannerPostMortemService } from '../lisa/services/main-scanner-postmortem.service';
+
+@Controller('admin/scanner-postmortem')
+export class AdminScannerPostMortemController {
+  private readonly logger = new Logger(AdminScannerPostMortemController.name);
+
+  constructor(
+    private readonly postMortem: MainScannerPostMortemService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Get('status')
+  async getStatus(@Headers('x-admin-token') providedToken: string | undefined) {
+    this.assertAdmin(providedToken);
+    return this.postMortem.getStatus();
+  }
+
+  @Post('run')
+  async run(
+    @Headers('x-admin-token') providedToken: string | undefined,
+    @Body() body: { windowHours?: number } | undefined,
+  ) {
+    this.assertAdmin(providedToken);
+    const windowHours = body?.windowHours && body.windowHours > 0 ? Math.min(168, body.windowHours) : 24;
+    this.logger.log(`[admin/scanner-postmortem] manual run, window=${windowHours}h`);
+    return this.postMortem.runPostMortem(windowHours);
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (providedToken !== expected) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'ADMIN_FORBIDDEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -42,6 +42,7 @@ import { AdminResearchController } from './admin-research.controller';
 import { AdminDebateGateMetricsController } from './admin-debate-gate-metrics.controller';
 import { AdminShadowSizingController } from './admin-shadow-sizing.controller';
 import { AdminTraderAgentController } from './admin-trader-agent.controller';
+import { AdminScannerPostMortemController } from './admin-scanner-postmortem.controller';
 import { AdminMarketCloseReportsController } from './admin-market-close-reports.controller';
 
 @Module({
@@ -76,6 +77,8 @@ import { AdminMarketCloseReportsController } from './admin-market-close-reports.
     AdminShadowSizingController,
     // Live Trader Agent (Gemini Pro) — observability + status portfolio dédié $10k
     AdminTraderAgentController,
+    // Scanner Post-Mortem (Gemini Pro) — lessons macro-conditionnelles + run manuel
+    AdminScannerPostMortemController,
     // Market Close Reports — comparatif 5 portfolios par session (Asia/EU/US + daily wrap)
     AdminMarketCloseReportsController,
   ],

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -52,6 +52,7 @@ import { TopGainersScannerService } from './services/top-gainers-scanner.service
 import { GainersUserShadowService } from './services/gainers-user-shadow.service';
 import { ShadowSizingOrchestratorService } from './services/shadow-sizing-orchestrator.service';
 import { LiveTraderAgentService } from './services/live-trader-agent.service';
+import { MainScannerPostMortemService } from './services/main-scanner-postmortem.service';
 import { MarketCloseReportService } from './services/market-close-report.service';
 import { GainersAutoRelaxService } from './services/gainers-auto-relax.service';
 import { PostSlBackfillService } from './services/post-sl-backfill.service';
@@ -193,6 +194,9 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     // Live Trader Agent — portfolio dédié $10k piloté à 100% par Gemini Pro.
     // Cron 5min decision + cron 02:00 UTC post-mortem nightly + memory store.
     LiveTraderAgentService,
+    // MainScannerPostMortemService — apprentissage Gemini Pro sur le scanner gainers
+    // (cron 02:30 UTC : analyse 24h × 4 portfolios → lessons macro-conditionnelles).
+    MainScannerPostMortemService,
     // Market Close Reports — comparatif 5 portfolios à chaque cloche (Asia/EU/US) + daily wrap.
     MarketCloseReportService,
     // PR #282 — Auto-relax adaptive : lit cumulative_regret 7j et propose/auto-applique relax
@@ -349,6 +353,8 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     ShadowSizingOrchestratorService,
     // Export pour AdminTraderAgentController (cf. /admin/trader-agent/status).
     LiveTraderAgentService,
+    // Export pour AdminScannerPostMortemController (cf. /admin/scanner-postmortem/{status,run}).
+    MainScannerPostMortemService,
     // Export pour AdminMarketCloseReportsController.
     MarketCloseReportService,
   ],

--- a/apps/api/src/modules/lisa/services/main-scanner-postmortem.service.ts
+++ b/apps/api/src/modules/lisa/services/main-scanner-postmortem.service.ts
@@ -1,0 +1,398 @@
+/**
+ * MainScannerPostMortemService — apprentissage Gemini Pro sur le scanner gainers.
+ *
+ * Le scanner gainers est volontairement déterministe (cf. ADR P19). Il ne s'auto-
+ * corrige pas. Cette classe comble le gap en :
+ *   1. Collectant chaque nuit (cron 02:30 UTC) les closed trades 24h × 4 portfolios
+ *      (MAIN + HIGH + MIDDLE + SMALL)
+ *   2. Récupérant le funnel stats (gainers_user_shadow_signals) — quels gates ont bloqué quoi
+ *   3. Récupérant le snapshot macro du jour (régime VIX/DXY/US10Y/HY OAS/etc.)
+ *   4. Demandant à Gemini Pro de générer des lessons macro-conditionnelles
+ *      ("Quand VIX>25 + Korea KOSDAQ + path_eff<0.5 → 100% perdants → désactiver"
+ *      avec sample_size, win_rate, proposed_config_change)
+ *   5. Persistant dans `scanner_lessons` (migration 0170)
+ *
+ * Gating ENV (default OFF) :
+ *   - MAIN_SCANNER_POSTMORTEM_ENABLED=true
+ *
+ * Endpoint admin pour trigger manuel : POST /admin/scanner-postmortem/run
+ * (utile pour tester sur la journée en cours sans attendre 02:30 UTC).
+ *
+ * Consumers à wirer (follow-up) :
+ *   - GeminiRiskManager : inject scanner_lessons WHERE is_active=true dans system prompt
+ *   - MacroVeto : idem
+ *   - TopGainersScanner signal_quality validation : idem
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { ScannerLlmRouterService } from './scanner-llm-router.service';
+import { LisaService } from './lisa.service';
+
+const SCANNER_PORTFOLIO_IDS = [
+  { id: '58439d86-3f20-4a60-82a4-307f3f252bc2', name: 'main' },
+  { id: 'a0000001-0000-0000-0000-000000000001', name: 'shadow_high' },
+  { id: 'a0000002-0000-0000-0000-000000000002', name: 'shadow_middle' },
+  { id: 'a0000003-0000-0000-0000-000000000003', name: 'shadow_small' },
+];
+
+const POST_MORTEM_SYSTEM_PROMPT = `Tu es un coach trader senior chargé d'analyser les trades du scanner momentum gainers de SmartVest. Le scanner est déterministe (calibrage via gates : persistence multi-TF, path efficiency, hour blacklist, ATR, anti-chase, etc.) — il ne s'auto-corrige pas. Ton job est d'identifier les patterns gagnants/perdants ET de proposer des AJUSTEMENTS CONCRETS de config.
+
+OBJECTIF : générer 5-10 lessons actionnables qui éviteront que les mêmes pertes se reproduisent.
+
+CONTRAINTES OBLIGATOIRES :
+1. Chaque lesson DOIT contenir une macro_condition (ex: VIX>25, US10Y>4.5, REGIME_CALME, ASIA_LATE_SESSION, EU_OPEN_FIRST_HOUR, KOREA_KOSDAQ, SMALL_CAP)
+2. Chaque lesson DOIT avoir sample_size ≥ 5 trades observés (sinon noise statistique → reject)
+3. Préférer les patterns LOCAUX (asia_only, eu_only, par classe d'asset) plutôt que all_scanner
+4. Si un pattern produit 100% pertes sur N≥5 trades → propose proposed_config_change concret
+
+CONFIG AJUSTABLES (env vars ou DB column lisa_session_configs):
+- GAINERS_TRAILING_STOP_BREAKEVEN_ENABLED (true/false) — trail BE à 0.05% post-pump
+- GAINERS_MIN_PATH_EFFICIENCY_US/EU/ASIA (0-1) — refuse les chaotic moves
+- gainers_min_persistence_score (0-1) — minimum TF persistents
+- gainers_default_tp_pct / gainers_default_sl_pct (DB par portfolio)
+- gainers_max_change_pct_<class> (anti-chase cap)
+- gainers_min_change_pct_<class> (anti-noise floor)
+- GAINERS_HOUR_BLACKLIST_<CLASS>_UTC (heures interdites par classe)
+- GAINERS_POST_SL_COOLDOWN_MIN (cooldown après SL)
+- GAINERS_EARNINGS_FILTER_DAYS
+
+CATEGORIES (lesson_kind):
+- losing_pattern : pattern qui produit ≥80% pertes sur N≥5
+- winning_pattern : pattern qui produit ≥70% gains sur N≥5
+- gate_calibration : ajustement seuil d'un gate existant
+- risk_observation : observation risque sans action immédiate
+- sizing_rule : règle sizing par classe
+- exit_rule : règle sortie (stop, trail, TP)
+- session_filter : filtre temporel (heure/session)
+
+RÉPONSE JSON OBLIGATOIRE :
+{
+  "summary": "1-2 phrases résumé journée 4 portfolios + régime macro dominant",
+  "macro_regime_today": "ex: VIX 22 (élevé), US10Y 4.45%, DXY 103, weekend US",
+  "trades_total": <N>,
+  "wins": <N>,
+  "losses": <N>,
+  "winning_patterns": ["pattern + chiffres + macro condition"],
+  "losing_patterns": ["pattern + chiffres + macro condition"],
+  "new_lessons": [
+    {
+      "lesson_kind": "losing_pattern|winning_pattern|gate_calibration|risk_observation|sizing_rule|exit_rule|session_filter",
+      "lesson_text": "Quand <CONDITION MACRO>, <ACTION CONCRÈTE> (référence: N trades, WR %, avg pnl)",
+      "macro_condition": "VIX>25|US10Y>4.5|DXY>103|REGIME_CALME|ASIA_LATE_SESSION|EU_OPEN_FIRST_HOUR|KOREA_KOSDAQ|...",
+      "scope": "all_scanner|main_only|shadows_only|asia_only|eu_only|us_only|crypto_only",
+      "confidence": 0.0-1.0,
+      "sample_size": N,
+      "win_rate_observed": 0.0-100.0,
+      "avg_pnl_usd": <num>,
+      "proposed_config_change": { "<env_var_or_db_col>": "<value>" } | null
+    }
+  ]
+}`;
+
+interface PostMortemPayload {
+  date: string;
+  macro: object;
+  trades_by_portfolio: Record<string, Array<{
+    symbol: string;
+    portfolio: string;
+    asset_class: string | null;
+    entry_price: number;
+    exit_price: number;
+    entry_notional_usd: number;
+    sl_pct: number | null;
+    tp_pct: number | null;
+    realized_pnl_usd: number;
+    pnl_pct: number;
+    hold_minutes: number;
+    exit_reason: string;
+    entry_timestamp: string;
+    exit_timestamp: string;
+  }>>;
+  funnel_stats: object;
+}
+
+@Injectable()
+export class MainScannerPostMortemService {
+  private readonly logger = new Logger(MainScannerPostMortemService.name);
+  private enabled = false;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+    private readonly llmRouter: ScannerLlmRouterService,
+    private readonly lisa: LisaService,
+    private readonly schedulerRegistry: SchedulerRegistry,
+  ) {}
+
+  onModuleInit(): void {
+    this.enabled =
+      (this.config.get<string>('MAIN_SCANNER_POSTMORTEM_ENABLED') ?? 'false').toLowerCase() === 'true';
+    this.logger.log(
+      `[scanner-postmortem] onModuleInit fired — enabled=${this.enabled}`,
+    );
+    if (this.enabled) {
+      // Registration manuelle via SchedulerRegistry (pattern TopGainersScanner / LiveTraderAgent).
+      // Cron 02:30 UTC : après Trader Agent post-mortem (02:00) pour pas saturer Gemini Pro.
+      try {
+        const job = new CronJob('30 2 * * *', () => {
+          this.runPostMortem(24).catch((e) =>
+            this.logger.error(`[scanner-postmortem] cron failed: ${String(e).slice(0, 200)}`),
+          );
+        });
+        this.schedulerRegistry.addCronJob('main-scanner-postmortem', job);
+        job.start();
+        this.logger.log('[scanner-postmortem] ENABLED — cron 02:30 UTC daily');
+      } catch (e) {
+        this.logger.error(`[scanner-postmortem] cron register failed: ${String(e).slice(0, 200)}`);
+      }
+    }
+  }
+
+  /**
+   * Lance un post-mortem manuel sur les dernières N heures.
+   * Appelable via cron OU endpoint admin /admin/scanner-postmortem/run.
+   */
+  async runPostMortem(windowHours: number = 24): Promise<{
+    success: boolean;
+    lessonsPersisted: number;
+    rejectedNoMacro: number;
+    rejectedSmallSample: number;
+    geminiCostUsd: number;
+    error?: string;
+  }> {
+    if (!this.supabase.isReady()) {
+      return { success: false, lessonsPersisted: 0, rejectedNoMacro: 0, rejectedSmallSample: 0, geminiCostUsd: 0, error: 'supabase not ready' };
+    }
+    if (!this.llmRouter.isEnabled()) {
+      return { success: false, lessonsPersisted: 0, rejectedNoMacro: 0, rejectedSmallSample: 0, geminiCostUsd: 0, error: 'llm router disabled' };
+    }
+
+    const since = new Date(Date.now() - windowHours * 60 * 60_000);
+    this.logger.log(`[scanner-postmortem] running for window ${since.toISOString()} → now`);
+
+    // 1. Fetch closed trades 4 portfolios
+    const tradesByPortfolio: Record<string, PostMortemPayload['trades_by_portfolio'][string]> = {};
+    let totalTrades = 0;
+    for (const p of SCANNER_PORTFOLIO_IDS) {
+      const { data } = await this.supabase.getClient()
+        .from('lisa_positions')
+        .select('symbol, asset_class, entry_price, exit_price, entry_notional_usd, stop_loss_price, take_profit_price, realized_pnl_usd, exit_reason, entry_timestamp, exit_timestamp')
+        .eq('portfolio_id', p.id)
+        .neq('status', 'open')
+        .gte('exit_timestamp', since.toISOString())
+        .order('exit_timestamp', { ascending: true });
+      const rows = (data ?? []).map((r) => {
+        const entry = Number(r.entry_price);
+        const exit = Number(r.exit_price);
+        const sl = Number(r.stop_loss_price);
+        const tp = Number(r.take_profit_price);
+        const slPct = Number.isFinite(entry) && entry > 0 && Number.isFinite(sl) ? Number(((sl / entry - 1) * 100).toFixed(2)) : null;
+        const tpPct = Number.isFinite(entry) && entry > 0 && Number.isFinite(tp) ? Number(((tp / entry - 1) * 100).toFixed(2)) : null;
+        const pnlPct = Number.isFinite(entry) && entry > 0 && Number.isFinite(exit) ? Number(((exit / entry - 1) * 100).toFixed(2)) : 0;
+        const holdMin = Math.round(
+          (new Date(r.exit_timestamp as string).getTime() - new Date(r.entry_timestamp as string).getTime()) / 60000,
+        );
+        return {
+          symbol: r.symbol as string,
+          portfolio: p.name,
+          asset_class: r.asset_class as string | null,
+          entry_price: entry,
+          exit_price: exit,
+          entry_notional_usd: Number(r.entry_notional_usd ?? 0),
+          sl_pct: slPct,
+          tp_pct: tpPct,
+          realized_pnl_usd: Number(r.realized_pnl_usd ?? 0),
+          pnl_pct: pnlPct,
+          hold_minutes: holdMin,
+          exit_reason: String(r.exit_reason ?? '').slice(0, 200),
+          entry_timestamp: r.entry_timestamp as string,
+          exit_timestamp: r.exit_timestamp as string,
+        };
+      });
+      tradesByPortfolio[p.name] = rows;
+      totalTrades += rows.length;
+    }
+
+    if (totalTrades === 0) {
+      this.logger.log('[scanner-postmortem] no trades in window, skip');
+      return { success: true, lessonsPersisted: 0, rejectedNoMacro: 0, rejectedSmallSample: 0, geminiCostUsd: 0 };
+    }
+
+    // 2. Macro snapshot
+    let macro: object;
+    try {
+      macro = await this.lisa.getRecentMarketSnapshot(180);
+    } catch (e) {
+      this.logger.warn(`[scanner-postmortem] macro fetch failed: ${String(e).slice(0, 100)}`);
+      macro = { note: 'macro_snapshot_unavailable' };
+    }
+
+    // 3. Funnel stats (gainers_user_shadow_signals) — quelles gates ont bloqué quoi
+    let funnelStats: object = {};
+    try {
+      const { data: funnel } = await this.supabase.getClient()
+        .from('gainers_user_shadow_signals')
+        .select('decision, asset_class')
+        .gte('captured_at', since.toISOString());
+      const agg: Record<string, Record<string, number>> = {};
+      for (const r of funnel ?? []) {
+        const cls = String(r.asset_class ?? 'unknown');
+        const dec = String(r.decision ?? 'unknown');
+        agg[cls] = agg[cls] ?? {};
+        agg[cls][dec] = (agg[cls][dec] ?? 0) + 1;
+      }
+      funnelStats = { by_class: agg };
+    } catch (e) {
+      this.logger.warn(`[scanner-postmortem] funnel fetch failed: ${String(e).slice(0, 100)}`);
+    }
+
+    // 4. Build payload
+    const payload: PostMortemPayload = {
+      date: new Date().toISOString().slice(0, 10),
+      macro,
+      trades_by_portfolio: tradesByPortfolio,
+      funnel_stats: funnelStats,
+    };
+
+    // 5. Call Gemini Pro
+    let response: { content: string; providerId: string; costUsd: number; latencyMs: number };
+    try {
+      response = await this.llmRouter.callWithPro({
+        system: POST_MORTEM_SYSTEM_PROMPT,
+        user: JSON.stringify(payload, null, 2),
+        temperature: 0.3,
+        maxTokens: 8000,
+        timeoutMs: 60_000,
+      });
+    } catch (e) {
+      const errMsg = `LLM call failed: ${String(e).slice(0, 200)}`;
+      this.logger.error(`[scanner-postmortem] ${errMsg}`);
+      return { success: false, lessonsPersisted: 0, rejectedNoMacro: 0, rejectedSmallSample: 0, geminiCostUsd: 0, error: errMsg };
+    }
+
+    this.logger.log(
+      `[scanner-postmortem] Gemini provider=${response.providerId} latency=${response.latencyMs}ms cost=$${response.costUsd.toFixed(4)}`,
+    );
+
+    if (!response.content || response.content.trim().length === 0) {
+      const errMsg = 'Gemini returned empty content (thinking tokens exhausted?)';
+      this.logger.error(`[scanner-postmortem] ${errMsg}`);
+      return { success: false, lessonsPersisted: 0, rejectedNoMacro: 0, rejectedSmallSample: 0, geminiCostUsd: response.costUsd, error: errMsg };
+    }
+
+    // 6. Parse JSON
+    let parsed: {
+      summary?: string;
+      macro_regime_today?: string;
+      trades_total?: number;
+      wins?: number;
+      losses?: number;
+      winning_patterns?: string[];
+      losing_patterns?: string[];
+      new_lessons?: Array<{
+        lesson_kind: string;
+        lesson_text: string;
+        macro_condition?: string;
+        scope?: string;
+        confidence?: number;
+        sample_size?: number;
+        win_rate_observed?: number;
+        avg_pnl_usd?: number;
+        proposed_config_change?: object | null;
+      }>;
+    };
+    try {
+      const cleaned = response.content.trim().replace(/^```json\s*/i, '').replace(/```\s*$/, '').trim();
+      parsed = JSON.parse(cleaned);
+    } catch (e) {
+      const errMsg = `parse JSON failed: ${String(e).slice(0, 150)}`;
+      this.logger.error(`[scanner-postmortem] ${errMsg} — raw start: ${response.content.slice(0, 300)}`);
+      return { success: false, lessonsPersisted: 0, rejectedNoMacro: 0, rejectedSmallSample: 0, geminiCostUsd: response.costUsd, error: errMsg };
+    }
+
+    const newLessons = parsed.new_lessons ?? [];
+    if (!Array.isArray(newLessons) || newLessons.length === 0) {
+      this.logger.warn('[scanner-postmortem] no lessons returned by Gemini');
+      return { success: true, lessonsPersisted: 0, rejectedNoMacro: 0, rejectedSmallSample: 0, geminiCostUsd: response.costUsd };
+    }
+
+    // 7. Validation + persistance
+    const today = new Date().toISOString().slice(0, 10);
+    let persisted = 0;
+    let rejectedNoMacro = 0;
+    let rejectedSmallSample = 0;
+    for (const l of newLessons) {
+      // Gate 1 : macro_condition obligatoire
+      const hasMacro = !!l.macro_condition && l.macro_condition.length > 0;
+      const inlineMacro = /quand\b.*\b(vix|dxy|10y|hy|oas|gold|brent|usdjpy|regime|us10y|asia|eu|us|korea|kosdaq|crypto|session)/i.test(l.lesson_text);
+      if (!hasMacro && !inlineMacro) {
+        this.logger.warn(`[scanner-postmortem] reject macro-blind: ${l.lesson_text.slice(0, 100)}`);
+        rejectedNoMacro++;
+        continue;
+      }
+      // Gate 2 : sample_size ≥ 5
+      const sampleSize = Number(l.sample_size ?? 0);
+      if (!Number.isFinite(sampleSize) || sampleSize < 5) {
+        this.logger.warn(`[scanner-postmortem] reject small-sample n=${sampleSize}: ${l.lesson_text.slice(0, 100)}`);
+        rejectedSmallSample++;
+        continue;
+      }
+      try {
+        await this.supabase.getClient().from('scanner_lessons').insert({
+          derived_from_date: today,
+          lesson_kind: l.lesson_kind,
+          lesson_text: l.lesson_text,
+          macro_condition: l.macro_condition ?? null,
+          scope: l.scope ?? 'all_scanner',
+          confidence: typeof l.confidence === 'number' ? Math.max(0, Math.min(1, l.confidence)) : 0.7,
+          proposed_config_change: l.proposed_config_change ?? null,
+          sample_size: sampleSize,
+          win_rate_observed: typeof l.win_rate_observed === 'number' ? l.win_rate_observed : null,
+          avg_pnl_usd: typeof l.avg_pnl_usd === 'number' ? l.avg_pnl_usd : null,
+          payload: {
+            summary: parsed.summary,
+            macro_regime_today: parsed.macro_regime_today,
+            trades_total: parsed.trades_total,
+            wins: parsed.wins,
+            losses: parsed.losses,
+            winning_patterns: parsed.winning_patterns,
+            losing_patterns: parsed.losing_patterns,
+            llm_meta: { providerId: response.providerId, latencyMs: response.latencyMs, costUsd: response.costUsd },
+          },
+        });
+        persisted++;
+      } catch (e) {
+        this.logger.warn(`[scanner-postmortem] insert failed: ${String(e).slice(0, 150)}`);
+      }
+    }
+
+    this.logger.log(
+      `[scanner-postmortem] done — persisted=${persisted} rejected_macro=${rejectedNoMacro} rejected_sample=${rejectedSmallSample}`,
+    );
+    return {
+      success: true,
+      lessonsPersisted: persisted,
+      rejectedNoMacro,
+      rejectedSmallSample,
+      geminiCostUsd: response.costUsd,
+    };
+  }
+
+  /** Status pour endpoint admin */
+  async getStatus(): Promise<object> {
+    const { data: recent } = await this.supabase.getClient()
+      .from('scanner_lessons')
+      .select('id, created_at, derived_from_date, lesson_kind, lesson_text, macro_condition, scope, confidence, sample_size, win_rate_observed, avg_pnl_usd, applied, proposed_config_change')
+      .eq('is_active', true)
+      .order('created_at', { ascending: false })
+      .limit(50);
+    return {
+      enabled: this.enabled,
+      active_lessons: recent ?? [],
+    };
+  }
+}

--- a/supabase/migrations/0170_scanner_lessons.sql
+++ b/supabase/migrations/0170_scanner_lessons.sql
@@ -1,0 +1,60 @@
+-- Migration 0170 — scanner_lessons : apprentissage Gemini pour le scanner gainers
+--
+-- Le scanner gainers est volontairement déterministe (cf. ADR P19, PR #250).
+-- Cette table accueille les lessons générées par MainScannerPostMortemService
+-- (cron 02:30 UTC) qui analyse chaque jour les positions closed des 4 portfolios
+-- (MAIN + HIGH + MIDDLE + SMALL) et génère des règles macro-conditionnelles
+-- réinjectées dans les system prompts de GeminiRiskManager + MacroVeto + scanner.
+--
+-- Critère de qualité : chaque lesson DOIT avoir une macro_condition + sample_size
+-- ≥ 5 trades pour être actionnable (sinon noise statistique).
+
+CREATE TABLE IF NOT EXISTS public.scanner_lessons (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  derived_from_date DATE NOT NULL,
+  -- Categorie : losing_pattern | winning_pattern | gate_calibration |
+  -- risk_observation | sizing_rule | exit_rule | session_filter
+  lesson_kind TEXT NOT NULL,
+  -- Texte actionable : "Quand <CONDITION>, alors <ACTION>"
+  lesson_text TEXT NOT NULL,
+  -- Condition macro éligible (enum souple)
+  -- ex: VIX>25, US10Y>4.5, REGIME_CALME, ASIA_LATE_SESSION, EU_OPEN_FIRST_HOUR
+  macro_condition TEXT,
+  -- Scope d'application
+  -- ex: all_scanner, main_only, shadows_only, asia_only, eu_only, us_only, crypto_only
+  scope TEXT NOT NULL DEFAULT 'all_scanner',
+  -- Confidence Gemini (0.0-1.0)
+  confidence NUMERIC(3, 2) DEFAULT 0.7 CHECK (confidence >= 0 AND confidence <= 1),
+  -- Si Gemini propose un changement de config concret (env var ou DB column)
+  -- ex: { "GAINERS_TRAILING_STOP_BREAKEVEN_ENABLED": "false" }
+  -- ex: { "lisa_session_configs.gainers_default_tp_pct": 2.0 }
+  proposed_config_change JSONB,
+  -- Si la proposition a été appliquée (par humain ou auto si confidence ≥ 0.95)
+  applied BOOLEAN NOT NULL DEFAULT false,
+  applied_at TIMESTAMPTZ,
+  applied_by TEXT,  -- 'auto' | 'human:<email>'
+  -- Stats source pour audit
+  sample_size INT,
+  win_rate_observed NUMERIC(5, 2),
+  avg_pnl_usd NUMERIC(10, 2),
+  -- Réinjecté dans les prompts si is_active. Désactivable manuellement.
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  -- Payload raw : breakdown trades, indicators, regime context
+  payload JSONB
+);
+
+CREATE INDEX IF NOT EXISTS idx_scanner_lessons_active
+  ON public.scanner_lessons(is_active, derived_from_date DESC)
+  WHERE is_active = true;
+CREATE INDEX IF NOT EXISTS idx_scanner_lessons_macro
+  ON public.scanner_lessons(macro_condition)
+  WHERE macro_condition IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_scanner_lessons_scope
+  ON public.scanner_lessons(scope);
+
+COMMENT ON TABLE public.scanner_lessons IS
+  'Lessons générées par MainScannerPostMortemService (cron 02:30 UTC daily). Réinjectées dans system prompts GeminiRiskManager + MacroVeto + scanner LLM validation.';
+
+-- Reload PostgREST schema cache (sinon API ne voit pas la table immédiatement)
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Phase 2 — Apprentissage Gemini Pro sur le scanner gainers

Le scanner gainers est volontairement déterministe (ADR P19) — il ne s'auto-corrige PAS. Aujourd'hui 0/12 win rate = **-$312.78** sans aucune réinjection vers Gemini.

## Ce que ce service fait

**`MainScannerPostMortemService`** (cron 02:30 UTC daily) :
1. Analyse 24h × 4 portfolios (MAIN + HIGH + MIDDLE + SMALL)
2. Récupère trades closed + macro snapshot + funnel stats `gainers_user_shadow_signals`
3. Envoie à Gemini Pro avec system prompt structuré
4. Persiste dans `scanner_lessons` (migration 0170)

## Garde-fous qualité

- **`macro_condition` OBLIGATOIRE** (rejet si lesson sans condition macro)
- **`sample_size ≥ 5`** trades observés (rejet si noise statistique)
- **`proposed_config_change`** concret (env var ou DB column) pour les `losing_pattern` à 80%+ pertes
- **Pas d'auto-apply** : `applied=false` par défaut, validation humaine requise (sauf confidence ≥ 0.95 en future PR)

## Endpoint admin pour test ad-hoc

```
POST /admin/scanner-postmortem/run { windowHours: 24 }  → trigger manuel
GET  /admin/scanner-postmortem/status                    → lessons actives
```

## Gating ENV

`MAIN_SCANNER_POSTMORTEM_ENABLED=true` (default OFF)

## Migration

`0170_scanner_lessons.sql` à appliquer (Studio SQL manuel OU trigger-branch workflow) AVANT enable du service.

## Follow-up (PR suivante)

Consumers à câbler : `GeminiRiskManager` + `MacroVeto` qui lisent `scanner_lessons WHERE is_active=true` pour injection dans system prompts.

## Test plan

- [x] `tsc -p apps/api --noEmit` OK
- [ ] Migration 0170 appliquée (Studio SQL)
- [ ] Fly secret `MAIN_SCANNER_POSTMORTEM_ENABLED=true`
- [ ] Trigger manuel `POST /admin/scanner-postmortem/run` sur les 12 trades du jour
- [ ] Vérifier rows dans `scanner_lessons` avec `lesson_text` + `proposed_config_change`

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_