### PR TITLE
feat(trader): enrich feed with KTOS math metrics (Option B)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
@@ -133,15 +133,14 @@ describe('fetchEodhdScreener — URL construction (P18c regression guard)', () =
     expect(decoded).not.toMatch(/[?&]order=/);
   });
 
-  it('P19s — bumps limit from 20 to 100 (max per spec) to compensate dropped sort', async () => {
+  it('bumps limit to 500 (max per spec) to compensate dropped sort', async () => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('US', 'test-key');
     const decoded = decodeURIComponent(capturedUrl!);
-    // Limit 100 = doc max. Compensates dropped sort: even if EODHD's natural
-    // order isn't changePct desc, we capture 5x more candidates so the
-    // client-side sort still surfaces the real top gainers.
-    expect(decoded).toContain('limit=100');
+    // Update 28-29/05/2026 : limit 100 → 500 (5× more candidates per fetch).
+    expect(decoded).toContain('limit=500');
     expect(decoded).not.toContain('limit=20');
+    expect(decoded).not.toContain('limit=100');
   });
 
   it('P19s++ HOTFIX — non-US exchanges build URL with UPPERCASE + NO 1d return filter', async () => {
@@ -369,6 +368,7 @@ describe('P20a — NON_EU_EXCHANGES registry correctness', () => {
     expect(queried).not.toContain('TSE');
     expect(queried).toContain('SHG');
     expect(queried).toContain('SHE');
-    expect(queried).toContain('T');
+    // Asia opening suffix ban 00-02h UTC (commit ed1dfe1) → 'T' retiré.
+    expect(queried).not.toContain('T');
   });
 });

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eu-session.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eu-session.spec.ts
@@ -120,14 +120,14 @@ describe('fetchAllCandidates — EU session gating', () => {
     await svc.fetchAllCandidates(new Date('2026-04-29T10:00:00Z'));
 
     const exchanges = exchangesQueried(capturedUrls);
-    // EU exchanges
+    // EU exchanges (cf. EU_EXCHANGES = ['LSE','XETRA','PA','SW','MC','AS','F','BR','TA','WAR'])
     expect(exchanges.has('LSE')).toBe(true);
     expect(exchanges.has('XETRA')).toBe(true);
     expect(exchanges.has('PA')).toBe(true);
-    expect(exchanges.has('AMS')).toBe(true);
-    // Non-EU still scanned (P20a: T = Tokyo, corrected from TSE)
+    expect(exchanges.has('AS')).toBe(true);  // Amsterdam (Euronext)
     expect(exchanges.has('US')).toBe(true);
-    expect(exchanges.has('T')).toBe(true);
+    // 'T' (Tokyo) banni du pipeline scanner depuis commit ed1dfe1 (28/05/2026)
+    expect(exchanges.has('T')).toBe(false);
   });
 
   it('skips EU exchanges when all 3 EU sessions closed (e.g. 22:00 UTC)', async () => {
@@ -304,9 +304,9 @@ describe('fetchAllCandidates — merge dedup', () => {
         data = [{ code: 'NVDA', last_price: 800, refund_1d_p: 6.0, volume: 50_000_000, avgvol_50d: 40_000_000, market_capitalization: 2e12 }];
       } else if (decoded.includes('"exchange","=","PA"')) {
         data = [{ code: 'AIR.PA', last_price: 150, refund_1d_p: 4.2, volume: 1_000_000, avgvol_50d: 800_000, market_capitalization: 1e11 }];
-      } else if (decoded.includes('"exchange","=","T"')) {
-        // P20a: Tokyo uses code 'T' (suffix .T), not 'TSE'
-        data = [{ code: '7203', last_price: 2500, refund_1d_p: 5.5, volume: 5_000_000, avgvol_50d: 4_000_000, market_capitalization: 3e11 }];
+      } else if (decoded.includes('"exchange","=","HK"')) {
+        // Asia ban 'T' (commit ed1dfe1) — fallback à HK (toujours dans NON_EU_EXCHANGES).
+        data = [{ code: '0700.HK', last_price: 320, refund_1d_p: 5.5, volume: 5_000_000, avgvol_50d: 4_000_000, market_capitalization: 3e11 }];
       }
       return { ok: true, status: 200, json: async () => ({ data }), text: async () => '' } as unknown as Response;
     });
@@ -315,18 +315,15 @@ describe('fetchAllCandidates — merge dedup', () => {
     const candidates = await svc.fetchAllCandidates(new Date('2026-04-29T10:00:00Z'));
 
     const symbols = candidates.map((c) => c.symbol);
-    // PR #234 (PR6.9) — ensureExchangeSuffix appended :
-    //   NVDA → NVDA.US, 7203 → 7203.TSE (T → TSE remap), AIR.PA déjà avec dot (idempotent)
     expect(symbols).toContain('NVDA.US');
     expect(symbols).toContain('AIR.PA');
-    expect(symbols).toContain('7203.TSE');
+    expect(symbols).toContain('0700.HK');
 
-    // Verify each candidate gets the correct asset class via detectAssetClass
     const nvda = candidates.find((c) => c.symbol === 'NVDA.US')!;
     const air = candidates.find((c) => c.symbol === 'AIR.PA')!;
-    const toyota = candidates.find((c) => c.symbol === '7203.TSE')!;
+    const tencent = candidates.find((c) => c.symbol === '0700.HK')!;
     expect(detectAssetClass(nvda.symbol, nvda.exchange, nvda.marketCap)).toBe('us_equity_large');
     expect(detectAssetClass(air.symbol, air.exchange)).toBe('eu_equity');
-    expect(detectAssetClass(toyota.symbol, toyota.exchange)).toBe('asia_equity');
+    expect(detectAssetClass(tencent.symbol, tencent.exchange)).toBe('asia_equity');
   });
 });

--- a/apps/api/src/modules/lisa/services/__tests__/mechanical-trading-trailing-tp.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/mechanical-trading-trailing-tp.spec.ts
@@ -23,6 +23,7 @@ interface Svc {
   closePosition: jest.Mock;
   checkReactiveSignals: jest.Mock;
   isGainersStrategy: jest.Mock;
+  isTrailingEligible: jest.Mock;
   checkStopTarget: (pos: unknown, isHyperActive?: boolean) => Promise<void>;
 }
 
@@ -34,6 +35,8 @@ function makeSvc(price: string, isGainers = true): Svc {
   svc.closePosition = jest.fn(async () => undefined);
   svc.checkReactiveSignals = jest.fn(async () => undefined);
   svc.isGainersStrategy = jest.fn(async () => isGainers);
+  // mechanical-trading.service.ts:2202 — trailing TP gate sur isTrailingEligible(portfolioId).
+  svc.isTrailingEligible = jest.fn(async () => isGainers);
   return svc;
 }
 

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -33,6 +33,7 @@ import { ScannerLlmRouterService } from './scanner-llm-router.service';
 import { LisaService } from './lisa.service';
 import { ScannerLessonsContextService } from './scanner-lessons-context.service';
 import { TopGainersScannerService } from './top-gainers-scanner.service';
+import type { TopGainerCandidate } from '@smartvest/ai-analyst';
 
 const TRADER_AGENT_PORTFOLIO_ID = 'b0000001-0000-0000-0000-000000000001';
 const TRADER_AGENT_USER_ID = '5f164201-9736-4867-8756-a1653d65fd1c';
@@ -1210,6 +1211,17 @@ Recommendation rules :
     // RWS.LSE que MAIN a pris) étaient enterrés position #30-50, hors top 20.
     // Fix : filtrer [TRADER_FEED_MIN_PCT, TRADER_FEED_MAX_PCT] AVANT top-N.
     // Bornes alignées sur l'overpump gate (15%) et un plancher anti-bruit (2%).
+    //
+    // P-KTOS ENRICHMENT (29/05 17:15) — chaque candidat est enrichi de 4 métriques
+    // computées pour aider le LLM Gemini à appliquer les lessons KTOS (#319e867e,
+    // #ab035237, #42101ada, #aa6eda5f) :
+    //   - pumpScore : changePct / max_changePct du pool (signal proximity-to-peak)
+    //   - closeToHighRatio : close / high (1.0 = au top du jour, < 0.9 = retrace)
+    //   - volumeRatio : volume / avgVol50d (>2.0 = momentum confirmé)
+    //   - kellyMaxNotional : USD plafond Kelly fraction (TP 2.5% SL 1.5% p_win=0.5 → max 20% cap)
+    //   - sweetSpotEntry : booléen, true si changePct ∈ [3,8]% (winning bucket)
+    // Ces champs sont injectés dans le userPrompt JSON et lus naturellement par le LLM.
+    // PAS de gate hardcodé — décision reste autonome côté Gemini Pro.
     const feedMin = Number(this.config.get<string>('TRADER_FEED_MIN_PCT') ?? '2');
     const feedMax = Number(this.config.get<string>('TRADER_FEED_MAX_PCT') ?? '15');
     try {
@@ -1230,13 +1242,11 @@ Recommendation rules :
           this.logger.debug(
             `[trader-agent] feed: ${candidates.length} scanned → ${sorted.length} in band [${feedMin},${feedMax}]% → top ${Math.min(n, sorted.length)}`,
           );
-          return sorted.slice(0, n).map((c) => ({
-            symbol: c.symbol,
-            assetClass: this.classifyAssetClass(c.exchange ?? undefined, c.symbol),
-            changePct: c.changePct,
-            close: c.close,
-            exchange: c.exchange,
-          }));
+          // P-KTOS — Compute pool-wide max for pumpScore
+          const maxChangePctInPool = sorted.reduce((m, c) => Math.max(m, c.changePct ?? 0), 0);
+          return sorted.slice(0, n).map((c) =>
+            this.enrichCandidateWithMath(c, maxChangePctInPool),
+          );
         }
       }
     } catch (e) {
@@ -1260,6 +1270,78 @@ Recommendation rules :
       persistenceScore: c.persistenceScore,
       close: c.close,
     }));
+  }
+
+  /**
+   * P-KTOS (29/05) — Enrichit un TopGainerCandidate avec 4 métriques computées
+   * pour aider le LLM Gemini Pro à appliquer les lessons KTOS (entry discipline +
+   * sizing). PAS de gate hardcodé — le LLM voit les chiffres et décide en autonomie.
+   *
+   * Formules :
+   *   - pumpScore = changePct / max_changePct_du_pool
+   *     · > 0.85 → au peak local, retrace probable
+   *     · 0.50-0.75 → sweet spot (retrace en cours, momentum encore présent)
+   *     · < 0.40 → momentum perdu
+   *   - closeToHighRatio = close / high (jour)
+   *     · 1.00 → au top du jour (chase the top)
+   *     · 0.95-0.98 → momentum sain
+   *     · < 0.90 → retrace significative
+   *   - volumeRatio = volume / avgVol50d
+   *     · > 2.0 → momentum confirmé volume
+   *     · 1.0-2.0 → volume normal
+   *     · < 0.8 → volume faible, signal douteux
+   *   - kellyMaxNotional = TRADER_CAPITAL × Kelly fraction (TP 2.5% SL 1.5% p_win=0.5 fallback)
+   *     · Formule : f* = (TP×p_win - SL×(1-p_win)) / TP = 0.20 (default 0.5 win prob)
+   *     · → max $2000 sur $10k capital tant que p_win pas remontée par P9
+   *   - sweetSpotEntry = (changePct ∈ [3,8]%) : true si dans le bucket gagnant historique
+   *
+   * Cf. scanner_lessons : 319e867e (PULLBACK_WAIT), ab035237 (velocity), 42101ada (Kelly),
+   * aa6eda5f (pump score).
+   */
+  private enrichCandidateWithMath(
+    c: TopGainerCandidate,
+    maxChangePctInPool: number,
+  ): Record<string, unknown> {
+    const changePct = c.changePct ?? 0;
+    const high = c.high ?? c.close ?? 0;
+    const close = c.close ?? 0;
+    const volume = c.volume ?? 0;
+    const avgVol50d = c.avgVol50d ?? 0;
+
+    const pumpScore = maxChangePctInPool > 0
+      ? Math.round((changePct / maxChangePctInPool) * 100) / 100
+      : null;
+    const closeToHighRatio = high > 0
+      ? Math.round((close / high) * 1000) / 1000
+      : null;
+    const volumeRatio = avgVol50d > 0
+      ? Math.round((volume / avgVol50d) * 100) / 100
+      : null;
+
+    // Kelly notional — TP/SL standards trader (2.5% / 1.5%), p_win=0.5 par défaut
+    // (sera affiné par P9 quand p_win_at_entry sera correctement persisté).
+    // f* = (TP*p_win - SL*(1-p_win)) / TP avec TP=2.5, SL=1.5, p_win=0.5
+    //    = (1.25 - 0.75) / 2.5 = 0.20
+    // Capital trader = $10000 → max $2000 = Kelly cap par défaut.
+    const kellyMaxNotional = Math.round(TRADER_AGENT_CAPITAL_USD * 0.20);
+
+    // Sweet spot bucket gagnant historique (lesson aa6eda5f) : [3,8]%
+    const sweetSpotEntry = changePct >= 3 && changePct <= 8;
+
+    return {
+      symbol: c.symbol,
+      assetClass: this.classifyAssetClass(c.exchange ?? undefined, c.symbol),
+      changePct,
+      close,
+      high,
+      exchange: c.exchange,
+      // P-KTOS enrichment fields :
+      pumpScore,
+      closeToHighRatio,
+      volumeRatio,
+      kellyMaxNotional,
+      sweetSpotEntry,
+    };
   }
 
   private async fetchMacroContext(): Promise<object> {

--- a/packages/ai-analyst/src/simulation/__tests__/paper-broker-staleness-r5.spec.ts
+++ b/packages/ai-analyst/src/simulation/__tests__/paper-broker-staleness-r5.spec.ts
@@ -83,7 +83,7 @@ describe('PaperBrokerService.closePosition — P19-staleness R5 reject', () => {
         livePriceSource: 'stale_twelvedata',
         rationale: '[FORCE_CLOSE] test',
       }),
-    ).rejects.toThrow(/R5_LIVE_PRICE_STALE_OR_FALLBACK/);
+    ).rejects.toThrow(/R5_LIVE_PRICE_(STALE|FALLBACK)/);
   });
 
   it('reject close avec source=stale_eodhd', async () => {
@@ -96,7 +96,7 @@ describe('PaperBrokerService.closePosition — P19-staleness R5 reject', () => {
         livePriceSource: 'stale_eodhd',
         rationale: 'test',
       }),
-    ).rejects.toThrow(/R5_LIVE_PRICE_STALE_OR_FALLBACK/);
+    ).rejects.toThrow(/R5_LIVE_PRICE_(STALE|FALLBACK)/);
   });
 
   it('reject close avec source=fallback_unknown', async () => {
@@ -109,7 +109,7 @@ describe('PaperBrokerService.closePosition — P19-staleness R5 reject', () => {
         livePriceSource: 'fallback_unknown',
         rationale: 'test',
       }),
-    ).rejects.toThrow(/R5_LIVE_PRICE_STALE_OR_FALLBACK/);
+    ).rejects.toThrow(/R5_LIVE_PRICE_(STALE|FALLBACK)/);
   });
 
   it('accepte close avec source=twelvedata (frais, non-stale)', async () => {
@@ -126,8 +126,8 @@ describe('PaperBrokerService.closePosition — P19-staleness R5 reject', () => {
         rationale: 'test',
       });
     } catch (e) {
-      // Ne doit PAS être un R5_LIVE_PRICE_STALE_OR_FALLBACK
-      expect(String(e)).not.toMatch(/R5_LIVE_PRICE_STALE_OR_FALLBACK/);
+      // Ne doit PAS être un R5_LIVE_PRICE_(STALE|FALLBACK)
+      expect(String(e)).not.toMatch(/R5_LIVE_PRICE_(STALE|FALLBACK)/);
     }
   });
 
@@ -141,8 +141,8 @@ describe('PaperBrokerService.closePosition — P19-staleness R5 reject', () => {
         rationale: 'test legacy caller without source',
       });
     } catch (e) {
-      // Ne doit PAS être un R5_LIVE_PRICE_STALE_OR_FALLBACK
-      expect(String(e)).not.toMatch(/R5_LIVE_PRICE_STALE_OR_FALLBACK/);
+      // Ne doit PAS être un R5_LIVE_PRICE_(STALE|FALLBACK)
+      expect(String(e)).not.toMatch(/R5_LIVE_PRICE_(STALE|FALLBACK)/);
     }
   });
 });


### PR DESCRIPTION
## Contexte

Post-mortem KTOS.US -$51 (29/05 16:27 UTC) → user a tranché : autonomie LLM préservée, apprentissage via lessons + enrichissement data côté code (Option C).

- **4 lessons KTOS insérées en DB** plus tôt (scanner_lessons : 319e867e PULLBACK_WAIT, ab035237 velocity, 42101ada Kelly, aa6eda5f pump score).
- **Cette PR = Option B** : enrichissement du feed TRADER pour que le LLM Gemini Pro voie les chiffres déjà calculés au lieu de devoir les "imaginer".

## Changements

### `feat(trader)` — `live-trader-agent.service.ts:fetchTopCandidates()`

Chaque candidate envoyée au prompt Gemini Pro est désormais enrichie de 5 champs computés :

| Champ | Formule | Référence lesson |
|-------|---------|------------------|
| `pumpScore` | `changePct / max_changePct_pool` | aa6eda5f |
| `closeToHighRatio` | `close / high` | aa6eda5f |
| `volumeRatio` | `volume / avgVol50d` | ab035237 (proxy velocity) |
| `kellyMaxNotional` | `TRADER_CAPITAL × Kelly fraction` | 42101ada |
| `sweetSpotEntry` | `changePct ∈ [3,8]%` | aa6eda5f |

**Aucun gate hardcodé** : le LLM lit, décide en autonomie. Conforme à la philosophie SmartVest (apprentissage via lessons, pas hardcoded rules).

Math détaillée dans le JSDoc de `enrichCandidateWithMath()`.

### `test` — fix 8 pre-existing failures

Mêmes fixes que PR #491 (qui n'est pas encore mergée). Tests cassés sur main par commits récents (ed1dfe1 Asia ban, refacto isTrailingEligible, codes R5 décomposés). Aucun changement de logique applicative.

## Test plan

- [x] TypeScript build : compilation OK (les 6 erreurs `lisa.service.ts` sont pré-existantes sur main, hors-scope)
- [x] Jest local apps/api : **222/222 suites, 2986/2986 tests verts**
- [x] Jest local ai-analyst : **36/36 suites, 686/686 tests verts**
- [ ] CI : à confirmer
- [ ] Live verif après deploy : prochains cycles TRADER doivent inclure les 5 nouveaux champs dans la thesis Gemini

## Effets attendus en prod

1. Au prochain cycle TRADER post-deploy, le user prompt JSON injecté dans Gemini Pro contient les nouveaux champs par candidate.
2. Le LLM, qui a déjà les 4 lessons KTOS dans son system prompt (cache 5min `ScannerLessonsContextService`), peut désormais raisonner sur des chiffres exacts plutôt que d'imaginer pumpScore/Kelly mentalement.
3. Cas KTOS-like (changePct > 10%, pumpScore > 0.85, closeToHighRatio = 1.0) → le LLM devrait répondre `hold` avec marker `[PULLBACK_WAIT_KTOS_LESSON]` ou `[PUMP_SCORE > 0.85 refusé]`.

## Notes follow-up (out of scope)

- Vrai velocity 1m (régression linéaire 5 candles) demanderait ~100 calls EODHD intraday supplémentaires par cycle. À faire plus tard via cache dédié si besoin.
- `closeToHighRatio` + `volumeRatio` servent de proxy de qualité à coût zéro pour le moment.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_