### PR TITLE
feat(scanner): EOS_NO_OPEN gate — symmetric to TRADER lesson END_OF_SESSION_WAIT

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
@@ -133,15 +133,14 @@ describe('fetchEodhdScreener — URL construction (P18c regression guard)', () =
     expect(decoded).not.toMatch(/[?&]order=/);
   });
 
-  it('P19s — bumps limit from 20 to 100 (max per spec) to compensate dropped sort', async () => {
+  it('bumps limit to 500 (max per spec) to compensate dropped sort', async () => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('US', 'test-key');
     const decoded = decodeURIComponent(capturedUrl!);
-    // Limit 100 = doc max. Compensates dropped sort: even if EODHD's natural
-    // order isn't changePct desc, we capture 5x more candidates so the
-    // client-side sort still surfaces the real top gainers.
-    expect(decoded).toContain('limit=100');
+    // Update 28-29/05/2026 : limit 100 → 500 (5× more candidates).
+    expect(decoded).toContain('limit=500');
     expect(decoded).not.toContain('limit=20');
+    expect(decoded).not.toContain('limit=100');
   });
 
   it('P19s++ HOTFIX — non-US exchanges build URL with UPPERCASE + NO 1d return filter', async () => {
@@ -369,6 +368,7 @@ describe('P20a — NON_EU_EXCHANGES registry correctness', () => {
     expect(queried).not.toContain('TSE');
     expect(queried).toContain('SHG');
     expect(queried).toContain('SHE');
-    expect(queried).toContain('T');
+    // Asia opening suffix ban 00-02h UTC (commit ed1dfe1) → 'T' retiré.
+    expect(queried).not.toContain('T');
   });
 });

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eu-session.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eu-session.spec.ts
@@ -120,14 +120,12 @@ describe('fetchAllCandidates — EU session gating', () => {
     await svc.fetchAllCandidates(new Date('2026-04-29T10:00:00Z'));
 
     const exchanges = exchangesQueried(capturedUrls);
-    // EU exchanges
     expect(exchanges.has('LSE')).toBe(true);
     expect(exchanges.has('XETRA')).toBe(true);
     expect(exchanges.has('PA')).toBe(true);
-    expect(exchanges.has('AMS')).toBe(true);
-    // Non-EU still scanned (P20a: T = Tokyo, corrected from TSE)
+    expect(exchanges.has('AS')).toBe(true);  // Amsterdam = AS dans EU_EXCHANGES
     expect(exchanges.has('US')).toBe(true);
-    expect(exchanges.has('T')).toBe(true);
+    expect(exchanges.has('T')).toBe(false);  // 'T' Tokyo banni (commit ed1dfe1)
   });
 
   it('skips EU exchanges when all 3 EU sessions closed (e.g. 22:00 UTC)', async () => {
@@ -304,9 +302,9 @@ describe('fetchAllCandidates — merge dedup', () => {
         data = [{ code: 'NVDA', last_price: 800, refund_1d_p: 6.0, volume: 50_000_000, avgvol_50d: 40_000_000, market_capitalization: 2e12 }];
       } else if (decoded.includes('"exchange","=","PA"')) {
         data = [{ code: 'AIR.PA', last_price: 150, refund_1d_p: 4.2, volume: 1_000_000, avgvol_50d: 800_000, market_capitalization: 1e11 }];
-      } else if (decoded.includes('"exchange","=","T"')) {
-        // P20a: Tokyo uses code 'T' (suffix .T), not 'TSE'
-        data = [{ code: '7203', last_price: 2500, refund_1d_p: 5.5, volume: 5_000_000, avgvol_50d: 4_000_000, market_capitalization: 3e11 }];
+      } else if (decoded.includes('"exchange","=","HK"')) {
+        // Asia ban 'T' (commit ed1dfe1) — fallback HK toujours dans NON_EU_EXCHANGES.
+        data = [{ code: '0700.HK', last_price: 320, refund_1d_p: 5.5, volume: 5_000_000, avgvol_50d: 4_000_000, market_capitalization: 3e11 }];
       }
       return { ok: true, status: 200, json: async () => ({ data }), text: async () => '' } as unknown as Response;
     });
@@ -315,18 +313,15 @@ describe('fetchAllCandidates — merge dedup', () => {
     const candidates = await svc.fetchAllCandidates(new Date('2026-04-29T10:00:00Z'));
 
     const symbols = candidates.map((c) => c.symbol);
-    // PR #234 (PR6.9) — ensureExchangeSuffix appended :
-    //   NVDA → NVDA.US, 7203 → 7203.TSE (T → TSE remap), AIR.PA déjà avec dot (idempotent)
     expect(symbols).toContain('NVDA.US');
     expect(symbols).toContain('AIR.PA');
-    expect(symbols).toContain('7203.TSE');
+    expect(symbols).toContain('0700.HK');
 
-    // Verify each candidate gets the correct asset class via detectAssetClass
     const nvda = candidates.find((c) => c.symbol === 'NVDA.US')!;
     const air = candidates.find((c) => c.symbol === 'AIR.PA')!;
-    const toyota = candidates.find((c) => c.symbol === '7203.TSE')!;
+    const tencent = candidates.find((c) => c.symbol === '0700.HK')!;
     expect(detectAssetClass(nvda.symbol, nvda.exchange, nvda.marketCap)).toBe('us_equity_large');
     expect(detectAssetClass(air.symbol, air.exchange)).toBe('eu_equity');
-    expect(detectAssetClass(toyota.symbol, toyota.exchange)).toBe('asia_equity');
+    expect(detectAssetClass(tencent.symbol, tencent.exchange)).toBe('asia_equity');
   });
 });

--- a/apps/api/src/modules/lisa/services/__tests__/mechanical-trading-trailing-tp.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/mechanical-trading-trailing-tp.spec.ts
@@ -23,6 +23,7 @@ interface Svc {
   closePosition: jest.Mock;
   checkReactiveSignals: jest.Mock;
   isGainersStrategy: jest.Mock;
+  isTrailingEligible: jest.Mock;
   checkStopTarget: (pos: unknown, isHyperActive?: boolean) => Promise<void>;
 }
 
@@ -34,6 +35,8 @@ function makeSvc(price: string, isGainers = true): Svc {
   svc.closePosition = jest.fn(async () => undefined);
   svc.checkReactiveSignals = jest.fn(async () => undefined);
   svc.isGainersStrategy = jest.fn(async () => isGainers);
+  // mechanical-trading.service.ts:2202 — trailing TP gate sur isTrailingEligible.
+  svc.isTrailingEligible = jest.fn(async () => isGainers);
   return svc;
 }
 

--- a/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/gainers-user-shadow.service.ts
@@ -52,6 +52,7 @@ export type ShadowDecision =
   | 'reject_volatile_regime'    // Phase C — symbole structurellement volatile (ATR/close > seuil), SL cassé par bruit
   | 'reject_stagflation_hedge_guard'  // Audit 23/05 — ticker dans watchlist stagflation_hedge, -$3,463 historiques (env-gated)
   | 'reject_dead_zone'          // Analyse 27/05 — buckets changePct 4-8% (Σpnl -28%) + 15-20% (Σpnl -111%) structurellement perdants
+  | 'reject_eos_no_open'        // EOS-OPEN gate (30/05) — refuse new opens dans les N dernières min avant cloche (symétrique lesson END_OF_SESSION_WAIT)
   | 'reject_other';
 
 export interface RecordDecisionInput {

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -2885,6 +2885,43 @@ export class TopGainersScannerService implements OnModuleInit {
         }
       }
 
+      // EOS-OPEN gate (30/05/2026) — refuse new opens in last N minutes before
+      // session close. Symétrique à la lesson 'END_OF_SESSION_WAIT' (a1dfac77,
+      // scope trader_agent_only) qui guide le LLM TRADER. Ici on protège les
+      // scanners gainers déterministes (MIDDLE/HIGH/SMALL/MAIN).
+      //
+      // Justification : TP standard (2.5-3%) demande ~30min médiane à se développer
+      // (vol 1m intraday ≈ 0.15%/min). Ouvrir < 30min avant la cloche =
+      // force-close à prix aléatoire via gainers_force_close_offset_min.
+      //
+      // Default 0 = OFF (opt-in via env). Per-class override possible :
+      //   GAINERS_NO_OPEN_LAST_MIN_BEFORE_CLOSE=30 (global, toutes classes equity)
+      //   GAINERS_NO_OPEN_LAST_MIN_BEFORE_CLOSE_US_EQUITY_LARGE=20 (override US large)
+      //   GAINERS_NO_OPEN_LAST_MIN_BEFORE_CLOSE_EU_EQUITY=45 (override EU)
+      // Crypto exempt par défaut (24/7, pas de notion de cloche).
+      const eosCls = sessionClassFor(String(cand.assetClass));
+      if (eosCls) {  // null = crypto, skip
+        const classUpperEos = String(cand.assetClass ?? '').toUpperCase();
+        const perClassNoOpenRaw = classUpperEos.length > 0
+          ? this.config.get<string>(`GAINERS_NO_OPEN_LAST_MIN_BEFORE_CLOSE_${classUpperEos}`)
+          : undefined;
+        const perClassNoOpen = perClassNoOpenRaw !== undefined ? Number(perClassNoOpenRaw) : NaN;
+        const globalNoOpen = Number(this.config.get<string>('GAINERS_NO_OPEN_LAST_MIN_BEFORE_CLOSE') ?? '0');
+        const noOpenMin = Number.isFinite(perClassNoOpen) && perClassNoOpen >= 0
+          ? perClassNoOpen
+          : globalNoOpen;
+        if (noOpenMin > 0 && isApproachingClose(eosCls, noOpenMin, nowUtc)) {
+          const closeUtcMinEos = MARKET_SESSION_HOURS[eosCls].closeUtcMin;
+          const nowMinEos = nowUtc.getUTCHours() * 60 + nowUtc.getUTCMinutes();
+          const minutesToClose = closeUtcMinEos - nowMinEos;
+          this.logger.log(
+            `[top-gainers] ${cand.symbol} (${cand.assetClass}) EOS_NO_OPEN actif (minutesToClose=${minutesToClose} ≤ ${noOpenMin}min) → skip long`,
+          );
+          recordShadowDecision(cand, 'reject_eos_no_open', undefined);
+          continue;
+        }
+      }
+
       // PR A — Gate horaire LONG. Data mining 15j (23/05/2026, n=7000 signaux) :
       //   - LONG mean H8 (EU open) = -0.60%, H19 (US close) = -1.01%, H22 = -0.93%, H0-H5 = -0.5%
       //   - LONG mean H13-H17 (US active) = neutre à légèrement positif (+0.03 à +0.27%)

--- a/packages/ai-analyst/src/simulation/__tests__/paper-broker-staleness-r5.spec.ts
+++ b/packages/ai-analyst/src/simulation/__tests__/paper-broker-staleness-r5.spec.ts
@@ -83,7 +83,7 @@ describe('PaperBrokerService.closePosition — P19-staleness R5 reject', () => {
         livePriceSource: 'stale_twelvedata',
         rationale: '[FORCE_CLOSE] test',
       }),
-    ).rejects.toThrow(/R5_LIVE_PRICE_STALE_OR_FALLBACK/);
+    ).rejects.toThrow(/R5_LIVE_PRICE_(STALE|FALLBACK)/);
   });
 
   it('reject close avec source=stale_eodhd', async () => {
@@ -96,7 +96,7 @@ describe('PaperBrokerService.closePosition — P19-staleness R5 reject', () => {
         livePriceSource: 'stale_eodhd',
         rationale: 'test',
       }),
-    ).rejects.toThrow(/R5_LIVE_PRICE_STALE_OR_FALLBACK/);
+    ).rejects.toThrow(/R5_LIVE_PRICE_(STALE|FALLBACK)/);
   });
 
   it('reject close avec source=fallback_unknown', async () => {
@@ -109,7 +109,7 @@ describe('PaperBrokerService.closePosition — P19-staleness R5 reject', () => {
         livePriceSource: 'fallback_unknown',
         rationale: 'test',
       }),
-    ).rejects.toThrow(/R5_LIVE_PRICE_STALE_OR_FALLBACK/);
+    ).rejects.toThrow(/R5_LIVE_PRICE_(STALE|FALLBACK)/);
   });
 
   it('accepte close avec source=twelvedata (frais, non-stale)', async () => {
@@ -126,8 +126,8 @@ describe('PaperBrokerService.closePosition — P19-staleness R5 reject', () => {
         rationale: 'test',
       });
     } catch (e) {
-      // Ne doit PAS être un R5_LIVE_PRICE_STALE_OR_FALLBACK
-      expect(String(e)).not.toMatch(/R5_LIVE_PRICE_STALE_OR_FALLBACK/);
+      // Ne doit PAS être un R5_LIVE_PRICE_(STALE|FALLBACK)
+      expect(String(e)).not.toMatch(/R5_LIVE_PRICE_(STALE|FALLBACK)/);
     }
   });
 
@@ -141,8 +141,8 @@ describe('PaperBrokerService.closePosition — P19-staleness R5 reject', () => {
         rationale: 'test legacy caller without source',
       });
     } catch (e) {
-      // Ne doit PAS être un R5_LIVE_PRICE_STALE_OR_FALLBACK
-      expect(String(e)).not.toMatch(/R5_LIVE_PRICE_STALE_OR_FALLBACK/);
+      // Ne doit PAS être un R5_LIVE_PRICE_(STALE|FALLBACK)
+      expect(String(e)).not.toMatch(/R5_LIVE_PRICE_(STALE|FALLBACK)/);
     }
   });
 });


### PR DESCRIPTION
## Contexte

Hier soir 20:22 UTC, on a inséré la lesson `END_OF_SESSION_WAIT` (a1dfac77, scope `trader_agent_only`) qui apprend au LLM TRADER à ne pas ouvrir < 30 min avant la cloche. **Cette PR ajoute le pendant déterministe pour les scanners gainers** (MIDDLE/HIGH/SMALL/MAIN) qui ne lisent pas les lessons.

## Le problème

Avant cette PR :
- TRADER : lesson `END_OF_SESSION_WAIT` ⇒ LLM hold à T-30min ✅
- MIDDLE/HIGH/SMALL/MAIN : **aucun gate** ⇒ peut ouvrir à T-5min ❌

`gainers_force_close_offset_min = 30` force-CLOSE les positions existantes 30 min avant la cloche, mais **ne bloque pas les nouvelles ouvertures**. Trou exploitable.

## Le fix

Nouveau gate dans `top-gainers-scanner.service.ts` après dead-zone, avant hour-gate :

```ts
const eosCls = sessionClassFor(String(cand.assetClass));
if (eosCls) {  // crypto exempt (null = 24/7)
  const noOpenMin = ... (per-class env > global env > 0=off);
  if (noOpenMin > 0 && isApproachingClose(eosCls, noOpenMin, nowUtc)) {
    log → skip + recordShadowDecision('reject_eos_no_open');
    continue;
  }
}
```

## Configuration (opt-in)

| Secret | Effet | Default |
|--------|-------|---------|
| `GAINERS_NO_OPEN_LAST_MIN_BEFORE_CLOSE` | Global toutes classes equity | `0` (off) |
| `GAINERS_NO_OPEN_LAST_MIN_BEFORE_CLOSE_US_EQUITY_LARGE` | Override US large | — |
| `GAINERS_NO_OPEN_LAST_MIN_BEFORE_CLOSE_EU_EQUITY` | Override EU | — |
| `GAINERS_NO_OPEN_LAST_MIN_BEFORE_CLOSE_ASIA_EQUITY` | Override Asia | — |

Crypto (`crypto_major` / `crypto_alt`) → `sessionClassFor` retourne `null` → gate skippé automatiquement.

## Math justificative

```
vol_per_min_intraday ≈ 0.15%/min
t_TP_3pct ≈ 3 / 0.15 = 20 min médiane
+ 50% marge sécurité = 30 min réaliste
```

→ Ouvrir < 30 min avant la cloche = TP statistiquement inatteignable → force-close à prix aléatoire.

## Symétrie lesson ↔ gate

| Système | Concerné | Mécanisme | Source de vérité |
|---------|----------|-----------|------------------|
| Lesson `END_OF_SESSION_WAIT` | TRADER (LLM autonome) | Cite `[END_OF_SESSION_WAIT]` marker dans thesis | `scanner_lessons` DB |
| Gate `EOS_NO_OPEN` | Scanners gainers (déterministe) | Log `EOS_NO_OPEN actif` + `reject_eos_no_open` | Fly secret env |

## Test plan

- [x] TypeScript build : OK (`tsc --noEmit` — pas de nouvelle erreur)
- [x] Jest apps/api : 222/222 suites, 2986/2986 tests verts
- [x] Jest ai-analyst : 36/36 suites, 685/685 tests verts
- [ ] CI vert (à vérifier)
- [ ] Activation prod après merge :
      ```bash
      fly secrets set GAINERS_NO_OPEN_LAST_MIN_BEFORE_CLOSE=30 -a smartvest
      ```
- [ ] Vérif live : logs Fly doivent montrer `EOS_NO_OPEN actif` dans la fenêtre 30 min avant US close (21:00 UTC), EU close (16:30 UTC), Asia close (08:00 UTC).

## Note importante

PR inclut aussi les 8 fixes de tests pré-existants (idem PR #491/#492) pour CI verte. Pas de changement de logique applicative.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_