### PR TITLE
feat(trader): inject recentClosesLast60min in state for self-awareness

### DIFF
--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -1136,9 +1136,22 @@ Recommendation rules :
     dailyPnlUsd: number;
     closedTodayCount: number;
     winRateTodayPct: number | null;
+    recentClosesLast60min: Array<{
+      symbol: string;
+      direction: string;
+      exit_at: string;
+      exit_reason: string;
+      pnl_usd: number;
+      pnl_pct: number;
+      minutes_ago: number;
+    }>;
   }> {
     const client = this.supabase.getClient();
     const todayStart = `${new Date().toISOString().slice(0, 10)}T00:00:00Z`;
+    // Fenêtre 60 min — couvre la lesson b4c48e13 ANTI_REENTRY_POST_INVALIDATION
+    // (30 min) avec marge contextuelle. Volume typique TRADER ≈ 1-2 closes/h
+    // donc liste typique de 1-2 entrées (~200-400 tokens prompt, négligeable).
+    const sixtyMinAgoIso = new Date(Date.now() - 60 * 60_000).toISOString();
 
     const { data: open } = await client
       .from('lisa_positions')
@@ -1153,6 +1166,17 @@ Recommendation rules :
       .gte('exit_timestamp', todayStart)
       .neq('status', 'open');
 
+    // Closes des 60 dernières minutes — injecté dans le state pour que le LLM
+    // voie ses propres actions récentes (sans cela il est aveugle aux closes
+    // qu'il vient lui-même de décider, cas vérifié XRPUSDT 30/05 02:05 -$22).
+    const { data: recentClosed } = await client
+      .from('lisa_positions')
+      .select('symbol, direction, exit_timestamp, exit_reason, realized_pnl_usd, realized_pnl_pct')
+      .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID)
+      .gte('exit_timestamp', sixtyMinAgoIso)
+      .neq('status', 'open')
+      .order('exit_timestamp', { ascending: false });
+
     const openPositions = (open ?? []).map((p) => ({
       symbol: p.symbol as string,
       direction: p.direction as string,
@@ -1165,6 +1189,17 @@ Recommendation rules :
     const wins = (closed ?? []).filter((c) => Number(c.realized_pnl_usd ?? 0) > 0).length;
     const winRate = (closed?.length ?? 0) > 0 ? (wins / closed!.length) * 100 : null;
 
+    const nowMs = Date.now();
+    const recentClosesLast60min = (recentClosed ?? []).map((c) => ({
+      symbol: c.symbol as string,
+      direction: c.direction as string,
+      exit_at: c.exit_timestamp as string,
+      exit_reason: (c.exit_reason as string | null) ?? 'unknown',
+      pnl_usd: Number(c.realized_pnl_usd ?? 0),
+      pnl_pct: Number(c.realized_pnl_pct ?? 0),
+      minutes_ago: Math.floor((nowMs - new Date(c.exit_timestamp as string).getTime()) / 60_000),
+    }));
+
     return {
       openPositions,
       openCount: openPositions.length,
@@ -1173,6 +1208,7 @@ Recommendation rules :
       dailyPnlUsd: dailyPnl,
       closedTodayCount: closed?.length ?? 0,
       winRateTodayPct: winRate,
+      recentClosesLast60min,
     };
   }
 


### PR DESCRIPTION
## Contexte

Cas vérifié **30/05 02:05 UTC — XRPUSDT -$22.13** :

```
02:04:45 UTC : LLM ferme XRPUSDT à $1.3586 (+$12.97 closed_invalidated)
02:05:00 UTC : nouveau cycle TRADER démarre
02:05:22 UTC : input_state ne contient PAS la close de 02:04:45
              LLM voit XRPUSDT comme candidat NEUF
              → open_directional XRPUSDT à $1.3574 (pumpScore=0.75)
04:32 UTC    : closed_invalidated -$22.13
```

**Contradiction interne du LLM en 37 secondes** que le LLM ne pouvait pas détecter — il était aveugle à sa propre fermeture précédente.

## Le problème

`readState()` renvoyait uniquement des compteurs agrégés :
```ts
{ openCount, dailyPnlUsd, deployedUsd, openPositions, winRateTodayPct, closedTodayCount, capitalAvailableUsd }
```

Aucune trace granulaire des closes récentes. Le LLM ne pouvait pas savoir qu'il venait de fermer XRPUSDT en `closed_invalidated` 37 secondes plus tôt.

## La fix

Ajout d'un champ `recentClosesLast60min` dans `readState()` :

```ts
recentClosesLast60min: [
  {
    symbol: "XRPUSDT",
    direction: "long",
    exit_at: "2026-05-30T02:04:45Z",
    exit_reason: "closed_invalidated",
    pnl_usd: 12.97,
    pnl_pct: 0.65,
    minutes_ago: 1
  }
]
```

## Combo avec lesson existante

La lesson `b4c48e13` (ANTI_REENTRY_POST_INVALIDATION, insérée 30/05 09:00) dit :
> *"si closed_invalidated sur ticker X < 30min → hold avec marker `[ANTI_REENTRY_POST_INVALIDATION]`"*

**Avant cette PR** : la lesson était inapplicable car le LLM n'avait pas les données nécessaires.

**Après cette PR** : le LLM voit explicitement `XRPUSDT closed_invalidated il y a 1 min` → applique la règle → refuse open.

## Pourquoi 60 min

| Window | Argument |
|--------|----------|
| < 30 min | Ne couvre pas la lesson (30 min de blocage) |
| **60 min** | Sweet spot : couvre la lesson + marge contextuelle |
| 120+ min | Pollution prompt sans valeur |

Volume typique TRADER ≈ 1-2 closes/h → liste typique 1-2 entrées → ~200-400 tokens prompt extra (+1-2% budget).

## Changement minimal

- **Un seul fichier** : `live-trader-agent.service.ts`
- **Une seule méthode** : `readState()`
- **Additif pur** : +36 lignes, -0 ligne, 0 modif de logique existante
- **Lecture seule DB** : pas d'UPDATE
- **Pas de changement décisionnel** : aucune modif des gates ou des règles d'ouverture

## Test plan

- [x] TypeScript build : OK (erreurs `lisa.service.ts` pré-existantes sur main, hors-scope)
- [x] Jest apps/api : 222/222 suites, 2986/2986 tests verts
- [x] Jest ai-analyst : 36/36 suites, 686/686 tests verts
- [ ] CI verte
- [ ] Vérif live post-deploy : prochain cycle TRADER doit logguer `recentClosesLast60min` dans `input_state` (visible via `trader_agent_decisions.input_state`)
- [ ] Vérif comportementale : au prochain cas de close récent < 30min, le LLM doit refuser le re-entry avec marker `[ANTI_REENTRY_POST_INVALIDATION]` dans la thesis

## Effet attendu

Aurait évité les **-$22 XRPUSDT** ce matin si déployée hier. Pour le futur :
- Réduit le pattern de "ré-évaluation à 1 minute" qui crée des ping-pongs perdants
- N=6 cas historiques `closed_invalidated → re-entry ≤15min` sont tous perdants (-$71 cumul TRADER)
- Forward-looking : protège contre les nouvelles itérations du même bug

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_