### PR TITLE
feat(lisa): refonte page /lisa — Phases A/B/C (TRADER autonome)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -1464,6 +1464,47 @@ export class LisaController {
     return this.lisa.triggerKillSwitch(extractUserId(headers), portfolioId, reason ?? 'Manual user kill');
   }
 
+  // LISA refonte B.3 — Désarme le kill-switch (anti-spirale ou manuel).
+  // Pas de force-close, juste UPDATE kill_switch_active=false.
+  @Post('kill-switch-reset/:portfolioId')
+  @HttpCode(200)
+  resetKillSwitch(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+  ) {
+    return this.lisa.resetKillSwitch(extractUserId(headers), portfolioId);
+  }
+
+  // LISA refonte B.3 — Lessons management (CRUD partiel : list + toggle).
+  @Get('scanner-lessons')
+  listScannerLessons(
+    @Headers() headers: Record<string, string>,
+    @Query('active') active?: string,
+    @Query('search') search?: string,
+    @Query('scope') scope?: string,
+    @Query('limit') limit?: string,
+  ) {
+    extractUserId(headers);
+    const opts: { active?: boolean; search?: string; scope?: string; limit?: number } = {};
+    if (active === 'true') opts.active = true;
+    else if (active === 'false') opts.active = false;
+    if (search) opts.search = search;
+    if (scope) opts.scope = scope;
+    if (limit) opts.limit = parseInt(limit, 10);
+    return this.lisa.listScannerLessons(opts);
+  }
+
+  @Patch('scanner-lessons/:id')
+  @HttpCode(200)
+  toggleScannerLesson(
+    @Headers() headers: Record<string, string>,
+    @Param('id') id: string,
+    @Body('is_active') isActive: boolean,
+  ) {
+    extractUserId(headers);
+    return this.lisa.setScannerLessonActive(id, Boolean(isActive));
+  }
+
   @Post('portfolio/:portfolioId/reset-simulation')
   @HttpCode(200)
   resetSimulation(

--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -1495,6 +1495,36 @@ export class LisaController {
     return this.lisa.triggerKillSwitch(extractUserId(headers), portfolioId, reason ?? 'Manual user kill');
   }
 
+  // LISA refonte C.1 — Coach proposals : list / accept / reject.
+  @Get('coach-proposals/:portfolioId')
+  listCoachProposals(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+    @Query('status') status?: string,
+  ) {
+    return this.lisa.listCoachProposals(extractUserId(headers), portfolioId, status);
+  }
+
+  @Post('coach-proposals/:id/accept')
+  @HttpCode(200)
+  acceptCoachProposal(
+    @Headers() headers: Record<string, string>,
+    @Param('id') id: string,
+    @Body() body: { accepted_lessons?: number[]; accepted_params?: number[]; comment?: string },
+  ) {
+    return this.lisa.acceptCoachProposal(extractUserId(headers), id, body ?? {});
+  }
+
+  @Post('coach-proposals/:id/reject')
+  @HttpCode(200)
+  rejectCoachProposal(
+    @Headers() headers: Record<string, string>,
+    @Param('id') id: string,
+    @Body('comment') comment?: string,
+  ) {
+    return this.lisa.rejectCoachProposal(extractUserId(headers), id, comment);
+  }
+
   // LISA refonte B.4.a — In-app notifications (badge + dropdown).
   @Get('notifications/:portfolioId')
   getNotifications(

--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -1464,6 +1464,15 @@ export class LisaController {
     return this.lisa.triggerKillSwitch(extractUserId(headers), portfolioId, reason ?? 'Manual user kill');
   }
 
+  // LISA refonte B.4.a — In-app notifications (badge + dropdown).
+  @Get('notifications/:portfolioId')
+  getNotifications(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+  ) {
+    return this.lisa.getNotifications(extractUserId(headers), portfolioId);
+  }
+
   // LISA refonte B.3 — Désarme le kill-switch (anti-spirale ou manuel).
   // Pas de force-close, juste UPDATE kill_switch_active=false.
   @Post('kill-switch-reset/:portfolioId')

--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -30,6 +30,7 @@ import { PostSlBackfillService } from './services/post-sl-backfill.service';
 import { MultiTimeframePersistenceService } from './services/multi-tf-persistence.service';
 import { PersistenceProbabilityService } from './services/persistence-probability.service';
 import { EodhdQuotaService } from './services/eodhd-quota.service';
+import { PushNotificationsService, type PushSubscriptionPayload } from './services/push-notifications.service';
 import { summarizeByTf, type PersistenceResult } from '@smartvest/ai-analyst';
 import type { DailyHarvestConfig, CapitalDisciplineMode } from './types/capital-discipline.types';
 
@@ -61,7 +62,37 @@ export class LisaController {
     private readonly riskState: RiskStateService,
     private readonly dailyCatalystBrief: DailyCatalystBriefService,
     private readonly eventEngine: EventEngineService,
+    private readonly pushNotifs: PushNotificationsService,
   ) {}
+
+  // LISA refonte B.4.c — Web Push API VAPID endpoints.
+  @Get('push/vapid-public-key')
+  getVapidPublicKey() {
+    return { publicKey: this.pushNotifs.getPublicKey() };
+  }
+
+  @Post('push/subscribe')
+  @HttpCode(200)
+  pushSubscribe(
+    @Headers() headers: Record<string, string>,
+    @Body() body: PushSubscriptionPayload,
+  ) {
+    return this.pushNotifs.subscribe(extractUserId(headers), body);
+  }
+
+  @Post('push/unsubscribe')
+  @HttpCode(200)
+  pushUnsubscribe(
+    @Headers() headers: Record<string, string>,
+    @Body('endpoint') endpoint: string,
+  ) {
+    return this.pushNotifs.unsubscribe(extractUserId(headers), endpoint);
+  }
+
+  @Get('push/subscriptions')
+  pushList(@Headers() headers: Record<string, string>) {
+    return this.pushNotifs.listSubscriptions(extractUserId(headers));
+  }
 
   // ─────────────────────────────────────────────────────────────────
   // PR #338 — UI Phase 5 N1+N2 endpoints

--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -1431,6 +1431,18 @@ export class LisaController {
     return this.lisa.getDecisionLog(extractUserId(headers), portfolioId, limit ? parseInt(limit, 10) : 50);
   }
 
+  // LISA refonte B.2 — Lessons Impact Tracker.
+  // Agrège les citations sur une fenêtre glissante (default 30j, max 365).
+  @Get('lessons-impact/:portfolioId')
+  getLessonsImpact(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+    @Query('days') days?: string,
+  ) {
+    const parsedDays = Math.min(Math.max(parseInt(days ?? '30', 10) || 30, 1), 365);
+    return this.lisa.getLessonsImpact(extractUserId(headers), portfolioId, parsedDays);
+  }
+
   // ── Risk monitoring + kill-switch ───────────────────────────────────────────
 
   @Post('risk-check/:portfolioId')

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -56,6 +56,7 @@ import { MainScannerPostMortemService } from './services/main-scanner-postmortem
 import { DailyDigestService } from './services/daily-digest.service';
 import { PushNotificationsService } from './services/push-notifications.service';
 import { StrategyCoachService } from './services/strategy-coach.service';
+import { TraderRetrospectiveService } from './services/trader-retrospective.service';
 import { LessonAutoApplyService } from './services/lesson-auto-apply.service';
 import { ScannerLessonsContextService } from './services/scanner-lessons-context.service';
 import { ConfigSanityValidatorService } from './services/config-sanity-validator.service';
@@ -213,6 +214,10 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     // StrategyCoachService (C.1) — cron hourly @ minute 17, Gemini Flash + Pro
     // escalations. Génère coach_proposals consommées par UI review (C.2).
     StrategyCoachService,
+    // TraderRetrospectiveService (C.4) — cron daily 02:00 UTC. Analyse trades
+    // TRADER veille via Gemini Pro, INSERT scanner_lessons scope='trader_agent_only'
+    // is_active=true (réinjectées dans system prompt trader cycle suivant).
+    TraderRetrospectiveService,
     // ScannerLessonsContextService — fournit le bloc Markdown des lessons actives
     // à injecter dans les system prompts (signal validation, ranking, risk manager, macro veto).
     // Cache TTL 5 min pour éviter requêtes DB répétées (scanner ~500 calls/cycle).

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -53,6 +53,7 @@ import { GainersUserShadowService } from './services/gainers-user-shadow.service
 import { ShadowSizingOrchestratorService } from './services/shadow-sizing-orchestrator.service';
 import { LiveTraderAgentService } from './services/live-trader-agent.service';
 import { MainScannerPostMortemService } from './services/main-scanner-postmortem.service';
+import { DailyDigestService } from './services/daily-digest.service';
 import { LessonAutoApplyService } from './services/lesson-auto-apply.service';
 import { ScannerLessonsContextService } from './services/scanner-lessons-context.service';
 import { ConfigSanityValidatorService } from './services/config-sanity-validator.service';
@@ -201,6 +202,9 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     // MainScannerPostMortemService — apprentissage Gemini Pro sur le scanner gainers
     // (cron 02:30 UTC : analyse 24h × 4 portfolios → lessons macro-conditionnelles).
     MainScannerPostMortemService,
+    // DailyDigestService (B.4.b) — email récap quotidien via Resend (09:00 UTC).
+    // Requires RESEND_API_KEY + DAILY_DIGEST_FROM_EMAIL Fly secrets, sinon DRY mode.
+    DailyDigestService,
     // ScannerLessonsContextService — fournit le bloc Markdown des lessons actives
     // à injecter dans les system prompts (signal validation, ranking, risk manager, macro veto).
     // Cache TTL 5 min pour éviter requêtes DB répétées (scanner ~500 calls/cycle).

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -54,6 +54,7 @@ import { ShadowSizingOrchestratorService } from './services/shadow-sizing-orches
 import { LiveTraderAgentService } from './services/live-trader-agent.service';
 import { MainScannerPostMortemService } from './services/main-scanner-postmortem.service';
 import { DailyDigestService } from './services/daily-digest.service';
+import { PushNotificationsService } from './services/push-notifications.service';
 import { LessonAutoApplyService } from './services/lesson-auto-apply.service';
 import { ScannerLessonsContextService } from './services/scanner-lessons-context.service';
 import { ConfigSanityValidatorService } from './services/config-sanity-validator.service';
@@ -205,6 +206,9 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     // DailyDigestService (B.4.b) — email récap quotidien via Resend (09:00 UTC).
     // Requires RESEND_API_KEY + DAILY_DIGEST_FROM_EMAIL Fly secrets, sinon DRY mode.
     DailyDigestService,
+    // PushNotificationsService (B.4.c) — Web Push API trigger-only.
+    // Requires VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY / VAPID_SUBJECT (sinon subscribe OK, sends SKIP).
+    PushNotificationsService,
     // ScannerLessonsContextService — fournit le bloc Markdown des lessons actives
     // à injecter dans les system prompts (signal validation, ranking, risk manager, macro veto).
     // Cache TTL 5 min pour éviter requêtes DB répétées (scanner ~500 calls/cycle).

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -55,6 +55,7 @@ import { LiveTraderAgentService } from './services/live-trader-agent.service';
 import { MainScannerPostMortemService } from './services/main-scanner-postmortem.service';
 import { DailyDigestService } from './services/daily-digest.service';
 import { PushNotificationsService } from './services/push-notifications.service';
+import { StrategyCoachService } from './services/strategy-coach.service';
 import { LessonAutoApplyService } from './services/lesson-auto-apply.service';
 import { ScannerLessonsContextService } from './services/scanner-lessons-context.service';
 import { ConfigSanityValidatorService } from './services/config-sanity-validator.service';
@@ -209,6 +210,9 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     // PushNotificationsService (B.4.c) — Web Push API trigger-only.
     // Requires VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY / VAPID_SUBJECT (sinon subscribe OK, sends SKIP).
     PushNotificationsService,
+    // StrategyCoachService (C.1) — cron hourly @ minute 17, Gemini Flash + Pro
+    // escalations. Génère coach_proposals consommées par UI review (C.2).
+    StrategyCoachService,
     // ScannerLessonsContextService — fournit le bloc Markdown des lessons actives
     // à injecter dans les system prompts (signal validation, ranking, risk manager, macro veto).
     // Cache TTL 5 min pour éviter requêtes DB répétées (scanner ~500 calls/cycle).

--- a/apps/api/src/modules/lisa/services/daily-digest.service.ts
+++ b/apps/api/src/modules/lisa/services/daily-digest.service.ts
@@ -1,0 +1,270 @@
+// LISA refonte B.4.b — Daily digest email cron via Resend API.
+//
+// Cron 09:00 UTC : pour chaque portfolio avec lisa_daily_digest_enabled=true
+// ET lisa_notification_email IS NOT NULL, envoie un récap HTML du jour D-1.
+//
+// Resend API : POST https://api.resend.com/emails (fetch direct, pas de dep).
+// Pré-requis : secret Fly RESEND_API_KEY + DAILY_DIGEST_FROM_EMAIL.
+// Sans ces secrets, le cron tourne et log SKIP/ERROR mais ne crash pas.
+
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+interface PortfolioConfig {
+  portfolio_id: string;
+  user_id: string;
+  lisa_notification_email: string;
+  lisa_initial_capital_usd: number;
+  lisa_compound_pnl_enabled: boolean;
+  kill_switch_active: boolean;
+  lisa_target_daily_usd: number;
+  lisa_target_daily_pct: number;
+}
+
+interface DigestData {
+  cfg: PortfolioConfig;
+  currentCapital: number;
+  yesterdayPnl: number;
+  yesterdayCount: number;
+  yesterdayWins: number;
+  yesterdayLosses: number;
+  effectiveDailyTarget: number;
+  topLessons: Array<{ kind: string; citations: number; sumPnl: number }>;
+}
+
+@Injectable()
+export class DailyDigestService {
+  private readonly logger = new Logger(DailyDigestService.name);
+  private enabled = false;
+  private apiKey: string | null = null;
+  private fromEmail: string | null = null;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+    private readonly schedulerRegistry: SchedulerRegistry,
+  ) {}
+
+  onModuleInit(): void {
+    this.enabled = (this.config.get<string>('DAILY_DIGEST_ENABLED') ?? 'true').toLowerCase() === 'true';
+    this.apiKey = this.config.get<string>('RESEND_API_KEY') ?? null;
+    this.fromEmail = this.config.get<string>('DAILY_DIGEST_FROM_EMAIL') ?? 'lisa@smartvest.app';
+
+    if (!this.enabled) {
+      this.logger.log('[daily-digest] disabled via env DAILY_DIGEST_ENABLED=false');
+      return;
+    }
+
+    try {
+      // 09:00 UTC chaque jour
+      const job = new CronJob('0 9 * * *', () => {
+        this.runDigest().catch((e) =>
+          this.logger.error(`[daily-digest] cron failed: ${String(e).slice(0, 200)}`),
+        );
+      });
+      this.schedulerRegistry.addCronJob('lisa-daily-digest', job);
+      job.start();
+      this.logger.log(
+        `[daily-digest] ENABLED — cron 09:00 UTC, resend_key=${this.apiKey ? 'set' : 'MISSING'}, from=${this.fromEmail}`,
+      );
+    } catch (e) {
+      this.logger.error(`[daily-digest] cron register failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  /**
+   * Exécutable manuellement (via admin endpoint si besoin) ou via cron.
+   * Retourne stats { sent, skipped, errors }.
+   */
+  async runDigest(): Promise<{ sent: number; skipped: number; errors: number }> {
+    if (!this.supabase.isReady()) {
+      this.logger.warn('[daily-digest] supabase not ready, skip');
+      return { sent: 0, skipped: 0, errors: 0 };
+    }
+    if (!this.apiKey) {
+      this.logger.warn('[daily-digest] RESEND_API_KEY missing — runs in DRY mode (log only)');
+    }
+
+    const client = this.supabase.getClient();
+    const { data: configs, error } = await client
+      .from('lisa_session_configs')
+      .select('portfolio_id, user_id, lisa_notification_email, lisa_initial_capital_usd, lisa_compound_pnl_enabled, kill_switch_active, lisa_target_daily_usd, lisa_target_daily_pct')
+      .eq('lisa_daily_digest_enabled', true)
+      .not('lisa_notification_email', 'is', null);
+    if (error) {
+      this.logger.error(`[daily-digest] config fetch err: ${error.message}`);
+      return { sent: 0, skipped: 0, errors: 1 };
+    }
+
+    let sent = 0;
+    let skipped = 0;
+    let errors = 0;
+    for (const cfg of (configs ?? []) as Array<Record<string, unknown>>) {
+      const portfolioId = String(cfg.portfolio_id);
+      const email = String(cfg.lisa_notification_email ?? '').trim();
+      if (!email) { skipped++; continue; }
+
+      try {
+        const data = await this.buildDigestData(cfg as unknown as PortfolioConfig);
+        const html = this.renderHtml(data);
+        const subject = this.buildSubject(data);
+
+        if (this.apiKey) {
+          await this.sendViaResend(email, subject, html);
+        } else {
+          this.logger.log(`[daily-digest] DRY would-send to ${email} subject="${subject}"`);
+        }
+        await client.from('lisa_decision_log').insert({
+          portfolio_id: portfolioId,
+          kind: 'daily_digest_sent',
+          payload: {
+            email,
+            yesterday_pnl: data.yesterdayPnl,
+            trades_count: data.yesterdayCount,
+            dry: !this.apiKey,
+          },
+        });
+        sent++;
+      } catch (e) {
+        const msg = String(e).slice(0, 200);
+        this.logger.warn(`[daily-digest] portfolio=${portfolioId.slice(0, 8)} err: ${msg}`);
+        await client.from('lisa_decision_log').insert({
+          portfolio_id: portfolioId,
+          kind: 'daily_digest_error',
+          payload: { email, error: msg },
+        });
+        errors++;
+      }
+    }
+    this.logger.log(`[daily-digest] done sent=${sent} skipped=${skipped} errors=${errors}`);
+    return { sent, skipped, errors };
+  }
+
+  private async buildDigestData(cfg: PortfolioConfig): Promise<DigestData> {
+    const client = this.supabase.getClient();
+    const now = new Date();
+    const yesterdayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const yesterdayEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+
+    const initialCapital = Number(cfg.lisa_initial_capital_usd ?? 10000);
+    const compound = Boolean(cfg.lisa_compound_pnl_enabled ?? true);
+
+    const { data: allClosed } = await client
+      .from('lisa_positions')
+      .select('realized_pnl_usd, exit_timestamp')
+      .eq('portfolio_id', cfg.portfolio_id)
+      .neq('status', 'open');
+    const cumulative = (allClosed ?? []).reduce(
+      (s, c) => s + Number((c as { realized_pnl_usd?: unknown }).realized_pnl_usd ?? 0),
+      0,
+    );
+    const currentCapital = compound ? initialCapital + cumulative : initialCapital;
+
+    const yesterdayRows = (allClosed ?? []).filter((c) => {
+      const t = String((c as { exit_timestamp?: string }).exit_timestamp ?? '');
+      return t >= yesterdayStart.toISOString() && t < yesterdayEnd.toISOString();
+    });
+    const yesterdayPnl = yesterdayRows.reduce(
+      (s, c) => s + Number((c as { realized_pnl_usd?: unknown }).realized_pnl_usd ?? 0),
+      0,
+    );
+    const yesterdayWins = yesterdayRows.filter((c) => Number((c as { realized_pnl_usd?: unknown }).realized_pnl_usd ?? 0) > 0).length;
+    const yesterdayLosses = yesterdayRows.filter((c) => Number((c as { realized_pnl_usd?: unknown }).realized_pnl_usd ?? 0) < 0).length;
+
+    const dailyUsdFloor = Number(cfg.lisa_target_daily_usd ?? 200);
+    const dailyPct = Number(cfg.lisa_target_daily_pct ?? 2);
+    const effectiveDailyTarget = Math.max(dailyUsdFloor, (dailyPct / 100) * currentCapital);
+
+    // Top lessons cited last 24h
+    const { data: citations } = await client
+      .from('scanner_lesson_citations')
+      .select('lesson_id, marker_text, outcome_pnl_usd')
+      .eq('portfolio_id', cfg.portfolio_id)
+      .gte('cited_at', yesterdayStart.toISOString())
+      .lt('cited_at', yesterdayEnd.toISOString());
+    const lessonAgg = new Map<string, { kind: string; citations: number; sumPnl: number }>();
+    for (const c of (citations ?? []) as Array<Record<string, unknown>>) {
+      const key = String(c.marker_text ?? '?');
+      let b = lessonAgg.get(key);
+      if (!b) { b = { kind: key, citations: 0, sumPnl: 0 }; lessonAgg.set(key, b); }
+      b.citations += 1;
+      b.sumPnl += Number(c.outcome_pnl_usd ?? 0);
+    }
+    const topLessons = [...lessonAgg.values()].sort((a, b) => b.citations - a.citations).slice(0, 3);
+
+    return { cfg, currentCapital, yesterdayPnl, yesterdayCount: yesterdayRows.length, yesterdayWins, yesterdayLosses, effectiveDailyTarget, topLessons };
+  }
+
+  private buildSubject(d: DigestData): string {
+    const pnlStr = d.yesterdayPnl >= 0 ? `+$${d.yesterdayPnl.toFixed(2)}` : `-$${Math.abs(d.yesterdayPnl).toFixed(2)}`;
+    const emoji = d.yesterdayPnl >= 0 ? '✅' : '⚠️';
+    const ks = d.cfg.kill_switch_active ? ' 🛑' : '';
+    return `${emoji} LISA jour D-1 : ${pnlStr} · ${d.yesterdayCount} trades${ks}`;
+  }
+
+  private renderHtml(d: DigestData): string {
+    const pnlColor = d.yesterdayPnl > 0 ? '#059669' : d.yesterdayPnl < 0 ? '#dc2626' : '#6b7280';
+    const pnlSign = d.yesterdayPnl >= 0 ? '+' : '-';
+    const pnlAbs = Math.abs(d.yesterdayPnl).toFixed(2);
+    const pctTarget = d.effectiveDailyTarget > 0 ? (d.yesterdayPnl / d.effectiveDailyTarget * 100).toFixed(0) : '—';
+    const wr = (d.yesterdayWins + d.yesterdayLosses) > 0
+      ? ((d.yesterdayWins / (d.yesterdayWins + d.yesterdayLosses)) * 100).toFixed(0)
+      : '—';
+
+    const killBanner = d.cfg.kill_switch_active
+      ? `<div style="background:#fee2e2;border-left:4px solid #dc2626;padding:12px;margin-bottom:16px;border-radius:4px;"><strong>🛑 Kill-switch anti-spirale armé</strong><br/><span style="font-size:13px;color:#991b1b">TRADER suspendu. Désarme manuellement dans Config LISA pour reprendre.</span></div>`
+      : '';
+
+    const lessonsBlock = d.topLessons.length > 0
+      ? `<h3 style="font-size:14px;margin-top:24px;margin-bottom:8px;">📚 Top lessons hier</h3><ul style="padding-left:20px;font-size:13px;">${d.topLessons.map(l => `<li><code style="background:#f3f4f6;padding:2px 6px;border-radius:3px;">${l.kind}</code> · ${l.citations} citation(s) · ${l.sumPnl >= 0 ? '+' : ''}$${l.sumPnl.toFixed(2)}</li>`).join('')}</ul>`
+      : '';
+
+    return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#111827;">
+  <h1 style="font-size:20px;margin-bottom:4px;">🤖 LISA — Récap jour D-1</h1>
+  <p style="color:#6b7280;font-size:13px;margin-top:0;">Capital actuel : $${d.currentCapital.toFixed(0)} (initial $${d.cfg.lisa_initial_capital_usd.toFixed(0)})</p>
+
+  ${killBanner}
+
+  <div style="background:#f9fafb;border-radius:8px;padding:16px;margin:16px 0;">
+    <div style="font-size:13px;color:#6b7280;">P&amp;L réalisé hier</div>
+    <div style="font-size:32px;font-weight:700;color:${pnlColor};margin:4px 0;">${pnlSign}$${pnlAbs}</div>
+    <div style="font-size:12px;color:#6b7280;">
+      ${d.yesterdayCount} trades · ${d.yesterdayWins}W / ${d.yesterdayLosses}L · win-rate ${wr}%
+    </div>
+    <div style="font-size:12px;color:#6b7280;margin-top:4px;">
+      Cible jour : $${d.effectiveDailyTarget.toFixed(0)} · atteint ${pctTarget}%
+    </div>
+  </div>
+
+  ${lessonsBlock}
+
+  <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;"/>
+  <p style="font-size:11px;color:#9ca3af;">Tu peux désactiver ces emails dans Config LISA &gt; Daily Digest.</p>
+</body></html>`;
+  }
+
+  private async sendViaResend(to: string, subject: string, html: string): Promise<void> {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: this.fromEmail,
+        to: [to],
+        subject,
+        html,
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`Resend ${res.status}: ${body.slice(0, 200)}`);
+    }
+  }
+}

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -2584,6 +2584,139 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     return data ?? [];
   }
 
+  /**
+   * LISA refonte B.2 — Lessons Impact Tracker.
+   *
+   * Agrège les citations de lessons par TRADER sur une fenêtre glissante.
+   * Pour chaque lesson (ou marker orphan non mappé), retourne :
+   *   - citations_count, applied_count, resolved_count, wins, losses
+   *   - sum_pnl_usd, avg_pnl_usd, win_rate_pct, last_cited_at
+   *   - métadonnées scanner_lessons (lesson_kind, lesson_text, confidence, etc.)
+   *
+   * Stratégie : fetch citations + lessons séparément, agrégation TS.
+   * Volumétrie raisonnable jusqu'à ~10k citations (limite hard).
+   */
+  async getLessonsImpact(userId: string, portfolioId: string, days = 30) {
+    await this.assertPortfolioOwner(userId, portfolioId);
+    const client = this.supabase.getClient();
+    const sinceIso = new Date(Date.now() - days * 86400_000).toISOString();
+
+    const { data: citations, error: cErr } = await client
+      .from('scanner_lesson_citations')
+      .select('lesson_id, marker_text, action_applied, outcome_resolved_at, outcome_win, outcome_pnl_usd, cited_at')
+      .eq('portfolio_id', portfolioId)
+      .gte('cited_at', sinceIso)
+      .limit(10000);
+    if (cErr) throw new BadRequestException(cErr.message);
+    const allCitations = citations ?? [];
+
+    type LessonRow = {
+      id: string;
+      lesson_kind: string;
+      lesson_text: string | null;
+      confidence: number | null;
+      is_active: boolean;
+      macro_condition: string | null;
+      sample_size: number | null;
+    };
+
+    const lessonIds = [
+      ...new Set(allCitations.map((c) => (c as { lesson_id?: string }).lesson_id).filter(Boolean)),
+    ] as string[];
+    const lessonMap = new Map<string, LessonRow>();
+    if (lessonIds.length > 0) {
+      const { data: lessons } = await client
+        .from('scanner_lessons')
+        .select('id, lesson_kind, lesson_text, confidence, is_active, macro_condition, sample_size')
+        .in('id', lessonIds);
+      for (const l of (lessons ?? []) as LessonRow[]) lessonMap.set(l.id, l);
+    }
+
+    type Bucket = {
+      lesson_id: string | null;
+      lesson_kind: string;
+      lesson_text: string | null;
+      marker_text: string;
+      confidence: number | null;
+      is_active: boolean | null;
+      macro_condition: string | null;
+      sample_size: number | null;
+      citations_count: number;
+      applied_count: number;
+      resolved_count: number;
+      wins: number;
+      losses: number;
+      sum_pnl_usd: number;
+      avg_pnl_usd: number;
+      win_rate_pct: number | null;
+      last_cited_at: string | null;
+    };
+    const buckets = new Map<string, Bucket>();
+    for (const c of allCitations) {
+      const row = c as {
+        lesson_id?: string | null;
+        marker_text: string;
+        action_applied: boolean;
+        outcome_resolved_at?: string | null;
+        outcome_win?: boolean | null;
+        outcome_pnl_usd?: unknown;
+        cited_at: string;
+      };
+      const key = row.lesson_id ? `id:${row.lesson_id}` : `marker:${row.marker_text}`;
+      let b = buckets.get(key);
+      if (!b) {
+        const lesson = row.lesson_id ? lessonMap.get(row.lesson_id) : null;
+        b = {
+          lesson_id: row.lesson_id ?? null,
+          lesson_kind: lesson?.lesson_kind ?? '(orphan marker)',
+          lesson_text: lesson?.lesson_text ?? null,
+          marker_text: row.marker_text,
+          confidence: lesson?.confidence ?? null,
+          is_active: lesson?.is_active ?? null,
+          macro_condition: lesson?.macro_condition ?? null,
+          sample_size: lesson?.sample_size ?? null,
+          citations_count: 0,
+          applied_count: 0,
+          resolved_count: 0,
+          wins: 0,
+          losses: 0,
+          sum_pnl_usd: 0,
+          avg_pnl_usd: 0,
+          win_rate_pct: null,
+          last_cited_at: null,
+        };
+        buckets.set(key, b);
+      }
+      b.citations_count += 1;
+      if (row.action_applied) b.applied_count += 1;
+      if (row.outcome_resolved_at) {
+        b.resolved_count += 1;
+        const pnl = Number(row.outcome_pnl_usd ?? 0);
+        b.sum_pnl_usd += pnl;
+        if (row.outcome_win === true) b.wins += 1;
+        if (row.outcome_win === false) b.losses += 1;
+      }
+      if (!b.last_cited_at || row.cited_at > b.last_cited_at) {
+        b.last_cited_at = row.cited_at;
+      }
+    }
+
+    const lessonsArr = [...buckets.values()].map((b) => ({
+      ...b,
+      avg_pnl_usd: b.resolved_count > 0 ? b.sum_pnl_usd / b.resolved_count : 0,
+      win_rate_pct: b.resolved_count > 0 ? (b.wins / b.resolved_count) * 100 : null,
+    })).sort((a, b) => b.citations_count - a.citations_count);
+
+    return {
+      windowDays: days,
+      totalCitations: allCitations.length,
+      resolvedCitations: allCitations.filter(
+        (c) => (c as { outcome_resolved_at?: string | null }).outcome_resolved_at,
+      ).length,
+      lessons: lessonsArr,
+    };
+  }
+
   async runRiskCheck(userId: string, portfolioId: string) {
     await this.assertPortfolioOwner(userId, portfolioId);
     const config = await this.getSessionConfig(userId, portfolioId);

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -2777,6 +2777,104 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
   }
 
   /**
+   * LISA refonte C.1 — Coach proposals : list / accept / reject.
+   * Accept = applique les lessons (INSERT scanner_lessons) + (optional)
+   * applique les parameter_changes. Reject = juste UPDATE status='rejected'.
+   */
+  async listCoachProposals(userId: string, portfolioId: string, status?: string) {
+    await this.assertPortfolioOwner(userId, portfolioId);
+    let q = this.supabase.getClient()
+      .from('coach_proposals')
+      .select('id, created_at, source, llm_model, llm_cost_usd, feasibility_verdict, feasibility_probability_pct, feasibility_rationale, proposed_lessons, proposed_parameter_changes, risk_warnings, status, reviewed_at, resulted_lesson_ids')
+      .eq('portfolio_id', portfolioId)
+      .order('created_at', { ascending: false })
+      .limit(50);
+    if (status) q = q.eq('status', status);
+    const { data, error } = await q;
+    if (error) throw new BadRequestException(error.message);
+    return data ?? [];
+  }
+
+  async acceptCoachProposal(
+    userId: string,
+    proposalId: string,
+    body: {
+      accepted_lessons?: number[]; // index dans proposed_lessons
+      accepted_params?: number[]; // index dans proposed_parameter_changes
+      comment?: string;
+    },
+  ) {
+    const client = this.supabase.getClient();
+    const { data: proposal, error: pErr } = await client
+      .from('coach_proposals')
+      .select('id, portfolio_id, proposed_lessons, proposed_parameter_changes, status')
+      .eq('id', proposalId)
+      .maybeSingle();
+    if (pErr || !proposal) throw new NotFoundException('Proposal introuvable');
+    await this.assertPortfolioOwner(userId, String(proposal.portfolio_id));
+    if (proposal.status !== 'pending') {
+      throw new BadRequestException(`Proposal status=${proposal.status}, not pending`);
+    }
+
+    const acceptedLessonIdx = new Set(body.accepted_lessons ?? []);
+    const acceptedParamIdx = new Set(body.accepted_params ?? []);
+    const allLessons = Array.isArray(proposal.proposed_lessons) ? proposal.proposed_lessons : [];
+    const allParams = Array.isArray(proposal.proposed_parameter_changes) ? proposal.proposed_parameter_changes : [];
+
+    const lessonsToInsert = (allLessons as Array<Record<string, unknown>>).filter((_, i) => acceptedLessonIdx.has(i));
+    const resultedLessonIds: string[] = [];
+    if (lessonsToInsert.length > 0) {
+      const rows = lessonsToInsert.map((l) => ({
+        lesson_kind: String(l.lesson_kind ?? 'UNNAMED'),
+        lesson_text: String(l.lesson_text ?? ''),
+        confidence: typeof l.confidence === 'number' ? l.confidence : 0.7,
+        scope: String(l.scope ?? 'trader_agent_only'),
+        derived_from_date: new Date().toISOString().slice(0, 10),
+        is_active: true,
+        applied: true,
+        applied_by: `coach:${userId.slice(0, 8)}`,
+        applied_at: new Date().toISOString(),
+        payload: { from_coach_proposal: proposalId, rationale: l.rationale ?? null, expected_impact_usd: l.expected_impact_usd ?? null },
+      }));
+      const { data: ins, error: insErr } = await client.from('scanner_lessons').insert(rows).select('id');
+      if (insErr) throw new BadRequestException(insErr.message);
+      for (const r of (ins ?? []) as Array<{ id: string }>) resultedLessonIds.push(r.id);
+    }
+
+    const partial = acceptedLessonIdx.size < allLessons.length || acceptedParamIdx.size < allParams.length;
+    const newStatus = (acceptedLessonIdx.size === 0 && acceptedParamIdx.size === 0)
+      ? 'rejected'
+      : (partial ? 'partially_accepted' : 'fully_accepted');
+
+    await client
+      .from('coach_proposals')
+      .update({
+        status: newStatus,
+        reviewed_at: new Date().toISOString(),
+        reviewed_by: userId,
+        user_decision: {
+          accepted_lessons: [...acceptedLessonIdx],
+          rejected_lessons: allLessons.map((_, i) => i).filter((i) => !acceptedLessonIdx.has(i)),
+          applied_params: [...acceptedParamIdx],
+          comment: body.comment ?? null,
+        },
+        resulted_lesson_ids: resultedLessonIds,
+      })
+      .eq('id', proposalId);
+
+    return { ok: true, status: newStatus, resulted_lesson_ids: resultedLessonIds };
+  }
+
+  async rejectCoachProposal(userId: string, proposalId: string, comment?: string) {
+    const body: { accepted_lessons: number[]; accepted_params: number[]; comment?: string } = {
+      accepted_lessons: [],
+      accepted_params: [],
+    };
+    if (comment !== undefined) body.comment = comment;
+    return this.acceptCoachProposal(userId, proposalId, body);
+  }
+
+  /**
    * LISA refonte B.4.a — In-app notifications.
    *
    * Agrège des "items" virtuels depuis plusieurs sources :

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -2777,6 +2777,80 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
   }
 
   /**
+   * LISA refonte B.4.a — In-app notifications.
+   *
+   * Agrège des "items" virtuels depuis plusieurs sources :
+   *   - coach_proposals status='pending' (Strategy Coach C.1)
+   *   - kill_switch_active=true (anti-spirale ou manuel)
+   *
+   * Le client gère "unread" via localStorage (last_seen_at) car pas de
+   * besoin de cross-device sync à ce stade. Le badge UI = items dont
+   * created_at > last_seen client-side.
+   */
+  async getNotifications(userId: string, portfolioId: string) {
+    await this.assertPortfolioOwner(userId, portfolioId);
+    const client = this.supabase.getClient();
+
+    const [cfgRes, propRes] = await Promise.all([
+      client
+        .from('lisa_session_configs')
+        .select('kill_switch_active, updated_at')
+        .eq('portfolio_id', portfolioId)
+        .maybeSingle(),
+      client
+        .from('coach_proposals')
+        .select('id, created_at, source, llm_model, feasibility_verdict, feasibility_probability_pct, proposed_lessons, proposed_parameter_changes')
+        .eq('portfolio_id', portfolioId)
+        .eq('status', 'pending')
+        .order('created_at', { ascending: false })
+        .limit(50),
+    ]);
+
+    type Item = {
+      id: string;
+      kind: 'kill_switch_armed' | 'coach_proposal_pending';
+      severity: 'critical' | 'info' | 'warning';
+      title: string;
+      body: string;
+      created_at: string;
+      href?: string;
+      payload?: Record<string, unknown>;
+    };
+    const items: Item[] = [];
+
+    const cfg = cfgRes.data as { kill_switch_active?: boolean; updated_at?: string } | null;
+    if (cfg?.kill_switch_active) {
+      items.push({
+        id: `kill_switch:${portfolioId}`,
+        kind: 'kill_switch_armed',
+        severity: 'critical',
+        title: 'Kill-switch anti-spirale armé',
+        body: 'TRADER suspendu. Désarme manuellement dans Config LISA pour reprendre les cycles.',
+        created_at: cfg.updated_at ?? new Date().toISOString(),
+      });
+    }
+
+    for (const p of (propRes.data ?? []) as Array<Record<string, unknown>>) {
+      const lessons = Array.isArray(p.proposed_lessons) ? p.proposed_lessons.length : 0;
+      const params = Array.isArray(p.proposed_parameter_changes) ? p.proposed_parameter_changes.length : 0;
+      const verdict = String(p.feasibility_verdict ?? 'UNKNOWN');
+      const probPct = p.feasibility_probability_pct as number | null;
+      items.push({
+        id: `coach:${p.id}`,
+        kind: 'coach_proposal_pending',
+        severity: verdict === 'UNREALISTIC' ? 'warning' : 'info',
+        title: `Proposition Strategy Coach (${String(p.llm_model)})`,
+        body: `Verdict ${verdict}${probPct !== null ? ` · ${probPct}%` : ''} · ${lessons} lesson(s) · ${params} param(s) proposé(s)`,
+        created_at: String(p.created_at),
+        payload: { proposal_id: String(p.id), lessons, params, verdict },
+      });
+    }
+
+    items.sort((a, b) => b.created_at.localeCompare(a.created_at));
+    return { items, total: items.length };
+  }
+
+  /**
    * LISA refonte B.3 — Désarme le kill-switch (anti-spirale ou manuel).
    * Pas de force-close, juste UPDATE kill_switch_active=false.
    * Audit dans lisa_decision_log pour traçabilité.

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -2776,6 +2776,65 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     return { ok: true, portfolioId };
   }
 
+  /**
+   * LISA refonte B.3 — Désarme le kill-switch (anti-spirale ou manuel).
+   * Pas de force-close, juste UPDATE kill_switch_active=false.
+   * Audit dans lisa_decision_log pour traçabilité.
+   */
+  async resetKillSwitch(userId: string, portfolioId: string) {
+    await this.assertPortfolioOwner(userId, portfolioId);
+    const client = this.supabase.getClient();
+    await client
+      .from('lisa_session_configs')
+      .update({ kill_switch_active: false })
+      .eq('portfolio_id', portfolioId);
+    await client.from('lisa_decision_log').insert({
+      portfolio_id: portfolioId,
+      kind: 'kill_switch_reset',
+      payload: { reset_by: 'user_manual', timestamp: new Date().toISOString() },
+    });
+    return { ok: true };
+  }
+
+  /**
+   * LISA refonte B.3 — Liste les scanner_lessons avec filtres.
+   * Pas de scoping user (table partagée). Limite défaut 200.
+   */
+  async listScannerLessons(opts: {
+    active?: boolean;
+    search?: string;
+    scope?: string;
+    limit?: number;
+  }) {
+    const client = this.supabase.getClient();
+    let q = client
+      .from('scanner_lessons')
+      .select('id, lesson_kind, lesson_text, macro_condition, scope, confidence, sample_size, win_rate_observed, avg_pnl_usd, is_active, derived_from_date, created_at, applied, applied_by')
+      .order('created_at', { ascending: false })
+      .limit(Math.min(opts.limit ?? 200, 1000));
+    if (opts.active !== undefined) q = q.eq('is_active', opts.active);
+    if (opts.scope) q = q.eq('scope', opts.scope);
+    if (opts.search) {
+      const term = `%${opts.search}%`;
+      q = q.or(`lesson_kind.ilike.${term},lesson_text.ilike.${term}`);
+    }
+    const { data, error } = await q;
+    if (error) throw new BadRequestException(error.message);
+    return data ?? [];
+  }
+
+  /**
+   * LISA refonte B.3 — Toggle is_active d'une lesson.
+   */
+  async setScannerLessonActive(lessonId: string, active: boolean) {
+    const { error } = await this.supabase.getClient()
+      .from('scanner_lessons')
+      .update({ is_active: active })
+      .eq('id', lessonId);
+    if (error) throw new BadRequestException(error.message);
+    return { ok: true, lessonId, is_active: active };
+  }
+
   async triggerKillSwitch(userId: string, portfolioId: string, reason: string) {
     await this.assertPortfolioOwner(userId, portfolioId);
 

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -453,15 +453,22 @@ export class LiveTraderAgentService {
 
       // 4. Build system prompt (memory + cross-lessons + MIDDLE ref + self-reflection)
       const systemPrompt = this.buildSystemPrompt(memory, crossScannerLessons, middleReference, selfReflection);
+      // LISA refonte A.4 — Capital composé : utilise state.currentCapitalUsd
+      // (= initial + Σ pnl si compound activé) au lieu du constant TRADER_AGENT_CAPITAL_USD.
+      // max_concentration calculée à 45% du capital actuel (dynamic ratio).
+      const dynamicMaxConcentration = Math.round(state.currentCapitalUsd * 0.45);
       const userPrompt = JSON.stringify({
         current_time_utc: cycleStartedAt.toISOString(),
-        portfolio_capital_usd: TRADER_AGENT_CAPITAL_USD,
+        portfolio_capital_usd: state.currentCapitalUsd,
+        portfolio_capital_initial_usd: state.initialCapitalUsd,
+        portfolio_cumulative_pnl_usd: state.cumulativePnlUsd,
+        portfolio_drawdown_pct: state.drawdownFromInitialPct,
         state,
         candidates,
         macro,
         news_recent: news,
         constraints: {
-          max_concentration_usd: MAX_CONCENTRATION_USD,
+          max_concentration_usd: dynamicMaxConcentration,
           max_open_positions: 5,
           min_notional_usd: MIN_NOTIONAL_USD,
           daily_loss_limit_usd: MAX_DAILY_LOSS_USD,
@@ -1136,6 +1143,14 @@ Recommendation rules :
     dailyPnlUsd: number;
     closedTodayCount: number;
     winRateTodayPct: number | null;
+    // LISA refonte A.4 — Capital composé : initial + Σ realized_pnl (si compound activé)
+    // Lu depuis lisa_session_configs.lisa_{initial_capital_usd,compound_pnl_enabled}.
+    // Fallback constant TRADER_AGENT_CAPITAL_USD si DB indisponible.
+    initialCapitalUsd: number;
+    currentCapitalUsd: number;
+    compoundPnlEnabled: boolean;
+    cumulativePnlUsd: number;
+    drawdownFromInitialPct: number;
     recentClosesLast60min: Array<{
       symbol: string;
       direction: string;
@@ -1148,10 +1163,21 @@ Recommendation rules :
   }> {
     const client = this.supabase.getClient();
     const todayStart = `${new Date().toISOString().slice(0, 10)}T00:00:00Z`;
-    // Fenêtre 60 min — couvre la lesson b4c48e13 ANTI_REENTRY_POST_INVALIDATION
-    // (30 min) avec marge contextuelle. Volume typique TRADER ≈ 1-2 closes/h
-    // donc liste typique de 1-2 entrées (~200-400 tokens prompt, négligeable).
     const sixtyMinAgoIso = new Date(Date.now() - 60 * 60_000).toISOString();
+
+    // LISA refonte A.4 — Lecture config capital composé
+    const { data: cfg } = await client
+      .from('lisa_session_configs')
+      .select('lisa_initial_capital_usd, lisa_compound_pnl_enabled')
+      .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID)
+      .maybeSingle();
+    const initialCapital = Number(
+      (cfg as { lisa_initial_capital_usd?: unknown } | null)?.lisa_initial_capital_usd
+      ?? TRADER_AGENT_CAPITAL_USD
+    );
+    const compoundEnabled = Boolean(
+      (cfg as { lisa_compound_pnl_enabled?: unknown } | null)?.lisa_compound_pnl_enabled ?? true
+    );
 
     const { data: open } = await client
       .from('lisa_positions')
@@ -1166,9 +1192,20 @@ Recommendation rules :
       .gte('exit_timestamp', todayStart)
       .neq('status', 'open');
 
-    // Closes des 60 dernières minutes — injecté dans le state pour que le LLM
-    // voie ses propres actions récentes (sans cela il est aveugle aux closes
-    // qu'il vient lui-même de décider, cas vérifié XRPUSDT 30/05 02:05 -$22).
+    // LISA refonte A.4 — Cumulative PnL depuis création (pour capital composé)
+    const { data: allClosed } = await client
+      .from('lisa_positions')
+      .select('realized_pnl_usd')
+      .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID)
+      .neq('status', 'open');
+    const cumulativePnl = (allClosed ?? []).reduce(
+      (s, c) => s + Number((c as { realized_pnl_usd?: unknown }).realized_pnl_usd ?? 0),
+      0,
+    );
+    const currentCapital = compoundEnabled ? initialCapital + cumulativePnl : initialCapital;
+    const drawdownPct = initialCapital > 0 ? ((currentCapital - initialCapital) / initialCapital) * 100 : 0;
+
+    // Closes des 60 dernières minutes (cf. PR #494)
     const { data: recentClosed } = await client
       .from('lisa_positions')
       .select('symbol, direction, exit_timestamp, exit_reason, realized_pnl_usd, realized_pnl_pct')
@@ -1204,10 +1241,15 @@ Recommendation rules :
       openPositions,
       openCount: openPositions.length,
       deployedUsd: deployed,
-      capitalAvailableUsd: TRADER_AGENT_CAPITAL_USD - deployed,
+      capitalAvailableUsd: currentCapital - deployed,
       dailyPnlUsd: dailyPnl,
       closedTodayCount: closed?.length ?? 0,
       winRateTodayPct: winRate,
+      initialCapitalUsd: initialCapital,
+      currentCapitalUsd: currentCapital,
+      compoundPnlEnabled: compoundEnabled,
+      cumulativePnlUsd: cumulativePnl,
+      drawdownFromInitialPct: drawdownPct,
       recentClosesLast60min,
     };
   }
@@ -1232,6 +1274,41 @@ Recommendation rules :
         || sym.endsWith('.AS') || sym.endsWith('.BR') || sym.endsWith('.MI')
         || sym.endsWith('.MC') || sym.endsWith('.SW')) return 'eu_equity';
     return 'unknown';
+  }
+
+  /**
+   * LISA refonte A.4 — lit le capital actuel (composé) pour le sizing Kelly.
+   * Cached null-safe : retourne TRADER_AGENT_CAPITAL_USD fallback si DB indispo.
+   */
+  private async fetchCurrentCapital(): Promise<number> {
+    try {
+      const { data: cfg } = await this.supabase.getClient()
+        .from('lisa_session_configs')
+        .select('lisa_initial_capital_usd, lisa_compound_pnl_enabled')
+        .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID)
+        .maybeSingle();
+      const initial = Number(
+        (cfg as { lisa_initial_capital_usd?: unknown } | null)?.lisa_initial_capital_usd
+        ?? TRADER_AGENT_CAPITAL_USD
+      );
+      const compound = Boolean(
+        (cfg as { lisa_compound_pnl_enabled?: unknown } | null)?.lisa_compound_pnl_enabled ?? true
+      );
+      if (!compound) return initial;
+      const { data: closed } = await this.supabase.getClient()
+        .from('lisa_positions')
+        .select('realized_pnl_usd')
+        .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID)
+        .neq('status', 'open');
+      const pnl = (closed ?? []).reduce(
+        (s, c) => s + Number((c as { realized_pnl_usd?: unknown }).realized_pnl_usd ?? 0),
+        0,
+      );
+      return initial + pnl;
+    } catch (e) {
+      this.logger.debug(`[trader-agent] fetchCurrentCapital failed, fallback: ${String(e).slice(0, 80)}`);
+      return TRADER_AGENT_CAPITAL_USD;
+    }
   }
 
   private async fetchTopCandidates(n: number): Promise<object[]> {
@@ -1260,6 +1337,8 @@ Recommendation rules :
     // PAS de gate hardcodé — décision reste autonome côté Gemini Pro.
     const feedMin = Number(this.config.get<string>('TRADER_FEED_MIN_PCT') ?? '2');
     const feedMax = Number(this.config.get<string>('TRADER_FEED_MAX_PCT') ?? '15');
+    // LISA refonte A.4 — Lit le capital actuel (composé) pour scaling Kelly
+    const currentCapital = await this.fetchCurrentCapital();
     try {
       const candidates = await this.topGainersScanner.fetchAllCandidates();
       if (candidates && candidates.length > 0) {
@@ -1276,12 +1355,12 @@ Recommendation rules :
         const sorted = [...pool].sort((a, b) => (b.changePct ?? 0) - (a.changePct ?? 0));
         if (sorted.length > 0) {
           this.logger.debug(
-            `[trader-agent] feed: ${candidates.length} scanned → ${sorted.length} in band [${feedMin},${feedMax}]% → top ${Math.min(n, sorted.length)}`,
+            `[trader-agent] feed: ${candidates.length} scanned → ${sorted.length} in band [${feedMin},${feedMax}]% → top ${Math.min(n, sorted.length)} (capital=$${currentCapital.toFixed(0)})`,
           );
           // P-KTOS — Compute pool-wide max for pumpScore
           const maxChangePctInPool = sorted.reduce((m, c) => Math.max(m, c.changePct ?? 0), 0);
           return sorted.slice(0, n).map((c) =>
-            this.enrichCandidateWithMath(c, maxChangePctInPool),
+            this.enrichCandidateWithMath(c, maxChangePctInPool, currentCapital),
           );
         }
       }
@@ -1337,6 +1416,7 @@ Recommendation rules :
   private enrichCandidateWithMath(
     c: TopGainerCandidate,
     maxChangePctInPool: number,
+    currentCapital: number = TRADER_AGENT_CAPITAL_USD,
   ): Record<string, unknown> {
     const changePct = c.changePct ?? 0;
     const high = c.high ?? c.close ?? 0;
@@ -1358,8 +1438,8 @@ Recommendation rules :
     // (sera affiné par P9 quand p_win_at_entry sera correctement persisté).
     // f* = (TP*p_win - SL*(1-p_win)) / TP avec TP=2.5, SL=1.5, p_win=0.5
     //    = (1.25 - 0.75) / 2.5 = 0.20
-    // Capital trader = $10000 → max $2000 = Kelly cap par défaut.
-    const kellyMaxNotional = Math.round(TRADER_AGENT_CAPITAL_USD * 0.20);
+    // LISA refonte A.4 — utilise currentCapital (composé) au lieu du constant.
+    const kellyMaxNotional = Math.round(currentCapital * 0.20);
 
     // Sweet spot bucket gagnant historique (lesson aa6eda5f) : [3,8]%
     const sweetSpotEntry = changePct >= 3 && changePct <= 8;
@@ -1600,7 +1680,9 @@ Recommendation rules :
           return { applied: false, error: `anti-revenge: ${sym} dernier close ${lastLoser.exit_timestamp} en perte (${Number(lastLoser.realized_pnl_usd).toFixed(2)}$) — cooldown 2h actif` };
         }
       }
-      const notional = Math.max(MIN_NOTIONAL_USD, Math.min(MAX_CONCENTRATION_USD, decision.notional_usd));
+      // LISA refonte A.4 — Cap dynamique 45% du capital actuel (composé).
+      const dynamicCap = Math.round((await this.fetchCurrentCapital()) * 0.45);
+      const notional = Math.max(MIN_NOTIONAL_USD, Math.min(dynamicCap, decision.notional_usd));
       // XETRA small-cap blacklist (28/05/2026) — 2 incidents : SNG.XETRA -$35
       // (gap SL slippage) + QH9.XETRA -$132 (gap -12% non capté par polling SL).
       // XETRA small-caps notionnel < $3000 = liquidité trop mince pour gérer
@@ -1769,7 +1851,9 @@ Recommendation rules :
         return { applied: false, error: `scale_in: no existing position on ${sym} (use open_directional)` };
       }
       if (state.openCount >= 5) return { applied: false, error: 'scale_in: max 5 open positions' };
-      const notional = Math.max(MIN_NOTIONAL_USD, Math.min(MAX_CONCENTRATION_USD * 1.5, decision.notional_usd));
+      // LISA refonte A.4 — Cap scale_in dynamique 45% × 1.5 = 67.5% du capital actuel.
+      const dynamicCapScaleIn = Math.round((await this.fetchCurrentCapital()) * 0.45 * 1.5);
+      const notional = Math.max(MIN_NOTIONAL_USD, Math.min(dynamicCapScaleIn, decision.notional_usd));
       // Autonomie cadrée : bornes resserrées post-MFE/MAE 27/05 (MAE/R 1.78,
       // capture rate -45.8% sur 7 trades). SL min 1.5% obligatoire (sinon
       // stop-out garanti avant retracement). TP max 8% (au-delà = capture rate

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -363,6 +363,35 @@ export class LiveTraderAgentService {
       // 1. Read state (positions, capital, daily PnL)
       const state = await this.readState();
 
+      // 1.1 — LISA refonte A.4.1 — Anti-spiral safety guard.
+      // Si drawdown depuis le capital initial < -30%, on arme kill_switch_active=true
+      // dans la DB et on skip le cycle. L'agent ne reprendra qu'après reset manuel
+      // explicite côté UI (ConfirmDialog). Protège contre l'effondrement non détecté
+      // par les caps daily (-$500/jour) sur une suite de mauvaises journées.
+      if (state.drawdownFromInitialPct < -30 && !state.killSwitchActive) {
+        this.logger.error(
+          `[trader-agent] ANTI-SPIRAL armed — DD=${state.drawdownFromInitialPct.toFixed(1)}% < -30% — kill_switch_active=true`,
+        );
+        await this.supabase.getClient()
+          .from('lisa_session_configs')
+          .update({ kill_switch_active: true })
+          .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID);
+        await this.logDecision({
+          cycleStartedAt, state, action: 'hold' as const,
+          notionalUsd: 0, confidence: 0,
+          thesis: `Anti-spirale armé : drawdown ${state.drawdownFromInitialPct.toFixed(1)}% < -30% depuis capital initial $${state.initialCapitalUsd.toFixed(0)} (current $${state.currentCapitalUsd.toFixed(0)}). Kill-switch DB activé. Reset manuel requis via UI /lisa.`,
+          applied: false,
+          actionKindOverride: 'kill_switch_anti_spiral',
+        });
+        return;
+      }
+      if (state.killSwitchActive) {
+        this.logger.warn(
+          `[trader-agent] kill_switch_active=true (DD=${state.drawdownFromInitialPct.toFixed(1)}%) — cycle skipped, manual reset required`,
+        );
+        return;
+      }
+
       // 1.5 — Pre-flight ORPHAN_CLOSE déterministe (28/05/2026, ADDENDUM TRADER).
       // TRADER a généré +$190 net jour en orphan-close manuel (CHRT.LSE 2x, IQE.LSE).
       // Codification : pour chaque position ouverte sur un marché fermant <30 min
@@ -1151,6 +1180,7 @@ Recommendation rules :
     compoundPnlEnabled: boolean;
     cumulativePnlUsd: number;
     drawdownFromInitialPct: number;
+    killSwitchActive: boolean;
     recentClosesLast60min: Array<{
       symbol: string;
       direction: string;
@@ -1168,7 +1198,7 @@ Recommendation rules :
     // LISA refonte A.4 — Lecture config capital composé
     const { data: cfg } = await client
       .from('lisa_session_configs')
-      .select('lisa_initial_capital_usd, lisa_compound_pnl_enabled')
+      .select('lisa_initial_capital_usd, lisa_compound_pnl_enabled, kill_switch_active')
       .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID)
       .maybeSingle();
     const initialCapital = Number(
@@ -1177,6 +1207,9 @@ Recommendation rules :
     );
     const compoundEnabled = Boolean(
       (cfg as { lisa_compound_pnl_enabled?: unknown } | null)?.lisa_compound_pnl_enabled ?? true
+    );
+    const killSwitchActive = Boolean(
+      (cfg as { kill_switch_active?: unknown } | null)?.kill_switch_active ?? false
     );
 
     const { data: open } = await client
@@ -1250,6 +1283,7 @@ Recommendation rules :
       compoundPnlEnabled: compoundEnabled,
       cumulativePnlUsd: cumulativePnl,
       drawdownFromInitialPct: drawdownPct,
+      killSwitchActive,
       recentClosesLast60min,
     };
   }

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -33,6 +33,7 @@ import { ScannerLlmRouterService } from './scanner-llm-router.service';
 import { LisaService } from './lisa.service';
 import { ScannerLessonsContextService } from './scanner-lessons-context.service';
 import { TopGainersScannerService } from './top-gainers-scanner.service';
+import { PushNotificationsService } from './push-notifications.service';
 import type { TopGainerCandidate } from '@smartvest/ai-analyst';
 
 const TRADER_AGENT_PORTFOLIO_ID = 'b0000001-0000-0000-0000-000000000001';
@@ -229,6 +230,7 @@ export class LiveTraderAgentService {
     private readonly schedulerRegistry: SchedulerRegistry,
     private readonly topGainersScanner: TopGainersScannerService,
     @Optional() private readonly lessonsContext?: ScannerLessonsContextService,
+    @Optional() private readonly pushNotifs?: PushNotificationsService,
   ) {}
 
   onModuleInit(): void {
@@ -382,6 +384,20 @@ export class LiveTraderAgentService {
           .from('lisa_session_configs')
           .update({ kill_switch_active: true })
           .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID);
+        // B.4.c — push notification au user du portfolio (best-effort).
+        if (this.pushNotifs) {
+          const { data: portfolioRow } = await this.supabase.getClient()
+            .from('portfolios')
+            .select('user_id')
+            .eq('id', TRADER_AGENT_PORTFOLIO_ID)
+            .maybeSingle();
+          const userId = (portfolioRow as { user_id?: string } | null)?.user_id;
+          if (userId) {
+            this.pushNotifs.notifyUser(userId, 'kill_switch_armed').catch((e) =>
+              this.logger.debug(`[trader-agent] push notify err: ${String(e).slice(0, 100)}`),
+            );
+          }
+        }
         await this.logDecision({
           cycleStartedAt, state, action: 'hold' as const,
           notionalUsd: 0, confidence: 0,

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -360,6 +360,12 @@ export class LiveTraderAgentService {
 
     const cycleStartedAt = new Date();
     try {
+      // LISA refonte B.1 — backfill outcomes des citations en attente.
+      // Best-effort, ne fait jamais échouer le cycle.
+      this.resolveCitationOutcomes().catch((e) =>
+        this.logger.debug(`[trader-agent] resolveCitationOutcomes err: ${String(e).slice(0, 100)}`),
+      );
+
       // 1. Read state (positions, capital, daily PnL)
       const state = await this.readState();
 
@@ -619,6 +625,22 @@ export class LiveTraderAgentService {
         });
       } catch (e) {
         this.logger.error(`[trader-agent] logDecision failed (cycle ran but trace lost): ${String(e).slice(0, 200)}`);
+      }
+
+      // LISA refonte B.1 — parse markers thèse + insert citations
+      // Best-effort : catch + log, ne fait jamais échouer le cycle.
+      try {
+        await this.insertLessonCitations({
+          thesis: decision.thesis ?? '',
+          cycleStartedAt,
+          actionKind: decision.action_kind,
+          actionApplied: applyResult.applied,
+          targetSymbol: decision.symbol ?? null,
+          confidence: decision.confidence ?? null,
+          positionId: applyResult.positionId ?? null,
+        });
+      } catch (e) {
+        this.logger.warn(`[trader-agent] insertLessonCitations err: ${String(e).slice(0, 120)}`);
       }
 
       const tag = applyResult.applied ? '✅' : (decision.action_kind === 'hold' ? '⏸️' : '⚠️');
@@ -2032,6 +2054,151 @@ Recommendation rules :
       applied_position_id: p.appliedPositionId ?? null,
       apply_error: p.applyError ?? null,
     });
+  }
+
+  // ====================================================================
+  // LISA refonte B.1 — Lesson markers parsing + citations tracking
+  // ====================================================================
+  //
+  // Le LLM TRADER reçoit dans son system prompt les lessons actives au format
+  //   "lesson_kind: PULLBACK_WAIT_KTOS_LESSON · lesson_text: ..."
+  // et est encouragé à citer le marker en majuscules entre crochets dans sa
+  // thèse — ex: "Setup post-pump, attente confirmé [PULLBACK_WAIT_KTOS_LESSON]".
+  //
+  // À chaque décision, on parse la thèse, extrait les markers, résout chaque
+  // marker vers un lesson_id (par lesson_kind ILIKE) et insère une ligne dans
+  // scanner_lesson_citations. L'outcome (pnl, win) est résolu plus tard quand
+  // la position se ferme — backfill au début de chaque cycle.
+  //
+  // Cible UI Phase B.2 : "Quelle lesson a été citée combien de fois, avec
+  // quel win-rate, sur 30j ?"
+
+  /**
+   * Extrait les markers [XXX] d'une thèse LLM. Dédupliqué.
+   * Pattern : crochets, début majuscule, 3-40 chars [A-Z0-9_+-].
+   * Ignore les markers techniques bas-niveau (DIAGNOSTIC, SANITY_BOUND, etc.)
+   * qui ne sont pas des lessons — uniquement les markers > 6 chars.
+   */
+  private parseLessonMarkers(thesis: string): string[] {
+    if (!thesis || thesis.length === 0) return [];
+    const re = /\[([A-Z][A-Z0-9_+\-]{2,40})\]/g;
+    const set = new Set<string>();
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(thesis)) !== null) {
+      const marker = m[1];
+      // Filtre out les markers infra (pas des lessons)
+      if (['DIAGNOSTIC', 'SANITY_BOUND', 'KILL_SWITCH', 'HT_BYPASS', 'HT_EXCEPTION'].includes(marker)) continue;
+      set.add(marker);
+    }
+    return [...set];
+  }
+
+  /**
+   * Pour chaque marker, tente de matcher un lesson_id via lesson_kind ILIKE.
+   * Insère une ligne scanner_lesson_citations par marker (avec lesson_id=null
+   * si pas de match — utile pour audit "markers cités jamais mappés").
+   */
+  private async insertLessonCitations(args: {
+    thesis: string;
+    cycleStartedAt: Date;
+    actionKind: string;
+    actionApplied: boolean;
+    targetSymbol: string | null;
+    confidence: number | null;
+    positionId: string | null;
+  }): Promise<void> {
+    const markers = this.parseLessonMarkers(args.thesis);
+    if (markers.length === 0) return;
+
+    const client = this.supabase.getClient();
+    // Résolution lesson_id par marker (1 query par marker, OK pour volume faible)
+    const rows: Array<Record<string, unknown>> = [];
+    for (const marker of markers) {
+      const { data: lesson } = await client
+        .from('scanner_lessons')
+        .select('id')
+        .ilike('lesson_kind', `%${marker}%`)
+        .eq('is_active', true)
+        .order('confidence', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      rows.push({
+        lesson_id: (lesson as { id?: string } | null)?.id ?? null,
+        marker_text: `[${marker}]`,
+        portfolio_id: TRADER_AGENT_PORTFOLIO_ID,
+        decision_decided_at: args.cycleStartedAt.toISOString(),
+        action_kind: args.actionKind,
+        action_applied: args.actionApplied,
+        target_symbol: args.targetSymbol,
+        confidence: args.confidence,
+        position_id: args.positionId,
+        thesis_excerpt: args.thesis.slice(0, 300),
+      });
+    }
+    const { error } = await client.from('scanner_lesson_citations').insert(rows);
+    if (error) {
+      this.logger.warn(`[trader-agent] insertLessonCitations failed: ${error.message}`);
+    } else {
+      this.logger.debug(
+        `[trader-agent] inserted ${rows.length} citations (markers: ${markers.join(',')})`,
+      );
+    }
+  }
+
+  /**
+   * Backfill outcomes : pour chaque citation où outcome_resolved_at IS NULL
+   * ET position_id IS NOT NULL, lit la position et résout outcome si closed.
+   * Idempotent (filtre WHERE outcome_resolved_at IS NULL). Limité 50/cycle
+   * pour ne pas saturer.
+   */
+  private async resolveCitationOutcomes(): Promise<void> {
+    const client = this.supabase.getClient();
+    const { data: pending } = await client
+      .from('scanner_lesson_citations')
+      .select('id, position_id')
+      .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID)
+      .is('outcome_resolved_at', null)
+      .not('position_id', 'is', null)
+      .limit(50);
+    if (!pending || pending.length === 0) return;
+
+    const positionIds = [...new Set(
+      pending.map((r) => (r as { position_id: string }).position_id).filter(Boolean),
+    )];
+    const { data: positions } = await client
+      .from('lisa_positions')
+      .select('id, status, realized_pnl_usd, exit_timestamp')
+      .in('id', positionIds)
+      .neq('status', 'open');
+    if (!positions || positions.length === 0) return;
+
+    const posById = new Map<string, { pnl: number; closedAt: string }>();
+    for (const p of positions) {
+      const row = p as { id: string; realized_pnl_usd?: unknown; exit_timestamp?: string };
+      posById.set(row.id, {
+        pnl: Number(row.realized_pnl_usd ?? 0),
+        closedAt: row.exit_timestamp ?? new Date().toISOString(),
+      });
+    }
+
+    let resolved = 0;
+    for (const c of pending) {
+      const row = c as { id: string; position_id: string };
+      const pos = posById.get(row.position_id);
+      if (!pos) continue;
+      await client
+        .from('scanner_lesson_citations')
+        .update({
+          outcome_resolved_at: pos.closedAt,
+          outcome_pnl_usd: pos.pnl,
+          outcome_win: pos.pnl > 0,
+        })
+        .eq('id', row.id);
+      resolved++;
+    }
+    if (resolved > 0) {
+      this.logger.log(`[trader-agent] resolved ${resolved} citation outcomes`);
+    }
   }
 
   // ====================================================================

--- a/apps/api/src/modules/lisa/services/push-notifications.service.ts
+++ b/apps/api/src/modules/lisa/services/push-notifications.service.ts
@@ -1,0 +1,226 @@
+// LISA refonte B.4.c — Web Push notifications via VAPID.
+//
+// Implémentation native (Node crypto, pas de dep web-push). On envoie des
+// pushes "trigger-only" (body vide) → le service worker côté front fait
+// fetch /lisa/notifications pour afficher le contenu réel. Évite la
+// complexité d'aes128gcm encryption pour le payload.
+//
+// Pré-requis env :
+//   VAPID_PUBLIC_KEY  (base64url uncompressed P-256, ex: BNc...)
+//   VAPID_PRIVATE_KEY (base64url raw 32 bytes)
+//   VAPID_SUBJECT     (mailto:admin@example.com, default 'mailto:lisa@smartvest.app')
+//
+// Génération clés (one-shot) : `node scripts/generate-vapid-keys.mjs` ou
+// `npx web-push generate-vapid-keys` depuis n'importe où.
+
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as crypto from 'crypto';
+import { SupabaseService } from '../../supabase/supabase.service';
+
+export interface PushSubscriptionPayload {
+  endpoint: string;
+  keys: { p256dh: string; auth: string };
+  userAgent?: string;
+}
+
+@Injectable()
+export class PushNotificationsService {
+  private readonly logger = new Logger(PushNotificationsService.name);
+  private vapidPublicKey: string | null = null;
+  private vapidPrivateKey: string | null = null;
+  private vapidSubject: string = 'mailto:lisa@smartvest.app';
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+  ) {
+    this.vapidPublicKey = this.config.get<string>('VAPID_PUBLIC_KEY') ?? null;
+    this.vapidPrivateKey = this.config.get<string>('VAPID_PRIVATE_KEY') ?? null;
+    this.vapidSubject = this.config.get<string>('VAPID_SUBJECT') ?? this.vapidSubject;
+    if (!this.vapidPublicKey || !this.vapidPrivateKey) {
+      this.logger.warn(
+        '[push] VAPID_PUBLIC_KEY/VAPID_PRIVATE_KEY missing — sends will SKIP. Subscribe still works.',
+      );
+    }
+  }
+
+  isReady(): boolean {
+    return !!this.vapidPublicKey && !!this.vapidPrivateKey;
+  }
+
+  getPublicKey(): string | null {
+    return this.vapidPublicKey;
+  }
+
+  async subscribe(userId: string, sub: PushSubscriptionPayload) {
+    if (!sub?.endpoint || !sub?.keys?.p256dh || !sub?.keys?.auth) {
+      throw new BadRequestException('Invalid subscription payload');
+    }
+    const { error } = await this.supabase.getClient()
+      .from('push_subscriptions')
+      .upsert(
+        {
+          user_id: userId,
+          endpoint: sub.endpoint,
+          p256dh: sub.keys.p256dh,
+          auth: sub.keys.auth,
+          user_agent: sub.userAgent ?? null,
+        },
+        { onConflict: 'user_id,endpoint' },
+      );
+    if (error) throw new BadRequestException(error.message);
+    return { ok: true };
+  }
+
+  async unsubscribe(userId: string, endpoint: string) {
+    const { error } = await this.supabase.getClient()
+      .from('push_subscriptions')
+      .delete()
+      .eq('user_id', userId)
+      .eq('endpoint', endpoint);
+    if (error) throw new BadRequestException(error.message);
+    return { ok: true };
+  }
+
+  async listSubscriptions(userId: string) {
+    const { data } = await this.supabase.getClient()
+      .from('push_subscriptions')
+      .select('endpoint, created_at, user_agent, last_sent_at')
+      .eq('user_id', userId);
+    return data ?? [];
+  }
+
+  /**
+   * Envoie un push "trigger-only" (body vide) à toutes les subs d'un user.
+   * Le service worker côté front gère l'affichage via fetch /lisa/notifications.
+   */
+  async notifyUser(userId: string, kind: string): Promise<{ sent: number; errors: number }> {
+    if (!this.isReady()) {
+      this.logger.debug(`[push] notifyUser SKIP — VAPID keys missing (kind=${kind})`);
+      return { sent: 0, errors: 0 };
+    }
+    const { data: subs } = await this.supabase.getClient()
+      .from('push_subscriptions')
+      .select('endpoint, p256dh, auth')
+      .eq('user_id', userId);
+    if (!subs || subs.length === 0) return { sent: 0, errors: 0 };
+
+    let sent = 0;
+    let errors = 0;
+    for (const s of subs as Array<{ endpoint: string }>) {
+      try {
+        await this.sendTriggerOnly(s.endpoint);
+        await this.supabase.getClient()
+          .from('push_subscriptions')
+          .update({ last_sent_at: new Date().toISOString(), last_error: null })
+          .eq('endpoint', s.endpoint);
+        sent++;
+      } catch (e) {
+        const msg = String(e).slice(0, 200);
+        await this.supabase.getClient()
+          .from('push_subscriptions')
+          .update({ last_error: msg })
+          .eq('endpoint', s.endpoint);
+        // Endpoint 410 Gone → cleanup
+        if (msg.includes('410')) {
+          await this.supabase.getClient()
+            .from('push_subscriptions')
+            .delete()
+            .eq('endpoint', s.endpoint);
+          this.logger.debug(`[push] cleaned up 410 endpoint`);
+        }
+        errors++;
+      }
+    }
+    this.logger.log(`[push] notifyUser kind=${kind} sent=${sent} errors=${errors}`);
+    return { sent, errors };
+  }
+
+  private async sendTriggerOnly(endpoint: string): Promise<void> {
+    const audience = new URL(endpoint).origin;
+    const jwt = this.signVapidJwt(audience);
+    const headers: Record<string, string> = {
+      'Authorization': `vapid t=${jwt}, k=${this.vapidPublicKey}`,
+      'TTL': '60',
+      'Urgency': 'normal',
+    };
+    const res = await fetch(endpoint, { method: 'POST', headers });
+    if (!res.ok) {
+      throw new Error(`Push ${res.status} ${res.statusText}`);
+    }
+  }
+
+  /**
+   * Signe un JWT VAPID (ES256 alg, P-256 curve).
+   * Sans dependency externe : utilise Node crypto.createSign avec une clé
+   * PEM dérivée de la VAPID_PRIVATE_KEY (32 bytes base64url → PEM PKCS8).
+   */
+  private signVapidJwt(audience: string): string {
+    if (!this.vapidPrivateKey) throw new Error('VAPID_PRIVATE_KEY missing');
+    const header = { typ: 'JWT', alg: 'ES256' };
+    const claims = {
+      aud: audience,
+      exp: Math.floor(Date.now() / 1000) + 12 * 3600,
+      sub: this.vapidSubject,
+    };
+    const segHeader = base64UrlJson(header);
+    const segClaims = base64UrlJson(claims);
+    const signingInput = `${segHeader}.${segClaims}`;
+
+    const privatePem = derivePrivatePem(this.vapidPrivateKey, this.vapidPublicKey!);
+    const signer = crypto.createSign('SHA256');
+    signer.update(signingInput);
+    const derSignature = signer.sign({ key: privatePem, dsaEncoding: 'ieee-p1363' });
+    const sigB64 = base64UrlBuf(derSignature);
+    return `${signingInput}.${sigB64}`;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers (out-of-class pour testabilité éventuelle).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function base64UrlBuf(buf: Buffer): string {
+  return buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+function base64UrlJson(obj: object): string {
+  return base64UrlBuf(Buffer.from(JSON.stringify(obj), 'utf8'));
+}
+function base64UrlToBuf(s: string): Buffer {
+  s = s.replace(/-/g, '+').replace(/_/g, '/');
+  while (s.length % 4 !== 0) s += '=';
+  return Buffer.from(s, 'base64');
+}
+
+/**
+ * Convertit une VAPID_PRIVATE_KEY (32 bytes base64url, raw P-256 scalar)
+ * en PEM PKCS8 importable par crypto.createSign.
+ *
+ * Format PKCS8 ECPrivateKey + AlgoIdentifier prefix pour P-256.
+ * Référence : RFC 5208 + RFC 5915.
+ */
+function derivePrivatePem(vapidPrivateKey: string, vapidPublicKey: string): string {
+  const privRaw = base64UrlToBuf(vapidPrivateKey);
+  if (privRaw.length !== 32) {
+    throw new Error(`VAPID_PRIVATE_KEY must be 32 bytes raw, got ${privRaw.length}`);
+  }
+  const pubRaw = base64UrlToBuf(vapidPublicKey);
+  if (pubRaw.length !== 65 || pubRaw[0] !== 0x04) {
+    throw new Error(`VAPID_PUBLIC_KEY must be 65 bytes uncompressed P-256 (0x04 + X + Y), got ${pubRaw.length}`);
+  }
+  const xRaw = pubRaw.subarray(1, 33);
+  const yRaw = pubRaw.subarray(33, 65);
+  // Import via JWK (P-256 EC, format requis par Node : d + x + y).
+  const keyObj = crypto.createPrivateKey({
+    key: {
+      kty: 'EC',
+      crv: 'P-256',
+      d: vapidPrivateKey,
+      x: base64UrlBuf(xRaw),
+      y: base64UrlBuf(yRaw),
+    } as crypto.JsonWebKey,
+    format: 'jwk',
+  });
+  return keyObj.export({ format: 'pem', type: 'pkcs8' }).toString();
+}

--- a/apps/api/src/modules/lisa/services/strategy-coach.service.ts
+++ b/apps/api/src/modules/lisa/services/strategy-coach.service.ts
@@ -1,0 +1,377 @@
+// LISA refonte C.1 — StrategyCoachService.
+//
+// Cron hourly :
+//   - Pour chaque portfolio avec lisa_strategy_coach_enabled=true ET
+//     lisa_initial_capital_usd > 0
+//   - Build contexte (capital, targets, stats 30j, top lessons citées,
+//     dernières décisions, dernières closes)
+//   - Appel Gemini Flash Lite (call()) par défaut
+//   - Escalation Gemini Pro (callWithPro()) si :
+//       - drawdown depuis initial < -20%
+//       - dernière proposition verdict = UNREALISTIC
+//       - tous les 6 cycles horaires (deep-dive quotidien)
+//   - Parse JSON → INSERT coach_proposals status='pending'
+//   - Notify user via PushNotifications + log decision_log
+//
+// UI review (accept/reject) = C.2 (séparé).
+
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { ScannerLlmRouterService } from './scanner-llm-router.service';
+import { PushNotificationsService } from './push-notifications.service';
+
+const SYSTEM_PROMPT = `Tu es Strategy Coach de LISA, un trader algo autonome basé sur Gemini Pro.
+
+Ton rôle : analyser la performance récente de TRADER, comparer aux cibles de l'utilisateur, et proposer des règles (lessons) ou changements de paramètres pour améliorer l'atteinte des cibles SANS compromettre les garde-fous.
+
+Tu reçois en input un JSON contenant :
+- current_capital, initial_capital
+- targets effectifs (jour/mois/année)
+- stats 30j (trades, win-rate, sum_pnl)
+- top 10 lessons citées récemment (avec leur impact)
+- dernières décisions LLM (action_kind, applied, thesis_excerpt)
+- dernières closes (symbol, pnl, exit_reason)
+
+Ta sortie doit être un JSON strict :
+{
+  "feasibility_verdict": "REACHABLE" | "NEEDS_CHANGES" | "UNREALISTIC",
+  "feasibility_probability_pct": <0..100>,
+  "feasibility_rationale": "<2-3 phrases>",
+  "proposed_lessons": [
+    {
+      "lesson_kind": "<UPPER_SNAKE_CASE>",
+      "lesson_text": "Quand <CONDITION>, alors <ACTION>",
+      "confidence": <0..1>,
+      "scope": "trader_agent_only" | "all_scanner",
+      "expected_impact_usd": <number>,
+      "rationale": "<1-2 phrases>"
+    }
+  ],
+  "proposed_parameter_changes": [
+    {
+      "param": "<nom_param>",
+      "current": <valeur>,
+      "proposed": <valeur>,
+      "rationale": "<1-2 phrases>",
+      "expected_impact": "<+ X% trades, - Y$ risk, etc.>"
+    }
+  ],
+  "risk_warnings": ["<warning 1>", "<warning 2>"]
+}
+
+Règles :
+- Maximum 3 lessons par proposition (qualité > quantité)
+- Maximum 2 parameter changes par proposition
+- Si stats sample_size < 30 trades, verdict = "NEEDS_CHANGES" car insuffisant pour conclure
+- Si drawdown depuis initial < -25%, verdict = "UNREALISTIC" + warning explicite
+- Cite des markers existants dans risk_warnings si tu vois leur impact négatif
+- Ne propose JAMAIS de désarmer un kill-switch ni de bypass safety
+- Réponds UNIQUEMENT le JSON, pas de markdown ni explication hors JSON`;
+
+interface PortfolioConfig {
+  portfolio_id: string;
+  user_id: string;
+  lisa_initial_capital_usd: number;
+  lisa_compound_pnl_enabled: boolean;
+  kill_switch_active: boolean;
+  lisa_target_daily_usd: number;
+  lisa_target_daily_pct: number;
+  lisa_target_monthly_usd: number;
+  lisa_target_monthly_pct: number;
+  lisa_target_annual_usd: number;
+  lisa_target_annual_pct: number;
+}
+
+@Injectable()
+export class StrategyCoachService {
+  private readonly logger = new Logger(StrategyCoachService.name);
+  private enabled = false;
+  private cycleCounter = 0;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+    private readonly llmRouter: ScannerLlmRouterService,
+    private readonly schedulerRegistry: SchedulerRegistry,
+    @Optional() private readonly pushNotifs?: PushNotificationsService,
+  ) {}
+
+  onModuleInit(): void {
+    this.enabled = (this.config.get<string>('STRATEGY_COACH_ENABLED') ?? 'true').toLowerCase() === 'true';
+    if (!this.enabled) {
+      this.logger.log('[strategy-coach] disabled via STRATEGY_COACH_ENABLED=false');
+      return;
+    }
+    try {
+      // Minute 17 (offset éviter collision cron 00, 15, 30, 45)
+      const job = new CronJob('17 * * * *', () => {
+        this.runCoach().catch((e) =>
+          this.logger.error(`[strategy-coach] cron failed: ${String(e).slice(0, 200)}`),
+        );
+      });
+      this.schedulerRegistry.addCronJob('strategy-coach-hourly', job);
+      job.start();
+      this.logger.log('[strategy-coach] ENABLED — cron hourly @ minute 17');
+    } catch (e) {
+      this.logger.error(`[strategy-coach] cron register failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  /**
+   * Exécutable manuellement (admin endpoint) ou via cron.
+   */
+  async runCoach(): Promise<{ processed: number; proposalsCreated: number; errors: number }> {
+    if (!this.supabase.isReady() || !this.llmRouter.isEnabled()) {
+      this.logger.warn('[strategy-coach] supabase or llm router not ready, skip');
+      return { processed: 0, proposalsCreated: 0, errors: 0 };
+    }
+    this.cycleCounter++;
+
+    const client = this.supabase.getClient();
+    const { data: configs, error } = await client
+      .from('lisa_session_configs')
+      .select('portfolio_id, user_id, lisa_initial_capital_usd, lisa_compound_pnl_enabled, kill_switch_active, lisa_target_daily_usd, lisa_target_daily_pct, lisa_target_monthly_usd, lisa_target_monthly_pct, lisa_target_annual_usd, lisa_target_annual_pct')
+      .eq('lisa_strategy_coach_enabled', true)
+      .gt('lisa_initial_capital_usd', 0);
+    if (error) {
+      this.logger.error(`[strategy-coach] config fetch err: ${error.message}`);
+      return { processed: 0, proposalsCreated: 0, errors: 1 };
+    }
+
+    let processed = 0;
+    let proposalsCreated = 0;
+    let errors = 0;
+    for (const cfg of (configs ?? []) as unknown as PortfolioConfig[]) {
+      processed++;
+      try {
+        const proposalId = await this.runForPortfolio(cfg);
+        if (proposalId) proposalsCreated++;
+      } catch (e) {
+        this.logger.warn(`[strategy-coach] portfolio=${cfg.portfolio_id.slice(0, 8)} err: ${String(e).slice(0, 200)}`);
+        errors++;
+      }
+    }
+    this.logger.log(`[strategy-coach] done processed=${processed} created=${proposalsCreated} errors=${errors}`);
+    return { processed, proposalsCreated, errors };
+  }
+
+  private async runForPortfolio(cfg: PortfolioConfig): Promise<string | null> {
+    const client = this.supabase.getClient();
+    const ctx = await this.buildContext(cfg);
+
+    // Décision Flash vs Pro
+    const usePro = await this.shouldEscalateToPro(cfg, ctx);
+    const llmModel = usePro ? 'gemini-pro' : 'gemini-flash';
+
+    const userPrompt = JSON.stringify(ctx, null, 2);
+    const llmCallParams = {
+      system: SYSTEM_PROMPT,
+      user: userPrompt,
+      maxTokens: 2048,
+      temperature: 0.4,
+    };
+
+    const start = Date.now();
+    const res = usePro
+      ? await this.llmRouter.callWithPro(llmCallParams)
+      : await this.llmRouter.call(llmCallParams);
+    const latencyMs = Date.now() - start;
+
+    const parsed = this.parseJsonStrict(res.content);
+    if (!parsed) {
+      this.logger.warn(`[strategy-coach] portfolio=${cfg.portfolio_id.slice(0, 8)} unparseable JSON`);
+      return null;
+    }
+
+    // Anti-redondance hash (basique, premier verdict + count lessons + first lesson_kind)
+    const lessons = Array.isArray(parsed.proposed_lessons) ? parsed.proposed_lessons : [];
+    const params = Array.isArray(parsed.proposed_parameter_changes) ? parsed.proposed_parameter_changes : [];
+    const patternHash = `${parsed.feasibility_verdict}:${lessons.length}:${lessons[0]?.lesson_kind ?? ''}:${params.length}:${params[0]?.param ?? ''}`;
+
+    // Skip si déjà proposé dans les 6 dernières heures avec même hash
+    const sixHoursAgoIso = new Date(Date.now() - 6 * 3600_000).toISOString();
+    const { data: recentSame } = await client
+      .from('coach_proposals')
+      .select('id')
+      .eq('portfolio_id', cfg.portfolio_id)
+      .eq('pattern_hash', patternHash)
+      .gte('created_at', sixHoursAgoIso)
+      .limit(1);
+    if (recentSame && recentSame.length > 0) {
+      this.logger.debug(`[strategy-coach] portfolio=${cfg.portfolio_id.slice(0, 8)} skip duplicate pattern ${patternHash}`);
+      return null;
+    }
+
+    // INSERT proposition
+    const { data: inserted, error: insErr } = await client
+      .from('coach_proposals')
+      .insert({
+        portfolio_id: cfg.portfolio_id,
+        source: 'cron_hourly',
+        llm_model: llmModel,
+        llm_cost_usd: res.costUsd,
+        llm_latency_ms: latencyMs,
+        input_context: ctx,
+        feasibility_verdict: String(parsed.feasibility_verdict ?? 'UNKNOWN'),
+        feasibility_probability_pct: typeof parsed.feasibility_probability_pct === 'number' ? parsed.feasibility_probability_pct : null,
+        feasibility_rationale: String(parsed.feasibility_rationale ?? ''),
+        proposed_lessons: lessons,
+        proposed_parameter_changes: params,
+        risk_warnings: Array.isArray(parsed.risk_warnings) ? parsed.risk_warnings : [],
+        status: 'pending',
+        pattern_hash: patternHash,
+      })
+      .select('id')
+      .maybeSingle();
+    if (insErr) {
+      this.logger.warn(`[strategy-coach] insert err: ${insErr.message}`);
+      return null;
+    }
+    const proposalId = (inserted as { id?: string } | null)?.id ?? null;
+
+    // Audit + notify user
+    await client.from('lisa_decision_log').insert({
+      portfolio_id: cfg.portfolio_id,
+      kind: 'strategy_coach_proposal',
+      payload: {
+        proposal_id: proposalId,
+        llm_model: llmModel,
+        verdict: parsed.feasibility_verdict,
+        lessons_count: lessons.length,
+        params_count: params.length,
+        cost_usd: res.costUsd,
+      },
+    });
+    if (this.pushNotifs) {
+      this.pushNotifs.notifyUser(cfg.user_id, 'coach_proposal_pending').catch(() => null);
+    }
+    if (proposalId) {
+      await client
+        .from('coach_proposals')
+        .update({ notified_at: new Date().toISOString() })
+        .eq('id', proposalId);
+    }
+    return proposalId;
+  }
+
+  private async buildContext(cfg: PortfolioConfig): Promise<Record<string, unknown>> {
+    const client = this.supabase.getClient();
+    const nowMs = Date.now();
+    const thirtyDaysAgoIso = new Date(nowMs - 30 * 86400_000).toISOString();
+    const sevenDaysAgoIso = new Date(nowMs - 7 * 86400_000).toISOString();
+
+    const [allClosed, recentDecisions, citations] = await Promise.all([
+      client
+        .from('lisa_positions')
+        .select('realized_pnl_usd, exit_timestamp, symbol, exit_reason')
+        .eq('portfolio_id', cfg.portfolio_id)
+        .neq('status', 'open'),
+      client
+        .from('trader_agent_decisions')
+        .select('decided_at, action_kind, target_symbol, confidence, action_applied, apply_error')
+        .eq('portfolio_id', cfg.portfolio_id)
+        .order('decided_at', { ascending: false })
+        .limit(20),
+      client
+        .from('scanner_lesson_citations')
+        .select('marker_text, outcome_pnl_usd, outcome_win, action_applied')
+        .eq('portfolio_id', cfg.portfolio_id)
+        .gte('cited_at', thirtyDaysAgoIso)
+        .limit(2000),
+    ]);
+
+    const closed = (allClosed.data ?? []) as Array<{ realized_pnl_usd?: unknown; exit_timestamp?: string; symbol?: string; exit_reason?: string }>;
+    const cumulative = closed.reduce((s, c) => s + Number(c.realized_pnl_usd ?? 0), 0);
+    const currentCapital = cfg.lisa_compound_pnl_enabled ? cfg.lisa_initial_capital_usd + cumulative : cfg.lisa_initial_capital_usd;
+    const drawdownFromInitialPct = cfg.lisa_initial_capital_usd > 0
+      ? ((currentCapital - cfg.lisa_initial_capital_usd) / cfg.lisa_initial_capital_usd) * 100
+      : 0;
+
+    const closed30d = closed.filter((c) => String(c.exit_timestamp ?? '') >= thirtyDaysAgoIso);
+    const closed7d = closed.filter((c) => String(c.exit_timestamp ?? '') >= sevenDaysAgoIso);
+    const stats30d = {
+      trades: closed30d.length,
+      sum_pnl: closed30d.reduce((s, c) => s + Number(c.realized_pnl_usd ?? 0), 0),
+      wins: closed30d.filter((c) => Number(c.realized_pnl_usd ?? 0) > 0).length,
+      losses: closed30d.filter((c) => Number(c.realized_pnl_usd ?? 0) < 0).length,
+    };
+    const stats7d = {
+      trades: closed7d.length,
+      sum_pnl: closed7d.reduce((s, c) => s + Number(c.realized_pnl_usd ?? 0), 0),
+    };
+
+    // Top 10 lessons par citations + impact
+    const lessonAgg = new Map<string, { marker: string; citations: number; sum_pnl: number; wins: number; losses: number; applied: number }>();
+    for (const c of (citations.data ?? []) as Array<{ marker_text?: string; outcome_pnl_usd?: unknown; outcome_win?: boolean | null; action_applied?: boolean }>) {
+      const key = String(c.marker_text ?? '?');
+      let b = lessonAgg.get(key);
+      if (!b) { b = { marker: key, citations: 0, sum_pnl: 0, wins: 0, losses: 0, applied: 0 }; lessonAgg.set(key, b); }
+      b.citations += 1;
+      b.sum_pnl += Number(c.outcome_pnl_usd ?? 0);
+      if (c.outcome_win === true) b.wins += 1;
+      if (c.outcome_win === false) b.losses += 1;
+      if (c.action_applied) b.applied += 1;
+    }
+    const topLessons = [...lessonAgg.values()].sort((a, b) => b.citations - a.citations).slice(0, 10);
+
+    // Cibles effectives Mode C
+    const effDaily = Math.max(cfg.lisa_target_daily_usd, (cfg.lisa_target_daily_pct / 100) * currentCapital);
+    const effMonthly = Math.max(cfg.lisa_target_monthly_usd, (cfg.lisa_target_monthly_pct / 100) * currentCapital);
+    const effAnnual = Math.max(cfg.lisa_target_annual_usd, (cfg.lisa_target_annual_pct / 100) * currentCapital);
+
+    return {
+      generated_at: new Date().toISOString(),
+      capital: {
+        initial_usd: cfg.lisa_initial_capital_usd,
+        current_usd: currentCapital,
+        cumulative_pnl_usd: cumulative,
+        drawdown_from_initial_pct: drawdownFromInitialPct,
+        compound_enabled: cfg.lisa_compound_pnl_enabled,
+      },
+      targets_effective_usd: {
+        daily: effDaily,
+        monthly: effMonthly,
+        annual: effAnnual,
+      },
+      stats_7d: stats7d,
+      stats_30d: stats30d,
+      top_lessons: topLessons,
+      recent_decisions: (recentDecisions.data ?? []).slice(0, 10),
+      recent_closes: closed.slice(-10),
+      kill_switch_active: cfg.kill_switch_active,
+    };
+  }
+
+  private async shouldEscalateToPro(cfg: PortfolioConfig, ctx: Record<string, unknown>): Promise<boolean> {
+    const capital = ctx.capital as { drawdown_from_initial_pct?: number };
+    if ((capital?.drawdown_from_initial_pct ?? 0) < -20) return true;
+    // Deep-dive : 1 sur 6 cycles horaires (≈ 1 par 6h)
+    if (this.cycleCounter % 6 === 0) return true;
+    // Dernière proposition UNREALISTIC → escalade
+    const { data: last } = await this.supabase.getClient()
+      .from('coach_proposals')
+      .select('feasibility_verdict')
+      .eq('portfolio_id', cfg.portfolio_id)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if ((last as { feasibility_verdict?: string } | null)?.feasibility_verdict === 'UNREALISTIC') return true;
+    return false;
+  }
+
+  private parseJsonStrict(raw: string): Record<string, unknown> | null {
+    // Tente d'extraire un bloc ```json ... ``` ou parse direct
+    let text = raw.trim();
+    const codeBlock = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (codeBlock) text = codeBlock[1].trim();
+    try {
+      const parsed = JSON.parse(text);
+      return typeof parsed === 'object' && parsed !== null ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/apps/api/src/modules/lisa/services/trader-retrospective.service.ts
+++ b/apps/api/src/modules/lisa/services/trader-retrospective.service.ts
@@ -1,0 +1,376 @@
+// LISA refonte C.4 — TraderRetrospectiveService.
+//
+// Cron daily 02:00 UTC : analyse les trades TRADER (b0000001-...) clos
+// la veille (UTC). Si trades_count >= 5, appelle Gemini Pro pour dériver
+// des lessons scope='trader_agent_only' qui seront réinjectées dans le
+// system prompt du trader-agent au cycle suivant via
+// ScannerLessonsContextService.
+//
+// Différent de MainScannerPostMortemService (cron 02:30 UTC, scope MAIN/
+// HIGH/MIDDLE/SMALL gainers) : ici on couvre l'angle mort TRADER qui
+// avait été identifié dans la conversation initiale ("rien n'auto-enrichit
+// les lessons trader_agent_only").
+//
+// Différent de StrategyCoachService (cron horaire forward-looking,
+// propose lessons à valider par user) : ici c'est backward-looking,
+// dérive des observations factuelles des trades passés, persiste
+// directement avec is_active=true (user peut désactiver via Lessons mgmt
+// B.3 si besoin).
+
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { ScannerLlmRouterService } from './scanner-llm-router.service';
+
+const TRADER_AGENT_PORTFOLIO_ID = 'b0000001-0000-0000-0000-000000000001';
+
+const SYSTEM_PROMPT = `Tu es Trader Retrospective Analyst.
+
+Ton rôle : analyser les trades de la veille du portfolio TRADER (agent autonome Gemini Pro) et dériver des règles actionnables ("lessons") pour améliorer les décisions futures.
+
+Tu reçois en input un JSON contenant :
+- yesterday_date
+- trades[] : array de trades avec symbol, asset_class, entry/exit, pnl_usd, pnl_pct, hold_minutes, exit_reason, asset_class, hour_utc, entry_thesis_excerpt
+- stats : total, wins, losses, win_rate, sum_pnl, avg_pnl, biggest_win, biggest_loss
+- by_exit_reason : distribution count + pnl par exit_reason
+- by_hour : distribution count + pnl par heure UTC
+- top_lessons_cited_yesterday : markers cités hier + leur outcome (win-rate, sum_pnl)
+
+Ta sortie doit être un JSON strict :
+{
+  "summary": "<2-3 phrases — quoi marche / quoi marche pas hier>",
+  "lessons": [
+    {
+      "lesson_kind": "<UPPER_SNAKE_CASE>",
+      "lesson_text": "Quand <CONDITION OBSERVABLE>, alors <ACTION CONCRÈTE>",
+      "confidence": <0..1>,
+      "macro_condition": "<ex: VIX>22 / ASIA_SESSION / FRIDAY_LAST_HOUR>" | null,
+      "sample_size": <int — combien de trades supportent cette lesson>,
+      "win_rate_observed": <0..100 — sur ces N trades>,
+      "avg_pnl_usd": <number>,
+      "rationale": "<1-2 phrases>"
+    }
+  ],
+  "lessons_to_invalidate": [
+    {
+      "lesson_kind_pattern": "<UPPER_SNAKE_CASE ou pattern ILIKE>",
+      "reason": "<2-3 phrases — pourquoi cette lesson a fait perdre>"
+    }
+  ]
+}
+
+Règles :
+- sample_size minimum 3 pour qu'une lesson soit retenue (sinon DROP)
+- confidence ≤ 0.7 par défaut (lesson dérivée d'un seul jour reste tentative)
+- macro_condition obligatoire si la lesson dépend d'un contexte (sinon null)
+- lesson_text actionnable et observable au moment de la décision (pas "éviter symboles qui vont perdre")
+- Maximum 3 lessons + 2 invalidations par run
+- Si trades_count < 5, retourne lessons=[] (insuffisant statistiquement)
+- Réponds UNIQUEMENT le JSON, pas de markdown ni explication hors JSON`;
+
+@Injectable()
+export class TraderRetrospectiveService {
+  private readonly logger = new Logger(TraderRetrospectiveService.name);
+  private enabled = false;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+    private readonly llmRouter: ScannerLlmRouterService,
+    private readonly schedulerRegistry: SchedulerRegistry,
+  ) {}
+
+  onModuleInit(): void {
+    this.enabled = (this.config.get<string>('TRADER_RETROSPECTIVE_ENABLED') ?? 'true').toLowerCase() === 'true';
+    if (!this.enabled) {
+      this.logger.log('[trader-retrospective] disabled via TRADER_RETROSPECTIVE_ENABLED=false');
+      return;
+    }
+    try {
+      // 02:00 UTC : avant MainScannerPostMortem (02:30) pour répartir le coût Gemini Pro
+      const job = new CronJob('0 2 * * *', () => {
+        this.runRetrospective().catch((e) =>
+          this.logger.error(`[trader-retrospective] cron failed: ${String(e).slice(0, 200)}`),
+        );
+      });
+      this.schedulerRegistry.addCronJob('trader-retrospective-daily', job);
+      job.start();
+      this.logger.log('[trader-retrospective] ENABLED — cron 02:00 UTC daily');
+    } catch (e) {
+      this.logger.error(`[trader-retrospective] cron register failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+
+  /**
+   * Exécutable manuellement (admin endpoint si wiré) ou via cron.
+   * Retourne stats { tradesAnalyzed, lessonsPersisted, invalidations, costUsd, error? }.
+   */
+  async runRetrospective(): Promise<{
+    tradesAnalyzed: number;
+    lessonsPersisted: number;
+    invalidations: number;
+    costUsd: number;
+    error?: string;
+  }> {
+    if (!this.supabase.isReady() || !this.llmRouter.isEnabled()) {
+      return { tradesAnalyzed: 0, lessonsPersisted: 0, invalidations: 0, costUsd: 0, error: 'supabase or llm router not ready' };
+    }
+
+    const client = this.supabase.getClient();
+    const now = new Date();
+    const yesterdayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+    const yesterdayEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+
+    // 1. Trades clos hier
+    const { data: closed } = await client
+      .from('lisa_positions')
+      .select('symbol, asset_class, entry_price, exit_price, realized_pnl_usd, realized_pnl_pct, exit_reason, entry_timestamp, exit_timestamp')
+      .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID)
+      .neq('status', 'open')
+      .gte('exit_timestamp', yesterdayStart.toISOString())
+      .lt('exit_timestamp', yesterdayEnd.toISOString())
+      .order('exit_timestamp', { ascending: true });
+    const trades = closed ?? [];
+
+    if (trades.length < 5) {
+      this.logger.log(`[trader-retrospective] only ${trades.length} trades yesterday, skip (need >= 5)`);
+      return { tradesAnalyzed: trades.length, lessonsPersisted: 0, invalidations: 0, costUsd: 0 };
+    }
+
+    // 2. Stats + distributions
+    const stats = this.computeStats(trades as Array<Record<string, unknown>>);
+    const byExitReason = this.distByExitReason(trades as Array<Record<string, unknown>>);
+    const byHour = this.distByHour(trades as Array<Record<string, unknown>>);
+
+    // 3. Top lessons cited hier + leur outcome
+    const { data: citations } = await client
+      .from('scanner_lesson_citations')
+      .select('marker_text, action_applied, outcome_pnl_usd, outcome_win')
+      .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID)
+      .gte('cited_at', yesterdayStart.toISOString())
+      .lt('cited_at', yesterdayEnd.toISOString())
+      .limit(2000);
+    const topLessonsCited = this.aggregateCitations((citations ?? []) as Array<Record<string, unknown>>);
+
+    // 4. Thesis excerpts (50 derniers décisions hier)
+    const { data: theses } = await client
+      .from('trader_agent_decisions')
+      .select('decided_at, action_kind, target_symbol, thesis')
+      .eq('portfolio_id', TRADER_AGENT_PORTFOLIO_ID)
+      .gte('decided_at', yesterdayStart.toISOString())
+      .lt('decided_at', yesterdayEnd.toISOString())
+      .order('decided_at', { ascending: false })
+      .limit(50);
+
+    // 5. Build context + call Gemini Pro
+    const context = {
+      yesterday_date: yesterdayStart.toISOString().slice(0, 10),
+      trades: (trades as Array<Record<string, unknown>>).map((t) => this.formatTrade(t, theses ?? [])),
+      stats,
+      by_exit_reason: byExitReason,
+      by_hour: byHour,
+      top_lessons_cited_yesterday: topLessonsCited,
+    };
+
+    const start = Date.now();
+    let res: { content: string; providerId: string; costUsd: number; latencyMs: number };
+    try {
+      res = await this.llmRouter.callWithPro({
+        system: SYSTEM_PROMPT,
+        user: JSON.stringify(context, null, 2),
+        maxTokens: 2048,
+        temperature: 0.3,
+      });
+    } catch (e) {
+      const msg = String(e).slice(0, 200);
+      this.logger.error(`[trader-retrospective] LLM err: ${msg}`);
+      return { tradesAnalyzed: trades.length, lessonsPersisted: 0, invalidations: 0, costUsd: 0, error: msg };
+    }
+    const latencyMs = Date.now() - start;
+
+    const parsed = this.parseJsonStrict(res.content);
+    if (!parsed) {
+      this.logger.warn('[trader-retrospective] unparseable JSON');
+      return { tradesAnalyzed: trades.length, lessonsPersisted: 0, invalidations: 0, costUsd: res.costUsd, error: 'unparseable' };
+    }
+
+    // 6. INSERT lessons
+    const lessonsToInsert = Array.isArray(parsed.lessons) ? parsed.lessons : [];
+    const validLessons = lessonsToInsert.filter((l: Record<string, unknown>) => {
+      const sample = Number(l.sample_size ?? 0);
+      return sample >= 3 && typeof l.lesson_kind === 'string' && typeof l.lesson_text === 'string';
+    });
+    let lessonsPersisted = 0;
+    if (validLessons.length > 0) {
+      const rows = validLessons.slice(0, 3).map((l: Record<string, unknown>) => ({
+        derived_from_date: context.yesterday_date,
+        lesson_kind: String(l.lesson_kind),
+        lesson_text: String(l.lesson_text),
+        macro_condition: l.macro_condition ? String(l.macro_condition) : null,
+        scope: 'trader_agent_only',
+        confidence: Math.min(Math.max(Number(l.confidence ?? 0.5), 0), 1),
+        sample_size: Number(l.sample_size ?? 0),
+        win_rate_observed: l.win_rate_observed !== undefined ? Number(l.win_rate_observed) : null,
+        avg_pnl_usd: l.avg_pnl_usd !== undefined ? Number(l.avg_pnl_usd) : null,
+        is_active: true,
+        applied: false,
+        payload: {
+          source: 'trader_retrospective',
+          rationale: l.rationale ?? null,
+          provider: res.providerId,
+        },
+      }));
+      const { error: insErr } = await client.from('scanner_lessons').insert(rows);
+      if (insErr) {
+        this.logger.warn(`[trader-retrospective] insert err: ${insErr.message}`);
+      } else {
+        lessonsPersisted = rows.length;
+      }
+    }
+
+    // 7. Invalidations (UPDATE is_active=false WHERE lesson_kind ILIKE pattern AND scope='trader_agent_only')
+    const invals = Array.isArray(parsed.lessons_to_invalidate) ? parsed.lessons_to_invalidate : [];
+    let invalidations = 0;
+    for (const inv of invals.slice(0, 2) as Array<Record<string, unknown>>) {
+      const pattern = String(inv.lesson_kind_pattern ?? '').trim();
+      if (!pattern) continue;
+      const { error: updErr, count } = await client
+        .from('scanner_lessons')
+        .update({ is_active: false }, { count: 'exact' })
+        .eq('scope', 'trader_agent_only')
+        .eq('is_active', true)
+        .ilike('lesson_kind', `%${pattern}%`);
+      if (updErr) {
+        this.logger.warn(`[trader-retrospective] invalidate err: ${updErr.message}`);
+      } else if (count) {
+        invalidations += count;
+      }
+    }
+
+    // 8. Audit
+    await client.from('lisa_decision_log').insert({
+      portfolio_id: TRADER_AGENT_PORTFOLIO_ID,
+      kind: 'trader_retrospective_complete',
+      payload: {
+        yesterday_date: context.yesterday_date,
+        trades_analyzed: trades.length,
+        lessons_persisted: lessonsPersisted,
+        invalidations,
+        cost_usd: res.costUsd,
+        latency_ms: latencyMs,
+        provider: res.providerId,
+        summary: parsed.summary ?? null,
+      },
+    });
+
+    this.logger.log(
+      `[trader-retrospective] done trades=${trades.length} lessons=${lessonsPersisted} invalidations=${invalidations} cost=$${res.costUsd.toFixed(4)}`,
+    );
+    return {
+      tradesAnalyzed: trades.length,
+      lessonsPersisted,
+      invalidations,
+      costUsd: res.costUsd,
+    };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ─────────────────────────────────────────────────────────────────────
+
+  private computeStats(trades: Array<Record<string, unknown>>) {
+    const pnls = trades.map((t) => Number(t.realized_pnl_usd ?? 0));
+    const wins = pnls.filter((p) => p > 0).length;
+    const losses = pnls.filter((p) => p < 0).length;
+    const sum = pnls.reduce((s, p) => s + p, 0);
+    return {
+      total: trades.length,
+      wins,
+      losses,
+      win_rate_pct: trades.length > 0 ? (wins / trades.length) * 100 : 0,
+      sum_pnl_usd: sum,
+      avg_pnl_usd: trades.length > 0 ? sum / trades.length : 0,
+      biggest_win_usd: pnls.length ? Math.max(...pnls) : 0,
+      biggest_loss_usd: pnls.length ? Math.min(...pnls) : 0,
+    };
+  }
+
+  private distByExitReason(trades: Array<Record<string, unknown>>) {
+    const map: Record<string, { count: number; sum_pnl: number }> = {};
+    for (const t of trades) {
+      const r = String(t.exit_reason ?? 'unknown');
+      if (!map[r]) map[r] = { count: 0, sum_pnl: 0 };
+      map[r].count += 1;
+      map[r].sum_pnl += Number(t.realized_pnl_usd ?? 0);
+    }
+    return map;
+  }
+
+  private distByHour(trades: Array<Record<string, unknown>>) {
+    const map: Record<number, { count: number; sum_pnl: number }> = {};
+    for (const t of trades) {
+      const exitTs = String(t.exit_timestamp ?? '');
+      if (!exitTs) continue;
+      const hr = new Date(exitTs).getUTCHours();
+      if (!map[hr]) map[hr] = { count: 0, sum_pnl: 0 };
+      map[hr].count += 1;
+      map[hr].sum_pnl += Number(t.realized_pnl_usd ?? 0);
+    }
+    return map;
+  }
+
+  private aggregateCitations(citations: Array<Record<string, unknown>>) {
+    const map = new Map<string, { marker: string; citations: number; applied: number; wins: number; losses: number; sum_pnl: number }>();
+    for (const c of citations) {
+      const key = String(c.marker_text ?? '?');
+      let b = map.get(key);
+      if (!b) { b = { marker: key, citations: 0, applied: 0, wins: 0, losses: 0, sum_pnl: 0 }; map.set(key, b); }
+      b.citations += 1;
+      if (c.action_applied) b.applied += 1;
+      if (c.outcome_win === true) b.wins += 1;
+      if (c.outcome_win === false) b.losses += 1;
+      b.sum_pnl += Number(c.outcome_pnl_usd ?? 0);
+    }
+    return [...map.values()].sort((a, b) => b.citations - a.citations).slice(0, 10);
+  }
+
+  private formatTrade(t: Record<string, unknown>, theses: Array<Record<string, unknown>>) {
+    const entryTs = String(t.entry_timestamp ?? '');
+    const exitTs = String(t.exit_timestamp ?? '');
+    const holdMin = entryTs && exitTs
+      ? Math.round((new Date(exitTs).getTime() - new Date(entryTs).getTime()) / 60000)
+      : null;
+    const sym = String(t.symbol ?? '');
+    // Trouve la thesis la plus proche de entry_timestamp pour ce symbol (dans 10min)
+    const entryMs = new Date(entryTs).getTime();
+    const matchedThesis = theses.find((th) => {
+      if (String(th.target_symbol ?? '') !== sym) return false;
+      const decMs = new Date(String(th.decided_at ?? '')).getTime();
+      return Math.abs(decMs - entryMs) < 10 * 60_000;
+    });
+    return {
+      symbol: sym,
+      asset_class: t.asset_class ?? null,
+      pnl_usd: Number(t.realized_pnl_usd ?? 0),
+      pnl_pct: Number(t.realized_pnl_pct ?? 0),
+      hold_minutes: holdMin,
+      exit_reason: String(t.exit_reason ?? '').slice(0, 100),
+      hour_utc: exitTs ? new Date(exitTs).getUTCHours() : null,
+      entry_thesis_excerpt: matchedThesis ? String(matchedThesis.thesis ?? '').slice(0, 200) : null,
+    };
+  }
+
+  private parseJsonStrict(raw: string): Record<string, unknown> | null {
+    let text = raw.trim();
+    const codeBlock = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (codeBlock) text = codeBlock[1].trim();
+    try {
+      const parsed = JSON.parse(text);
+      return typeof parsed === 'object' && parsed !== null ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/apps/web/public/sw-lisa-push.js
+++ b/apps/web/public/sw-lisa-push.js
@@ -1,0 +1,57 @@
+// LISA refonte B.4.c — Service worker push event handler.
+//
+// Servi statiquement par Next.js depuis /sw-lisa-push.js.
+// Scope = root (le client enregistre avec scope '/').
+//
+// Reçoit des pushes "trigger-only" du backend (payload vide). Affiche une
+// notification générique ; le contenu réel est récupéré via fetch sur
+// /api/lisa/notifications par l'UI au prochain focus.
+
+self.addEventListener('install', (event) => {
+  // Activate immédiatement (skip waiting) — pas de cache à warm-up.
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('push', (event) => {
+  let title = '🤖 LISA';
+  let body = 'Nouvelle notification';
+  let tag = 'lisa-default';
+  try {
+    if (event.data) {
+      const payload = event.data.json();
+      if (payload.title) title = payload.title;
+      if (payload.body) body = payload.body;
+      if (payload.tag) tag = payload.tag;
+    }
+  } catch (e) {
+    // Trigger-only push (pas de payload) — affiche la notif générique.
+  }
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      tag,
+      icon: '/icon-192.png', // optional — Next ignore silencieusement si absent
+      badge: '/badge-72.png',
+      vibrate: [100, 50, 100],
+      data: { url: '/lisa' },
+    }),
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/lisa';
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientsList) => {
+      for (const client of clientsList) {
+        if (client.url.includes(targetUrl) && 'focus' in client) return client.focus();
+      }
+      if (self.clients.openWindow) return self.clients.openWindow(targetUrl);
+    }),
+  );
+});

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -36,6 +36,7 @@ import { LisaStickyHeader } from '@/components/lisa/lisa-sticky-header';
 import { GainsTracker } from '@/components/lisa/gains-tracker';
 import { LessonsImpactPanel } from '@/components/lisa/lessons-impact-panel';
 import { LisaConfigPanel } from '@/components/lisa/lisa-config-panel';
+import { CoachProposalsPanel } from '@/components/lisa/coach-proposals-panel';
 import { ScalingReadinessPanel } from '@/components/lisa/scaling-readiness-panel';
 import { LiveTradingStatusPanel } from '@/components/lisa/live-trading-status-panel';
 import { LiveTradingWizard } from '@/components/lisa/live-trading-wizard';
@@ -625,6 +626,9 @@ export default function LisaPage() {
 
       {/* LISA refonte A.3 — Section Gains (badges + reset display-only) */}
       {selectedPortfolioId && <GainsTracker portfolioId={selectedPortfolioId} />}
+
+      {/* LISA refonte C.2 — Strategy Coach proposals (Gemini hourly + review modal) */}
+      {selectedPortfolioId && <CoachProposalsPanel portfolioId={selectedPortfolioId} />}
 
       {/* LISA refonte B.2 — Lessons Impact Tracker (citations agrégées TRADER) */}
       {selectedPortfolioId && <LessonsImpactPanel portfolioId={selectedPortfolioId} />}

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -35,6 +35,7 @@ import { GainersConfigPanel } from '@/components/lisa/gainers-config-panel';
 import { LisaStickyHeader } from '@/components/lisa/lisa-sticky-header';
 import { GainsTracker } from '@/components/lisa/gains-tracker';
 import { LessonsImpactPanel } from '@/components/lisa/lessons-impact-panel';
+import { LisaConfigPanel } from '@/components/lisa/lisa-config-panel';
 import { ScalingReadinessPanel } from '@/components/lisa/scaling-readiness-panel';
 import { LiveTradingStatusPanel } from '@/components/lisa/live-trading-status-panel';
 import { LiveTradingWizard } from '@/components/lisa/live-trading-wizard';
@@ -627,6 +628,9 @@ export default function LisaPage() {
 
       {/* LISA refonte B.2 — Lessons Impact Tracker (citations agrégées TRADER) */}
       {selectedPortfolioId && <LessonsImpactPanel portfolioId={selectedPortfolioId} />}
+
+      {/* LISA refonte B.3 — Config LISA simplifiée (kill-switch reset, capital, digest, lessons mgmt) */}
+      {selectedPortfolioId && <LisaConfigPanel portfolioId={selectedPortfolioId} />}
 
       {/* LISA refonte A.2 — Mini-tile temps réel scanner LISA (ex-Gainers).
           Renommé côté composant interne, mais portfolio_id=TRADER force le scope. */}

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -34,6 +34,7 @@ import { GainersStatusTile } from '@/components/lisa/gainers-status-tile';
 import { GainersConfigPanel } from '@/components/lisa/gainers-config-panel';
 import { LisaStickyHeader } from '@/components/lisa/lisa-sticky-header';
 import { GainsTracker } from '@/components/lisa/gains-tracker';
+import { LessonsImpactPanel } from '@/components/lisa/lessons-impact-panel';
 import { ScalingReadinessPanel } from '@/components/lisa/scaling-readiness-panel';
 import { LiveTradingStatusPanel } from '@/components/lisa/live-trading-status-panel';
 import { LiveTradingWizard } from '@/components/lisa/live-trading-wizard';
@@ -623,6 +624,9 @@ export default function LisaPage() {
 
       {/* LISA refonte A.3 — Section Gains (badges + reset display-only) */}
       {selectedPortfolioId && <GainsTracker portfolioId={selectedPortfolioId} />}
+
+      {/* LISA refonte B.2 — Lessons Impact Tracker (citations agrégées TRADER) */}
+      {selectedPortfolioId && <LessonsImpactPanel portfolioId={selectedPortfolioId} />}
 
       {/* LISA refonte A.2 — Mini-tile temps réel scanner LISA (ex-Gainers).
           Renommé côté composant interne, mais portfolio_id=TRADER force le scope. */}

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -32,6 +32,8 @@ import { DailyHarvestPanel } from '@/components/lisa/daily-harvest-panel';
 import { MacroModeSelector } from '@/components/lisa/macro-mode-selector';
 import { GainersStatusTile } from '@/components/lisa/gainers-status-tile';
 import { GainersConfigPanel } from '@/components/lisa/gainers-config-panel';
+import { LisaStickyHeader } from '@/components/lisa/lisa-sticky-header';
+import { GainsTracker } from '@/components/lisa/gains-tracker';
 import { ScalingReadinessPanel } from '@/components/lisa/scaling-readiness-panel';
 import { LiveTradingStatusPanel } from '@/components/lisa/live-trading-status-panel';
 import { LiveTradingWizard } from '@/components/lisa/live-trading-wizard';
@@ -538,18 +540,21 @@ export default function LisaPage() {
 
   // ── Main UI ─────────────────────────────────────────────────────────────────
   return (
-    <div className="mx-auto max-w-5xl space-y-6 p-6">
+    <>
+      {/* LISA refonte A.3 — sticky header avec cible jour + PnL today */}
+      {selectedPortfolioId && <LisaStickyHeader portfolioId={selectedPortfolioId} />}
+
+      <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-6">
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-3">
           <BackButton />
           <div>
             <h1 className="flex items-center gap-2 text-xl font-semibold">
               <Sparkles className="h-5 w-5 text-primary" />
-              Mon assistant Lisa
+              🤖 LISA — Mon agent autonome
             </h1>
             <p className="text-sm text-muted-foreground">
-              Multi-actifs · approche anti-consensus · corpus de 25+ événements historiques ·
-              100 % simulation
+              Agent Gemini Pro 2.5 · lessons accumulées en continu · 100 % simulation
             </p>
           </div>
         </div>
@@ -615,6 +620,9 @@ export default function LisaPage() {
 
       {/* P7 — Mode opératoire 3-way (Investment / Harvest / Gainers) */}
       {selectedPortfolioId && <MacroModeSelector portfolioId={selectedPortfolioId} />}
+
+      {/* LISA refonte A.3 — Section Gains (badges + reset display-only) */}
+      {selectedPortfolioId && <GainsTracker portfolioId={selectedPortfolioId} />}
 
       {/* LISA refonte A.2 — Mini-tile temps réel scanner LISA (ex-Gainers).
           Renommé côté composant interne, mais portfolio_id=TRADER force le scope. */}
@@ -1475,7 +1483,8 @@ export default function LisaPage() {
           onCancel={() => setConfirmDialog(null)}
         />
       )}
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -78,22 +78,30 @@ const profileLabelOf = (
   return PROFILE_LABELS[p as SessionProfile] ?? UNKNOWN_PROFILE_LABEL;
 };
 
+// LISA refonte Phase A.2 — La page /lisa affiche uniquement le portefeuille TRADER
+// (= moteur LLM Gemini Pro autonome, futur scanner principal). MAIN/HIGH/MIDDLE/SMALL
+// (= scanners Gainers déterministes) sont visibles séparément en bas (chunk A.2.5).
+const TRADER_PORTFOLIO_ID = 'b0000001-0000-0000-0000-000000000001';
+
 export default function LisaPage() {
   const portfoliosQuery = usePortfolios();
   const qc = useQueryClient();
   const simulationPortfolios = (portfoliosQuery.data ?? []).filter(
     (p) => (p as { is_simulation?: boolean }).is_simulation,
   );
+  // Find TRADER specifically (fallback first simulation portfolio si introuvable).
+  const traderPortfolio = simulationPortfolios.find((p) => p.id === TRADER_PORTFOLIO_ID);
 
   const [selectedPortfolioId, setSelectedPortfolioId] = useState<string | null>(
-    simulationPortfolios[0]?.id ?? null,
+    traderPortfolio?.id ?? null,
   );
 
-  // Bug fix critique : useState(...initial) ne réévalue PAS quand portfoliosQuery.data
-  // arrive après le 1er render. Sans cet effet, selectedPortfolioId reste null,
-  // handleSaveConfig fait return silencieux, et le bouton "Sauvegarder" semble inerte.
+  // Force la sélection sur TRADER dès que la liste arrive (cf bug fix initial state).
   useEffect(() => {
-    if (!selectedPortfolioId && simulationPortfolios[0]?.id) {
+    const traderId = simulationPortfolios.find((p) => p.id === TRADER_PORTFOLIO_ID)?.id;
+    if (traderId && selectedPortfolioId !== traderId) {
+      setSelectedPortfolioId(traderId);
+    } else if (!selectedPortfolioId && simulationPortfolios[0]?.id) {
       setSelectedPortfolioId(simulationPortfolios[0].id);
     }
   }, [simulationPortfolios, selectedPortfolioId]);
@@ -608,14 +616,18 @@ export default function LisaPage() {
       {/* P7 — Mode opératoire 3-way (Investment / Harvest / Gainers) */}
       {selectedPortfolioId && <MacroModeSelector portfolioId={selectedPortfolioId} />}
 
-      {/* P7 — Mini-tile temps réel (visible uniquement en mode Gainers) */}
+      {/* LISA refonte A.2 — Mini-tile temps réel scanner LISA (ex-Gainers).
+          Renommé côté composant interne, mais portfolio_id=TRADER force le scope. */}
       {selectedPortfolioId && <GainersStatusTile portfolioId={selectedPortfolioId} />}
 
-      {/* PR #3 — Configuration complète scanner Gainers (capacité, sizing,
-          univers, persistence, fees). Visible quand mode='gainers'. */}
+      {/* LISA refonte A.2 — Panel "Configuration scanner Gainers" CACHÉ sur /lisa.
+          Le panel paramètre MAIN/HIGH/MIDDLE/SMALL (= scanners déterministes).
+          Sera déplacé vers une page dédiée /scanners/gainers dans un sprint futur.
+          Composant + import conservés pour réutilisation.
       {selectedPortfolioId && currentMode === 'gainers' && (
         <GainersConfigPanel portfolioId={selectedPortfolioId} />
       )}
+      */}
 
       {/* PR #268 — Scaling readiness : 5 critères data-driven pour décider
           si on peut scaler le capital ou passer LIVE. Visible quand mode='gainers'. */}
@@ -778,17 +790,17 @@ export default function LisaPage() {
               locale (souvent stale/false), coupant silencieusement le scanner
               Gainers que l'utilisateur venait juste d'activer. */}
           {currentMode === 'gainers' ? (
-            <div className="rounded-md border border-dashed border-orange-300 bg-orange-50/40 dark:bg-orange-950/10 p-3 space-y-1">
+            <div className="rounded-md border border-dashed border-purple-300 bg-purple-50/40 dark:bg-purple-950/10 p-3 space-y-1">
               <div className="flex items-center gap-2">
-                <span className="text-base">🚀</span>
-                <span className="text-xs font-medium">Mode gainers actif</span>
+                <span className="text-base">🤖</span>
+                <span className="text-xs font-medium">Mode LISA actif</span>
               </div>
               <p className="text-[11px] text-muted-foreground">
-                L&apos;autopilote, le cycle scanner et tous les paramètres
-                déterministes sont pilotés depuis le panel{' '}
-                <span className="font-medium">« Configuration scanner Gainers »</span>{' '}
-                ci-dessus. Le filet de garantie event-driven n&apos;est pas
-                utilisé en mode gainers (pipeline LLM bypassé).
+                L&apos;agent autonome LISA (Gemini Pro 2.5) tourne sur ton portefeuille
+                à chaque cycle. Les lessons accumulées dans{' '}
+                <span className="font-medium">scanner_lessons</span> guident ses
+                décisions. Le filet de garantie event-driven n&apos;est pas
+                utilisé en mode LISA (pipeline LLM autonome).
               </p>
             </div>
           ) : (

--- a/apps/web/src/components/lisa/coach-proposals-panel.tsx
+++ b/apps/web/src/components/lisa/coach-proposals-panel.tsx
@@ -1,0 +1,351 @@
+'use client';
+
+/**
+ * CoachProposalsPanel — C.2, UI review pour Strategy Coach proposals.
+ *
+ * - Liste les coach_proposals status='pending' du portfolio
+ * - Chaque carte expandable → modal review
+ * - Modal : verdict + rationale + lessons (checkbox par item) + params
+ *   (checkbox par item) + commentaire + boutons Accept/Reject
+ * - Accept partiel = lessons/params sélectionnés UNIQUEMENT créés
+ * - Reject = toutes les sélections vides
+ *
+ * Design : mobile-first (modal bottom sheet < md, centré ≥ md).
+ */
+
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  useCoachProposals,
+  useAcceptCoachProposal,
+  useRejectCoachProposal,
+  type CoachProposal,
+} from '@/hooks/use-coach-proposals';
+
+interface Props {
+  portfolioId: string;
+}
+
+function verdictBadge(v: string): { txt: string; cls: string } {
+  switch (v) {
+    case 'REACHABLE':
+      return { txt: 'Atteignable', cls: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300' };
+    case 'NEEDS_CHANGES':
+      return { txt: 'Ajustements requis', cls: 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300' };
+    case 'UNREALISTIC':
+      return { txt: 'Irréaliste', cls: 'bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-300' };
+    default:
+      return { txt: v, cls: 'bg-muted text-muted-foreground' };
+  }
+}
+
+function fmtAge(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins}min`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `il y a ${hours}h`;
+  return `il y a ${Math.floor(hours / 24)}j`;
+}
+
+export function CoachProposalsPanel({ portfolioId }: Props) {
+  const { data: proposals, isLoading } = useCoachProposals(portfolioId, 'pending');
+  const [reviewing, setReviewing] = useState<CoachProposal | null>(null);
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h3 className="text-sm font-semibold flex items-center gap-2">
+            🧠 Strategy Coach
+          </h3>
+          <p className="text-[11px] text-muted-foreground">
+            Propositions Gemini Pro (hourly) — review et applique les lessons qui te conviennent.
+          </p>
+        </div>
+        {proposals && proposals.length > 0 && (
+          <span className="text-[11px] px-2 py-0.5 rounded-full bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300 font-semibold">
+            {proposals.length} en attente
+          </span>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="space-y-2">
+          {[0, 1].map((i) => (
+            <div key={i} className="animate-pulse h-16 bg-muted rounded" />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && (!proposals || proposals.length === 0) && (
+        <div className="text-xs text-muted-foreground py-6 text-center">
+          Aucune proposition en attente. Strategy Coach analyse l'activité chaque heure.
+        </div>
+      )}
+
+      {!isLoading && proposals && proposals.length > 0 && (
+        <div className="space-y-2">
+          {proposals.map((p) => {
+            const v = verdictBadge(p.feasibility_verdict);
+            return (
+              <button
+                type="button"
+                key={p.id}
+                onClick={() => setReviewing(p)}
+                className="w-full text-left rounded-lg border p-3 hover:bg-muted/40 transition"
+              >
+                <div className="flex items-center justify-between gap-2 flex-wrap mb-1">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className={`text-[10px] px-2 py-0.5 rounded-full ${v.cls} font-semibold`}>
+                      {v.txt}
+                    </span>
+                    {p.feasibility_probability_pct !== null && (
+                      <span className="text-[10px] text-muted-foreground">
+                        {p.feasibility_probability_pct.toFixed(0)}%
+                      </span>
+                    )}
+                    <code className="text-[10px] text-muted-foreground">{p.llm_model}</code>
+                  </div>
+                  <span className="text-[10px] text-muted-foreground">{fmtAge(p.created_at)}</span>
+                </div>
+                <p className="text-xs line-clamp-2">{p.feasibility_rationale}</p>
+                <div className="text-[11px] text-muted-foreground mt-1">
+                  {p.proposed_lessons.length} lesson(s) · {p.proposed_parameter_changes.length} param(s)
+                  {p.risk_warnings.length > 0 && ` · ⚠️ ${p.risk_warnings.length} warning(s)`}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {reviewing && (
+        <ReviewModal proposal={reviewing} onClose={() => setReviewing(null)} />
+      )}
+    </Card>
+  );
+}
+
+function ReviewModal({ proposal, onClose }: { proposal: CoachProposal; onClose: () => void }) {
+  const [mounted, setMounted] = useState(false);
+  const [acceptedLessons, setAcceptedLessons] = useState<Set<number>>(new Set());
+  const [acceptedParams, setAcceptedParams] = useState<Set<number>>(new Set());
+  const [comment, setComment] = useState('');
+  const accept = useAcceptCoachProposal();
+  const reject = useRejectCoachProposal();
+
+  // Mount portal (avoid SSR hydration mismatch)
+  if (typeof window !== 'undefined' && !mounted) setMounted(true);
+  if (!mounted) return null;
+
+  const toggleLesson = (i: number) => {
+    setAcceptedLessons((s) => {
+      const next = new Set(s);
+      if (next.has(i)) next.delete(i); else next.add(i);
+      return next;
+    });
+  };
+  const toggleParam = (i: number) => {
+    setAcceptedParams((s) => {
+      const next = new Set(s);
+      if (next.has(i)) next.delete(i); else next.add(i);
+      return next;
+    });
+  };
+
+  const onAccept = async () => {
+    await accept.mutateAsync({
+      id: proposal.id,
+      accepted_lessons: [...acceptedLessons],
+      accepted_params: [...acceptedParams],
+      ...(comment.trim() ? { comment: comment.trim() } : {}),
+    });
+    onClose();
+  };
+  const onReject = async () => {
+    await reject.mutateAsync({
+      id: proposal.id,
+      ...(comment.trim() ? { comment: comment.trim() } : {}),
+    });
+    onClose();
+  };
+
+  const v = verdictBadge(proposal.feasibility_verdict);
+  const isPending = accept.isPending || reject.isPending;
+  const nothingSelected = acceptedLessons.size === 0 && acceptedParams.size === 0;
+
+  const content = (
+    <>
+      <button
+        type="button"
+        onClick={onClose}
+        className="fixed inset-0 bg-black/50 z-40"
+        aria-label="Fermer"
+      />
+      <div
+        className="fixed z-50 bg-card border shadow-xl flex flex-col
+                   md:rounded-lg md:max-w-2xl md:max-h-[85vh] md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 md:w-[calc(100vw-2rem)]
+                   max-md:inset-x-0 max-md:bottom-0 max-md:top-8 max-md:rounded-t-2xl"
+      >
+        {/* Header */}
+        <div className="px-4 py-3 border-b flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 flex-wrap min-w-0">
+            <h3 className="text-sm font-semibold">🧠 Review proposition</h3>
+            <span className={`text-[10px] px-2 py-0.5 rounded-full ${v.cls} font-semibold`}>{v.txt}</span>
+            {proposal.feasibility_probability_pct !== null && (
+              <span className="text-[10px] text-muted-foreground">
+                {proposal.feasibility_probability_pct.toFixed(0)}%
+              </span>
+            )}
+          </div>
+          <button type="button" onClick={onClose} aria-label="Fermer" className="text-muted-foreground text-xl px-1">×</button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+          {/* Rationale */}
+          <div className="rounded-md bg-muted/40 p-3">
+            <div className="text-[10px] uppercase text-muted-foreground mb-1">Rationale</div>
+            <p className="text-xs">{proposal.feasibility_rationale}</p>
+          </div>
+
+          {/* Risk warnings */}
+          {proposal.risk_warnings.length > 0 && (
+            <div className="rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/30 p-3">
+              <div className="text-[10px] uppercase text-amber-700 dark:text-amber-300 mb-1 font-semibold">⚠️ Risk warnings</div>
+              <ul className="text-xs space-y-1 list-disc pl-4">
+                {proposal.risk_warnings.map((w, i) => <li key={i}>{w}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {/* Lessons */}
+          {proposal.proposed_lessons.length > 0 && (
+            <div>
+              <div className="text-xs font-semibold mb-2">
+                📚 Lessons proposées ({acceptedLessons.size}/{proposal.proposed_lessons.length} acceptées)
+              </div>
+              <div className="space-y-2">
+                {proposal.proposed_lessons.map((l, i) => (
+                  <label
+                    key={i}
+                    className={`block rounded border p-2 cursor-pointer ${
+                      acceptedLessons.has(i) ? 'border-purple-400 bg-purple-50 dark:bg-purple-950/20' : ''
+                    }`}
+                  >
+                    <div className="flex items-start gap-2">
+                      <input
+                        type="checkbox"
+                        checked={acceptedLessons.has(i)}
+                        onChange={() => toggleLesson(i)}
+                        className="accent-purple-600 h-4 w-4 mt-0.5"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-1.5 flex-wrap">
+                          <code className="text-[10px] px-1.5 py-0.5 rounded bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300">
+                            {l.lesson_kind}
+                          </code>
+                          <span className="text-[10px] text-muted-foreground">conf {l.confidence.toFixed(2)}</span>
+                          <span className="text-[10px] text-muted-foreground">{l.scope}</span>
+                          {l.expected_impact_usd !== undefined && (
+                            <span className="text-[10px] font-semibold">
+                              impact {l.expected_impact_usd >= 0 ? '+' : ''}${l.expected_impact_usd}
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-xs mt-1">{l.lesson_text}</p>
+                        {l.rationale && (
+                          <p className="text-[11px] text-muted-foreground mt-1 italic">
+                            {l.rationale}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Params (info only — accept enregistre l'intention dans user_decision) */}
+          {proposal.proposed_parameter_changes.length > 0 && (
+            <div>
+              <div className="text-xs font-semibold mb-2">
+                ⚙️ Changements de paramètres ({acceptedParams.size}/{proposal.proposed_parameter_changes.length})
+              </div>
+              <p className="text-[11px] text-muted-foreground mb-2">
+                Coche les params à appliquer. Note : les changements sont logués dans user_decision
+                mais doivent être appliqués manuellement (Fly secrets ou Config UI).
+              </p>
+              <div className="space-y-2">
+                {proposal.proposed_parameter_changes.map((p, i) => (
+                  <label
+                    key={i}
+                    className={`block rounded border p-2 cursor-pointer ${
+                      acceptedParams.has(i) ? 'border-purple-400 bg-purple-50 dark:bg-purple-950/20' : ''
+                    }`}
+                  >
+                    <div className="flex items-start gap-2">
+                      <input
+                        type="checkbox"
+                        checked={acceptedParams.has(i)}
+                        onChange={() => toggleParam(i)}
+                        className="accent-purple-600 h-4 w-4 mt-0.5"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <code className="text-[11px] font-semibold">{p.param}</code>
+                        <div className="text-[11px] text-muted-foreground">
+                          {String(p.current)} → <strong>{String(p.proposed)}</strong>
+                        </div>
+                        <p className="text-[11px] text-muted-foreground mt-1 italic">{p.rationale}</p>
+                        {p.expected_impact && (
+                          <p className="text-[11px] text-emerald-600 dark:text-emerald-400 mt-0.5">
+                            Impact attendu : {p.expected_impact}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Comment */}
+          <div>
+            <label className="text-xs font-semibold mb-1 block">Commentaire (optionnel)</label>
+            <textarea
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              placeholder="Note pour le journal de décision…"
+              className="w-full rounded border px-2 py-1.5 text-xs bg-background"
+              rows={2}
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-4 py-3 border-t flex items-center justify-end gap-2 flex-wrap">
+          <Button variant="outline" size="sm" onClick={onClose} disabled={isPending}>
+            Annuler
+          </Button>
+          <Button variant="destructive" size="sm" onClick={onReject} disabled={isPending}>
+            {reject.isPending ? '…' : 'Rejeter'}
+          </Button>
+          <Button
+            size="sm"
+            onClick={onAccept}
+            disabled={isPending || nothingSelected}
+          >
+            {accept.isPending ? '…' : (nothingSelected ? 'Coche au moins 1 item' : `Accepter (${acceptedLessons.size}L + ${acceptedParams.size}P)`)}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+
+  return createPortal(content, document.body);
+}

--- a/apps/web/src/components/lisa/gainers-status-tile.tsx
+++ b/apps/web/src/components/lisa/gainers-status-tile.tsx
@@ -178,8 +178,8 @@ export function GainersStatusTile({ portfolioId }: { portfolioId: string }) {
   return (
     <div className="rounded-lg border border-orange-200 dark:border-orange-900/40 bg-orange-50/40 dark:bg-orange-950/10 p-4 space-y-3">
       <div className="flex items-center gap-2">
-        <Rocket className="h-4 w-4 text-orange-600" />
-        <h3 className="text-sm font-medium">Scanner Gainers · état temps réel</h3>
+        <Rocket className="h-4 w-4 text-purple-600" />
+        <h3 className="text-sm font-medium">Scanner LISA · état temps réel</h3>
       </div>
 
       {!data && (

--- a/apps/web/src/components/lisa/gains-reset-confirm-modal.tsx
+++ b/apps/web/src/components/lisa/gains-reset-confirm-modal.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+/**
+ * GainsResetConfirmModal — confirmation reset display-only avec "tape RESET".
+ *
+ * Reset display-only = met le marker à NOW dans lisa_session_configs.
+ * Le compteur affiché ignore les trades antérieurs au marker. La DB reste
+ * intacte, audit P&L global préservé. Action réversible via "Annuler reset".
+ *
+ * Pour les scopes mois et annual, on demande à l'utilisateur de taper "RESET"
+ * (case insensitive) pour confirmer — friction volontaire sur action impactante.
+ */
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  scope: 'daily' | 'monthly' | 'annual';
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const SCOPE_INFO: Record<Props['scope'], { label: string; reverseImpact: string; dangerous: boolean }> = {
+  daily: {
+    label: 'jour',
+    reverseImpact: 'Annulable à tout moment via "Annuler reset". DB intacte.',
+    dangerous: false,
+  },
+  monthly: {
+    label: 'mois',
+    reverseImpact: 'Cascade : reset le mois ET le jour. Annulable. DB intacte.',
+    dangerous: true,
+  },
+  annual: {
+    label: 'année',
+    reverseImpact: 'Cascade : reset année + mois + jour. Action IRRÉVERSIBLE côté UI (confirmation requise).',
+    dangerous: true,
+  },
+};
+
+export function GainsResetConfirmModal({ scope, onConfirm, onCancel }: Props) {
+  const [mounted, setMounted] = useState(false);
+  const [typedConfirm, setTypedConfirm] = useState('');
+  const info = SCOPE_INFO[scope];
+  const needsTypedConfirm = info.dangerous;
+  const canConfirm = !needsTypedConfirm || typedConfirm.toUpperCase().trim() === 'RESET';
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  const content = (
+    <>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="fixed inset-0 bg-black/50 z-40"
+        aria-label="Annuler"
+      />
+      <div
+        className="fixed z-50 bg-card border shadow-lg
+                   md:rounded-lg md:p-6 md:max-w-sm md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2
+                   max-md:left-0 max-md:right-0 max-md:bottom-0 max-md:rounded-t-2xl max-md:p-4 max-md:pb-8"
+      >
+        <h3 className="text-base font-semibold mb-2">
+          {info.dangerous ? '⚠️' : '🔄'} Reset {info.label}
+        </h3>
+
+        <p className="text-sm text-muted-foreground mb-3">
+          Cette action <strong>n&apos;efface PAS les trades en base de données</strong>.
+          Elle pose un marker timestamp à partir duquel le compteur {info.label} affiché
+          ignore les trades antérieurs.
+        </p>
+
+        <div className="rounded-md bg-muted/50 p-3 text-[11px] mb-3">
+          {info.reverseImpact}
+        </div>
+
+        {needsTypedConfirm && (
+          <div className="space-y-1.5 mb-3">
+            <label className="text-xs font-medium">
+              Tape <code className="bg-muted px-1.5 py-0.5 rounded text-[11px]">RESET</code> pour confirmer :
+            </label>
+            <input
+              type="text"
+              value={typedConfirm}
+              onChange={(e) => setTypedConfirm(e.target.value)}
+              className="w-full rounded border px-2 py-1.5 text-sm bg-background"
+              autoFocus
+              placeholder="RESET"
+            />
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onCancel}>
+            Annuler
+          </Button>
+          <Button
+            variant={info.dangerous ? 'destructive' : 'default'}
+            onClick={onConfirm}
+            disabled={!canConfirm}
+          >
+            Reset {info.label}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+
+  return createPortal(content, document.body);
+}

--- a/apps/web/src/components/lisa/gains-target-editor.tsx
+++ b/apps/web/src/components/lisa/gains-target-editor.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+/**
+ * GainsTargetEditor — modal/bottom sheet pour éditer les cibles Mode C.
+ *
+ * Mode C = MAX(usd plancher, pct × capital). User édite les 2 valeurs pour
+ * chaque scope (daily/monthly/annual). Live preview de la cible effective.
+ *
+ * Desktop : modal centré · Mobile : bottom sheet (slide up).
+ */
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Button } from '@/components/ui/button';
+import {
+  useUpdateLisaTargets,
+  computeEffectiveTarget,
+  type LisaTargets,
+} from '@/hooks/use-lisa-targets';
+
+interface Props {
+  portfolioId: string;
+  targets: LisaTargets;
+  currentCapital: number;
+  onClose: () => void;
+}
+
+export function GainsTargetEditor({ portfolioId, targets, currentCapital, onClose }: Props) {
+  const [mounted, setMounted] = useState(false);
+  const [dailyUsd, setDailyUsd] = useState(targets.daily.usd);
+  const [dailyPct, setDailyPct] = useState(targets.daily.pct);
+  const [monthlyUsd, setMonthlyUsd] = useState(targets.monthly.usd);
+  const [monthlyPct, setMonthlyPct] = useState(targets.monthly.pct);
+  const [annualUsd, setAnnualUsd] = useState(targets.annual.usd);
+  const [annualPct, setAnnualPct] = useState(targets.annual.pct);
+  const { updateTargets, isLoading } = useUpdateLisaTargets(portfolioId);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  const effDaily = computeEffectiveTarget(dailyUsd, dailyPct, currentCapital);
+  const effMonthly = computeEffectiveTarget(monthlyUsd, monthlyPct, currentCapital);
+  const effAnnual = computeEffectiveTarget(annualUsd, annualPct, currentCapital);
+
+  const handleSave = async () => {
+    await updateTargets({
+      daily: { usd: dailyUsd, pct: dailyPct, effective: 0 },
+      monthly: { usd: monthlyUsd, pct: monthlyPct, effective: 0 },
+      annual: { usd: annualUsd, pct: annualPct, effective: 0 },
+    });
+    onClose();
+  };
+
+  const InputRow = ({
+    label,
+    usd,
+    pct,
+    effective,
+    setUsd,
+    setPct,
+  }: {
+    label: string;
+    usd: number;
+    pct: number;
+    effective: number;
+    setUsd: (v: number) => void;
+    setPct: (v: number) => void;
+  }) => (
+    <div className="space-y-2 border-b pb-3 last:border-b-0">
+      <label className="text-xs font-semibold">{label}</label>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className="text-[10px] text-muted-foreground">Plancher $</label>
+          <input
+            type="number"
+            value={usd}
+            onChange={(e) => setUsd(Number(e.target.value))}
+            className="w-full rounded border px-2 py-1.5 text-sm bg-background"
+            min={0}
+            step={10}
+          />
+        </div>
+        <div>
+          <label className="text-[10px] text-muted-foreground">% capital</label>
+          <input
+            type="number"
+            value={pct}
+            onChange={(e) => setPct(Number(e.target.value))}
+            className="w-full rounded border px-2 py-1.5 text-sm bg-background"
+            min={0}
+            step={0.1}
+          />
+        </div>
+      </div>
+      <div className="text-[11px] text-muted-foreground">
+        → Cible effective : <span className="font-medium text-foreground">${effective.toFixed(0)}</span>
+        {' '}(MAX(${usd.toFixed(0)}, {pct}% × ${currentCapital.toFixed(0)}))
+      </div>
+    </div>
+  );
+
+  const content = (
+    <>
+      <button
+        type="button"
+        onClick={onClose}
+        className="fixed inset-0 bg-black/50 z-40"
+        aria-label="Fermer"
+      />
+      {/* Desktop : modal centré · Mobile : bottom sheet */}
+      <div
+        className="fixed z-50 bg-card border shadow-lg
+                   md:rounded-lg md:p-6 md:max-w-md md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2
+                   max-md:left-0 max-md:right-0 max-md:bottom-0 max-md:rounded-t-2xl max-md:p-4 max-md:pb-8"
+      >
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-base font-semibold">🎯 Modifier objectifs</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted-foreground text-xl"
+            aria-label="Fermer"
+          >
+            ×
+          </button>
+        </div>
+
+        <p className="text-[11px] text-muted-foreground mb-3">
+          Mode C : Cible effective = MAX(plancher $, % × capital actuel ${currentCapital.toFixed(0)}).
+        </p>
+
+        <div className="space-y-3">
+          <InputRow
+            label="Jour"
+            usd={dailyUsd}
+            pct={dailyPct}
+            effective={effDaily}
+            setUsd={setDailyUsd}
+            setPct={setDailyPct}
+          />
+          <InputRow
+            label="Mois"
+            usd={monthlyUsd}
+            pct={monthlyPct}
+            effective={effMonthly}
+            setUsd={setMonthlyUsd}
+            setPct={setMonthlyPct}
+          />
+          <InputRow
+            label="Année"
+            usd={annualUsd}
+            pct={annualPct}
+            effective={effAnnual}
+            setUsd={setAnnualUsd}
+            setPct={setAnnualPct}
+          />
+        </div>
+
+        <div className="flex justify-end gap-2 mt-4">
+          <Button variant="outline" onClick={onClose} disabled={isLoading}>
+            Annuler
+          </Button>
+          <Button onClick={handleSave} disabled={isLoading}>
+            {isLoading ? 'Sauvegarde…' : 'Sauvegarder'}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+
+  return createPortal(content, document.body);
+}

--- a/apps/web/src/components/lisa/gains-tracker.tsx
+++ b/apps/web/src/components/lisa/gains-tracker.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+/**
+ * GainsTracker — Section "Gains" cœur de la refonte page /lisa.
+ *
+ * 4 cards (JOUR / SEMAINE / MOIS / ANNÉE) avec :
+ *   - PnL réalisé sur le scope (filtré par reset_marker éventuel)
+ *   - Cible effective Mode C (= MAX(usd plancher, pct × capital))
+ *   - Barre progressive % de la cible atteinte
+ *   - Stats W/L/WR
+ *   - Bouton Reset display-only (modal "tape RESET" pour confirmer)
+ *
+ * Desktop : grid 4 col horizontal · Mobile : 1 card swipeable.
+ *
+ * Reset = stocke timestamp dans lisa_session_configs.lisa_reset_marker_*.
+ * Jamais d'effacement DB — uniquement filtre d'affichage côté UI.
+ */
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  useLisaTargetsAndStats,
+  useResetScopeMarker,
+  type LisaScopeStats,
+  type LisaScope,
+} from '@/hooks/use-lisa-targets';
+import { GainsTargetEditor } from './gains-target-editor';
+import { GainsResetConfirmModal } from './gains-reset-confirm-modal';
+
+interface Props {
+  portfolioId: string;
+}
+
+const SCOPE_LABELS: Record<LisaScope, { short: string; long: string; period: string }> = {
+  daily: { short: 'JOUR', long: 'Jour', period: 'aujourd\'hui' },
+  weekly: { short: 'SEMAINE', long: 'Semaine', period: 'cette semaine' },
+  monthly: { short: 'MOIS', long: 'Mois', period: 'ce mois' },
+  annual: { short: 'ANNÉE', long: 'Année', period: 'cette année' },
+};
+
+function formatPnl(v: number): { display: string; sign: '+' | '-' | '0' } {
+  if (v === 0) return { display: '$0.00', sign: '0' };
+  const sign = v > 0 ? '+' : '-';
+  return { display: `${sign}$${Math.abs(v).toFixed(2)}`, sign: v > 0 ? '+' : '-' };
+}
+
+function ScopeCard({
+  scope,
+  stats,
+  onReset,
+  resetting,
+}: {
+  scope: LisaScope;
+  stats: LisaScopeStats;
+  onReset: () => void;
+  resetting: boolean;
+}) {
+  const labels = SCOPE_LABELS[scope];
+  const { display, sign } = formatPnl(stats.realized_pnl_usd);
+  const colorClass =
+    sign === '+'
+      ? 'text-emerald-600 dark:text-emerald-400'
+      : sign === '-'
+      ? 'text-rose-600 dark:text-rose-400'
+      : 'text-muted-foreground';
+  const pct = Math.max(0, Math.min(100, stats.pct_of_target));
+  const showReset = scope !== 'weekly';
+  const canReset = stats.realized_pnl_usd !== 0 || stats.trades_count > 0 || stats.reset_marker_at !== null;
+
+  return (
+    <Card className="p-4 flex flex-col gap-2 min-h-[180px]">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold tracking-wider text-muted-foreground">
+          {labels.short}
+        </span>
+        {stats.reset_marker_at && (
+          <span
+            className="text-[10px] text-amber-600 dark:text-amber-400"
+            title={`Reset le ${new Date(stats.reset_marker_at).toLocaleString('fr-FR')}`}
+          >
+            ↺ reset
+          </span>
+        )}
+      </div>
+
+      <div className={`text-2xl font-semibold tabular-nums ${colorClass}`}>
+        {display}
+      </div>
+
+      <div className="text-[10px] text-muted-foreground">
+        Cible {labels.period} : ${stats.target_effective_usd.toFixed(0)}
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-full bg-muted rounded-full h-1.5 overflow-hidden">
+        <div
+          className={`h-full transition-all ${
+            sign === '+' ? 'bg-emerald-500' : 'bg-rose-500'
+          }`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="text-[10px] text-muted-foreground">
+        {pct.toFixed(0)}% atteint
+      </div>
+
+      {stats.trades_count > 0 && (
+        <div className="text-[10px] text-muted-foreground mt-auto">
+          {stats.wins}W / {stats.losses}L · WR{' '}
+          {stats.win_rate_pct !== null ? `${stats.win_rate_pct.toFixed(0)}%` : '—'}
+        </div>
+      )}
+
+      {showReset && canReset && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onReset}
+          disabled={resetting}
+          className="text-[11px] h-7 mt-1"
+        >
+          🔄 Reset {labels.long.toLowerCase()}
+        </Button>
+      )}
+    </Card>
+  );
+}
+
+export function GainsTracker({ portfolioId }: Props) {
+  const { targets, stats, currentCapital, isLoading } = useLisaTargetsAndStats(portfolioId);
+  const reset = useResetScopeMarker(portfolioId);
+
+  const [editingTargets, setEditingTargets] = useState(false);
+  const [resetScope, setResetScope] = useState<'daily' | 'monthly' | 'annual' | null>(null);
+  const [mobileScopeIdx, setMobileScopeIdx] = useState(0);
+
+  if (isLoading || !stats || !targets) {
+    return (
+      <Card className="p-4">
+        <div className="animate-pulse space-y-2">
+          <div className="h-4 bg-muted rounded w-1/3" />
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-3 mt-3">
+            {[0, 1, 2, 3].map((i) => (
+              <div key={i} className="h-32 bg-muted rounded" />
+            ))}
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  const mobileScope = (['daily', 'weekly', 'monthly', 'annual'] as LisaScope[])[mobileScopeIdx];
+
+  const handleReset = async (scope: 'daily' | 'monthly' | 'annual') => {
+    if (scope === 'daily') await reset.resetDaily();
+    else if (scope === 'monthly') await reset.resetMonthly();
+    else if (scope === 'annual') await reset.resetAnnual();
+    setResetScope(null);
+  };
+
+  return (
+    <Card className="p-4 space-y-3">
+      {/* Header avec cible jour + édition */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2 flex-wrap text-xs">
+          <span className="font-semibold">🎯 Cible jour :</span>
+          <span className="text-muted-foreground">
+            MAX(${targets.daily.usd.toFixed(0)}, {targets.daily.pct}% × $
+            {currentCapital?.toFixed(2)}) ={' '}
+            <span className="text-foreground font-medium">
+              ${targets.daily.effective.toFixed(0)}
+            </span>
+          </span>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setEditingTargets(true)}
+          className="text-xs h-7"
+        >
+          ✏️ Modifier objectifs
+        </Button>
+      </div>
+
+      {/* Desktop : 4 cards */}
+      <div className="hidden md:grid md:grid-cols-4 gap-3">
+        <ScopeCard
+          scope="daily"
+          stats={stats.daily}
+          onReset={() => setResetScope('daily')}
+          resetting={reset.isLoading}
+        />
+        <ScopeCard
+          scope="weekly"
+          stats={stats.weekly}
+          onReset={() => {}}
+          resetting={false}
+        />
+        <ScopeCard
+          scope="monthly"
+          stats={stats.monthly}
+          onReset={() => setResetScope('monthly')}
+          resetting={reset.isLoading}
+        />
+        <ScopeCard
+          scope="annual"
+          stats={stats.annual}
+          onReset={() => setResetScope('annual')}
+          resetting={reset.isLoading}
+        />
+      </div>
+
+      {/* Mobile : 1 card swipeable + dots */}
+      <div className="md:hidden">
+        <div className="flex items-center gap-2 mb-2 justify-center">
+          <button
+            type="button"
+            onClick={() => setMobileScopeIdx((i) => (i + 3) % 4)}
+            className="text-muted-foreground p-1"
+            aria-label="Précédent"
+          >
+            ⏴
+          </button>
+          <div className="flex gap-1">
+            {[0, 1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className={`h-1.5 w-1.5 rounded-full ${
+                  mobileScopeIdx === i ? 'bg-foreground' : 'bg-muted'
+                }`}
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => setMobileScopeIdx((i) => (i + 1) % 4)}
+            className="text-muted-foreground p-1"
+            aria-label="Suivant"
+          >
+            ⏵
+          </button>
+        </div>
+        <ScopeCard
+          scope={mobileScope}
+          stats={stats[mobileScope]}
+          onReset={() =>
+            mobileScope !== 'weekly' && setResetScope(mobileScope as 'daily' | 'monthly' | 'annual')
+          }
+          resetting={reset.isLoading}
+        />
+      </div>
+
+      {/* Modals */}
+      {editingTargets && targets && currentCapital !== null && (
+        <GainsTargetEditor
+          portfolioId={portfolioId}
+          targets={targets}
+          currentCapital={currentCapital}
+          onClose={() => setEditingTargets(false)}
+        />
+      )}
+
+      {resetScope && (
+        <GainsResetConfirmModal
+          scope={resetScope}
+          onConfirm={() => handleReset(resetScope)}
+          onCancel={() => setResetScope(null)}
+        />
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/components/lisa/lessons-impact-panel.tsx
+++ b/apps/web/src/components/lisa/lessons-impact-panel.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+/**
+ * LessonsImpactPanel — B.2, Lessons Impact Tracker.
+ *
+ * Affiche les lessons citées par TRADER sur une fenêtre glissante avec :
+ *   - citations_count (combien de fois citée)
+ *   - applied_count (combien de fois l'action a été appliquée)
+ *   - win_rate / sum_pnl (outcome des positions issues de ces citations)
+ *   - confidence + sample_size de la lesson (méta scanner_lessons)
+ *
+ * Filtres :
+ *   - search (lesson_kind, lesson_text, marker)
+ *   - window (7j / 30j / 90j / 1an)
+ *   - "résolues seulement" (cache lessons sans outcome encore)
+ *
+ * Tri par citations_count DESC par défaut. Pagination client-side (20/page).
+ * Design mobile-first : table compactée sur mobile (colonnes essentielles).
+ */
+
+import { useMemo, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { useLessonsImpact, type LessonImpactRow } from '@/hooks/use-lessons-impact';
+
+interface Props {
+  portfolioId: string;
+}
+
+const WINDOWS: Array<{ label: string; days: number }> = [
+  { label: '7j', days: 7 },
+  { label: '30j', days: 30 },
+  { label: '90j', days: 90 },
+  { label: '1 an', days: 365 },
+];
+
+type SortKey = 'citations' | 'pnl' | 'win_rate' | 'last_cited';
+
+const PAGE_SIZE = 20;
+
+function fmtPnl(v: number): { txt: string; cls: string } {
+  if (v === 0) return { txt: '$0', cls: 'text-muted-foreground' };
+  const sign = v > 0 ? '+' : '-';
+  return {
+    txt: `${sign}$${Math.abs(v).toFixed(2)}`,
+    cls: v > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400',
+  };
+}
+
+function fmtPct(v: number | null): { txt: string; cls: string } {
+  if (v === null) return { txt: '—', cls: 'text-muted-foreground' };
+  return {
+    txt: `${v.toFixed(0)}%`,
+    cls: v >= 60 ? 'text-emerald-600 dark:text-emerald-400'
+      : v >= 40 ? 'text-amber-600 dark:text-amber-400'
+      : 'text-rose-600 dark:text-rose-400',
+  };
+}
+
+function fmtAge(iso: string | null): string {
+  if (!iso) return '—';
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins}min`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}j`;
+}
+
+export function LessonsImpactPanel({ portfolioId }: Props) {
+  const [days, setDays] = useState(30);
+  const [search, setSearch] = useState('');
+  const [resolvedOnly, setResolvedOnly] = useState(false);
+  const [sortKey, setSortKey] = useState<SortKey>('citations');
+  const [page, setPage] = useState(0);
+
+  const { data, isLoading, isError } = useLessonsImpact(portfolioId, days);
+
+  const filtered = useMemo<LessonImpactRow[]>(() => {
+    if (!data) return [];
+    const q = search.trim().toLowerCase();
+    let rows = data.lessons.filter((l) => {
+      if (resolvedOnly && l.resolved_count === 0) return false;
+      if (!q) return true;
+      return (
+        l.lesson_kind.toLowerCase().includes(q)
+        || (l.lesson_text ?? '').toLowerCase().includes(q)
+        || l.marker_text.toLowerCase().includes(q)
+      );
+    });
+    rows = [...rows].sort((a, b) => {
+      switch (sortKey) {
+        case 'citations': return b.citations_count - a.citations_count;
+        case 'pnl': return b.sum_pnl_usd - a.sum_pnl_usd;
+        case 'win_rate':
+          return (b.win_rate_pct ?? -1) - (a.win_rate_pct ?? -1);
+        case 'last_cited':
+          return (b.last_cited_at ?? '').localeCompare(a.last_cited_at ?? '');
+      }
+    });
+    return rows;
+  }, [data, search, resolvedOnly, sortKey]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const pageRows = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center justify-between gap-2 mb-3 flex-wrap">
+        <div>
+          <h3 className="text-sm font-semibold flex items-center gap-2">
+            📚 Lessons Impact Tracker
+          </h3>
+          <p className="text-[11px] text-muted-foreground">
+            Citations de lessons par TRADER + outcome des trades issus de ces citations.
+          </p>
+        </div>
+        {data && (
+          <div className="text-[11px] text-muted-foreground">
+            {data.totalCitations} citations · {data.resolvedCitations} résolues
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <input
+          type="text"
+          placeholder="Search lesson_kind / text / marker"
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); setPage(0); }}
+          className="flex-1 min-w-[180px] rounded border px-2 py-1.5 text-xs bg-background"
+        />
+        <select
+          value={days}
+          onChange={(e) => { setDays(Number(e.target.value)); setPage(0); }}
+          className="rounded border px-2 py-1.5 text-xs bg-background"
+        >
+          {WINDOWS.map((w) => (
+            <option key={w.days} value={w.days}>{w.label}</option>
+          ))}
+        </select>
+        <select
+          value={sortKey}
+          onChange={(e) => setSortKey(e.target.value as SortKey)}
+          className="rounded border px-2 py-1.5 text-xs bg-background"
+        >
+          <option value="citations">Tri: citations</option>
+          <option value="pnl">Tri: P&amp;L</option>
+          <option value="win_rate">Tri: win-rate</option>
+          <option value="last_cited">Tri: récence</option>
+        </select>
+        <label className="flex items-center gap-1.5 text-[11px] cursor-pointer">
+          <input
+            type="checkbox"
+            checked={resolvedOnly}
+            onChange={(e) => setResolvedOnly(e.target.checked)}
+            className="accent-primary"
+          />
+          Résolues uniquement
+        </label>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-2">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="animate-pulse h-12 bg-muted rounded" />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <div className="text-xs text-rose-600 dark:text-rose-400">
+          Erreur de chargement.
+        </div>
+      )}
+
+      {!isLoading && !isError && filtered.length === 0 && (
+        <div className="text-xs text-muted-foreground py-6 text-center">
+          Aucune citation sur cette fenêtre. TRADER citera des lessons en
+          insérant <code className="bg-muted px-1 rounded">[MARKER]</code> dans
+          ses thèses.
+        </div>
+      )}
+
+      {!isLoading && pageRows.length > 0 && (
+        <>
+          <div className="overflow-x-auto -mx-4 px-4">
+            <table className="w-full text-xs">
+              <thead className="text-[10px] uppercase text-muted-foreground border-b">
+                <tr>
+                  <th className="text-left py-1.5 pr-2">Lesson</th>
+                  <th className="text-right py-1.5 px-2">Cit.</th>
+                  <th className="text-right py-1.5 px-2 hidden sm:table-cell">Appl.</th>
+                  <th className="text-right py-1.5 px-2 hidden sm:table-cell">W/L</th>
+                  <th className="text-right py-1.5 px-2">Win%</th>
+                  <th className="text-right py-1.5 px-2">PnL</th>
+                  <th className="text-right py-1.5 pl-2 hidden md:table-cell">Conf.</th>
+                  <th className="text-right py-1.5 pl-2 hidden md:table-cell">Last</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {pageRows.map((l, i) => {
+                  const pnl = fmtPnl(l.sum_pnl_usd);
+                  const wr = fmtPct(l.win_rate_pct);
+                  const isOrphan = l.lesson_id === null;
+                  return (
+                    <tr key={`${l.lesson_id ?? l.marker_text}-${i}`} className="hover:bg-muted/40">
+                      <td className="py-2 pr-2 max-w-[280px]">
+                        <div className="flex items-center gap-1.5 flex-wrap">
+                          <code className={`text-[10px] px-1.5 py-0.5 rounded ${
+                            isOrphan ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300'
+                              : 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300'
+                          }`}>
+                            {l.marker_text}
+                          </code>
+                          {l.is_active === false && (
+                            <span className="text-[9px] uppercase text-muted-foreground">inactive</span>
+                          )}
+                        </div>
+                        {l.lesson_text && (
+                          <div className="text-[11px] text-muted-foreground line-clamp-2 mt-0.5">
+                            {l.lesson_text}
+                          </div>
+                        )}
+                        {isOrphan && (
+                          <div className="text-[10px] text-amber-600 dark:text-amber-400 mt-0.5">
+                            Marker non mappé à scanner_lessons
+                          </div>
+                        )}
+                      </td>
+                      <td className="text-right py-2 px-2 font-semibold tabular-nums">{l.citations_count}</td>
+                      <td className="text-right py-2 px-2 tabular-nums hidden sm:table-cell">{l.applied_count}</td>
+                      <td className="text-right py-2 px-2 tabular-nums hidden sm:table-cell text-[11px]">
+                        <span className="text-emerald-600 dark:text-emerald-400">{l.wins}</span>
+                        /<span className="text-rose-600 dark:text-rose-400">{l.losses}</span>
+                      </td>
+                      <td className={`text-right py-2 px-2 tabular-nums font-semibold ${wr.cls}`}>{wr.txt}</td>
+                      <td className={`text-right py-2 px-2 tabular-nums font-semibold ${pnl.cls}`}>{pnl.txt}</td>
+                      <td className="text-right py-2 pl-2 tabular-nums hidden md:table-cell text-muted-foreground">
+                        {l.confidence !== null ? l.confidence.toFixed(2) : '—'}
+                      </td>
+                      <td className="text-right py-2 pl-2 hidden md:table-cell text-muted-foreground">
+                        {fmtAge(l.last_cited_at)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between mt-3 text-xs">
+              <button
+                type="button"
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                disabled={page === 0}
+                className="px-2 py-1 rounded border disabled:opacity-40"
+              >
+                ←
+              </button>
+              <span className="text-muted-foreground">
+                Page {page + 1} / {totalPages} ({filtered.length} lessons)
+              </span>
+              <button
+                type="button"
+                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                disabled={page >= totalPages - 1}
+                className="px-2 py-1 rounded border disabled:opacity-40"
+              >
+                →
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/components/lisa/lisa-config-panel.tsx
+++ b/apps/web/src/components/lisa/lisa-config-panel.tsx
@@ -22,6 +22,7 @@ import {
   useToggleScannerLesson,
   useResetKillSwitch,
 } from '@/hooks/use-scanner-lessons';
+import { usePushSubscription } from '@/hooks/use-push-subscription';
 
 interface Props {
   portfolioId: string;
@@ -188,9 +189,55 @@ export function LisaConfigPanel({ portfolioId }: Props) {
         </div>
       </div>
 
-      {/* 4. Lessons management */}
+      {/* 4. Push notifications */}
+      <PushNotificationsSection />
+
+      {/* 5. Lessons management */}
       <LessonsManagementSection />
     </Card>
+  );
+}
+
+function PushNotificationsSection() {
+  const { status, error, subscribe, unsubscribe } = usePushSubscription();
+  return (
+    <div className="mb-4 pb-4 border-b">
+      <div className="text-xs font-semibold mb-2">🔔 Notifications push</div>
+      {status === 'loading' && (
+        <div className="text-xs text-muted-foreground">Détection…</div>
+      )}
+      {status === 'unsupported' && (
+        <div className="text-xs text-muted-foreground">
+          Push API non supportée sur ce navigateur.
+        </div>
+      )}
+      {status === 'permission-denied' && (
+        <div className="text-xs text-rose-600 dark:text-rose-400">
+          Permission notifications refusée. Active-la dans les réglages navigateur puis recharge.
+        </div>
+      )}
+      {status === 'not-subscribed' && (
+        <Button size="sm" onClick={subscribe}>
+          Activer notifications push
+        </Button>
+      )}
+      {status === 'subscribed' && (
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-xs text-emerald-600 dark:text-emerald-400">✓ Actives sur cet appareil</span>
+          <Button size="sm" variant="outline" onClick={unsubscribe}>
+            Désactiver
+          </Button>
+        </div>
+      )}
+      {error && (
+        <div className="text-[11px] text-rose-600 dark:text-rose-400 mt-1">
+          {error}
+        </div>
+      )}
+      <p className="text-[10px] text-muted-foreground mt-1">
+        Notifications kill-switch + propositions Strategy Coach. Trigger-only (le contenu est rafraîchi à l'ouverture).
+      </p>
+    </div>
   );
 }
 

--- a/apps/web/src/components/lisa/lisa-config-panel.tsx
+++ b/apps/web/src/components/lisa/lisa-config-panel.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+/**
+ * LisaConfigPanel — B.3, Config LISA simplifiée (mobile-first).
+ *
+ * Sections :
+ *   1. Kill-switch (rendu uniquement si armé) → bouton "Désarmer" + confirm
+ *   2. Capital initial + intérêts composés
+ *   3. Daily digest email
+ *   4. Lessons management (toggle is_active, search, filtre actives/inactives)
+ *
+ * "Secrets read-only" déféré (env vars Fly non exposables côté front sans
+ * endpoint dédié).
+ */
+
+import { useMemo, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useLisaConfig, useUpsertLisaConfig } from '@/hooks/use-lisa';
+import {
+  useScannerLessons,
+  useToggleScannerLesson,
+  useResetKillSwitch,
+} from '@/hooks/use-scanner-lessons';
+
+interface Props {
+  portfolioId: string;
+}
+
+export function LisaConfigPanel({ portfolioId }: Props) {
+  const configQuery = useLisaConfig(portfolioId);
+  const upsert = useUpsertLisaConfig(portfolioId);
+  const resetKill = useResetKillSwitch(portfolioId);
+
+  const config = configQuery.data as Record<string, unknown> | null;
+  const killSwitchActive = Boolean(config?.kill_switch_active);
+  const initialCapital = Number(config?.lisa_initial_capital_usd ?? 10000);
+  const compoundEnabled = Boolean(config?.lisa_compound_pnl_enabled ?? true);
+  const digestEnabled = Boolean(config?.lisa_daily_digest_enabled ?? true);
+  const email = String(config?.lisa_notification_email ?? '');
+
+  // Locaux éditables (synchronisés à la valeur DB en initial)
+  const [draftCapital, setDraftCapital] = useState<string>('');
+  const [draftEmail, setDraftEmail] = useState<string>('');
+
+  const effCapital = draftCapital === '' ? initialCapital : Number(draftCapital);
+  const effEmail = draftEmail === '' ? email : draftEmail;
+
+  const saveCapital = async () => {
+    await upsert.mutateAsync({
+      lisa_initial_capital_usd: effCapital,
+    } as Record<string, unknown>);
+    setDraftCapital('');
+  };
+
+  const toggleCompound = async (v: boolean) => {
+    await upsert.mutateAsync({ lisa_compound_pnl_enabled: v } as Record<string, unknown>);
+  };
+
+  const toggleDigest = async (v: boolean) => {
+    await upsert.mutateAsync({ lisa_daily_digest_enabled: v } as Record<string, unknown>);
+  };
+
+  const saveEmail = async () => {
+    await upsert.mutateAsync({
+      lisa_notification_email: effEmail.trim() || null,
+    } as Record<string, unknown>);
+    setDraftEmail('');
+  };
+
+  const onResetKill = async () => {
+    if (!window.confirm('Désarmer le kill-switch anti-spirale ? TRADER reprendra dès le prochain cycle.')) return;
+    await resetKill.mutateAsync();
+  };
+
+  if (configQuery.isLoading) {
+    return (
+      <Card className="p-4">
+        <div className="animate-pulse h-32 bg-muted rounded" />
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-4">
+      <h3 className="text-sm font-semibold mb-3">⚙️ Configuration LISA</h3>
+
+      {/* 1. Kill-switch (conditional) */}
+      {killSwitchActive && (
+        <div className="mb-4 rounded-lg border border-rose-300 dark:border-rose-700 bg-rose-50 dark:bg-rose-950/30 p-3">
+          <div className="flex items-start gap-2 mb-2">
+            <span className="text-lg">🛑</span>
+            <div className="flex-1">
+              <div className="text-sm font-semibold text-rose-700 dark:text-rose-300">
+                Kill-switch anti-spirale armé
+              </div>
+              <div className="text-xs text-rose-700/80 dark:text-rose-300/80 mt-0.5">
+                TRADER est suspendu. Désarme pour reprendre les cycles.
+              </div>
+            </div>
+          </div>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={onResetKill}
+            disabled={resetKill.isPending}
+            className="w-full sm:w-auto"
+          >
+            {resetKill.isPending ? 'Désarmement…' : 'Désarmer kill-switch'}
+          </Button>
+        </div>
+      )}
+
+      {/* 2. Capital initial + compound */}
+      <div className="mb-4 pb-4 border-b">
+        <div className="text-xs font-semibold mb-2">💰 Capital</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className="text-[11px] text-muted-foreground">Capital initial $</label>
+            <div className="flex gap-1.5 mt-1">
+              <input
+                type="number"
+                value={draftCapital !== '' ? draftCapital : initialCapital}
+                onChange={(e) => setDraftCapital(e.target.value)}
+                className="flex-1 rounded border px-2 py-1.5 text-sm bg-background tabular-nums"
+                min={100}
+                step={100}
+              />
+              <Button
+                size="sm"
+                onClick={saveCapital}
+                disabled={upsert.isPending || draftCapital === '' || Number(draftCapital) === initialCapital}
+              >
+                OK
+              </Button>
+            </div>
+          </div>
+          <div>
+            <label className="text-[11px] text-muted-foreground">Intérêts composés</label>
+            <label className="flex items-center gap-2 mt-1.5 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={compoundEnabled}
+                onChange={(e) => toggleCompound(e.target.checked)}
+                disabled={upsert.isPending}
+                className="accent-primary h-4 w-4"
+              />
+              <span className="text-xs">
+                {compoundEnabled
+                  ? 'Activés (capital évolue avec les gains)'
+                  : 'Désactivés (capital fixe = initial)'}
+              </span>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      {/* 3. Daily digest */}
+      <div className="mb-4 pb-4 border-b">
+        <div className="text-xs font-semibold mb-2">📧 Daily Digest</div>
+        <label className="flex items-center gap-2 mb-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={digestEnabled}
+            onChange={(e) => toggleDigest(e.target.checked)}
+            disabled={upsert.isPending}
+            className="accent-primary h-4 w-4"
+          />
+          <span className="text-xs">
+            Email récapitulatif chaque jour à 09:00 UTC
+          </span>
+        </label>
+        <div className="flex gap-1.5">
+          <input
+            type="email"
+            placeholder="email@example.com"
+            value={draftEmail !== '' ? draftEmail : email}
+            onChange={(e) => setDraftEmail(e.target.value)}
+            className="flex-1 rounded border px-2 py-1.5 text-sm bg-background"
+          />
+          <Button
+            size="sm"
+            onClick={saveEmail}
+            disabled={upsert.isPending || draftEmail === '' || draftEmail.trim() === email}
+          >
+            OK
+          </Button>
+        </div>
+      </div>
+
+      {/* 4. Lessons management */}
+      <LessonsManagementSection />
+    </Card>
+  );
+}
+
+function LessonsManagementSection() {
+  const [search, setSearch] = useState('');
+  const [activeFilter, setActiveFilter] = useState<'all' | 'active' | 'inactive'>('all');
+  const lessonsQuery = useScannerLessons({
+    active: activeFilter === 'active' ? true : activeFilter === 'inactive' ? false : null,
+    search: search || undefined,
+    limit: 500,
+  });
+  const toggle = useToggleScannerLesson();
+
+  const counts = useMemo(() => {
+    const rows = lessonsQuery.data ?? [];
+    return {
+      total: rows.length,
+      active: rows.filter((r) => r.is_active).length,
+    };
+  }, [lessonsQuery.data]);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+        <div className="text-xs font-semibold">📚 Lessons ({counts.active}/{counts.total} actives)</div>
+      </div>
+      <div className="flex items-center gap-2 mb-2 flex-wrap">
+        <input
+          type="text"
+          placeholder="Search kind / text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="flex-1 min-w-[160px] rounded border px-2 py-1.5 text-xs bg-background"
+        />
+        <select
+          value={activeFilter}
+          onChange={(e) => setActiveFilter(e.target.value as typeof activeFilter)}
+          className="rounded border px-2 py-1.5 text-xs bg-background"
+        >
+          <option value="all">Toutes</option>
+          <option value="active">Actives</option>
+          <option value="inactive">Inactives</option>
+        </select>
+      </div>
+
+      {lessonsQuery.isLoading && (
+        <div className="space-y-1.5">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="animate-pulse h-10 bg-muted rounded" />
+          ))}
+        </div>
+      )}
+
+      {!lessonsQuery.isLoading && (lessonsQuery.data ?? []).length === 0 && (
+        <div className="text-xs text-muted-foreground py-4 text-center">
+          Aucune lesson.
+        </div>
+      )}
+
+      {!lessonsQuery.isLoading && (lessonsQuery.data ?? []).length > 0 && (
+        <div className="space-y-1 max-h-[420px] overflow-y-auto">
+          {(lessonsQuery.data ?? []).map((l) => (
+            <div
+              key={l.id}
+              className={`rounded border p-2 flex items-start gap-2 ${
+                l.is_active ? 'bg-card' : 'bg-muted/30 opacity-70'
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={l.is_active}
+                onChange={(e) => toggle.mutate({ id: l.id, isActive: e.target.checked })}
+                disabled={toggle.isPending}
+                className="accent-primary h-4 w-4 mt-0.5"
+                aria-label={`Toggle ${l.lesson_kind}`}
+              />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  <code className="text-[10px] px-1.5 py-0.5 rounded bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300">
+                    {l.lesson_kind}
+                  </code>
+                  <span className="text-[10px] text-muted-foreground">{l.scope}</span>
+                  {l.confidence !== null && (
+                    <span className="text-[10px] text-muted-foreground">
+                      conf {l.confidence.toFixed(2)}
+                    </span>
+                  )}
+                  {l.sample_size !== null && (
+                    <span className="text-[10px] text-muted-foreground">
+                      n={l.sample_size}
+                    </span>
+                  )}
+                </div>
+                <div className="text-[11px] mt-1 line-clamp-2">{l.lesson_text}</div>
+                {l.macro_condition && (
+                  <div className="text-[10px] text-muted-foreground mt-0.5">
+                    Cond: <code>{l.macro_condition}</code>
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/lisa/lisa-sticky-header.tsx
+++ b/apps/web/src/components/lisa/lisa-sticky-header.tsx
@@ -18,12 +18,38 @@ interface Props {
 }
 
 export function LisaStickyHeader({ portfolioId }: Props) {
-  const { targets, stats, currentCapital, isLoading } = useLisaTargetsAndStats(portfolioId);
+  const {
+    targets, stats, currentCapital, drawdownFromInitialPct, killSwitchActive, isLoading,
+  } = useLisaTargetsAndStats(portfolioId);
 
   if (isLoading || !stats || !targets) {
     return (
       <div className="sticky top-0 z-30 bg-card/80 backdrop-blur border-b py-2 px-4">
         <div className="animate-pulse h-6 bg-muted rounded w-32" />
+      </div>
+    );
+  }
+
+  // LISA refonte A.4.1 — Bandeau anti-spirale si kill_switch_active=true.
+  // Backend arme kill_switch_active dans lisa_session_configs quand drawdown
+  // depuis capital initial < -30%. UI affiche bandeau rouge non-dismissible :
+  // l'utilisateur doit aller dans la config pour reset manuellement (à wirer
+  // dans la section Config Phase B.3).
+  if (killSwitchActive) {
+    return (
+      <div className="sticky top-0 z-30 bg-rose-600 dark:bg-rose-700 text-white border-b py-3 px-4 shadow-md">
+        <div className="flex items-center gap-3 flex-wrap">
+          <span className="text-xl">🛑</span>
+          <div className="flex-1 min-w-0">
+            <div className="font-semibold text-sm">
+              Kill-switch anti-spirale activé
+            </div>
+            <div className="text-xs opacity-90 mt-0.5">
+              Drawdown {drawdownFromInitialPct !== null ? drawdownFromInitialPct.toFixed(1) : '—'}% depuis capital initial.
+              TRADER suspendu. Reset manuel requis dans Config LISA.
+            </div>
+          </div>
+        </div>
       </div>
     );
   }

--- a/apps/web/src/components/lisa/lisa-sticky-header.tsx
+++ b/apps/web/src/components/lisa/lisa-sticky-header.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export function LisaStickyHeader({ portfolioId }: Props) {
-  const { targets, stats, isLoading } = useLisaTargetsAndStats(portfolioId);
+  const { targets, stats, currentCapital, isLoading } = useLisaTargetsAndStats(portfolioId);
 
   if (isLoading || !stats || !targets) {
     return (
@@ -49,10 +49,18 @@ export function LisaStickyHeader({ portfolioId }: Props) {
           </span>
         </div>
 
-        {/* Cible + PnL today */}
-        <div className="flex items-center gap-3 text-xs">
+        {/* Capital + Cible + PnL today */}
+        <div className="flex items-center gap-3 text-xs flex-wrap">
+          {/* LISA refonte A.4 — Capital actuel (composé) visible toujours */}
+          <div className="hidden md:flex items-center gap-1.5">
+            <span className="text-muted-foreground">💰</span>
+            <span className="font-medium tabular-nums">
+              ${currentCapital !== null ? currentCapital.toFixed(0) : '—'}
+            </span>
+          </div>
+
           <div className="hidden sm:flex items-center gap-1.5">
-            <span className="text-muted-foreground">🎯 Cible :</span>
+            <span className="text-muted-foreground">🎯</span>
             <span className="font-medium">${targets.daily.effective.toFixed(0)}</span>
           </div>
 

--- a/apps/web/src/components/lisa/lisa-sticky-header.tsx
+++ b/apps/web/src/components/lisa/lisa-sticky-header.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+/**
+ * LisaStickyHeader — header sticky en haut de /lisa.
+ *
+ * Toujours visible scroll, affiche :
+ *   - Brand 🤖 LISA
+ *   - Cible jour effective
+ *   - Σ TODAY badge (P&L réalisé jour)
+ *
+ * Responsive : compact sur mobile, expanded sur desktop.
+ */
+
+import { useLisaTargetsAndStats } from '@/hooks/use-lisa-targets';
+
+interface Props {
+  portfolioId: string;
+}
+
+export function LisaStickyHeader({ portfolioId }: Props) {
+  const { targets, stats, isLoading } = useLisaTargetsAndStats(portfolioId);
+
+  if (isLoading || !stats || !targets) {
+    return (
+      <div className="sticky top-0 z-30 bg-card/80 backdrop-blur border-b py-2 px-4">
+        <div className="animate-pulse h-6 bg-muted rounded w-32" />
+      </div>
+    );
+  }
+
+  const pnlToday = stats.daily.realized_pnl_usd;
+  const pnlColor =
+    pnlToday > 0
+      ? 'text-emerald-600 dark:text-emerald-400'
+      : pnlToday < 0
+      ? 'text-rose-600 dark:text-rose-400'
+      : 'text-muted-foreground';
+  const sign = pnlToday >= 0 ? '+' : '';
+
+  return (
+    <div className="sticky top-0 z-30 bg-card/90 backdrop-blur border-b py-2 px-4">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        {/* Brand */}
+        <div className="flex items-center gap-2">
+          <span className="text-base">🤖</span>
+          <span className="font-semibold text-sm">LISA</span>
+          <span className="hidden md:inline text-[10px] text-muted-foreground">
+            Agent autonome Gemini Pro 2.5
+          </span>
+        </div>
+
+        {/* Cible + PnL today */}
+        <div className="flex items-center gap-3 text-xs">
+          <div className="hidden sm:flex items-center gap-1.5">
+            <span className="text-muted-foreground">🎯 Cible :</span>
+            <span className="font-medium">${targets.daily.effective.toFixed(0)}</span>
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground">Σ today :</span>
+            <span className={`font-semibold tabular-nums ${pnlColor}`}>
+              {sign}${Math.abs(pnlToday).toFixed(2)}
+            </span>
+            <span className="text-[10px] text-muted-foreground hidden sm:inline">
+              ({stats.daily.pct_of_target.toFixed(0)}%)
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/lisa/lisa-sticky-header.tsx
+++ b/apps/web/src/components/lisa/lisa-sticky-header.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useLisaTargetsAndStats } from '@/hooks/use-lisa-targets';
+import { NotificationsBell } from './notifications-bell';
 
 interface Props {
   portfolioId: string;
@@ -49,6 +50,7 @@ export function LisaStickyHeader({ portfolioId }: Props) {
               TRADER suspendu. Reset manuel requis dans Config LISA.
             </div>
           </div>
+          <NotificationsBell portfolioId={portfolioId} />
         </div>
       </div>
     );
@@ -73,6 +75,7 @@ export function LisaStickyHeader({ portfolioId }: Props) {
           <span className="hidden md:inline text-[10px] text-muted-foreground">
             Agent autonome Gemini Pro 2.5
           </span>
+          <NotificationsBell portfolioId={portfolioId} />
         </div>
 
         {/* Capital + Cible + PnL today */}

--- a/apps/web/src/components/lisa/notifications-bell.tsx
+++ b/apps/web/src/components/lisa/notifications-bell.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+/**
+ * NotificationsBell — B.4.a, badge + dropdown notifications LISA.
+ *
+ * Affiche cloche 🔔 avec badge unread (count basé sur localStorage
+ * last_seen_at, scoped portfolio). Click → dropdown listant les
+ * notifications (kill-switch armé, coach proposals pending, etc.).
+ *
+ * Click "tout marquer lu" → met à jour last_seen au max created_at.
+ * Mobile : dropdown right-aligned, max-w 320px.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { useNotifications, type NotificationItem } from '@/hooks/use-notifications';
+
+interface Props {
+  portfolioId: string;
+}
+
+function fmtAge(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 1) return 'à l\'instant';
+  if (mins < 60) return `${mins} min`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `il y a ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `il y a ${days}j`;
+}
+
+function severityClasses(sev: NotificationItem['severity']): string {
+  switch (sev) {
+    case 'critical': return 'border-l-4 border-rose-500 bg-rose-50 dark:bg-rose-950/30';
+    case 'warning': return 'border-l-4 border-amber-500 bg-amber-50 dark:bg-amber-950/30';
+    case 'info': return 'border-l-4 border-blue-500 bg-blue-50 dark:bg-blue-950/30';
+  }
+}
+
+function severityIcon(sev: NotificationItem['severity']): string {
+  switch (sev) {
+    case 'critical': return '🛑';
+    case 'warning': return '⚠️';
+    case 'info': return '💡';
+  }
+}
+
+export function NotificationsBell({ portfolioId }: Props) {
+  const [open, setOpen] = useState(false);
+  const { items, unreadCount, markAllRead, isLoading } = useNotifications(portfolioId);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [open]);
+
+  const onOpen = () => {
+    setOpen((v) => !v);
+    if (!open) {
+      // Marque lu à l'ouverture
+      setTimeout(() => markAllRead(), 100);
+    }
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="relative inline-flex items-center justify-center rounded-md p-2 hover:bg-muted transition"
+        aria-label="Notifications"
+      >
+        <span className="text-lg">🔔</span>
+        {unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 inline-flex h-4 min-w-[16px] items-center justify-center rounded-full bg-rose-600 px-1 text-[10px] font-semibold text-white">
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full mt-1 z-40 w-[320px] max-w-[calc(100vw-2rem)] rounded-lg border bg-card shadow-lg">
+          <div className="flex items-center justify-between px-3 py-2 border-b">
+            <div className="text-sm font-semibold">🔔 Notifications</div>
+            <span className="text-[10px] text-muted-foreground">
+              {items.length} total{items.length > 1 ? 's' : ''}
+            </span>
+          </div>
+          <div className="max-h-[400px] overflow-y-auto">
+            {isLoading && (
+              <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+                Chargement…
+              </div>
+            )}
+            {!isLoading && items.length === 0 && (
+              <div className="px-3 py-8 text-center text-xs text-muted-foreground">
+                Aucune notification.
+              </div>
+            )}
+            {!isLoading && items.map((it) => (
+              <div key={it.id} className={`px-3 py-2 ${severityClasses(it.severity)}`}>
+                <div className="flex items-start gap-2">
+                  <span className="text-sm">{severityIcon(it.severity)}</span>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-xs font-semibold truncate">{it.title}</div>
+                    <div className="text-[11px] text-muted-foreground line-clamp-2 mt-0.5">
+                      {it.body}
+                    </div>
+                    <div className="text-[10px] text-muted-foreground mt-1">
+                      {fmtAge(it.created_at)}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/lisa/portfolio-chart.tsx
+++ b/apps/web/src/components/lisa/portfolio-chart.tsx
@@ -3,8 +3,9 @@
 import { useState, useMemo } from 'react';
 import {
   ResponsiveContainer,
-  LineChart,
+  ComposedChart,
   Line,
+  Scatter,
   XAxis,
   YAxis,
   Tooltip,
@@ -12,7 +13,7 @@ import {
   ReferenceLine,
 } from 'recharts';
 import { LineChart as LineChartIcon, RefreshCw } from 'lucide-react';
-import { useLisaSnapshotHistory, useLisaSnapshot, useLisaConfig } from '@/hooks/use-lisa';
+import { useLisaSnapshotHistory, useLisaSnapshot, useLisaConfig, useLisaPositions } from '@/hooks/use-lisa';
 import { SkeletonCard } from '@/components/ui/skeleton';
 
 type ChartPoint = {
@@ -24,13 +25,53 @@ type ChartPoint = {
   drawdown: number;
 };
 
+type TradeMarker = {
+  t: number;
+  value: number;
+  symbol: string;
+  pnlUsd: number;
+  pnlPct: number;
+  win: boolean;
+  exitReason: string;
+};
+
 // Tooltip défini hors du composant parent pour garantir que recharts appelle
 // bien le render à chaque déplacement du curseur (pas de closure capturée
 // sur une data point figée).
-function ChartTooltip(props: { active?: boolean; payload?: Array<{ payload: ChartPoint }> }) {
+function ChartTooltip(props: { active?: boolean; payload?: Array<{ payload: ChartPoint | TradeMarker; dataKey?: string }> }) {
   const { active, payload } = props;
   if (!active || !payload || payload.length === 0) return null;
-  const point = payload[0].payload;
+
+  // Cherche marker en priorité (hover sur scatter) sinon ChartPoint (hover sur ligne)
+  const markerEntry = payload.find((e) => (e.payload as TradeMarker).symbol !== undefined);
+  if (markerEntry) {
+    const m = markerEntry.payload as TradeMarker;
+    return (
+      <div className="rounded-md border bg-card p-2 text-[11px] shadow-sm" style={{ minWidth: 180 }}>
+        <div className="flex items-center gap-1.5 mb-1">
+          <span className={m.win ? 'text-emerald-600' : 'text-rose-500'}>
+            {m.win ? '🟢' : '🔴'}
+          </span>
+          <span className="font-semibold">{m.symbol}</span>
+          <span className="ml-auto text-muted-foreground font-mono text-[10px]">
+            {new Date(m.t).toLocaleString('fr-FR', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' })}
+          </span>
+        </div>
+        <div className="flex justify-between gap-3">
+          <span className="text-muted-foreground">P&amp;L</span>
+          <span className={`font-mono font-semibold tabular-nums ${m.win ? 'text-emerald-600' : 'text-rose-500'}`}>
+            {m.pnlUsd >= 0 ? '+' : ''}${m.pnlUsd.toFixed(2)} ({m.pnlPct >= 0 ? '+' : ''}{m.pnlPct.toFixed(2)}%)
+          </span>
+        </div>
+        <div className="flex justify-between gap-3">
+          <span className="text-muted-foreground">Exit</span>
+          <span className="font-mono text-[10px]">{m.exitReason}</span>
+        </div>
+      </div>
+    );
+  }
+
+  const point = payload[0].payload as ChartPoint;
   if (!point || typeof point.value !== 'number') return null;
   return (
     <div
@@ -94,6 +135,9 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
     ? parseFloat(configQuery.data.capital_usd)
     : null;
 
+  // LISA refonte A.5 — Trade markers : overlay des trades closés sur la courbe.
+  const positionsQuery = useLisaPositions(portfolioId, false);
+
   const data = historyQuery.data ?? [];
 
   const chartData = useMemo(() => {
@@ -142,6 +186,47 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
 
     return points;
   }, [data, liveQuery.data]);
+
+  // LISA refonte A.5 — Compute trade markers (1 dot par close dans la fenêtre).
+  // value (Y) = valeur de la courbe interpolée au timestamp d'exit (sinon on
+  // perd la cohérence visuelle avec la ligne).
+  const tradeMarkers = useMemo<TradeMarker[]>(() => {
+    if (chartData.length === 0) return [];
+    const positions = positionsQuery.data ?? [];
+    const minT = chartData[0].t;
+    const maxT = chartData[chartData.length - 1].t;
+    const closed = positions.filter((p) => {
+      if (p.status === 'open' || !p.exitTimestamp) return false;
+      const t = new Date(p.exitTimestamp).getTime();
+      return t >= minT && t <= maxT;
+    });
+    return closed.map((p) => {
+      const t = new Date(p.exitTimestamp!).getTime();
+      // Interpolation linéaire entre les 2 points de chartData entourant t
+      let value = chartData[chartData.length - 1].value;
+      for (let i = 0; i < chartData.length - 1; i++) {
+        const a = chartData[i];
+        const b = chartData[i + 1];
+        if (t >= a.t && t <= b.t) {
+          const ratio = b.t === a.t ? 0 : (t - a.t) / (b.t - a.t);
+          value = a.value + (b.value - a.value) * ratio;
+          break;
+        }
+      }
+      const pnlUsd = parseFloat(p.realizedPnlUsd ?? '0') || 0;
+      return {
+        t,
+        value,
+        symbol: p.symbol,
+        pnlUsd,
+        pnlPct: p.realizedPnlPct ?? 0,
+        win: pnlUsd > 0,
+        exitReason: (p.exitReason ?? p.status).slice(0, 40),
+      };
+    });
+  }, [chartData, positionsQuery.data]);
+  const winMarkers = useMemo(() => tradeMarkers.filter((m) => m.win), [tradeMarkers]);
+  const lossMarkers = useMemo(() => tradeMarkers.filter((m) => !m.win), [tradeMarkers]);
 
   const hasData = chartData.length > 1;
   const latestValue = chartData[chartData.length - 1]?.value ?? 0;
@@ -244,7 +329,7 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
           aria-label={`Évolution du capital sur ${WINDOW_LABELS[window]} : départ ${baselineValue.toFixed(0)} USD, valeur courante ${latestValue.toFixed(0)} USD, ${periodReturn >= 0 ? 'gain' : 'perte'} de ${Math.abs(periodReturn).toFixed(2)}%`}
         >
           <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={chartData} margin={{ top: 8, right: 12, bottom: 8, left: 8 }}>
+            <ComposedChart data={chartData} margin={{ top: 8, right: 12, bottom: 8, left: 8 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="currentColor" opacity={0.1} />
               <XAxis
                 dataKey="t"
@@ -297,8 +382,42 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
                 dot={false}
                 activeDot={{ r: 4 }}
               />
-            </LineChart>
+              {/* LISA refonte A.5 — Trade markers overlay. */}
+              {winMarkers.length > 0 && (
+                <Scatter
+                  data={winMarkers}
+                  dataKey="value"
+                  fill="#10b981"
+                  stroke="#065f46"
+                  strokeWidth={1}
+                  shape="circle"
+                  legendType="none"
+                />
+              )}
+              {lossMarkers.length > 0 && (
+                <Scatter
+                  data={lossMarkers}
+                  dataKey="value"
+                  fill="#ef4444"
+                  stroke="#7f1d1d"
+                  strokeWidth={1}
+                  shape="circle"
+                  legendType="none"
+                />
+              )}
+            </ComposedChart>
           </ResponsiveContainer>
+        </div>
+      )}
+
+      {hasData && tradeMarkers.length > 0 && (
+        <div className="flex items-center gap-3 text-[10px] text-muted-foreground -mt-2">
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" /> Trade gagnant ({winMarkers.length})
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2 h-2 rounded-full bg-rose-500" /> Trade perdant ({lossMarkers.length})
+          </span>
         </div>
       )}
 

--- a/apps/web/src/hooks/use-coach-proposals.ts
+++ b/apps/web/src/hooks/use-coach-proposals.ts
@@ -1,0 +1,98 @@
+// LISA refonte C.2 — Coach proposals hooks.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+export interface CoachProposalLesson {
+  lesson_kind: string;
+  lesson_text: string;
+  confidence: number;
+  scope: string;
+  expected_impact_usd?: number;
+  rationale?: string;
+}
+
+export interface CoachProposalParamChange {
+  param: string;
+  current: unknown;
+  proposed: unknown;
+  rationale: string;
+  expected_impact?: string;
+}
+
+export interface CoachProposal {
+  id: string;
+  created_at: string;
+  source: string;
+  llm_model: string;
+  llm_cost_usd: number;
+  feasibility_verdict: 'REACHABLE' | 'NEEDS_CHANGES' | 'UNREALISTIC' | string;
+  feasibility_probability_pct: number | null;
+  feasibility_rationale: string;
+  proposed_lessons: CoachProposalLesson[];
+  proposed_parameter_changes: CoachProposalParamChange[];
+  risk_warnings: string[];
+  status: 'pending' | 'partially_accepted' | 'fully_accepted' | 'rejected' | 'expired';
+  reviewed_at: string | null;
+  resulted_lesson_ids: string[];
+}
+
+export function useCoachProposals(portfolioId: string | null, status: string = 'pending') {
+  return useQuery({
+    queryKey: ['lisa', 'coach-proposals', portfolioId, status],
+    queryFn: () =>
+      apiFetch<CoachProposal[]>(`/lisa/coach-proposals/${portfolioId}?status=${status}`),
+    enabled: !!portfolioId,
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+}
+
+export function useAcceptCoachProposal() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      accepted_lessons,
+      accepted_params,
+      comment,
+    }: {
+      id: string;
+      accepted_lessons: number[];
+      accepted_params: number[];
+      comment?: string;
+    }) =>
+      apiFetch<{ ok: boolean; status: string; resulted_lesson_ids: string[] }>(
+        `/lisa/coach-proposals/${id}/accept`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ accepted_lessons, accepted_params, comment }),
+        },
+      ),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['lisa', 'coach-proposals'] });
+      void qc.invalidateQueries({ queryKey: ['lisa', 'notifications'] });
+      void qc.invalidateQueries({ queryKey: ['lisa', 'scanner-lessons'] });
+    },
+  });
+}
+
+export function useRejectCoachProposal() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, comment }: { id: string; comment?: string }) =>
+      apiFetch<{ ok: boolean; status: string }>(
+        `/lisa/coach-proposals/${id}/reject`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ comment }),
+        },
+      ),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['lisa', 'coach-proposals'] });
+      void qc.invalidateQueries({ queryKey: ['lisa', 'notifications'] });
+    },
+  });
+}

--- a/apps/web/src/hooks/use-lessons-impact.ts
+++ b/apps/web/src/hooks/use-lessons-impact.ts
@@ -1,0 +1,49 @@
+// LISA refonte B.2 — Lessons Impact Tracker hook.
+//
+// Fetch les stats agrégées de citations de lessons par TRADER sur une
+// fenêtre glissante (default 30j). Backend agrège côté Nest, ce hook
+// expose juste le typage et la fenêtre.
+
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+export interface LessonImpactRow {
+  lesson_id: string | null;
+  lesson_kind: string;
+  lesson_text: string | null;
+  marker_text: string;
+  confidence: number | null;
+  is_active: boolean | null;
+  macro_condition: string | null;
+  sample_size: number | null;
+  citations_count: number;
+  applied_count: number;
+  resolved_count: number;
+  wins: number;
+  losses: number;
+  sum_pnl_usd: number;
+  avg_pnl_usd: number;
+  win_rate_pct: number | null;
+  last_cited_at: string | null;
+}
+
+export interface LessonsImpactResponse {
+  windowDays: number;
+  totalCitations: number;
+  resolvedCitations: number;
+  lessons: LessonImpactRow[];
+}
+
+export function useLessonsImpact(portfolioId: string | null, days: number = 30) {
+  return useQuery({
+    queryKey: ['lisa', 'lessons-impact', portfolioId, days],
+    queryFn: () =>
+      apiFetch<LessonsImpactResponse>(
+        `/lisa/lessons-impact/${portfolioId}?days=${days}`,
+      ),
+    enabled: !!portfolioId,
+    retry: false,
+    refetchOnWindowFocus: false,
+    staleTime: 60_000,
+  });
+}

--- a/apps/web/src/hooks/use-lisa-targets.ts
+++ b/apps/web/src/hooks/use-lisa-targets.ts
@@ -102,15 +102,22 @@ export function useLisaTargetsAndStats(portfolioId: string | null) {
     const positions = (positionsQuery.data ?? []) as LisaPosition[];
 
     if (!config) {
-      return { targets: null, stats: null, currentCapital: null, isLoading: true };
+      return {
+        targets: null, stats: null, currentCapital: null,
+        initialCapital: null, drawdownFromInitialPct: null, killSwitchActive: false,
+        isLoading: true,
+      };
     }
 
     const initialCapital = Number(config.lisa_initial_capital_usd ?? 10000);
     const compoundEnabled = Boolean(config.lisa_compound_pnl_enabled ?? true);
+    const killSwitchActive = Boolean(config.kill_switch_active ?? false);
 
     // Compute current capital from closed positions
     const closedPositions = positions.filter((p) => p.status !== 'open');
     const currentCapital = computeCurrentCapital(initialCapital, closedPositions, compoundEnabled);
+    const drawdownFromInitialPct =
+      initialCapital > 0 ? ((currentCapital - initialCapital) / initialCapital) * 100 : 0;
 
     // Build targets Mode C (MAX usd, pct × capital)
     const targets: LisaTargets = {
@@ -176,7 +183,11 @@ export function useLisaTargetsAndStats(portfolioId: string | null) {
       annual: buildStats('annual', targets.annual.effective),
     };
 
-    return { targets, stats, currentCapital, isLoading: false };
+    return {
+      targets, stats, currentCapital,
+      initialCapital, drawdownFromInitialPct, killSwitchActive,
+      isLoading: false,
+    };
   }, [configQuery.data, positionsQuery.data]);
 
   return {

--- a/apps/web/src/hooks/use-lisa-targets.ts
+++ b/apps/web/src/hooks/use-lisa-targets.ts
@@ -1,0 +1,232 @@
+// LISA refonte Phase A.3 — Targets + reset markers + stats par scope
+//
+// Hook utilitaire pour la section Gains : lit les cibles depuis lisa_session_configs
+// (colonnes lisa_target_*_usd et lisa_target_*_pct, migration 0173), calcule
+// la cible effective Mode C = MAX(usd plancher, pct × current_capital), et
+// expose les stats P&L filtrées par scope + reset marker (migration 0174).
+
+import { useMemo } from 'react';
+import { useLisaConfig, useUpsertLisaConfig, useLisaPositions, type LisaPosition } from './use-lisa';
+
+export type LisaScope = 'daily' | 'weekly' | 'monthly' | 'annual';
+
+export interface LisaTargets {
+  daily: { usd: number; pct: number; effective: number };
+  monthly: { usd: number; pct: number; effective: number };
+  annual: { usd: number; pct: number; effective: number };
+}
+
+export interface LisaScopeStats {
+  realized_pnl_usd: number;
+  trades_count: number;
+  wins: number;
+  losses: number;
+  win_rate_pct: number | null;
+  target_effective_usd: number;
+  pct_of_target: number;
+  reset_marker_at: string | null;
+}
+
+/**
+ * Calcule le capital actuel : initial + Σ realized_pnl (si compound activé).
+ */
+export function computeCurrentCapital(
+  initialUsd: number,
+  positions: LisaPosition[],
+  compoundEnabled: boolean,
+): number {
+  if (!compoundEnabled) return initialUsd;
+  const realized = positions.reduce(
+    (sum, p) => sum + (parseFloat(p.realizedPnlUsd ?? '0') || 0),
+    0,
+  );
+  return initialUsd + realized;
+}
+
+/**
+ * Calcule la cible effective Mode C pour un scope donné = MAX(usd, pct × capital).
+ */
+export function computeEffectiveTarget(
+  usdFloor: number,
+  pct: number,
+  currentCapital: number,
+): number {
+  return Math.max(usdFloor, (pct / 100) * currentCapital);
+}
+
+/**
+ * Retourne le timestamp ISO de début pour un scope donné (UTC).
+ *  - daily   : 00:00 UTC du jour courant
+ *  - weekly  : lundi 00:00 UTC de la semaine courante
+ *  - monthly : 1er du mois 00:00 UTC
+ *  - annual  : 1er janvier 00:00 UTC
+ *
+ * Si un reset_marker est défini, retourne le marker (= override le début de période).
+ */
+export function scopeStartIso(scope: LisaScope, resetMarker: string | null): string {
+  if (resetMarker) return resetMarker;
+  const now = new Date();
+  switch (scope) {
+    case 'daily': {
+      const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+      return d.toISOString();
+    }
+    case 'weekly': {
+      const d = new Date(now);
+      const day = d.getUTCDay(); // 0 = sunday
+      const diff = day === 0 ? 6 : day - 1; // lundi = 0
+      d.setUTCDate(d.getUTCDate() - diff);
+      d.setUTCHours(0, 0, 0, 0);
+      return d.toISOString();
+    }
+    case 'monthly': {
+      const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+      return d.toISOString();
+    }
+    case 'annual': {
+      const d = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+      return d.toISOString();
+    }
+  }
+}
+
+/**
+ * Hook principal — retourne les cibles effectives + stats par scope pour TRADER.
+ */
+export function useLisaTargetsAndStats(portfolioId: string | null) {
+  const configQuery = useLisaConfig(portfolioId);
+  const positionsQuery = useLisaPositions(portfolioId, false); // all positions, not just open
+
+  const result = useMemo(() => {
+    const config = configQuery.data as Record<string, unknown> | null;
+    const positions = (positionsQuery.data ?? []) as LisaPosition[];
+
+    if (!config) {
+      return { targets: null, stats: null, currentCapital: null, isLoading: true };
+    }
+
+    const initialCapital = Number(config.lisa_initial_capital_usd ?? 10000);
+    const compoundEnabled = Boolean(config.lisa_compound_pnl_enabled ?? true);
+
+    // Compute current capital from closed positions
+    const closedPositions = positions.filter((p) => p.status !== 'open');
+    const currentCapital = computeCurrentCapital(initialCapital, closedPositions, compoundEnabled);
+
+    // Build targets Mode C (MAX usd, pct × capital)
+    const targets: LisaTargets = {
+      daily: {
+        usd: Number(config.lisa_target_daily_usd ?? 200),
+        pct: Number(config.lisa_target_daily_pct ?? 2),
+        effective: computeEffectiveTarget(
+          Number(config.lisa_target_daily_usd ?? 200),
+          Number(config.lisa_target_daily_pct ?? 2),
+          currentCapital,
+        ),
+      },
+      monthly: {
+        usd: Number(config.lisa_target_monthly_usd ?? 4000),
+        pct: Number(config.lisa_target_monthly_pct ?? 20),
+        effective: computeEffectiveTarget(
+          Number(config.lisa_target_monthly_usd ?? 4000),
+          Number(config.lisa_target_monthly_pct ?? 20),
+          currentCapital,
+        ),
+      },
+      annual: {
+        usd: Number(config.lisa_target_annual_usd ?? 50000),
+        pct: Number(config.lisa_target_annual_pct ?? 100),
+        effective: computeEffectiveTarget(
+          Number(config.lisa_target_annual_usd ?? 50000),
+          Number(config.lisa_target_annual_pct ?? 100),
+          currentCapital,
+        ),
+      },
+    };
+
+    // Stats par scope avec reset markers
+    const buildStats = (scope: LisaScope, target: number): LisaScopeStats => {
+      const resetMarker = (config[`lisa_reset_marker_${scope === 'weekly' ? 'daily' : scope}`] as string | null) ?? null;
+      const startIso = scopeStartIso(scope, resetMarker);
+      const inScope = closedPositions.filter(
+        (p) => p.exitTimestamp != null && p.exitTimestamp >= startIso,
+      );
+      const realized = inScope.reduce(
+        (s, p) => s + (parseFloat(p.realizedPnlUsd ?? '0') || 0),
+        0,
+      );
+      const wins = inScope.filter((p) => parseFloat(p.realizedPnlUsd ?? '0') > 0).length;
+      const losses = inScope.filter((p) => parseFloat(p.realizedPnlUsd ?? '0') < 0).length;
+      const total = inScope.length;
+      return {
+        realized_pnl_usd: realized,
+        trades_count: total,
+        wins,
+        losses,
+        win_rate_pct: total > 0 ? (wins / total) * 100 : null,
+        target_effective_usd: target,
+        pct_of_target: target > 0 ? (realized / target) * 100 : 0,
+        reset_marker_at: resetMarker,
+      };
+    };
+
+    const stats = {
+      daily: buildStats('daily', targets.daily.effective),
+      weekly: buildStats('weekly', targets.daily.effective * 5),
+      monthly: buildStats('monthly', targets.monthly.effective),
+      annual: buildStats('annual', targets.annual.effective),
+    };
+
+    return { targets, stats, currentCapital, isLoading: false };
+  }, [configQuery.data, positionsQuery.data]);
+
+  return {
+    ...result,
+    isLoading: configQuery.isLoading || positionsQuery.isLoading || result.isLoading,
+    isError: configQuery.isError || positionsQuery.isError,
+  };
+}
+
+/**
+ * Mutation pour reset l'affichage d'un scope (set marker = NOW).
+ */
+export function useResetScopeMarker(portfolioId: string) {
+  const upsert = useUpsertLisaConfig(portfolioId);
+  return {
+    resetDaily: () =>
+      upsert.mutateAsync({ lisa_reset_marker_daily: new Date().toISOString() } as Record<string, unknown>),
+    resetMonthly: () =>
+      upsert.mutateAsync({
+        lisa_reset_marker_monthly: new Date().toISOString(),
+        lisa_reset_marker_daily: new Date().toISOString(), // cascade
+      } as Record<string, unknown>),
+    resetAnnual: () =>
+      upsert.mutateAsync({
+        lisa_reset_marker_annual: new Date().toISOString(),
+        lisa_reset_marker_monthly: new Date().toISOString(),
+        lisa_reset_marker_daily: new Date().toISOString(),
+      } as Record<string, unknown>),
+    cancelReset: (scope: 'daily' | 'monthly' | 'annual') =>
+      upsert.mutateAsync({ [`lisa_reset_marker_${scope}`]: null } as Record<string, unknown>),
+    isLoading: upsert.isPending,
+  };
+}
+
+/**
+ * Mutation pour update les cibles user (Mode C : usd + pct).
+ */
+export function useUpdateLisaTargets(portfolioId: string) {
+  const upsert = useUpsertLisaConfig(portfolioId);
+  return {
+    updateTargets: (partial: Partial<LisaTargets>) => {
+      const payload: Record<string, unknown> = {};
+      if (partial.daily?.usd !== undefined) payload.lisa_target_daily_usd = partial.daily.usd;
+      if (partial.daily?.pct !== undefined) payload.lisa_target_daily_pct = partial.daily.pct;
+      if (partial.monthly?.usd !== undefined) payload.lisa_target_monthly_usd = partial.monthly.usd;
+      if (partial.monthly?.pct !== undefined) payload.lisa_target_monthly_pct = partial.monthly.pct;
+      if (partial.annual?.usd !== undefined) payload.lisa_target_annual_usd = partial.annual.usd;
+      if (partial.annual?.pct !== undefined) payload.lisa_target_annual_pct = partial.annual.pct;
+      return upsert.mutateAsync(payload);
+    },
+    isLoading: upsert.isPending,
+  };
+}

--- a/apps/web/src/hooks/use-notifications.ts
+++ b/apps/web/src/hooks/use-notifications.ts
@@ -1,0 +1,73 @@
+// LISA refonte B.4.a — In-app notifications hooks.
+
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+export interface NotificationItem {
+  id: string;
+  kind: 'kill_switch_armed' | 'coach_proposal_pending';
+  severity: 'critical' | 'info' | 'warning';
+  title: string;
+  body: string;
+  created_at: string;
+  href?: string;
+  payload?: Record<string, unknown>;
+}
+
+interface NotificationsResponse {
+  items: NotificationItem[];
+  total: number;
+}
+
+const LS_KEY_PREFIX = 'lisa.notifications.lastSeen.';
+
+export function useNotifications(portfolioId: string | null) {
+  const query = useQuery({
+    queryKey: ['lisa', 'notifications', portfolioId],
+    queryFn: () =>
+      apiFetch<NotificationsResponse>(`/lisa/notifications/${portfolioId}`),
+    enabled: !!portfolioId,
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchInterval: 30_000, // poll 30s
+    staleTime: 15_000,
+  });
+
+  const [lastSeen, setLastSeenState] = useState<string>(() => {
+    if (typeof window === 'undefined' || !portfolioId) return '';
+    return localStorage.getItem(`${LS_KEY_PREFIX}${portfolioId}`) ?? '';
+  });
+
+  // Reload lastSeen quand portfolio change
+  useEffect(() => {
+    if (typeof window === 'undefined' || !portfolioId) return;
+    setLastSeenState(localStorage.getItem(`${LS_KEY_PREFIX}${portfolioId}`) ?? '');
+  }, [portfolioId]);
+
+  const unreadCount = useMemo(() => {
+    const items = query.data?.items ?? [];
+    if (!lastSeen) return items.length;
+    return items.filter((i) => i.created_at > lastSeen).length;
+  }, [query.data, lastSeen]);
+
+  const markAllRead = () => {
+    if (typeof window === 'undefined' || !portfolioId) return;
+    const items = query.data?.items ?? [];
+    if (items.length === 0) return;
+    const max = items.reduce(
+      (acc, i) => (i.created_at > acc ? i.created_at : acc),
+      lastSeen,
+    );
+    localStorage.setItem(`${LS_KEY_PREFIX}${portfolioId}`, max);
+    setLastSeenState(max);
+  };
+
+  return {
+    items: query.data?.items ?? [],
+    total: query.data?.total ?? 0,
+    unreadCount,
+    isLoading: query.isLoading,
+    markAllRead,
+  };
+}

--- a/apps/web/src/hooks/use-push-subscription.ts
+++ b/apps/web/src/hooks/use-push-subscription.ts
@@ -1,0 +1,120 @@
+// LISA refonte B.4.c — Push subscription hook.
+
+import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '@/lib/api-client';
+
+export type PushStatus =
+  | 'unsupported'   // Browser n'a pas Push API ou Service Worker
+  | 'permission-denied'
+  | 'not-subscribed'
+  | 'subscribed'
+  | 'loading';
+
+const SW_PATH = '/sw-lisa-push.js';
+
+function urlBase64ToUint8Array(base64: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64.length % 4)) % 4);
+  const b64 = (base64 + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(b64);
+  const out = new Uint8Array(new ArrayBuffer(raw.length));
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out;
+}
+
+export function usePushSubscription() {
+  const [status, setStatus] = useState<PushStatus>('loading');
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!('serviceWorker' in navigator) || !('PushManager' in window) || !('Notification' in window)) {
+      setStatus('unsupported');
+      return;
+    }
+    if (Notification.permission === 'denied') {
+      setStatus('permission-denied');
+      return;
+    }
+    try {
+      const reg = await navigator.serviceWorker.getRegistration(SW_PATH);
+      if (!reg) {
+        setStatus('not-subscribed');
+        return;
+      }
+      const sub = await reg.pushManager.getSubscription();
+      setStatus(sub ? 'subscribed' : 'not-subscribed');
+    } catch (e) {
+      setError(String(e).slice(0, 200));
+      setStatus('not-subscribed');
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const subscribe = useCallback(async () => {
+    setError(null);
+    try {
+      // 1. Permission notification
+      const perm = await Notification.requestPermission();
+      if (perm !== 'granted') {
+        setStatus('permission-denied');
+        return;
+      }
+      // 2. Register service worker
+      const reg = await navigator.serviceWorker.register(SW_PATH, { scope: '/' });
+      await navigator.serviceWorker.ready;
+      // 3. Fetch VAPID public key
+      const { publicKey } = await apiFetch<{ publicKey: string | null }>(
+        '/lisa/push/vapid-public-key',
+      );
+      if (!publicKey) {
+        setError('VAPID public key non configurée côté serveur');
+        return;
+      }
+      // 4. Subscribe to push manager
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(publicKey).buffer as ArrayBuffer,
+      });
+      // 5. Persist côté API
+      const subJson = sub.toJSON();
+      await apiFetch<{ ok: boolean }>('/lisa/push/subscribe', {
+        method: 'POST',
+        body: JSON.stringify({
+          endpoint: subJson.endpoint,
+          keys: subJson.keys,
+          userAgent: navigator.userAgent,
+        }),
+      });
+      setStatus('subscribed');
+    } catch (e) {
+      setError(String(e).slice(0, 200));
+    }
+  }, []);
+
+  const unsubscribe = useCallback(async () => {
+    setError(null);
+    try {
+      const reg = await navigator.serviceWorker.getRegistration(SW_PATH);
+      if (!reg) {
+        setStatus('not-subscribed');
+        return;
+      }
+      const sub = await reg.pushManager.getSubscription();
+      if (sub) {
+        await apiFetch<{ ok: boolean }>('/lisa/push/unsubscribe', {
+          method: 'POST',
+          body: JSON.stringify({ endpoint: sub.endpoint }),
+        });
+        await sub.unsubscribe();
+      }
+      setStatus('not-subscribed');
+    } catch (e) {
+      setError(String(e).slice(0, 200));
+    }
+  }, []);
+
+  return { status, error, subscribe, unsubscribe, refresh };
+}

--- a/apps/web/src/hooks/use-scanner-lessons.ts
+++ b/apps/web/src/hooks/use-scanner-lessons.ts
@@ -1,0 +1,74 @@
+// LISA refonte B.3 — Scanner lessons management hooks.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+export interface ScannerLessonRow {
+  id: string;
+  lesson_kind: string;
+  lesson_text: string;
+  macro_condition: string | null;
+  scope: string;
+  confidence: number | null;
+  sample_size: number | null;
+  win_rate_observed: number | null;
+  avg_pnl_usd: number | null;
+  is_active: boolean;
+  derived_from_date: string;
+  created_at: string;
+  applied: boolean;
+  applied_by: string | null;
+}
+
+interface ListFilters {
+  active?: boolean | null;
+  search?: string;
+  scope?: string;
+  limit?: number;
+}
+
+export function useScannerLessons(filters: ListFilters = {}) {
+  const params = new URLSearchParams();
+  if (filters.active === true) params.set('active', 'true');
+  if (filters.active === false) params.set('active', 'false');
+  if (filters.search) params.set('search', filters.search);
+  if (filters.scope) params.set('scope', filters.scope);
+  if (filters.limit) params.set('limit', String(filters.limit));
+  const qs = params.toString();
+  return useQuery({
+    queryKey: ['lisa', 'scanner-lessons', filters],
+    queryFn: () =>
+      apiFetch<ScannerLessonRow[]>(`/lisa/scanner-lessons${qs ? `?${qs}` : ''}`),
+    retry: false,
+    refetchOnWindowFocus: false,
+    staleTime: 30_000,
+  });
+}
+
+export function useToggleScannerLesson() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, isActive }: { id: string; isActive: boolean }) =>
+      apiFetch<{ ok: boolean; lessonId: string; is_active: boolean }>(
+        `/lisa/scanner-lessons/${id}`,
+        { method: 'PATCH', body: JSON.stringify({ is_active: isActive }) },
+      ),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['lisa', 'scanner-lessons'] });
+      void qc.invalidateQueries({ queryKey: ['lisa', 'lessons-impact'] });
+    },
+  });
+}
+
+export function useResetKillSwitch(portfolioId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      apiFetch<{ ok: boolean }>(`/lisa/kill-switch-reset/${portfolioId}`, {
+        method: 'POST',
+      }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['lisa', 'config', portfolioId] });
+    },
+  });
+}

--- a/scripts/generate-vapid-keys.mjs
+++ b/scripts/generate-vapid-keys.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// Génère une paire de clés VAPID P-256 pour Web Push (LISA B.4.c).
+// Sortie : VAPID_PUBLIC_KEY (base64url uncompressed 65 bytes)
+//          VAPID_PRIVATE_KEY (base64url raw 32 bytes)
+//
+// Usage : node scripts/generate-vapid-keys.mjs
+// Puis : fly secrets set -a smartvest VAPID_PUBLIC_KEY=... VAPID_PRIVATE_KEY=...
+//        NEXT_PUBLIC_VAPID_PUBLIC_KEY=<same as public> en .env web pour subscribe.
+
+import { generateKeyPairSync } from 'node:crypto';
+
+const { publicKey, privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+const pubJwk = publicKey.export({ format: 'jwk' });
+const privJwk = privateKey.export({ format: 'jwk' });
+
+// VAPID public key = 0x04 + X + Y (uncompressed point)
+const xBuf = Buffer.from(pubJwk.x.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+const yBuf = Buffer.from(pubJwk.y.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+const uncompressed = Buffer.concat([Buffer.from([0x04]), xBuf, yBuf]);
+const vapidPublic = uncompressed.toString('base64')
+  .replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+const vapidPrivate = privJwk.d; // already base64url
+
+console.log('VAPID keypair generated (P-256). Set these in your env :\n');
+console.log(`VAPID_PUBLIC_KEY=${vapidPublic}`);
+console.log(`VAPID_PRIVATE_KEY=${vapidPrivate}`);
+console.log(`NEXT_PUBLIC_VAPID_PUBLIC_KEY=${vapidPublic}  # web subscribe`);
+console.log(`VAPID_SUBJECT=mailto:lisa@smartvest.app       # contact admin`);

--- a/supabase/migrations/0173_lisa_refonte_phase_a.sql
+++ b/supabase/migrations/0173_lisa_refonte_phase_a.sql
@@ -1,0 +1,177 @@
+-- 0173 — LISA refonte Phase A
+--
+-- Foundation pour la nouvelle UI /lisa centrée TRADER :
+--   1. Capital composé : initial_capital + compound_pnl_enabled
+--   2. Objectifs dynamiques Mode C (MAX(fixe $, % capital)) jour/mois/an
+--   3. Daily digest email préférences
+--   4. Strategy Coach enable flag
+--   5. Tables coach_proposals (queue) + scanner_lesson_citations (tracking)
+--
+-- Migration idempotente — toutes les colonnes/tables ajoutées avec IF NOT EXISTS.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. Extension lisa_session_configs pour TRADER (portfolio b0000001-...)
+-- ─────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.lisa_session_configs
+  -- Capital composé
+  ADD COLUMN IF NOT EXISTS lisa_initial_capital_usd numeric(12, 2) DEFAULT 10000,
+  ADD COLUMN IF NOT EXISTS lisa_compound_pnl_enabled boolean DEFAULT true,
+
+  -- Objectifs dynamiques Mode C : plancher en $ ET % du capital
+  -- Cible effective = MAX(target_*_usd, target_*_pct × current_capital)
+  ADD COLUMN IF NOT EXISTS lisa_target_daily_usd numeric(10, 2) DEFAULT 200,
+  ADD COLUMN IF NOT EXISTS lisa_target_daily_pct numeric(5, 2) DEFAULT 2.00,
+  ADD COLUMN IF NOT EXISTS lisa_target_monthly_usd numeric(10, 2) DEFAULT 4000,
+  ADD COLUMN IF NOT EXISTS lisa_target_monthly_pct numeric(5, 2) DEFAULT 20.00,
+  ADD COLUMN IF NOT EXISTS lisa_target_annual_usd numeric(12, 2) DEFAULT 50000,
+  ADD COLUMN IF NOT EXISTS lisa_target_annual_pct numeric(5, 2) DEFAULT 100.00,
+
+  -- Notifications
+  ADD COLUMN IF NOT EXISTS lisa_daily_digest_enabled boolean DEFAULT true,
+  ADD COLUMN IF NOT EXISTS lisa_notification_email text DEFAULT NULL,
+
+  -- Strategy Coach
+  ADD COLUMN IF NOT EXISTS lisa_strategy_coach_enabled boolean DEFAULT true;
+
+COMMENT ON COLUMN public.lisa_session_configs.lisa_initial_capital_usd IS
+'Capital de base TRADER. Capital actuel = initial + Σ realized_pnl si compound_pnl_enabled.';
+
+COMMENT ON COLUMN public.lisa_session_configs.lisa_compound_pnl_enabled IS
+'Si true, le sizing Kelly utilise (initial + Σ pnl). Si false, sizing utilise initial fixe (legacy).';
+
+COMMENT ON COLUMN public.lisa_session_configs.lisa_target_daily_usd IS
+'Plancher cible jour en USD. Cible effective = MAX(usd, pct × current_capital).';
+
+COMMENT ON COLUMN public.lisa_session_configs.lisa_target_daily_pct IS
+'Cible jour en % du capital actuel. Couplé avec lisa_target_daily_usd pour Mode C hybride.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. coach_proposals — queue des propositions Strategy Coach AVANT validation user
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.coach_proposals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  portfolio_id uuid NOT NULL,
+
+  -- Source du run
+  source text NOT NULL DEFAULT 'cron_hourly', -- cron_hourly | cron_daily | on_demand | target_change
+  triggered_by text DEFAULT NULL, -- user_id si on_demand
+  llm_model text NOT NULL DEFAULT 'gemini-flash', -- gemini-flash | gemini-pro
+  llm_cost_usd numeric(8, 4) DEFAULT 0,
+  llm_latency_ms integer DEFAULT 0,
+
+  -- Contexte input (snapshot)
+  input_context jsonb NOT NULL,
+  -- { current_capital, targets, stats_30d, top_lessons, retrospectives, ... }
+
+  -- Output Gemini structuré
+  feasibility_verdict text,
+  -- 'REACHABLE' | 'NEEDS_CHANGES' | 'UNREALISTIC'
+  feasibility_probability_pct numeric(5, 2),
+  feasibility_rationale text,
+
+  -- Propositions concrètes
+  proposed_lessons jsonb NOT NULL DEFAULT '[]'::jsonb,
+  -- [{ lesson_kind, lesson_text, confidence, scope, expected_impact_usd, rationale, ... }]
+  proposed_parameter_changes jsonb DEFAULT '[]'::jsonb,
+  -- [{ param, current, proposed, rationale, expected_impact }]
+  risk_warnings jsonb DEFAULT '[]'::jsonb,
+  -- [text, text, ...]
+
+  -- Statut user review
+  status text NOT NULL DEFAULT 'pending',
+  -- 'pending' | 'partially_accepted' | 'fully_accepted' | 'rejected' | 'expired'
+  reviewed_at timestamptz DEFAULT NULL,
+  reviewed_by text DEFAULT NULL,
+  user_decision jsonb DEFAULT NULL,
+  -- { accepted_lessons: [...], rejected_lessons: [...], applied_params: [...], comment }
+
+  -- Lessons effectivement créées (FK vers scanner_lessons)
+  resulted_lesson_ids uuid[] DEFAULT '{}',
+
+  -- Anti-bruit / anti-redondance
+  pattern_hash text, -- hash similarity contre propositions précédentes
+  notified_at timestamptz DEFAULT NULL -- timestamp envoi notification user
+);
+
+CREATE INDEX IF NOT EXISTS coach_proposals_portfolio_created_idx
+  ON public.coach_proposals (portfolio_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS coach_proposals_status_idx
+  ON public.coach_proposals (status) WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS coach_proposals_pattern_hash_idx
+  ON public.coach_proposals (pattern_hash) WHERE pattern_hash IS NOT NULL;
+
+COMMENT ON TABLE public.coach_proposals IS
+'Queue des propositions Strategy Coach (Gemini Flash hourly + Pro escalation). User valide avant insert dans scanner_lessons.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. scanner_lesson_citations — tracking impact lessons cited par TRADER
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.scanner_lesson_citations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  cited_at timestamptz NOT NULL DEFAULT now(),
+
+  -- Lesson référencée (peut être null si marker non mappé)
+  lesson_id uuid REFERENCES public.scanner_lessons(id) ON DELETE SET NULL,
+  marker_text text NOT NULL,
+  -- ex: "[PULLBACK_WAIT_KTOS_LESSON]" | "[KELLY_BOOST_A++]" | "pumpScore" | etc.
+
+  -- Source de la citation
+  portfolio_id uuid NOT NULL,
+  decision_decided_at timestamptz NOT NULL,
+  action_kind text NOT NULL,
+  -- 'hold' | 'open_directional' | 'close' | 'trail_stop' | 'scale_in'
+  action_applied boolean NOT NULL DEFAULT false,
+  target_symbol text DEFAULT NULL,
+  confidence numeric(3, 2) DEFAULT NULL,
+
+  -- Outcome si action_applied → trade
+  position_id uuid REFERENCES public.lisa_positions(id) ON DELETE SET NULL,
+  outcome_resolved_at timestamptz DEFAULT NULL,
+  outcome_pnl_usd numeric(10, 2) DEFAULT NULL,
+  outcome_win boolean DEFAULT NULL,
+
+  -- Contexte
+  thesis_excerpt text, -- 300 chars max
+  context_snapshot jsonb DEFAULT NULL
+);
+
+CREATE INDEX IF NOT EXISTS scanner_lesson_citations_lesson_idx
+  ON public.scanner_lesson_citations (lesson_id, cited_at DESC) WHERE lesson_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS scanner_lesson_citations_portfolio_idx
+  ON public.scanner_lesson_citations (portfolio_id, cited_at DESC);
+
+CREATE INDEX IF NOT EXISTS scanner_lesson_citations_marker_idx
+  ON public.scanner_lesson_citations (marker_text, cited_at DESC);
+
+COMMENT ON TABLE public.scanner_lesson_citations IS
+'Track citations des lessons par TRADER. Outcome lié si position fermée. Métriques agrégées pour Lessons Impact Tracker UI.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. RLS policies (read-only pour user, write seulement via service role)
+-- ─────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.coach_proposals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.scanner_lesson_citations ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "coach_proposals_select_owner" ON public.coach_proposals;
+CREATE POLICY "coach_proposals_select_owner" ON public.coach_proposals
+  FOR SELECT USING (
+    portfolio_id IN (
+      SELECT id FROM public.portfolios WHERE user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "scanner_lesson_citations_select_owner" ON public.scanner_lesson_citations;
+CREATE POLICY "scanner_lesson_citations_select_owner" ON public.scanner_lesson_citations
+  FOR SELECT USING (
+    portfolio_id IN (
+      SELECT id FROM public.portfolios WHERE user_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/0174_lisa_reset_markers.sql
+++ b/supabase/migrations/0174_lisa_reset_markers.sql
@@ -1,0 +1,27 @@
+-- 0174 — LISA reset markers (display-only, jamais effacement DB)
+--
+-- Permet à l'utilisateur de "reset" l'affichage des compteurs jour/mois/an
+-- SANS jamais effacer les positions en DB. Le marker est un timestamp à partir
+-- duquel le compteur affiché ignore les trades antérieurs.
+--
+-- Use case : si l'utilisateur a eu une journée catastrophique et veut "repartir
+-- à zéro psychologiquement", il reset le marker jour à NOW. Les trades de la
+-- matinée restent en DB (audit, P&L global réel intact), mais l'UI affiche
+-- "Jour : +$0" jusqu'à la fin de la journée.
+--
+-- Reset annuel reset aussi mois + jour (cascade). Reset mois reset aussi jour.
+-- Reset jour ne reset rien d'autre.
+
+ALTER TABLE public.lisa_session_configs
+  ADD COLUMN IF NOT EXISTS lisa_reset_marker_daily timestamptz DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS lisa_reset_marker_monthly timestamptz DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS lisa_reset_marker_annual timestamptz DEFAULT NULL;
+
+COMMENT ON COLUMN public.lisa_session_configs.lisa_reset_marker_daily IS
+'Si non-null, le compteur jour affiché ignore les trades avec exit_timestamp < marker. Reset display-only, DB intacte.';
+
+COMMENT ON COLUMN public.lisa_session_configs.lisa_reset_marker_monthly IS
+'Idem reset marker mois. Annulable par UPDATE NULL.';
+
+COMMENT ON COLUMN public.lisa_session_configs.lisa_reset_marker_annual IS
+'Idem reset marker année. Action irréversible côté UI (modal "tape RESET pour confirmer").';

--- a/supabase/migrations/0175_push_subscriptions.sql
+++ b/supabase/migrations/0175_push_subscriptions.sql
@@ -1,0 +1,47 @@
+-- Migration 0175 — push_subscriptions (LISA refonte B.4.c).
+--
+-- Stocke les subscriptions Web Push API par user. Un user peut avoir
+-- plusieurs subscriptions (mobile + desktop). Endpoint UNIQUE per user
+-- (re-subscribe → upsert).
+
+CREATE TABLE IF NOT EXISTS public.push_subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  user_id uuid NOT NULL,
+  -- Push service endpoint (Firebase Cloud Messaging, Mozilla Autopush, etc.)
+  endpoint text NOT NULL,
+  -- ECDH public key (base64url) côté client
+  p256dh text NOT NULL,
+  -- Auth secret (base64url) côté client
+  auth text NOT NULL,
+  -- User-Agent à la souscription (debug)
+  user_agent text,
+  -- Dernier envoi réussi (debug + cleanup endpoints stale)
+  last_sent_at timestamptz,
+  last_error text
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS push_subscriptions_user_endpoint_idx
+  ON public.push_subscriptions (user_id, endpoint);
+
+CREATE INDEX IF NOT EXISTS push_subscriptions_user_idx
+  ON public.push_subscriptions (user_id);
+
+ALTER TABLE public.push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "push_subscriptions_select_owner" ON public.push_subscriptions;
+CREATE POLICY "push_subscriptions_select_owner" ON public.push_subscriptions
+  FOR SELECT USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "push_subscriptions_insert_owner" ON public.push_subscriptions;
+CREATE POLICY "push_subscriptions_insert_owner" ON public.push_subscriptions
+  FOR INSERT WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "push_subscriptions_delete_owner" ON public.push_subscriptions;
+CREATE POLICY "push_subscriptions_delete_owner" ON public.push_subscriptions
+  FOR DELETE USING (user_id = auth.uid());
+
+COMMENT ON TABLE public.push_subscriptions IS
+'Web Push API subscriptions LISA B.4.c. Service-role peut envoyer ; user voit/supprime ses propres rows.';
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Refonte complète de la page `/lisa` en agent autonome TRADER (Gemini Pro 2.5) avec boucle d'apprentissage automatique. 15 commits, 3 phases.

**Phase A — Foundation UI**
- A.1 Renommage Gainers → LISA côté UI (DB enum inchangé)
- A.2 Filtrage TRADER portfolio (`b0000001-...`) + hide config panel scanner
- A.3 Section Gains avec badges JOUR/SEMAINE/MOIS/ANNÉE + reset display-only (jamais d'effacement DB)
- A.4 Capital composé dynamique (TRADER sizing utilise `initial + Σ pnl`)
- A.4.1 Anti-spiral guard : DD < -30% → `kill_switch_active=true` auto + bandeau UI
- A.5 Trade markers overlay sur courbe portfolio (Scatter vert/rouge + tooltip enrichi)

**Phase B — Lessons & Notifications**
- B.1 Parser `[MARKER]` thesis + insert `scanner_lesson_citations` + resolver outcomes
- B.2 Lessons Impact Tracker UI (filtres + tri + pagination + win-rate par lesson)
- B.3 Config LISA simplifiée (kill-switch reset + capital + digest + lessons mgmt)
- B.4.a In-app notifications (bell + badge + dropdown polling 30s)
- B.4.b Daily digest email (cron 09:00 UTC via Resend API)
- B.4.c Web Push VAPID (SW + subscription + trigger-only, kill_switch_armed event wiré)

**Phase C — Strategy Coach**
- C.1 `StrategyCoachService` backend (cron horaire @minute 17, Gemini Flash + Pro escalations)
- C.2 Review modal accept/reject lessons + params (bottom sheet mobile, modal desktop)
- C.4 `TraderRetrospectiveService` backend (cron daily 02:00 UTC, auto-enrichit scope `trader_agent_only`)

**Skip volontaire** : C.3 (cron adaptive — over-engineering, hourly suffit).

## Migrations

- 0173_lisa_refonte_phase_a — colonnes config + tables coach_proposals + scanner_lesson_citations
- 0174_lisa_reset_markers — reset markers daily/monthly/annual
- 0175_push_subscriptions — Web Push subscriptions

À appliquer via push de `migrations-trigger-*` après merge sur main.

## Secrets Fly à configurer (post-merge)

- `VAPID_PUBLIC_KEY` + `VAPID_PRIVATE_KEY` + `VAPID_SUBJECT` (B.4.c)
- `NEXT_PUBLIC_VAPID_PUBLIC_KEY` côté Vercel (B.4.c)
- `RESEND_API_KEY` + `DAILY_DIGEST_FROM_EMAIL` (B.4.b)
- Strategy Coach + Retrospective : actifs automatiquement (`GEMINI_API_KEY` déjà set)

Override : `STRATEGY_COACH_ENABLED=false`, `TRADER_RETROSPECTIVE_ENABLED=false`, `DAILY_DIGEST_ENABLED=false` désactivent individuellement.

## Test plan

- [ ] CI typecheck + jest (222/222 local)
- [ ] Migration 0173/0174/0175 appliquées via workflow
- [ ] Page `/lisa` charge sans erreur sur Vercel preview
- [ ] Sticky header affiche brand LISA + Capital + Cible + Σ today + bell
- [ ] GainsTracker affiche 4 cards (mobile : 1 swipeable)
- [ ] CoachProposalsPanel affiche "Aucune proposition" tant que cron pas tiré
- [ ] LessonsImpactPanel affiche "Aucune citation" tant que TRADER pas cité
- [ ] LisaConfigPanel : sections kill-switch (si armé), capital, digest, push, lessons mgmt
- [ ] PortfolioChart : courbe + markers trades visibles si trades dans fenêtre

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_