### PR TITLE
feat(lisa): shadows summary widget read-only (compare HIGH/MIDDLE/SMALL vs TRADER)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -1525,6 +1525,13 @@ export class LisaController {
     return this.lisa.rejectCoachProposal(extractUserId(headers), id, comment);
   }
 
+  // LISA Shadows Summary read-only widget (compare TRADER vs HIGH/MIDDLE/SMALL).
+  @Get('shadows-summary')
+  getShadowsSummary(@Headers() headers: Record<string, string>) {
+    extractUserId(headers); // auth check anti-abuse, pas de filtre user_id
+    return this.lisa.getShadowsSummary();
+  }
+
   // LISA refonte B.4.a — In-app notifications (badge + dropdown).
   @Get('notifications/:portfolioId')
   getNotifications(

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -2875,6 +2875,92 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
   }
 
   /**
+   * LISA — Shadows Summary read-only (B-shadow widget).
+   *
+   * Retourne un snapshot compact des 3 Shadow Sizing portfolios (HIGH/MIDDLE/SMALL)
+   * pour comparaison vs TRADER côté UI. Pas de check ownership : ces portfolios
+   * sont system-managed par ShadowSizingOrchestrator et peuvent ne pas être
+   * owned par l'user qui consulte. Le service-role bypass RLS, donc OK.
+   *
+   * Endpoint public (auth simple via extractUserId pour anti-abuse) — read-only.
+   */
+  async getShadowsSummary() {
+    const client = this.supabase.getClient();
+    const SHADOW_IDS = [
+      { id: 'a0000001-0000-0000-0000-000000000001', name: 'Shadow High Sizing', label: 'HIGH' },
+      { id: 'a0000002-0000-0000-0000-000000000002', name: 'Shadow Middle Sizing', label: 'MIDDLE' },
+      { id: 'a0000003-0000-0000-0000-000000000003', name: 'Shadow Small Sizing', label: 'SMALL' },
+    ];
+    const todayStart = `${new Date().toISOString().slice(0, 10)}T00:00:00Z`;
+
+    const results = await Promise.all(SHADOW_IDS.map(async (shadow) => {
+      const [openRes, closedTodayRes, allClosedRes, configRes] = await Promise.all([
+        client.from('lisa_positions')
+          .select('symbol, entry_price, entry_notional_usd, entry_timestamp')
+          .eq('portfolio_id', shadow.id)
+          .eq('status', 'open'),
+        client.from('lisa_positions')
+          .select('realized_pnl_usd')
+          .eq('portfolio_id', shadow.id)
+          .gte('exit_timestamp', todayStart)
+          .neq('status', 'open'),
+        client.from('lisa_positions')
+          .select('realized_pnl_usd')
+          .eq('portfolio_id', shadow.id)
+          .neq('status', 'open'),
+        client.from('lisa_session_configs')
+          .select('capital_usd, kill_switch_active')
+          .eq('portfolio_id', shadow.id)
+          .maybeSingle(),
+      ]);
+
+      const open = openRes.data ?? [];
+      const closedToday = (closedTodayRes.data ?? []) as Array<{ realized_pnl_usd?: unknown }>;
+      const allClosed = (allClosedRes.data ?? []) as Array<{ realized_pnl_usd?: unknown }>;
+
+      const todayPnl = closedToday.reduce((s, p) => s + Number(p.realized_pnl_usd ?? 0), 0);
+      const todayWins = closedToday.filter((p) => Number(p.realized_pnl_usd ?? 0) > 0).length;
+      const todayLosses = closedToday.filter((p) => Number(p.realized_pnl_usd ?? 0) < 0).length;
+      const cumulativePnl = allClosed.reduce((s, p) => s + Number(p.realized_pnl_usd ?? 0), 0);
+      const allWins = allClosed.filter((p) => Number(p.realized_pnl_usd ?? 0) > 0).length;
+      const allLosses = allClosed.filter((p) => Number(p.realized_pnl_usd ?? 0) < 0).length;
+
+      const cfg = configRes.data as { capital_usd?: string; kill_switch_active?: boolean } | null;
+      const baseCapital = cfg?.capital_usd ? parseFloat(cfg.capital_usd) : 10000;
+      const deployedUsd = open.reduce((s, p) => s + Number((p as { entry_notional_usd?: unknown }).entry_notional_usd ?? 0), 0);
+
+      return {
+        id: shadow.id,
+        name: shadow.name,
+        label: shadow.label,
+        base_capital_usd: baseCapital,
+        current_capital_usd: baseCapital + cumulativePnl,
+        cumulative_pnl_usd: cumulativePnl,
+        return_from_inception_pct: baseCapital > 0 ? (cumulativePnl / baseCapital) * 100 : 0,
+        open_positions: open.length,
+        deployed_usd: deployedUsd,
+        today: {
+          pnl_usd: todayPnl,
+          trades: closedToday.length,
+          wins: todayWins,
+          losses: todayLosses,
+          win_rate_pct: closedToday.length > 0 ? (todayWins / closedToday.length) * 100 : null,
+        },
+        all_time: {
+          trades: allClosed.length,
+          wins: allWins,
+          losses: allLosses,
+          win_rate_pct: allClosed.length > 0 ? (allWins / allClosed.length) * 100 : null,
+        },
+        kill_switch_active: cfg?.kill_switch_active === true,
+        open_symbols: open.map((p) => (p as { symbol?: string }).symbol).filter(Boolean),
+      };
+    }));
+
+    return { generated_at: new Date().toISOString(), shadows: results };
+  }
+
+  /**
    * LISA refonte B.4.a — In-app notifications.
    *
    * Agrège des "items" virtuels depuis plusieurs sources :

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -37,6 +37,7 @@ import { GainsTracker } from '@/components/lisa/gains-tracker';
 import { LessonsImpactPanel } from '@/components/lisa/lessons-impact-panel';
 import { LisaConfigPanel } from '@/components/lisa/lisa-config-panel';
 import { CoachProposalsPanel } from '@/components/lisa/coach-proposals-panel';
+import { ShadowsSummaryPanel } from '@/components/lisa/shadows-summary-panel';
 import { ScalingReadinessPanel } from '@/components/lisa/scaling-readiness-panel';
 import { LiveTradingStatusPanel } from '@/components/lisa/live-trading-status-panel';
 import { LiveTradingWizard } from '@/components/lisa/live-trading-wizard';
@@ -629,6 +630,9 @@ export default function LisaPage() {
 
       {/* LISA refonte C.2 — Strategy Coach proposals (Gemini hourly + review modal) */}
       {selectedPortfolioId && <CoachProposalsPanel portfolioId={selectedPortfolioId} />}
+
+      {/* Shadow Sizing read-only — comparatif HIGH/MIDDLE/SMALL vs TRADER */}
+      <ShadowsSummaryPanel />
 
       {/* LISA refonte B.2 — Lessons Impact Tracker (citations agrégées TRADER) */}
       {selectedPortfolioId && <LessonsImpactPanel portfolioId={selectedPortfolioId} />}

--- a/apps/web/src/components/lisa/shadows-summary-panel.tsx
+++ b/apps/web/src/components/lisa/shadows-summary-panel.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+/**
+ * ShadowsSummaryPanel — comparaison read-only TRADER vs HIGH/MIDDLE/SMALL.
+ *
+ * Affiche 3 cards (1 par shadow portfolio) avec :
+ *   - Capital actuel (initial + Σ pnl) + return %
+ *   - PnL jour + W/L + win-rate jour
+ *   - Positions ouvertes (count + symbols)
+ *   - Stats all-time (trades / WR)
+ *   - Badge kill-switch si armé
+ *
+ * Mobile : grid 1 col stacked. Desktop : 3 col horizontal.
+ * Polling 60s.
+ */
+
+import { Card } from '@/components/ui/card';
+import { useShadowsSummary, type ShadowSummaryRow } from '@/hooks/use-shadows-summary';
+
+function fmtPnl(v: number): { txt: string; cls: string } {
+  if (v === 0) return { txt: '$0.00', cls: 'text-muted-foreground' };
+  const sign = v > 0 ? '+' : '-';
+  return {
+    txt: `${sign}$${Math.abs(v).toFixed(2)}`,
+    cls: v > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400',
+  };
+}
+
+function fmtPct(v: number | null): { txt: string; cls: string } {
+  if (v === null) return { txt: '—', cls: 'text-muted-foreground' };
+  return {
+    txt: `${v.toFixed(0)}%`,
+    cls: v >= 50 ? 'text-emerald-600 dark:text-emerald-400'
+      : v >= 35 ? 'text-amber-600 dark:text-amber-400'
+      : 'text-rose-600 dark:text-rose-400',
+  };
+}
+
+function ShadowCard({ shadow }: { shadow: ShadowSummaryRow }) {
+  const todayPnl = fmtPnl(shadow.today.pnl_usd);
+  const cumPnl = fmtPnl(shadow.cumulative_pnl_usd);
+  const todayWR = fmtPct(shadow.today.win_rate_pct);
+  const allWR = fmtPct(shadow.all_time.win_rate_pct);
+  const retCls = shadow.return_from_inception_pct >= 0
+    ? 'text-emerald-600 dark:text-emerald-400'
+    : 'text-rose-600 dark:text-rose-400';
+
+  return (
+    <div className={`rounded-lg border p-3 space-y-2 ${shadow.kill_switch_active ? 'border-rose-400 bg-rose-50/40 dark:bg-rose-950/20' : ''}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 font-bold">
+            {shadow.label}
+          </span>
+          {shadow.kill_switch_active && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-rose-600 text-white font-semibold">🛑 KILLED</span>
+          )}
+        </div>
+        <span className={`text-xs font-semibold ${retCls} tabular-nums`}>
+          {shadow.return_from_inception_pct >= 0 ? '+' : ''}{shadow.return_from_inception_pct.toFixed(2)}%
+        </span>
+      </div>
+
+      {/* Capital line */}
+      <div className="text-xs">
+        <span className="text-muted-foreground">Capital</span>{' '}
+        <span className="font-semibold tabular-nums">${shadow.current_capital_usd.toFixed(0)}</span>
+        <span className={`ml-1 ${cumPnl.cls} text-[11px]`}>({cumPnl.txt})</span>
+      </div>
+
+      {/* Today metrics */}
+      <div className="rounded bg-muted/40 p-2 text-[11px] space-y-0.5">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">P&amp;L jour</span>
+          <span className={`font-semibold tabular-nums ${todayPnl.cls}`}>{todayPnl.txt}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Trades</span>
+          <span className="tabular-nums">
+            {shadow.today.trades} ({shadow.today.wins}W/{shadow.today.losses}L · <span className={todayWR.cls}>{todayWR.txt}</span>)
+          </span>
+        </div>
+      </div>
+
+      {/* Open positions */}
+      <div className="text-[11px]">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Ouvertes</span>
+          <span className="tabular-nums font-medium">
+            {shadow.open_positions} · ${shadow.deployed_usd.toFixed(0)}
+          </span>
+        </div>
+        {shadow.open_symbols.length > 0 && (
+          <div className="text-[10px] text-muted-foreground truncate mt-0.5">
+            {shadow.open_symbols.join(' · ')}
+          </div>
+        )}
+      </div>
+
+      {/* All-time footer */}
+      <div className="text-[10px] text-muted-foreground border-t pt-1.5">
+        All-time : {shadow.all_time.trades} trades · WR <span className={allWR.cls}>{allWR.txt}</span>
+      </div>
+    </div>
+  );
+}
+
+export function ShadowsSummaryPanel() {
+  const { data, isLoading, isError } = useShadowsSummary();
+
+  return (
+    <Card className="p-4">
+      <div className="mb-3">
+        <h3 className="text-sm font-semibold flex items-center gap-2">
+          🥽 Shadow Sizing — comparatif HIGH / MIDDLE / SMALL
+        </h3>
+        <p className="text-[11px] text-muted-foreground mt-0.5">
+          Portfolios système A/B (read-only). Comparer la perf des 3 profils de sizing vs TRADER pour calibrer le sizing optimal.
+        </p>
+      </div>
+
+      {isLoading && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="animate-pulse h-40 bg-muted rounded-lg" />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <div className="text-xs text-rose-600 dark:text-rose-400 py-2">
+          Erreur de chargement des shadows.
+        </div>
+      )}
+
+      {!isLoading && data && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          {data.shadows.map((s) => (
+            <ShadowCard key={s.id} shadow={s} />
+          ))}
+        </div>
+      )}
+
+      {data && (
+        <div className="text-[10px] text-muted-foreground mt-2 text-right">
+          Snapshot {new Date(data.generated_at).toLocaleTimeString('fr-FR')} · refresh 60s
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/hooks/use-shadows-summary.ts
+++ b/apps/web/src/hooks/use-shadows-summary.ts
@@ -1,0 +1,47 @@
+// LISA — Shadows Summary hook (compare TRADER vs HIGH/MIDDLE/SMALL).
+
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+export interface ShadowSummaryRow {
+  id: string;
+  name: string;
+  label: 'HIGH' | 'MIDDLE' | 'SMALL';
+  base_capital_usd: number;
+  current_capital_usd: number;
+  cumulative_pnl_usd: number;
+  return_from_inception_pct: number;
+  open_positions: number;
+  deployed_usd: number;
+  today: {
+    pnl_usd: number;
+    trades: number;
+    wins: number;
+    losses: number;
+    win_rate_pct: number | null;
+  };
+  all_time: {
+    trades: number;
+    wins: number;
+    losses: number;
+    win_rate_pct: number | null;
+  };
+  kill_switch_active: boolean;
+  open_symbols: string[];
+}
+
+export interface ShadowsSummaryResponse {
+  generated_at: string;
+  shadows: ShadowSummaryRow[];
+}
+
+export function useShadowsSummary() {
+  return useQuery({
+    queryKey: ['lisa', 'shadows-summary'],
+    queryFn: () => apiFetch<ShadowsSummaryResponse>('/lisa/shadows-summary'),
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+}


### PR DESCRIPTION
## Summary

Le user a seulement TRADER comme portfolio `is_simulation=true` (Shadows resetés par `ShadowSizingOrchestratorService`). Le dropdown selector est caché par design (length === 1). Ce widget read-only permet quand même de **comparer TRADER vs HIGH/MIDDLE/SMALL** sans toucher au mécanisme système.

## Backend

- `LisaService.getShadowsSummary()` — fetch parallel pour chacun des 3 IDs hardcodés (`a0000001/2/3`) : open + closed today + cumulative + config. Bypass RLS via service-role, pas de check ownership.
- `GET /lisa/shadows-summary` endpoint (auth simple anti-abuse).

## Frontend

- `useShadowsSummary()` hook polling 60s
- `<ShadowsSummaryPanel>` :
  - Grid responsive : `md:grid-cols-3` desktop, 1 col stacked mobile
  - Par card : badge label (HIGH/MIDDLE/SMALL bleu), return inception vert/rouge, capital, cumulative P&L, P&L jour, W/L, win-rate jour coloré (≥50 vert, ≥35 ambre, <35 rouge), positions ouvertes count + symbols, footer all-time
  - Badge **🛑 KILLED** rouge si `kill_switch_active=true`
- Intégré dans `/lisa` sous `CoachProposalsPanel`, au-dessus de `LessonsImpactPanel`

## Test plan

- [ ] CI typecheck + jest (222/222 local)
- [ ] Page `/lisa` charge → widget Shadow Summary visible
- [ ] 3 cards affichent stats HIGH/MIDDLE/SMALL avec leurs IDs hardcodés
- [ ] Refresh 60s auto via React Query
- [ ] Mobile : 1 col stacked, lisible

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_