### PR TITLE
fix(lisa): shadows widget — bonne source shadow_sizing_snapshot + reposition au-dessus de Strategy Coach

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -2891,43 +2891,88 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       { id: 'a0000002-0000-0000-0000-000000000002', name: 'Shadow Middle Sizing', label: 'MIDDLE' },
       { id: 'a0000003-0000-0000-0000-000000000003', name: 'Shadow Small Sizing', label: 'SMALL' },
     ];
-    const todayStart = `${new Date().toISOString().slice(0, 10)}T00:00:00Z`;
 
-    const results = await Promise.all(SHADOW_IDS.map(async (shadow) => {
-      const [openRes, closedTodayRes, allClosedRes, configRes] = await Promise.all([
-        client.from('lisa_positions')
-          .select('symbol, entry_price, entry_notional_usd, entry_timestamp')
-          .eq('portfolio_id', shadow.id)
-          .eq('status', 'open'),
-        client.from('lisa_positions')
-          .select('realized_pnl_usd')
-          .eq('portfolio_id', shadow.id)
-          .gte('exit_timestamp', todayStart)
-          .neq('status', 'open'),
-        client.from('lisa_positions')
-          .select('realized_pnl_usd')
-          .eq('portfolio_id', shadow.id)
-          .neq('status', 'open'),
-        client.from('lisa_session_configs')
-          .select('capital_usd, kill_switch_active')
-          .eq('portfolio_id', shadow.id)
-          .maybeSingle(),
-      ]);
+    // Latest snapshot par portfolio (table shadow_sizing_snapshot, écrite chaque
+    // cycle 5min par ShadowSizingOrchestratorService).
+    const { data: snapshots } = await client
+      .from('shadow_sizing_snapshot')
+      .select('portfolio_id, profile_name, open_positions, closed_today, realized_pnl_usd, unrealized_pnl_usd, total_pnl_usd, win_rate_pct, fees_paid_usd, net_pnl_after_fees_usd, daily_pnl_extrapolated_usd, target_progress_pct, drawdown_today_pct, capacity_used_pct, created_at')
+      .in('portfolio_id', SHADOW_IDS.map((s) => s.id))
+      .order('created_at', { ascending: false })
+      .limit(30);
 
-      const open = openRes.data ?? [];
-      const closedToday = (closedTodayRes.data ?? []) as Array<{ realized_pnl_usd?: unknown }>;
-      const allClosed = (allClosedRes.data ?? []) as Array<{ realized_pnl_usd?: unknown }>;
+    const latestByPortfolio = new Map<string, Record<string, unknown>>();
+    for (const row of (snapshots ?? []) as Array<Record<string, unknown>>) {
+      const pid = String(row.portfolio_id ?? '');
+      if (!latestByPortfolio.has(pid)) latestByPortfolio.set(pid, row);
+    }
 
-      const todayPnl = closedToday.reduce((s, p) => s + Number(p.realized_pnl_usd ?? 0), 0);
-      const todayWins = closedToday.filter((p) => Number(p.realized_pnl_usd ?? 0) > 0).length;
-      const todayLosses = closedToday.filter((p) => Number(p.realized_pnl_usd ?? 0) < 0).length;
-      const cumulativePnl = allClosed.reduce((s, p) => s + Number(p.realized_pnl_usd ?? 0), 0);
-      const allWins = allClosed.filter((p) => Number(p.realized_pnl_usd ?? 0) > 0).length;
-      const allLosses = allClosed.filter((p) => Number(p.realized_pnl_usd ?? 0) < 0).length;
+    const [configsRes, openSymbolsRes, cumPnlRes] = await Promise.all([
+      client
+        .from('lisa_session_configs')
+        .select('portfolio_id, capital_usd, kill_switch_active')
+        .in('portfolio_id', SHADOW_IDS.map((s) => s.id)),
+      client
+        .from('lisa_positions')
+        .select('portfolio_id, symbol, entry_notional_usd')
+        .in('portfolio_id', SHADOW_IDS.map((s) => s.id))
+        .eq('status', 'open'),
+      client
+        .from('lisa_positions')
+        .select('portfolio_id, realized_pnl_usd')
+        .in('portfolio_id', SHADOW_IDS.map((s) => s.id))
+        .neq('status', 'open'),
+    ]);
 
-      const cfg = configRes.data as { capital_usd?: string; kill_switch_active?: boolean } | null;
+    const configByPortfolio = new Map<string, { capital_usd?: string; kill_switch_active?: boolean }>();
+    for (const c of (configsRes.data ?? []) as Array<{ portfolio_id: string; capital_usd?: string; kill_switch_active?: boolean }>) {
+      configByPortfolio.set(c.portfolio_id, c);
+    }
+    const symbolsByPortfolio = new Map<string, string[]>();
+    const deployedByPortfolio = new Map<string, number>();
+    for (const p of (openSymbolsRes.data ?? []) as Array<{ portfolio_id: string; symbol?: string; entry_notional_usd?: unknown }>) {
+      const arr = symbolsByPortfolio.get(p.portfolio_id) ?? [];
+      if (p.symbol) arr.push(p.symbol);
+      symbolsByPortfolio.set(p.portfolio_id, arr);
+      deployedByPortfolio.set(p.portfolio_id, (deployedByPortfolio.get(p.portfolio_id) ?? 0) + Number(p.entry_notional_usd ?? 0));
+    }
+    const cumPnlByPortfolio = new Map<string, number>();
+    const tradesByPortfolio = new Map<string, number>();
+    const winsByPortfolio = new Map<string, number>();
+    for (const p of (cumPnlRes.data ?? []) as Array<{ portfolio_id: string; realized_pnl_usd?: unknown }>) {
+      const pnl = Number(p.realized_pnl_usd ?? 0);
+      cumPnlByPortfolio.set(p.portfolio_id, (cumPnlByPortfolio.get(p.portfolio_id) ?? 0) + pnl);
+      tradesByPortfolio.set(p.portfolio_id, (tradesByPortfolio.get(p.portfolio_id) ?? 0) + 1);
+      if (pnl > 0) winsByPortfolio.set(p.portfolio_id, (winsByPortfolio.get(p.portfolio_id) ?? 0) + 1);
+    }
+
+    const results = SHADOW_IDS.map((shadow) => {
+      const snap = latestByPortfolio.get(shadow.id);
+      const cfg = configByPortfolio.get(shadow.id);
+      const openSyms = symbolsByPortfolio.get(shadow.id) ?? [];
       const baseCapital = cfg?.capital_usd ? parseFloat(cfg.capital_usd) : 10000;
-      const deployedUsd = open.reduce((s, p) => s + Number((p as { entry_notional_usd?: unknown }).entry_notional_usd ?? 0), 0);
+      const cumulativePnl = cumPnlByPortfolio.get(shadow.id) ?? 0;
+
+      const openPositions = snap ? Number(snap.open_positions ?? 0) : openSyms.length;
+      const closedToday = snap ? Number(snap.closed_today ?? 0) : 0;
+      const realizedToday = snap ? Number(snap.realized_pnl_usd ?? 0) : 0;
+      const netToday = snap ? Number(snap.net_pnl_after_fees_usd ?? 0) : 0;
+      const winRateToday = snap?.win_rate_pct !== undefined && snap?.win_rate_pct !== null
+        ? Number(snap.win_rate_pct)
+        : null;
+      const winsToday = winRateToday !== null && closedToday > 0
+        ? Math.round((winRateToday / 100) * closedToday)
+        : 0;
+      const lossesToday = winRateToday !== null && closedToday > 0
+        ? closedToday - winsToday
+        : 0;
+      const drawdownToday = snap ? Number(snap.drawdown_today_pct ?? 0) : 0;
+      const targetProgress = snap ? Number(snap.target_progress_pct ?? 0) : 0;
+      const feesToday = snap ? Number(snap.fees_paid_usd ?? 0) : 0;
+
+      const allTimeTrades = tradesByPortfolio.get(shadow.id) ?? 0;
+      const allTimeWins = winsByPortfolio.get(shadow.id) ?? 0;
+      const allTimeWinRate = allTimeTrades > 0 ? (allTimeWins / allTimeTrades) * 100 : null;
 
       return {
         id: shadow.id,
@@ -2937,25 +2982,30 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         current_capital_usd: baseCapital + cumulativePnl,
         cumulative_pnl_usd: cumulativePnl,
         return_from_inception_pct: baseCapital > 0 ? (cumulativePnl / baseCapital) * 100 : 0,
-        open_positions: open.length,
-        deployed_usd: deployedUsd,
+        open_positions: openPositions,
+        deployed_usd: deployedByPortfolio.get(shadow.id) ?? 0,
         today: {
-          pnl_usd: todayPnl,
-          trades: closedToday.length,
-          wins: todayWins,
-          losses: todayLosses,
-          win_rate_pct: closedToday.length > 0 ? (todayWins / closedToday.length) * 100 : null,
+          pnl_usd: realizedToday,
+          net_pnl_after_fees_usd: netToday,
+          fees_usd: feesToday,
+          trades: closedToday,
+          wins: winsToday,
+          losses: lossesToday,
+          win_rate_pct: winRateToday,
+          drawdown_pct: drawdownToday,
+          target_progress_pct: targetProgress,
         },
         all_time: {
-          trades: allClosed.length,
-          wins: allWins,
-          losses: allLosses,
-          win_rate_pct: allClosed.length > 0 ? (allWins / allClosed.length) * 100 : null,
+          trades: allTimeTrades,
+          wins: allTimeWins,
+          losses: allTimeTrades - allTimeWins,
+          win_rate_pct: allTimeWinRate,
         },
         kill_switch_active: cfg?.kill_switch_active === true,
-        open_symbols: open.map((p) => (p as { symbol?: string }).symbol).filter(Boolean),
+        open_symbols: openSyms,
+        snapshot_at: snap?.created_at ? String(snap.created_at) : null,
       };
-    }));
+    });
 
     return { generated_at: new Date().toISOString(), shadows: results };
   }

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -640,11 +640,11 @@ export default function LisaPage() {
       {/* LISA refonte A.3 — Section Gains (badges + reset display-only) */}
       {selectedPortfolioId && <GainsTracker portfolioId={selectedPortfolioId} />}
 
-      {/* LISA refonte C.2 — Strategy Coach proposals (Gemini hourly + review modal) */}
-      {selectedPortfolioId && <CoachProposalsPanel portfolioId={selectedPortfolioId} />}
-
       {/* Shadow Sizing read-only — comparatif HIGH/MIDDLE/SMALL vs TRADER */}
       <ShadowsSummaryPanel />
+
+      {/* LISA refonte C.2 — Strategy Coach proposals (Gemini hourly + review modal) */}
+      {selectedPortfolioId && <CoachProposalsPanel portfolioId={selectedPortfolioId} />}
 
       {/* LISA refonte B.2 — Lessons Impact Tracker (citations agrégées TRADER) */}
       {selectedPortfolioId && <LessonsImpactPanel portfolioId={selectedPortfolioId} />}

--- a/apps/web/src/components/lisa/shadows-summary-panel.tsx
+++ b/apps/web/src/components/lisa/shadows-summary-panel.tsx
@@ -72,14 +72,24 @@ function ShadowCard({ shadow }: { shadow: ShadowSummaryRow }) {
       {/* Today metrics */}
       <div className="rounded bg-muted/40 p-2 text-[11px] space-y-0.5">
         <div className="flex justify-between">
-          <span className="text-muted-foreground">P&amp;L jour</span>
+          <span className="text-muted-foreground">P&amp;L jour (réalisé)</span>
           <span className={`font-semibold tabular-nums ${todayPnl.cls}`}>{todayPnl.txt}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Net après frais</span>
+          <span className={`tabular-nums ${fmtPnl(shadow.today.net_pnl_after_fees_usd).cls}`}>
+            {fmtPnl(shadow.today.net_pnl_after_fees_usd).txt}
+          </span>
         </div>
         <div className="flex justify-between">
           <span className="text-muted-foreground">Trades</span>
           <span className="tabular-nums">
             {shadow.today.trades} ({shadow.today.wins}W/{shadow.today.losses}L · <span className={todayWR.cls}>{todayWR.txt}</span>)
           </span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Cible $200/j</span>
+          <span className="tabular-nums">{shadow.today.target_progress_pct.toFixed(0)}%</span>
         </div>
       </div>
 
@@ -142,9 +152,10 @@ export function ShadowsSummaryPanel() {
         </div>
       )}
 
-      {data && (
+      {data && data.shadows[0]?.snapshot_at && (
         <div className="text-[10px] text-muted-foreground mt-2 text-right">
-          Snapshot {new Date(data.generated_at).toLocaleTimeString('fr-FR')} · refresh 60s
+          Snapshot shadow {new Date(data.shadows[0].snapshot_at).toLocaleTimeString('fr-FR')} ·
+          refresh client 60s · données 5min cycle backend
         </div>
       )}
     </Card>

--- a/apps/web/src/hooks/use-shadows-summary.ts
+++ b/apps/web/src/hooks/use-shadows-summary.ts
@@ -1,4 +1,5 @@
 // LISA — Shadows Summary hook (compare TRADER vs HIGH/MIDDLE/SMALL).
+// Source : shadow_sizing_snapshot (latest par portfolio) + cumul lisa_positions.
 
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api-client';
@@ -15,10 +16,14 @@ export interface ShadowSummaryRow {
   deployed_usd: number;
   today: {
     pnl_usd: number;
+    net_pnl_after_fees_usd: number;
+    fees_usd: number;
     trades: number;
     wins: number;
     losses: number;
     win_rate_pct: number | null;
+    drawdown_pct: number;
+    target_progress_pct: number;
   };
   all_time: {
     trades: number;
@@ -28,6 +33,7 @@ export interface ShadowSummaryRow {
   };
   kill_switch_active: boolean;
   open_symbols: string[];
+  snapshot_at: string | null;
 }
 
 export interface ShadowsSummaryResponse {


### PR DESCRIPTION
## Summary

2 fixes :

### 1. Bug data zéro
Le widget Shadow Summary affichait tout à 0 car j'interrogeais `lisa_positions` alors que `ShadowSizingOrchestratorService` stocke les KPIs cycle 5min dans la table dédiée `shadow_sizing_snapshot`.

**Fix** : `LisaService.getShadowsSummary()` query maintenant `shadow_sizing_snapshot` ORDER BY created_at DESC LIMIT 30, dedup par portfolio_id (Map), récupère les vraies KPIs (open_positions, closed_today, realized_pnl_usd, net_pnl_after_fees_usd, win_rate_pct, fees_paid_usd, drawdown_today_pct, target_progress_pct). Agrège `lisa_positions` pour cumulative all-time. Fetch parallel config + open symbols.

### 2. Repositionnement visuel
User demande : Shadow Summary AU-DESSUS de Strategy Coach (pas en-dessous) — pour comparer les KPIs naturellement avant de lire les propositions Coach.

**Nouvel ordre** : Sticky → Mode → GainsTracker → **Shadow Summary** → Strategy Coach → Lessons Impact → Config

### 3. Enrichissement carte
La carte today affiche maintenant : P&L réalisé + Net après frais + Trades W/L + WR + % cible $200/j. Footer affiche timestamp snapshot backend (5min cycle).

## Test plan

- [ ] CI TS + Jest (222/222 local)
- [ ] Vercel preview : widget affiche les vraies KPIs (pas tout zéro)
- [ ] Position : entre GainsTracker et Strategy Coach
- [ ] Carte today : 4 lignes (P&L réalisé, Net après frais, Trades, Cible)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_