### PR TITLE
fix(lisa): UI résiliente — dropdown toujours visible + bouton retour TRADER + défauts si pas de config

### DIFF
--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -575,29 +575,40 @@ export default function LisaPage() {
 
       <DisclaimerBanner />
 
-      {/* Portfolio selector — TRADER par défaut (agent autonome Gemini Pro).
-          Switch vers MAIN/HIGH/MIDDLE/SMALL pour inspecter les scanners
-          Gainers déterministes (shadow sizing A/B/C). */}
-      {simulationPortfolios.length > 1 && (
+      {/* Portfolio selector — TOUJOURS visible (même 1 portfolio) + bouton
+          retour rapide TRADER si pas sélectionné. */}
+      {simulationPortfolios.length >= 1 && (
         <div className="space-y-1.5">
           <label className="block text-sm font-medium">Portefeuille de simulation</label>
-          <select
-            value={selectedPortfolioId ?? ''}
-            onChange={(e) => setSelectedPortfolioId(e.target.value || null)}
-            className="h-9 w-full rounded-md border bg-background px-3 text-sm"
-          >
-            {simulationPortfolios.map((p) => {
-              const isTrader = p.id === TRADER_PORTFOLIO_ID;
-              const label = isTrader
-                ? `🤖 ${p.name} (agent autonome LISA)`
-                : `🎯 ${p.name} (scanner Gainers)`;
-              return (
-                <option key={p.id} value={p.id}>{label}</option>
-              );
-            })}
-          </select>
+          <div className="flex gap-2 flex-wrap">
+            <select
+              value={selectedPortfolioId ?? ''}
+              onChange={(e) => setSelectedPortfolioId(e.target.value || null)}
+              className="h-9 flex-1 min-w-[200px] rounded-md border bg-background px-3 text-sm"
+            >
+              {simulationPortfolios.map((p) => {
+                const isTrader = p.id === TRADER_PORTFOLIO_ID;
+                const label = isTrader
+                  ? `🤖 ${p.name} (agent autonome LISA)`
+                  : `🎯 ${p.name}`;
+                return (
+                  <option key={p.id} value={p.id}>{label}</option>
+                );
+              })}
+            </select>
+            {selectedPortfolioId !== TRADER_PORTFOLIO_ID &&
+              simulationPortfolios.some((p) => p.id === TRADER_PORTFOLIO_ID) && (
+                <button
+                  type="button"
+                  onClick={() => setSelectedPortfolioId(TRADER_PORTFOLIO_ID)}
+                  className="h-9 px-4 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 whitespace-nowrap"
+                >
+                  🤖 Retour TRADER
+                </button>
+              )}
+          </div>
           <p className="text-[11px] text-muted-foreground">
-            TRADER = agent LLM autonome Gemini Pro 2.5. MAIN/HIGH/MIDDLE/SMALL = scanners momentum déterministes (shadow sizing).
+            TRADER = agent LLM autonome Gemini Pro 2.5. Shadow High/Middle/Small = scanners momentum A/B (read-only).
           </p>
         </div>
       )}

--- a/apps/web/src/hooks/use-lisa-targets.ts
+++ b/apps/web/src/hooks/use-lisa-targets.ts
@@ -101,17 +101,16 @@ export function useLisaTargetsAndStats(portfolioId: string | null) {
     const config = configQuery.data as Record<string, unknown> | null;
     const positions = (positionsQuery.data ?? []) as LisaPosition[];
 
-    if (!config) {
-      return {
-        targets: null, stats: null, currentCapital: null,
-        initialCapital: null, drawdownFromInitialPct: null, killSwitchActive: false,
-        isLoading: true,
-      };
-    }
+    // Robustesse : si pas de config (portfolio nouvellement créé sans
+    // lisa_session_configs row), on utilise un objet vide → tous les
+    // ?? défauts ci-dessous s'appliquent (capital $10k, target $200/j,
+    // etc.). Évite que GainsTracker et LisaStickyHeader restent en
+    // skeleton infini quand l'user switch sur un Shadow portfolio.
+    const safeCfg = config ?? ({} as Record<string, unknown>);
 
-    const initialCapital = Number(config.lisa_initial_capital_usd ?? 10000);
-    const compoundEnabled = Boolean(config.lisa_compound_pnl_enabled ?? true);
-    const killSwitchActive = Boolean(config.kill_switch_active ?? false);
+    const initialCapital = Number(safeCfg.lisa_initial_capital_usd ?? 10000);
+    const compoundEnabled = Boolean(safeCfg.lisa_compound_pnl_enabled ?? true);
+    const killSwitchActive = Boolean(safeCfg.kill_switch_active ?? false);
 
     // Compute current capital from closed positions
     const closedPositions = positions.filter((p) => p.status !== 'open');
@@ -122,29 +121,29 @@ export function useLisaTargetsAndStats(portfolioId: string | null) {
     // Build targets Mode C (MAX usd, pct × capital)
     const targets: LisaTargets = {
       daily: {
-        usd: Number(config.lisa_target_daily_usd ?? 200),
-        pct: Number(config.lisa_target_daily_pct ?? 2),
+        usd: Number(safeCfg.lisa_target_daily_usd ?? 200),
+        pct: Number(safeCfg.lisa_target_daily_pct ?? 2),
         effective: computeEffectiveTarget(
-          Number(config.lisa_target_daily_usd ?? 200),
-          Number(config.lisa_target_daily_pct ?? 2),
+          Number(safeCfg.lisa_target_daily_usd ?? 200),
+          Number(safeCfg.lisa_target_daily_pct ?? 2),
           currentCapital,
         ),
       },
       monthly: {
-        usd: Number(config.lisa_target_monthly_usd ?? 4000),
-        pct: Number(config.lisa_target_monthly_pct ?? 20),
+        usd: Number(safeCfg.lisa_target_monthly_usd ?? 4000),
+        pct: Number(safeCfg.lisa_target_monthly_pct ?? 20),
         effective: computeEffectiveTarget(
-          Number(config.lisa_target_monthly_usd ?? 4000),
-          Number(config.lisa_target_monthly_pct ?? 20),
+          Number(safeCfg.lisa_target_monthly_usd ?? 4000),
+          Number(safeCfg.lisa_target_monthly_pct ?? 20),
           currentCapital,
         ),
       },
       annual: {
-        usd: Number(config.lisa_target_annual_usd ?? 50000),
-        pct: Number(config.lisa_target_annual_pct ?? 100),
+        usd: Number(safeCfg.lisa_target_annual_usd ?? 50000),
+        pct: Number(safeCfg.lisa_target_annual_pct ?? 100),
         effective: computeEffectiveTarget(
-          Number(config.lisa_target_annual_usd ?? 50000),
-          Number(config.lisa_target_annual_pct ?? 100),
+          Number(safeCfg.lisa_target_annual_usd ?? 50000),
+          Number(safeCfg.lisa_target_annual_pct ?? 100),
           currentCapital,
         ),
       },
@@ -152,7 +151,7 @@ export function useLisaTargetsAndStats(portfolioId: string | null) {
 
     // Stats par scope avec reset markers
     const buildStats = (scope: LisaScope, target: number): LisaScopeStats => {
-      const resetMarker = (config[`lisa_reset_marker_${scope === 'weekly' ? 'daily' : scope}`] as string | null) ?? null;
+      const resetMarker = (safeCfg[`lisa_reset_marker_${scope === 'weekly' ? 'daily' : scope}`] as string | null) ?? null;
       const startIso = scopeStartIso(scope, resetMarker);
       const inScope = closedPositions.filter(
         (p) => p.exitTimestamp != null && p.exitTimestamp >= startIso,


### PR DESCRIPTION
## Summary

User bloqué sur Shadow High portfolio sans moyen évident de revenir à TRADER. 3 fixes UX :

1. **Dropdown TOUJOURS visible** (avant : caché si `length > 1`, now : `>= 1`)
2. **Bouton "🤖 Retour TRADER"** à droite du dropdown (1 clic, visible)
3. **Hook `useLisaTargetsAndStats` robuste** : `safeCfg = config ?? {}` au lieu de retourner `isLoading: true` quand config null → GainsTracker et LisaStickyHeader rendent avec défauts ($10k capital, $200/j target) au lieu de skeleton infini

Résultat : page utilisable sur tous les portfolios, même Shadow nouvellement créés sans `lisa_session_configs`.

## Test plan

- [x] TypeScript clean
- [ ] Vercel preview : dropdown visible avec >= 1 portfolio
- [ ] Bouton "🤖 Retour TRADER" visible si pas sur TRADER
- [ ] Switch Shadow → GainsTracker + StickyHeader rendent avec défauts (pas skeleton)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_