### PR TITLE
fix(lisa): force TRADER toujours présent dans dropdown portfolios (fallback synthétique)

### DIFF
--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { Sparkles, Target, ShieldAlert, TrendingUp, Activity, ChevronDown, ChevronUp, SlidersHorizontal } from 'lucide-react';
 import { usePortfolios } from '@/hooks/use-portfolio';
-import { deduplicateSimulationPortfolios } from '@/app/actions/paper-portfolio';
+// import { deduplicateSimulationPortfolios } from '@/app/actions/paper-portfolio'; // ⚠️ DÉSACTIVÉ (bug cascade delete)
 import { useQueryClient } from '@tanstack/react-query';
 import {
   useLisaConfig,
@@ -142,14 +142,13 @@ export default function LisaPage() {
     }
   }, [simulationPortfolios, selectedPortfolioId]);
 
-  // Déduplique silencieusement les portefeuilles de simulation au montage.
-  useEffect(() => {
-    if (simulationPortfolios.length > 1) {
-      deduplicateSimulationPortfolios()
-        .then((n) => { if (n > 0) qc.invalidateQueries({ queryKey: ['portfolios'] }); })
-        .catch(() => {});
-    }
-  }, [simulationPortfolios.length]); // eslint-disable-line
+  // 🚨 DÉSACTIVÉ — la fonction deduplicateSimulationPortfolios garde le
+  // portfolio le PLUS RÉCENT et SUPPRIME tous les autres. Sur /lisa où on
+  // a TRADER + 3 Shadows par design (et pas des doublons), elle DESTRUIT
+  // tous les portfolios sauf le dernier créé. Bug catastrophique observé
+  // 30/05/2026 : TRADER + Shadow Middle + Small supprimés en cascade.
+  // La logique reste dispo côté /actions/paper-portfolio.ts pour les pages
+  // qui en ont vraiment besoin (dashboard standard).
   const [userFocus, setUserFocus] = useState('');
   const [killReason, setKillReason] = useState('');
 

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -92,9 +92,36 @@ const TRADER_PORTFOLIO_ID = 'b0000001-0000-0000-0000-000000000001';
 export default function LisaPage() {
   const portfoliosQuery = usePortfolios();
   const qc = useQueryClient();
-  const simulationPortfolios = (portfoliosQuery.data ?? []).filter(
+  // Filter sim portfolios par is_simulation. TRADER + 3 Shadows + le perso.
+  const rawSimPortfolios = (portfoliosQuery.data ?? []).filter(
     (p) => (p as { is_simulation?: boolean }).is_simulation,
   );
+
+  // Garantit que TRADER est TOUJOURS dans la liste (même si is_simulation
+  // est False côté DB suite à un reset par un service système). Évite que
+  // l'user se retrouve bloqué sur un Shadow sans pouvoir revenir.
+  const simulationPortfolios = useMemo(() => {
+    const list = [...rawSimPortfolios];
+    const allPortfolios = portfoliosQuery.data ?? [];
+    const traderInList = list.some((p) => p.id === TRADER_PORTFOLIO_ID);
+    if (!traderInList) {
+      // Cherche TRADER dans la liste complète (sans filtre is_simulation)
+      const traderRaw = allPortfolios.find(
+        (p) => (p as { id?: string }).id === TRADER_PORTFOLIO_ID,
+      );
+      if (traderRaw) {
+        list.unshift(traderRaw as typeof list[number]);
+      } else {
+        // Fallback : entry synthétique. Au moins l'option apparaît au dropdown.
+        list.unshift({
+          id: TRADER_PORTFOLIO_ID,
+          name: 'Trader Agent (Gemini Pro)',
+        } as typeof list[number]);
+      }
+    }
+    return list;
+  }, [rawSimPortfolios, portfoliosQuery.data]);
+
   // Find TRADER specifically (fallback first simulation portfolio si introuvable).
   const traderPortfolio = simulationPortfolios.find((p) => p.id === TRADER_PORTFOLIO_ID);
 


### PR DESCRIPTION
## Summary

TRADER (b0000001) parfois absent de la liste portfolios DB (suppressions/réassignations user_id par services système). User se retrouvait bloqué sur Shadow sans option de retour.

**Fix** : `useMemo` qui prepend TRADER au dropdown :
- Si TRADER dans portfolios full list → ajoute
- Sinon → entry synthétique `{ id: TRADER_PORTFOLIO_ID, name: 'Trader Agent (Gemini Pro)' }`

Combiné avec le bouton "🤖 Retour TRADER" du commit précédent, l'user peut TOUJOURS revenir à TRADER.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_