### PR TITLE
feat(cost): Gemini cost-cuts Tier 1 (A,B,D,F,G — économie estimée $15-30/jour)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.llm.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.llm.spec.ts
@@ -41,9 +41,16 @@ function makeLlmRouter(isEnabled: boolean, callImpl?: jest.Mock): ScannerLlmRout
   } as unknown as ScannerLlmRouterService;
 }
 
-function makeService(llmRouter: ScannerLlmRouterService): TopGainersScannerService {
+function makeService(
+  llmRouter: ScannerLlmRouterService,
+  envOverrides: Record<string, string | undefined> = {},
+): TopGainersScannerService {
   mockConfig.get.mockImplementation((key: string) => {
+    if (envOverrides[key] !== undefined) return envOverrides[key];
     if (key === 'SCAN_INTERVAL_MINUTES') return '15';
+    // 31/05/2026 cost-cut : SCANNER_LLM_RANKING_ENABLED default OFF en prod.
+    // Les tests rankCandidates qui veulent la branche LLM doivent l'enable
+    // explicitement via envOverrides.
     return undefined;
   });
   return new TopGainersScannerService(
@@ -186,7 +193,8 @@ describe('rankCandidates', () => {
       latencyMs: 900,
       fallbackUsed: false,
     });
-    const svc = makeService(makeLlmRouter(true, callMock));
+    // 31/05/2026 — enable LLM ranking explicitly (default OFF en prod après cost-cuts).
+    const svc = makeService(makeLlmRouter(true, callMock), { SCANNER_LLM_RANKING_ENABLED: 'true' });
     const result = await (svc as any).rankCandidates([candA, candB, candC]);
     expect(result.map((c: typeof candA) => c.symbol)).toEqual(['SOLUSDT', 'BTCUSDT', 'ETHUSDT']);
   });
@@ -199,7 +207,7 @@ describe('rankCandidates', () => {
       latencyMs: 700,
       fallbackUsed: false,
     });
-    const svc = makeService(makeLlmRouter(true, callMock));
+    const svc = makeService(makeLlmRouter(true, callMock), { SCANNER_LLM_RANKING_ENABLED: 'true' });
     const result = await (svc as any).rankCandidates([candA, candB, candC]);
     expect(result[0].symbol).toBe('BTCUSDT');
     // Missing symbols are appended in original order
@@ -210,9 +218,25 @@ describe('rankCandidates', () => {
 
   it('C: returns deterministic order when LLM throws', async () => {
     const callMock = jest.fn().mockRejectedValue(new Error('timeout'));
+    const svc = makeService(makeLlmRouter(true, callMock), { SCANNER_LLM_RANKING_ENABLED: 'true' });
+    const result = await (svc as any).rankCandidates([candA, candB, candC]);
+    expect(result.map((c: typeof candA) => c.symbol)).toEqual(['BTCUSDT', 'ETHUSDT', 'SOLUSDT']);
+  });
+
+  // 31/05/2026 — cost-cut Tier 1 default behavior validation.
+  it('D: returns deterministic order when SCANNER_LLM_RANKING_ENABLED is false (default)', async () => {
+    const callMock = jest.fn().mockResolvedValue({
+      content: JSON.stringify(['SOLUSDT', 'ETHUSDT', 'BTCUSDT']),  // LLM would re-order
+      providerId: 'gemini-flash-lite',
+      costUsd: 0.00013,
+      latencyMs: 900,
+      fallbackUsed: false,
+    });
+    // Pas d'envOverrides → flag undefined → default OFF → LLM NON appelé.
     const svc = makeService(makeLlmRouter(true, callMock));
     const result = await (svc as any).rankCandidates([candA, candB, candC]);
     expect(result.map((c: typeof candA) => c.symbol)).toEqual(['BTCUSDT', 'ETHUSDT', 'SOLUSDT']);
+    expect(callMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/modules/lisa/services/early-exit-guard.service.ts
+++ b/apps/api/src/modules/lisa/services/early-exit-guard.service.ts
@@ -82,7 +82,11 @@ export class EarlyExitGuardService {
     }
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'early-exit-guard', timeZone: 'UTC' })
+  // 31/05/2026 cost-cut : passé de EVERY_MINUTE → EVERY_5_MINUTES.
+  // MechanicalTradingService (cron 60sec) reste actif pour SL/TP rapides ;
+  // EarlyExitGuard ne gère que les exits préventifs LLM sur momentum perdu,
+  // 5 min de latence est acceptable vs 1×/min × LLM call (~$2-3/jour économisés).
+  @Cron(CronExpression.EVERY_5_MINUTES, { name: 'early-exit-guard', timeZone: 'UTC' })
   async runCycle(): Promise<void> {
     if (!this.enabled) return;
     if (!this.supabase.isReady()) return;

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -502,6 +502,25 @@ export class LiveTraderAgentService {
         this.logger.log(`[trader-agent] SELF-REFLECTION triggered : ${selfReflection.slice(0, 100)}...`);
       }
 
+      // 31/05/2026 cost-cut (G) — Skip Gemini Pro call when no actionable candidates.
+      // S'il y a 0 candidat à analyser ET 0 position ouverte (rien à fermer/trailer),
+      // appeler Gemini ne génère qu'un "hold" sans valeur. Économie sur weekend
+      // crypto-only où l'univers est souvent vide pendant plusieurs heures.
+      // Garde-fou : on log dans trader_agent_decisions pour traçabilité du skip.
+      const openPositionsCount = Array.isArray(state.openPositions) ? state.openPositions.length : 0;
+      const skipForEmptyContext = (this.config.get<string>('TRADER_SKIP_LLM_WHEN_EMPTY') ?? 'true').toLowerCase() === 'true';
+      if (skipForEmptyContext && candidates.length === 0 && openPositionsCount === 0) {
+        await this.logDecision({
+          cycleStartedAt, state, action: 'hold' as const,
+          notionalUsd: 0, confidence: 0,
+          thesis: '[SKIP_LLM_EMPTY_CONTEXT] 0 candidat in band + 0 position ouverte → skip Gemini call (cost optimization)',
+          applied: false,
+          actionKindOverride: 'hold',
+        }).catch((e) => this.logger.warn(`[trader-agent] log skip failed: ${String(e).slice(0, 120)}`));
+        this.logger.debug('[trader-agent] skip cycle — empty context (0 candidates, 0 open positions)');
+        return;
+      }
+
       // 4. Build system prompt (memory + cross-lessons + MIDDLE ref + self-reflection)
       const systemPrompt = this.buildSystemPrompt(memory, crossScannerLessons, middleReference, selfReflection);
       // LISA refonte A.4 — Capital composé : utilise state.currentCapitalUsd

--- a/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
@@ -179,9 +179,14 @@ export class ShadowSizingOrchestratorService {
   /**
    * Cron toutes les 5 minutes (cadence alignée avec Trader Agent).
    * Boucle complète : tracking → analyse IA → auto-correction → log.
-   * Coût LLM : ~$0.03/jour (288 calls × Gemini Flash Lite).
+   * Coût LLM : ~$0.03/jour (288 calls × Gemini Flash Lite) — chiffrage indicatif
+   * historique. La consommation Gemini Pro réelle est ~$6-9/jour (cf. étude 31/05).
+   *
+   * 31/05/2026 cost-cut : passé de cron 5 min à cron 15 min (3× moins d'appels Gemini
+   * Pro). Le WR shadow met plusieurs heures à converger, donc auto-tune toutes les
+   * 15 min reste très réactif. Snapshots PnL continuent à être calculés.
    */
-  @Cron('*/5 * * * *', { name: 'shadow-sizing-orchestrator', timeZone: 'UTC' })
+  @Cron('*/15 * * * *', { name: 'shadow-sizing-orchestrator', timeZone: 'UTC' })
   async runCycle(): Promise<void> {
     // Log inconditionnel chaque tick.
     this.logger.log(`[shadow-sizing] cron tick @ ${new Date().toISOString()} enabled=${this.enabled} supabase=${this.supabase.isReady()}`);

--- a/apps/api/src/modules/lisa/services/strategy-coach.service.ts
+++ b/apps/api/src/modules/lisa/services/strategy-coach.service.ts
@@ -531,16 +531,27 @@ export class StrategyCoachService {
     return (Date.now() - createdAt) / 86400_000;
   }
 
-  private async shouldEscalateToPro(cfg: PortfolioConfig, ctx: Record<string, unknown>): Promise<boolean> {
-    const capital = ctx.capital as { drawdown_from_initial_pct?: number };
+  private async shouldEscalateToPro(_cfg: PortfolioConfig, _ctx: Record<string, unknown>): Promise<boolean> {
+    // 31/05/2026 cost-cut : escalation Pro désactivée par défaut.
+    // Réactivable via env STRATEGY_COACH_PRO_ESCALATION_ENABLED=true.
+    //
+    // Raison : observations 30/05 — les propositions Pro du coach étaient toutes à
+    // rejeter (faux positifs « bot inactif → relâcher discipline »). Le gain de
+    // qualité Pro ne justifiait pas le coût Pro (~8× Flash Lite).
+    //
+    // Logique précédente conservée pour réactivation :
+    //   - drawdown < -20% → Pro
+    //   - 1 cycle sur 6 (deep-dive 6h) → Pro
+    //   - dernière proposition UNREALISTIC → Pro
+    const proEnabled = (this.config.get<string>('STRATEGY_COACH_PRO_ESCALATION_ENABLED') ?? 'false').toLowerCase() === 'true';
+    if (!proEnabled) return false;
+    const capital = _ctx.capital as { drawdown_from_initial_pct?: number };
     if ((capital?.drawdown_from_initial_pct ?? 0) < -20) return true;
-    // Deep-dive : 1 sur 6 cycles horaires (≈ 1 par 6h)
     if (this.cycleCounter % 6 === 0) return true;
-    // Dernière proposition UNREALISTIC → escalade
     const { data: last } = await this.supabase.getClient()
       .from('coach_proposals')
       .select('feasibility_verdict')
-      .eq('portfolio_id', cfg.portfolio_id)
+      .eq('portfolio_id', _cfg.portfolio_id)
       .order('created_at', { ascending: false })
       .limit(1)
       .maybeSingle();

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -4948,11 +4948,20 @@ export class TopGainersScannerService implements OnModuleInit {
   /**
    * P18 — Re-ranking LLM : réordonne les top candidats par probabilité de continuation.
    * Fallback : ordre déterministe si router off ou échec LLM — comportement P17 préservé.
+   *
+   * 31/05/2026 — désactivé par défaut via SCANNER_LLM_RANKING_ENABLED (cost-cuts Tier 1).
+   * Le LLM ranking changeait rarement l'ordre déterministe (score-based) et coûtait
+   * 1 call Gemini par cycle scanner (~288/jour) pour un bénéfice marginal. Le scanner
+   * conserve son ordre score-based (changePct × volume × persistence) qui est déjà
+   * optimal pour un momentum scanner. Réactivable via env si A/B test souhaité.
    */
   private async rankCandidates(
     top: Array<TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass }>,
   ): Promise<Array<TopGainerCandidate & { score: number; assetClass: TopGainerAssetClass }>> {
     if (!this.llmRouter.isEnabled() || top.length <= 1) return top;
+    // 31/05/2026 cost-cut : default OFF. Réactiver via SCANNER_LLM_RANKING_ENABLED=true.
+    const enabled = (this.config.get<string>('SCANNER_LLM_RANKING_ENABLED') ?? 'false').toLowerCase() === 'true';
+    if (!enabled) return top;
     try {
       const user = JSON.stringify(
         top.map((c) => ({ symbol: c.symbol, assetClass: c.assetClass, changePct: c.changePct, score: c.score, exchange: c.exchange })),


### PR DESCRIPTION
## Contexte

Étude session 31/05 — dépassement plafond mensuel Google AI Studio (**414 €**) avec un tracking interne `api_costs_daily` qui sous-déclarait massivement la facturation réelle (~$6/jour trackés vs ~80-180€ facturé sur 26-28 mai).

Inventaire des consommateurs Gemini actifs + estimation coût/jour → ~$50-80/jour total. Cible : passer à $20-40/jour ($600-700 €/mois).

L'utilisateur a validé point par point : A, B, D, F, G **OUI**. C, E **NON**.

## Changements

### A. TopGainersScanner.rankCandidates() — désactivé (env `SCANNER_LLM_RANKING_ENABLED=false` default)
- 1 call Gemini/cycle scanner économisé (288 calls/jour)
- L'ordre score-based déterministe (changePct × volume × persistence) reste pertinent
- Re-rank LLM changeait rarement l'ordre dans les logs prod
- Note : `generateThesis()` déjà déconnectée du pipeline depuis PR #250

### B. EarlyExitGuard — cron `EVERY_MINUTE` → `EVERY_5_MINUTES`
- MechanicalTrading (cron 60sec) reste actif pour SL/TP rapides
- 5 min de latence sur exit préventif LLM acceptable
- Économie ~$2-3/jour

### D. ShadowSizingOrchestrator — cron 5 min → 15 min
- 3× moins d'appels Gemini Pro
- WR shadow met plusieurs heures à converger → auto-tune 15 min reste réactif
- Snapshots PnL continuent à être calculés (juste l'auto-tune LLM ralenti)
- Économie ~$6-9/jour

### F. StrategyCoach — escalation Gemini Pro désactivée par défaut
- Env `STRATEGY_COACH_PRO_ESCALATION_ENABLED=false` default
- Observations 30/05 : propositions Pro toutes des faux positifs ("bot inactif → relâcher discipline") à rejeter
- Logique d'escalation conservée pour réactivation
- Économie ~$1-2/jour

### G. LiveTraderAgent — skip Gemini call quand contexte vide
- Env `TRADER_SKIP_LLM_WHEN_EMPTY=true` default
- Skip si `candidates.length === 0 && openPositions.length === 0`
- Sur weekend crypto-only où l'univers est souvent vide pendant des heures
- Audit `trader_agent_decisions` kind=hold thesis=`[SKIP_LLM_EMPTY_CONTEXT]`
- Économie ~$5-10/jour (variable selon activité)

## NON modifiés (utilisateur a explicitement demandé de conserver)

- **C. LiveTraderAgent cron 5 min** — cadence inchangée (fenêtre opportunité courte sur pumps gainers)
- **E. DailyRetrospective / TraderRetrospective / MainScannerPostmortem en Pro** — qualité des lessons générées justifie le coût ~$4-6/jour

## Économie estimée totale

**~$15-30/jour économisés** sur base ~$50-80/jour observé fin mai.  
Cible mensuelle : **~$500-700** vs ~$1500-2000 actuel.

## Roll-back

Tous les changements sont gatés par env vars Fly :
- `SCANNER_LLM_RANKING_ENABLED=true` → réactive ranking LLM
- `STRATEGY_COACH_PRO_ESCALATION_ENABLED=true` → réactive escalation Pro
- `TRADER_SKIP_LLM_WHEN_EMPTY=false` → désactive le skip
- Crons (B + D) sont en code → rollback nécessite une PR (mais trivial)

## Tests

Typecheck `apps/api` clean. 25/25 tests existants passent (early-exit-guard + strategy-coach-conflict-post-filter).

## Suite

PR2 à venir : kill-switch $30/jour automatique + endpoint API + UI panel coût quotidien/mensuel (demandé par utilisateur). Cf. session 31/05.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_