### PR TITLE
feat(cost): kill-switch Gemini quotidien + override manuel + UI panel (H)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -31,6 +31,7 @@ import { MultiTimeframePersistenceService } from './services/multi-tf-persistenc
 import { PersistenceProbabilityService } from './services/persistence-probability.service';
 import { EodhdQuotaService } from './services/eodhd-quota.service';
 import { PushNotificationsService, type PushSubscriptionPayload } from './services/push-notifications.service';
+import { GeminiBudgetGuardService } from './services/gemini-budget-guard.service';
 import { summarizeByTf, type PersistenceResult } from '@smartvest/ai-analyst';
 import type { DailyHarvestConfig, CapitalDisciplineMode } from './types/capital-discipline.types';
 
@@ -63,6 +64,7 @@ export class LisaController {
     private readonly dailyCatalystBrief: DailyCatalystBriefService,
     private readonly eventEngine: EventEngineService,
     private readonly pushNotifs: PushNotificationsService,
+    private readonly geminiBudgetGuard: GeminiBudgetGuardService,
   ) {}
 
   // LISA refonte B.4.c — Web Push API VAPID endpoints.
@@ -1803,6 +1805,34 @@ export class LisaController {
   ) {
     const userId = extractUserId(headers);
     return this.lisa.getDailyPnl(userId, portfolioId);
+  }
+
+  // PR2 cost-cuts (H) — endpoints kill-switch quotidien Gemini.
+  //
+  // GET  /lisa/gemini-cost/status
+  // POST /lisa/gemini-cost/manual-override  body { reason?: string }
+  // POST /lisa/gemini-cost/clear-override
+
+  @Get('gemini-cost/status')
+  async getGeminiCostStatus(@Headers() headers: Record<string, string>) {
+    extractUserId(headers); // require authenticated user
+    return this.geminiBudgetGuard.getStatus(true);
+  }
+
+  @Post('gemini-cost/manual-override')
+  async overrideGeminiKillSwitch(
+    @Headers() headers: Record<string, string>,
+    @Body() body: { reason?: string } | null,
+  ) {
+    const userId = extractUserId(headers);
+    const reason = body?.reason;
+    return this.geminiBudgetGuard.manualOverride(reason ? { userId, reason } : { userId });
+  }
+
+  @Post('gemini-cost/clear-override')
+  async clearGeminiOverride(@Headers() headers: Record<string, string>) {
+    extractUserId(headers);
+    return this.geminiBudgetGuard.clearOverride();
   }
 }
 

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -45,6 +45,7 @@ import { ProfitSweepService } from './services/profit-sweep.service';
 import { DailyProfitGovernor } from './services/daily-profit-governor.service';
 import { MacroModeService } from './services/macro-mode.service';
 import { ApiCostTrackerService } from './services/api-cost-tracker.service';
+import { GeminiBudgetGuardService } from './services/gemini-budget-guard.service';
 import { ReboundMonitorService } from './services/rebound-monitor.service';
 import { ReboundScannerService } from './services/rebound-scanner.service';
 import { OhlcvCacheService } from './services/ohlcv-cache.service';
@@ -184,6 +185,8 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     MacroModeService,
     // PATCH 4 — running total + hard-stop budget API
     ApiCostTrackerService,
+    // PR2 cost-cuts (H) — kill-switch quotidien Gemini avec override manuel
+    GeminiBudgetGuardService,
     // P1 — classifier de régime tactique (BULL/BEAR/RANGE/VOL_SPIKE/NEWS_SHOCK)
     MarketRegimeService,
     // P3-A — cron monitor pour rebound_positions (TP/SL/timeout toutes les 5 min)

--- a/apps/api/src/modules/lisa/services/__tests__/gemini-budget-guard.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/gemini-budget-guard.spec.ts
@@ -1,0 +1,174 @@
+// PR2 cost-cuts (H) — tests unitaires GeminiBudgetGuardService.
+//
+// Focus sur la logique de décision isAllowed/assertAllowed + parsing du status.
+// Pas de test live Supabase (mocké) — la logique pure est ce qui compte.
+
+import { ConfigService } from '@nestjs/config';
+import { GeminiBudgetGuardService, GeminiBudgetExceededError } from '../gemini-budget-guard.service';
+
+type SupabaseRow = Record<string, unknown> | null;
+
+function makeSupabaseMock(rows: {
+  apiCostsDailyToday?: SupabaseRow;
+  apiCostsDailyMonth?: SupabaseRow[];
+  override?: SupabaseRow;
+}) {
+  const calls: { table: string; method: string }[] = [];
+  const builder = (table: string) => {
+    const ctx = {
+      table,
+      _filterEq: false,
+      _filterGte: false,
+      _isMaybeSingle: false,
+    };
+    const result: Record<string, unknown> = {
+      select: (_cols?: string) => result,
+      eq: (_col: string, _val: unknown) => {
+        ctx._filterEq = true;
+        return result;
+      },
+      gte: (_col: string, _val: unknown) => {
+        ctx._filterGte = true;
+        return result;
+      },
+      is: (_col: string, _val: unknown) => result,
+      update: () => result,
+      upsert: () => Promise.resolve({ data: null, error: null }),
+      delete: () => result,
+      maybeSingle: () => {
+        calls.push({ table, method: 'maybeSingle' });
+        if (table === 'api_costs_daily') {
+          return Promise.resolve({ data: rows.apiCostsDailyToday ?? null, error: null });
+        }
+        if (table === 'gemini_cost_override') {
+          return Promise.resolve({ data: rows.override ?? null, error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      },
+      // For non-single queries, the chain ends with await on the chained builder.
+      then: (cb: (v: { data: unknown; error: unknown }) => unknown) => {
+        if (table === 'api_costs_daily' && ctx._filterGte) {
+          return Promise.resolve({ data: rows.apiCostsDailyMonth ?? [], error: null }).then(cb);
+        }
+        return Promise.resolve({ data: null, error: null }).then(cb);
+      },
+    };
+    return result;
+  };
+  return {
+    isReady: () => true,
+    getClient: () => ({ from: builder }),
+    _calls: calls,
+  } as unknown as { isReady: () => boolean; getClient: () => unknown };
+}
+
+function makeConfig(envs: Record<string, string>): ConfigService {
+  return {
+    get: (key: string) => envs[key],
+  } as unknown as ConfigService;
+}
+
+function makeCostTracker() {
+  return { record: jest.fn(), recordApiCost: jest.fn(), getTodayTotalUsd: jest.fn() } as never;
+}
+
+describe('GeminiBudgetGuardService', () => {
+  it('hard cap par défaut $30 si env absent', () => {
+    const svc = new GeminiBudgetGuardService(makeConfig({}), makeSupabaseMock({}) as never, makeCostTracker());
+    expect(svc.getHardCapUsd()).toBe(30);
+  });
+
+  it('hard cap configurable via GEMINI_DAILY_HARD_CAP_USD', () => {
+    const svc = new GeminiBudgetGuardService(makeConfig({ GEMINI_DAILY_HARD_CAP_USD: '50' }), makeSupabaseMock({}) as never, makeCostTracker());
+    expect(svc.getHardCapUsd()).toBe(50);
+  });
+
+  it('hard cap ignore valeur invalide (négative ou non-numeric)', () => {
+    const svc1 = new GeminiBudgetGuardService(makeConfig({ GEMINI_DAILY_HARD_CAP_USD: '-5' }), makeSupabaseMock({}) as never, makeCostTracker());
+    expect(svc1.getHardCapUsd()).toBe(30);
+    const svc2 = new GeminiBudgetGuardService(makeConfig({ GEMINI_DAILY_HARD_CAP_USD: 'abc' }), makeSupabaseMock({}) as never, makeCostTracker());
+    expect(svc2.getHardCapUsd()).toBe(30);
+  });
+
+  it('isAllowed=true quand todayUsd < cap', async () => {
+    const supabase = makeSupabaseMock({
+      apiCostsDailyToday: { total_usd: 5, by_model: { 'gemini-2.5-pro': 5 } },
+      override: null,
+    });
+    const svc = new GeminiBudgetGuardService(makeConfig({}), supabase as never, makeCostTracker());
+    expect(await svc.isAllowed()).toBe(true);
+  });
+
+  it('isAllowed=false quand todayUsd >= cap ET pas d override', async () => {
+    const supabase = makeSupabaseMock({
+      apiCostsDailyToday: { total_usd: 35, by_model: { 'gemini-2.5-pro': 35 } },
+      override: null,
+    });
+    const svc = new GeminiBudgetGuardService(makeConfig({}), supabase as never, makeCostTracker());
+    expect(await svc.isAllowed()).toBe(false);
+  });
+
+  it('isAllowed=true quand todayUsd >= cap MAIS override actif', async () => {
+    const supabase = makeSupabaseMock({
+      apiCostsDailyToday: { total_usd: 35, by_model: { 'gemini-2.5-pro': 35 } },
+      override: { overridden_at: '2026-05-31T05:30:00Z', reason: 'A++ setup' },
+    });
+    const svc = new GeminiBudgetGuardService(makeConfig({}), supabase as never, makeCostTracker());
+    expect(await svc.isAllowed()).toBe(true);
+  });
+
+  it('assertAllowed throw GeminiBudgetExceededError quand bloqué', async () => {
+    const supabase = makeSupabaseMock({
+      apiCostsDailyToday: { total_usd: 35, by_model: { 'gemini-2.5-pro': 35 } },
+      override: null,
+    });
+    const svc = new GeminiBudgetGuardService(makeConfig({}), supabase as never, makeCostTracker());
+    await expect(svc.assertAllowed()).rejects.toThrow(GeminiBudgetExceededError);
+  });
+
+  it('assertAllowed ne throw pas quand override actif', async () => {
+    const supabase = makeSupabaseMock({
+      apiCostsDailyToday: { total_usd: 35, by_model: { 'gemini-2.5-pro': 35 } },
+      override: { overridden_at: '2026-05-31T05:30:00Z', reason: null },
+    });
+    const svc = new GeminiBudgetGuardService(makeConfig({}), supabase as never, makeCostTracker());
+    await expect(svc.assertAllowed()).resolves.toBeUndefined();
+  });
+
+  it('getStatus retourne shape complet attendu', async () => {
+    const supabase = makeSupabaseMock({
+      apiCostsDailyToday: { total_usd: 12.34, by_model: { 'gemini-2.5-pro': 10, 'gemini-2.5-flash-lite': 2.34 } },
+      override: null,
+    });
+    const svc = new GeminiBudgetGuardService(makeConfig({}), supabase as never, makeCostTracker());
+    const status = await svc.getStatus();
+    expect(status.todayUsd).toBe(12.34);
+    expect(status.hardCapUsd).toBe(30);
+    expect(status.killSwitchActive).toBe(false);
+    expect(status.manualOverrideActive).toBe(false);
+    expect(status.capUsedPct).toBe(41.1); // 12.34 / 30 * 100 = 41.13
+    expect(typeof status.nextResetUtc).toBe('string');
+  });
+
+  it('getStatus aggregate uniquement les modeles Gemini (ignore Claude)', async () => {
+    const supabase = makeSupabaseMock({
+      apiCostsDailyToday: {
+        total_usd: 100,
+        by_model: { 'gemini-2.5-pro': 8, 'claude-opus-4-7': 92 },
+      },
+      override: null,
+    });
+    const svc = new GeminiBudgetGuardService(makeConfig({}), supabase as never, makeCostTracker());
+    const status = await svc.getStatus();
+    expect(status.todayUsd).toBe(8); // Pas 100
+  });
+
+  it('GeminiBudgetExceededError porte les valeurs todayCostUsd + hardCapUsd', () => {
+    const err = new GeminiBudgetExceededError(45.67, 30);
+    expect(err.todayCostUsd).toBe(45.67);
+    expect(err.hardCapUsd).toBe(30);
+    expect(err.message).toContain('$45.67');
+    expect(err.message).toContain('$30.00');
+    expect(err.name).toBe('GeminiBudgetExceededError');
+  });
+});

--- a/apps/api/src/modules/lisa/services/gemini-budget-guard.service.ts
+++ b/apps/api/src/modules/lisa/services/gemini-budget-guard.service.ts
@@ -1,0 +1,297 @@
+// GeminiBudgetGuardService — kill-switch quotidien Gemini avec override manuel.
+//
+// Contexte : 30/05/2026, dépassement plafond mensuel Google AI Studio (414€,
+// service suspendu plusieurs heures). Le tracking interne `api_costs_daily`
+// sous-déclare la facturation réelle (~5-50× selon les jours) — ce guard
+// reste basé sur le tracking interne (rapide, O(1) Supabase lookup), avec
+// un cap conservateur (default $30/jour) qui correspondrait à ~$150-300
+// facturé réellement (marge × 5-10).
+//
+// Cf. migration 0177 + PR2 cost-cuts.
+
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { ApiCostTrackerService } from './api-cost-tracker.service';
+
+/**
+ * Lancée quand le hard cap Gemini quotidien est dépassé ET aucun override
+ * manuel actif. Catchée par les wrappers du router LLM qui fallback à
+ * `fallbackUsed=true` (comportement existant des providers KO).
+ */
+export class GeminiBudgetExceededError extends Error {
+  readonly todayCostUsd: number;
+  readonly hardCapUsd: number;
+
+  constructor(todayCostUsd: number, hardCapUsd: number) {
+    super(
+      `[GEMINI_BUDGET_EXCEEDED] Coût Gemini quotidien $${todayCostUsd.toFixed(2)} >= ` +
+      `hard cap $${hardCapUsd.toFixed(2)}. Override manuel requis ou attendre minuit UTC.`,
+    );
+    this.name = 'GeminiBudgetExceededError';
+    this.todayCostUsd = todayCostUsd;
+    this.hardCapUsd = hardCapUsd;
+  }
+}
+
+export interface GeminiCostStatus {
+  /** Coût Gemini agrégé pour aujourd'hui (date UTC). */
+  todayUsd: number;
+  /** Coût Gemini agrégé sur le mois en cours (date UTC). */
+  monthToDateUsd: number;
+  /** Hard cap quotidien depuis l'env GEMINI_DAILY_HARD_CAP_USD (default 30). */
+  hardCapUsd: number;
+  /** True si todayUsd >= hardCapUsd ET pas d'override actif. */
+  killSwitchActive: boolean;
+  /** True si l'utilisateur a forcé le bypass aujourd'hui. */
+  manualOverrideActive: boolean;
+  /** Timestamp de l'override courant (si actif). */
+  overrideAt: string | null;
+  /** Raison de l'override (si saisie). */
+  overrideReason: string | null;
+  /** Pourcentage de consommation du cap [0, 100+]. */
+  capUsedPct: number;
+  /** Date UTC du prochain reset auto (00:00 UTC demain). */
+  nextResetUtc: string;
+}
+
+@Injectable()
+export class GeminiBudgetGuardService {
+  private readonly logger = new Logger(GeminiBudgetGuardService.name);
+  private cachedStatus: { status: GeminiCostStatus; asOf: number } | null = null;
+  private static readonly CACHE_TTL_MS = 30_000;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+    private readonly costTracker: ApiCostTrackerService,
+  ) {}
+
+  /**
+   * Hard cap quotidien lu depuis l'env. Default $30 (conservateur).
+   * Réajustable via Fly secret sans redeploy code.
+   */
+  getHardCapUsd(): number {
+    const raw = this.config.get<string>('GEMINI_DAILY_HARD_CAP_USD');
+    const parsed = Number.parseFloat(raw ?? '');
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+    return 30;
+  }
+
+  /**
+   * Check si un appel Gemini est autorisé pour ce cycle. Cache 30s pour éviter
+   * SUM Supabase à chaque LLM call.
+   *
+   * Décision :
+   *   - Si todayUsd < cap → ALLOW
+   *   - Si todayUsd >= cap ET override actif aujourd'hui → ALLOW (flag used_at)
+   *   - Sinon → DENY
+   */
+  async isAllowed(): Promise<boolean> {
+    const status = await this.getStatus();
+    if (!status.killSwitchActive) return true;
+    if (status.manualOverrideActive) {
+      // Flag used_at au premier usage. Best-effort (ne bloque pas si fail).
+      this.markOverrideUsed().catch((e) =>
+        this.logger.debug(`[gemini-guard] markOverrideUsed fail: ${String(e).slice(0, 100)}`),
+      );
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Lève GeminiBudgetExceededError si non autorisé. À appeler avant chaque
+   * llmRouter.call/callWithPro pour propager l'erreur jusqu'au caller qui
+   * peut fallback à `fallbackUsed=true`.
+   */
+  async assertAllowed(): Promise<void> {
+    const status = await this.getStatus();
+    if (status.killSwitchActive && !status.manualOverrideActive) {
+      throw new GeminiBudgetExceededError(status.todayUsd, status.hardCapUsd);
+    }
+    if (status.killSwitchActive && status.manualOverrideActive) {
+      this.markOverrideUsed().catch(() => null);
+    }
+  }
+
+  /**
+   * Status complet pour endpoint API + UI panel.
+   * Cache 30s, invalidé manuellement après recordCost ou manualOverride.
+   */
+  async getStatus(forceRefresh = false): Promise<GeminiCostStatus> {
+    if (!forceRefresh && this.cachedStatus && Date.now() - this.cachedStatus.asOf < GeminiBudgetGuardService.CACHE_TTL_MS) {
+      return this.cachedStatus.status;
+    }
+    const hardCap = this.getHardCapUsd();
+    const [todayTotal, monthTotal, override] = await Promise.all([
+      this.getTodayGeminiCost(),
+      this.getMonthToDateGeminiCost(),
+      this.getActiveOverride(),
+    ]);
+    const killSwitchActive = todayTotal >= hardCap;
+    const manualOverrideActive = override !== null;
+    const capUsedPct = hardCap > 0 ? Math.round((todayTotal / hardCap) * 1000) / 10 : 0;
+    const status: GeminiCostStatus = {
+      todayUsd: Math.round(todayTotal * 100) / 100,
+      monthToDateUsd: Math.round(monthTotal * 100) / 100,
+      hardCapUsd: hardCap,
+      killSwitchActive,
+      manualOverrideActive,
+      overrideAt: override?.overridden_at ?? null,
+      overrideReason: override?.reason ?? null,
+      capUsedPct,
+      nextResetUtc: this.getNextMidnightUtc(),
+    };
+    this.cachedStatus = { status, asOf: Date.now() };
+    return status;
+  }
+
+  /**
+   * Déclenche un override manuel pour aujourd'hui. Idempotent (1 row par date PK).
+   * Returns le status post-override.
+   */
+  async manualOverride(opts: { userId?: string; reason?: string } = {}): Promise<GeminiCostStatus> {
+    if (!this.supabase.isReady()) {
+      this.logger.warn('[gemini-guard] supabase not ready, override skipped');
+      return this.getStatus(true);
+    }
+    const today = this.getTodayUtcDate();
+    try {
+      const { error } = await this.supabase.getClient()
+        .from('gemini_cost_override')
+        .upsert(
+          {
+            date: today,
+            overridden_at: new Date().toISOString(),
+            overridden_by_user_id: opts.userId ?? null,
+            reason: opts.reason ?? null,
+          },
+          { onConflict: 'date' },
+        );
+      if (error) {
+        this.logger.warn(`[gemini-guard] override upsert failed: ${error.message}`);
+      } else {
+        this.logger.log(`[gemini-guard] manual override activated for ${today} (user=${opts.userId ?? '?'}, reason="${opts.reason ?? ''}")`);
+      }
+    } catch (e) {
+      this.logger.warn(`[gemini-guard] override exception: ${String(e).slice(0, 100)}`);
+    }
+    // Invalidate cache to refresh next status read.
+    this.cachedStatus = null;
+    return this.getStatus(true);
+  }
+
+  /**
+   * Supprime l'override actif pour aujourd'hui (utile pour test ou si user
+   * change d'avis). Idempotent.
+   */
+  async clearOverride(): Promise<GeminiCostStatus> {
+    if (!this.supabase.isReady()) return this.getStatus(true);
+    const today = this.getTodayUtcDate();
+    try {
+      await this.supabase.getClient()
+        .from('gemini_cost_override')
+        .delete()
+        .eq('date', today);
+      this.logger.log(`[gemini-guard] manual override cleared for ${today}`);
+    } catch (e) {
+      this.logger.warn(`[gemini-guard] clearOverride exception: ${String(e).slice(0, 100)}`);
+    }
+    this.cachedStatus = null;
+    return this.getStatus(true);
+  }
+
+  // ───────────────────────────────────────────────────────── private
+
+  private async getTodayGeminiCost(): Promise<number> {
+    if (!this.supabase.isReady()) return 0;
+    try {
+      const today = this.getTodayUtcDate();
+      const { data } = await this.supabase.getClient()
+        .from('api_costs_daily')
+        .select('total_usd, by_model')
+        .eq('date', today)
+        .maybeSingle();
+      if (!data) return 0;
+      const byModel = (data.by_model as Record<string, number> | null) ?? {};
+      let geminiTotal = 0;
+      for (const [model, cost] of Object.entries(byModel)) {
+        if (model.toLowerCase().includes('gemini')) {
+          geminiTotal += Number(cost) || 0;
+        }
+      }
+      // Si pas de breakdown Gemini, fallback sur total (tracking ancien sans by_model).
+      return geminiTotal > 0 ? geminiTotal : Number(data.total_usd) || 0;
+    } catch (e) {
+      this.logger.debug(`[gemini-guard] getTodayGeminiCost fail: ${String(e).slice(0, 100)}`);
+      return 0;
+    }
+  }
+
+  private async getMonthToDateGeminiCost(): Promise<number> {
+    if (!this.supabase.isReady()) return 0;
+    try {
+      const monthStart = this.getMonthStartUtcDate();
+      const { data } = await this.supabase.getClient()
+        .from('api_costs_daily')
+        .select('total_usd, by_model')
+        .gte('date', monthStart);
+      if (!data || data.length === 0) return 0;
+      let geminiTotal = 0;
+      for (const row of data) {
+        const byModel = (row.by_model as Record<string, number> | null) ?? {};
+        for (const [model, cost] of Object.entries(byModel)) {
+          if (model.toLowerCase().includes('gemini')) {
+            geminiTotal += Number(cost) || 0;
+          }
+        }
+      }
+      return geminiTotal;
+    } catch (e) {
+      this.logger.debug(`[gemini-guard] getMonthToDateGeminiCost fail: ${String(e).slice(0, 100)}`);
+      return 0;
+    }
+  }
+
+  private async getActiveOverride(): Promise<{ overridden_at: string; reason: string | null } | null> {
+    if (!this.supabase.isReady()) return null;
+    try {
+      const today = this.getTodayUtcDate();
+      const { data } = await this.supabase.getClient()
+        .from('gemini_cost_override')
+        .select('overridden_at, reason')
+        .eq('date', today)
+        .maybeSingle();
+      return (data as { overridden_at: string; reason: string | null } | null) ?? null;
+    } catch (e) {
+      this.logger.debug(`[gemini-guard] getActiveOverride fail: ${String(e).slice(0, 100)}`);
+      return null;
+    }
+  }
+
+  private async markOverrideUsed(): Promise<void> {
+    if (!this.supabase.isReady()) return;
+    const today = this.getTodayUtcDate();
+    await this.supabase.getClient()
+      .from('gemini_cost_override')
+      .update({ used_at: new Date().toISOString() })
+      .eq('date', today)
+      .is('used_at', null);
+  }
+
+  private getTodayUtcDate(): string {
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  private getMonthStartUtcDate(): string {
+    const now = new Date();
+    return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-01`;
+  }
+
+  private getNextMidnightUtc(): string {
+    const now = new Date();
+    const tomorrow = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
+    return tomorrow.toISOString();
+  }
+}

--- a/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
+++ b/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
@@ -16,7 +16,7 @@
  * Cf. docs/decision_records/ADR-001-llm-architecture.md
  */
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
   MultiVendorLlmRouter,
@@ -24,6 +24,7 @@ import {
   type LlmCallParams,
   type MultiVendorCallMetrics,
 } from '@smartvest/ai-analyst';
+import { GeminiBudgetGuardService } from './gemini-budget-guard.service';
 
 @Injectable()
 export class ScannerLlmRouterService {
@@ -35,7 +36,13 @@ export class ScannerLlmRouterService {
   // Coût ~×125 vs flash-lite mais qualité de raisonnement multi-facteurs supérieure.
   private readonly routerPro: MultiVendorLlmRouter | null;
 
-  constructor(private readonly config: ConfigService) {
+  constructor(
+    private readonly config: ConfigService,
+    // Optional injection : si le module ne wire pas le guard, le router fonctionne
+    // sans hard cap (comportement pré-PR2 préservé). En prod, le guard est toujours
+    // injecté.
+    @Optional() @Inject(GeminiBudgetGuardService) private readonly budgetGuard?: GeminiBudgetGuardService,
+  ) {
     this.enabled = (this.config.get<string>('SCANNER_LLM_ROUTER_ENABLED') ?? 'false').toLowerCase() === 'true';
 
     if (!this.enabled) {
@@ -99,6 +106,10 @@ export class ScannerLlmRouterService {
     if (!this.router) {
       throw new Error('ScannerLlmRouterService.call() — router disabled (check SCANNER_LLM_ROUTER_ENABLED + GEMINI_API_KEY)');
     }
+    // PR2 cost-cuts (H) — kill-switch hard cap quotidien Gemini avec override manuel.
+    if (this.budgetGuard) {
+      await this.budgetGuard.assertAllowed();
+    }
     const res = await this.router.call(params);
     return {
       content: res.content,
@@ -120,6 +131,10 @@ export class ScannerLlmRouterService {
    * silencieusement skipé à cause d'un quota/modèle Pro indisponible.
    */
   async callWithPro(params: LlmCallParams): Promise<{ content: string; providerId: string; costUsd: number; latencyMs: number; fallbackUsed: boolean }> {
+    // PR2 cost-cuts (H) — kill-switch hard cap quotidien Gemini avec override manuel.
+    if (this.budgetGuard) {
+      await this.budgetGuard.assertAllowed();
+    }
     if (this.routerPro) {
       try {
         const res = await this.routerPro.call(params);

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -43,6 +43,7 @@ import { LiveTradingStatusPanel } from '@/components/lisa/live-trading-status-pa
 import { LiveTradingWizard } from '@/components/lisa/live-trading-wizard';
 import { useOperatingMode } from '@/hooks/use-operating-mode';
 import { AutopilotBudgetBadge } from '@/components/lisa/autopilot-budget-badge';
+import { GeminiCostPanel } from '@/components/lisa/gemini-cost-panel';
 import { RiskStateBanner } from '@/components/lisa/risk-state-banner';
 import { LisaDecisionLog } from '@/components/lisa/decision-log';
 import { MechanicalAgentCard } from '@/components/lisa/mechanical-agent-card';
@@ -673,6 +674,9 @@ export default function LisaPage() {
 
       {/* P7 — Mode opératoire 3-way (Investment / Harvest / Gainers) */}
       {selectedPortfolioId && <MacroModeSelector portfolioId={selectedPortfolioId} />}
+
+      {/* PR2 cost-cuts (H) — Panel coûts Gemini quotidien/mensuel + kill-switch */}
+      <GeminiCostPanel />
 
       {/* LISA refonte A.3 — Section Gains (badges + reset display-only) */}
       {selectedPortfolioId && <GainsTracker portfolioId={selectedPortfolioId} />}

--- a/apps/web/src/components/lisa/gemini-cost-panel.tsx
+++ b/apps/web/src/components/lisa/gemini-cost-panel.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+// PR2 cost-cuts (H) — Panel UI Coûts Gemini + kill-switch + bouton "Relancer".
+//
+// Affiche :
+//  - Coût quotidien Gemini ($X / cap $Y) avec barre de progression
+//  - Coût mensuel cumulé
+//  - Status (🟢 OK / 🟡 approaching / 🔴 blocked)
+//  - Bouton "Relancer maintenant" visible UNIQUEMENT si killSwitchActive
+//  - Bandeau info si manualOverrideActive (overrideAt + reason)
+//  - Lien vers Google AI Studio billing pour vérification facturation réelle
+//
+// Le tracking interne sous-déclare ~5-50× la facturation Google réelle (cf.
+// session 30/05). Un message informatif dans le panel le rappelle.
+
+import { useState } from 'react';
+import { AlertTriangle, CheckCircle2, ExternalLink, Loader2, PlayCircle, RefreshCw } from 'lucide-react';
+import {
+  useGeminiCostStatus,
+  useGeminiManualOverride,
+  useGeminiClearOverride,
+} from '@/hooks/use-gemini-cost';
+
+export function GeminiCostPanel() {
+  const statusQ = useGeminiCostStatus();
+  const overrideMut = useGeminiManualOverride();
+  const clearMut = useGeminiClearOverride();
+  const [reasonInput, setReasonInput] = useState('');
+
+  if (statusQ.isLoading) {
+    return (
+      <div className="rounded-lg border p-4 text-sm text-muted-foreground">
+        <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
+        Chargement coûts Gemini…
+      </div>
+    );
+  }
+
+  if (statusQ.isError || !statusQ.data) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 dark:bg-red-950/20 p-4 text-sm text-red-700 dark:text-red-400">
+        Erreur lecture coûts Gemini : {String(statusQ.error ?? 'unknown')}
+      </div>
+    );
+  }
+
+  const s = statusQ.data;
+  const pct = Math.min(100, s.capUsedPct);
+  const status: 'ok' | 'warn' | 'blocked' = s.killSwitchActive && !s.manualOverrideActive
+    ? 'blocked'
+    : pct >= 80
+      ? 'warn'
+      : 'ok';
+
+  const colorClasses = {
+    ok: 'border-emerald-200 bg-emerald-50/50 dark:bg-emerald-950/10',
+    warn: 'border-amber-300 bg-amber-50 dark:bg-amber-950/20',
+    blocked: 'border-red-400 bg-red-50 dark:bg-red-950/30',
+  };
+  const barColor = {
+    ok: 'bg-emerald-500',
+    warn: 'bg-amber-500',
+    blocked: 'bg-red-500',
+  };
+  const statusIcon = {
+    ok: <CheckCircle2 className="h-5 w-5 text-emerald-600" />,
+    warn: <AlertTriangle className="h-5 w-5 text-amber-600" />,
+    blocked: <AlertTriangle className="h-5 w-5 text-red-600" />,
+  };
+  const statusLabel = {
+    ok: 'OK',
+    warn: 'Attention — proche du cap',
+    blocked: 'BLOQUÉ — kill-switch actif',
+  };
+
+  const handleOverride = async () => {
+    const reason = reasonInput.trim() || undefined;
+    await overrideMut.mutateAsync(reason);
+    setReasonInput('');
+  };
+
+  return (
+    <div className={`rounded-lg border p-4 ${colorClasses[status]}`}>
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className="text-lg">💰</span>
+          <h3 className="font-semibold text-sm">Coûts Gemini (Google AI Studio)</h3>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs">
+          {statusIcon[status]}
+          <span className="font-medium">{statusLabel[status]}</span>
+        </div>
+      </div>
+
+      {/* Coût quotidien + barre */}
+      <div className="space-y-1.5 mb-3">
+        <div className="flex justify-between text-xs">
+          <span className="text-muted-foreground">Aujourd'hui</span>
+          <span className="font-mono">
+            ${s.todayUsd.toFixed(2)} / ${s.hardCapUsd.toFixed(2)} ({pct.toFixed(0)}%)
+          </span>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className={`h-full ${barColor[status]} transition-all`}
+            style={{ width: `${Math.min(100, pct)}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Coût mensuel */}
+      <div className="flex justify-between text-xs mb-3">
+        <span className="text-muted-foreground">Ce mois (tracking interne)</span>
+        <span className="font-mono">${s.monthToDateUsd.toFixed(2)}</span>
+      </div>
+
+      {/* Bandeau override actif */}
+      {s.manualOverrideActive && (
+        <div className="rounded border border-blue-300 bg-blue-50 dark:bg-blue-950/20 p-2 text-xs mb-3">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-1.5 text-blue-700 dark:text-blue-400">
+              <PlayCircle className="h-3.5 w-3.5" />
+              <span className="font-medium">Override manuel actif</span>
+            </div>
+            <button
+              onClick={() => clearMut.mutate()}
+              disabled={clearMut.isPending}
+              className="text-blue-600 hover:underline disabled:opacity-50"
+            >
+              {clearMut.isPending ? 'Suspension…' : 'Suspendre'}
+            </button>
+          </div>
+          {s.overrideAt && (
+            <div className="text-blue-600 dark:text-blue-300 mt-1">
+              Activé : {new Date(s.overrideAt).toLocaleTimeString('fr-FR')}
+              {s.overrideReason && <span className="ml-1">— {s.overrideReason}</span>}
+            </div>
+          )}
+          <div className="text-blue-600/70 dark:text-blue-400/70 mt-0.5 text-[10px]">
+            Override valide jusqu'au reset automatique à minuit UTC
+          </div>
+        </div>
+      )}
+
+      {/* Bouton relancer si bloqué */}
+      {status === 'blocked' && (
+        <div className="rounded border border-red-300 bg-red-100/50 dark:bg-red-950/40 p-3 mb-3 space-y-2">
+          <div className="text-xs text-red-700 dark:text-red-400">
+            Toutes les actions Gemini (TRADER, Shadow, Risk Manager, Coach…) sont
+            suspendues jusqu'au reset auto à minuit UTC, ou jusqu'à override manuel.
+          </div>
+          <input
+            type="text"
+            value={reasonInput}
+            onChange={(e) => setReasonInput(e.target.value)}
+            placeholder="Raison (optionnel) — ex: setup A++ détecté, debug, etc."
+            className="w-full rounded border border-red-200 bg-white px-2 py-1 text-xs dark:bg-red-950/30 dark:border-red-700"
+          />
+          <button
+            onClick={handleOverride}
+            disabled={overrideMut.isPending}
+            className="w-full flex items-center justify-center gap-1.5 rounded bg-red-600 hover:bg-red-700 text-white text-xs font-medium py-1.5 disabled:opacity-50"
+          >
+            {overrideMut.isPending ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Relance…
+              </>
+            ) : (
+              <>
+                <RefreshCw className="h-3.5 w-3.5" />
+                ⚡ Relancer maintenant (bypass kill-switch)
+              </>
+            )}
+          </button>
+        </div>
+      )}
+
+      {/* Footer infos */}
+      <div className="text-[10px] text-muted-foreground space-y-0.5">
+        <div>
+          Reset auto : {new Date(s.nextResetUtc).toLocaleString('fr-FR')}
+        </div>
+        <div>
+          ⚠ Tracking interne sous-déclare ~5-50× la facturation Google réelle.{' '}
+          <a
+            href="https://aistudio.google.com/usage"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-0.5"
+          >
+            Vérifier Google AI Studio <ExternalLink className="h-2.5 w-2.5" />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-gemini-cost.ts
+++ b/apps/web/src/hooks/use-gemini-cost.ts
@@ -1,0 +1,68 @@
+// PR2 cost-cuts (H) — hooks React Query pour le kill-switch Gemini.
+//
+// Backend endpoints (lisa.controller) :
+//   GET  /lisa/gemini-cost/status
+//   POST /lisa/gemini-cost/manual-override  body { reason?: string }
+//   POST /lisa/gemini-cost/clear-override
+//
+// L'UI panel `GeminiCostPanel` poll status toutes les 30s pour rafraîchir le
+// montant quotidien + état kill-switch + bouton "Relancer" si bloqué.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+export interface GeminiCostStatus {
+  todayUsd: number;
+  monthToDateUsd: number;
+  hardCapUsd: number;
+  killSwitchActive: boolean;
+  manualOverrideActive: boolean;
+  overrideAt: string | null;
+  overrideReason: string | null;
+  capUsedPct: number;
+  nextResetUtc: string;
+}
+
+export function useGeminiCostStatus() {
+  return useQuery({
+    queryKey: ['lisa', 'gemini-cost', 'status'],
+    queryFn: () => apiFetch<GeminiCostStatus>('/lisa/gemini-cost/status'),
+    // Poll 30s — aligné avec le cache backend GeminiBudgetGuardService.CACHE_TTL_MS.
+    refetchInterval: 30_000,
+    // On garde le polling même quand l'onglet est en background, pour que la
+    // facturation reste visible si l'utilisateur revient après une longue absence.
+    // Coût Supabase faible (1 query agrégée + 1 lookup override par 30s).
+    refetchIntervalInBackground: true,
+    staleTime: 15_000,
+  });
+}
+
+export function useGeminiManualOverride() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (reason?: string) =>
+      apiFetch<GeminiCostStatus>('/lisa/gemini-cost/manual-override', {
+        method: 'POST',
+        body: JSON.stringify(reason ? { reason } : {}),
+      }),
+    onSuccess: (data) => {
+      // Invalide le cache + write back direct pour update instant de l'UI.
+      qc.setQueryData(['lisa', 'gemini-cost', 'status'], data);
+      qc.invalidateQueries({ queryKey: ['lisa', 'gemini-cost', 'status'] });
+    },
+  });
+}
+
+export function useGeminiClearOverride() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      apiFetch<GeminiCostStatus>('/lisa/gemini-cost/clear-override', {
+        method: 'POST',
+      }),
+    onSuccess: (data) => {
+      qc.setQueryData(['lisa', 'gemini-cost', 'status'], data);
+      qc.invalidateQueries({ queryKey: ['lisa', 'gemini-cost', 'status'] });
+    },
+  });
+}

--- a/supabase/migrations/0177_gemini_cost_killswitch.sql
+++ b/supabase/migrations/0177_gemini_cost_killswitch.sql
@@ -1,0 +1,50 @@
+-- Migration 0177 — Gemini cost kill-switch + manual override
+--
+-- Suite à dépassement plafond mensuel Google AI Studio 30/05 (414€, service
+-- suspendu). Ajout d'un kill-switch automatique sur le coût journalier Gemini
+-- avec possibilité d'override manuel par l'utilisateur jusqu'à minuit UTC.
+--
+-- Architecture :
+--   - Daily cost tracker existant : api_costs_daily (table créée migration 0072)
+--   - Hard cap : env GEMINI_DAILY_HARD_CAP_USD (default $30)
+--   - Manual override : table gemini_cost_override (1 row par date UTC)
+--   - GeminiBudgetGuardService.isAllowed() check both
+--   - Reset auto à 00:00 UTC quand la date change
+--
+-- Idempotente.
+
+CREATE TABLE IF NOT EXISTS public.gemini_cost_override (
+  date date PRIMARY KEY,
+  overridden_at timestamptz NOT NULL DEFAULT NOW(),
+  overridden_by_user_id uuid,
+  reason text,
+  -- Si l'override est utilisé (au moins 1 LLM call après l'override), on flag.
+  -- Sert à différencier "override activé mais inutilisé" vs "override appliqué".
+  used_at timestamptz
+);
+
+COMMENT ON TABLE public.gemini_cost_override IS
+'Override manuel du kill-switch Gemini quotidien. 1 row par jour UTC max. L''utilisateur clique "Relancer" depuis l''UI quand le service est bloqué par hard cap. Reset auto à minuit UTC (la PK date change). Cf. migration 0177 + GeminiBudgetGuardService.';
+
+COMMENT ON COLUMN public.gemini_cost_override.date IS
+'Date UTC du jour (PK). À minuit UTC, une nouvelle date démarre → ancien override expire automatiquement.';
+
+COMMENT ON COLUMN public.gemini_cost_override.overridden_by_user_id IS
+'UUID de l''utilisateur qui a déclenché l''override (audit). NULL si déclenché par admin token ou cron.';
+
+COMMENT ON COLUMN public.gemini_cost_override.reason IS
+'Raison libre saisie par l''utilisateur lors du bypass (optionnel). Ex: "Trade A++ détecté", "test debug", etc.';
+
+COMMENT ON COLUMN public.gemini_cost_override.used_at IS
+'Timestamp du premier LLM call passé après l''override. NULL si override jamais consommé (hard cap n''a plus été atteint).';
+
+-- RLS — table accessible uniquement via service role (pas exposée en lecture user).
+-- Le panel UI lit via endpoint API qui passe par la service key.
+ALTER TABLE public.gemini_cost_override ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "gemini_cost_override_service_only" ON public.gemini_cost_override;
+CREATE POLICY "gemini_cost_override_service_only" ON public.gemini_cost_override
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Contexte

Suite à dépassement plafond mensuel Google AI Studio (**414 €**, service suspendu plusieurs heures 30/05/2026). Ajout d'un kill-switch hard cap quotidien Gemini + **override manuel par l'utilisateur depuis l'UI** (bouton "Relancer").

## Architecture

### 1. Migration `0177_gemini_cost_killswitch.sql`
- Table `gemini_cost_override` (1 row par date UTC, PK)
- Colonnes : `date`, `overridden_at`, `overridden_by_user_id`, `reason`, `used_at` (flag)
- Reset auto à minuit UTC : la PK date change → ancien override expire
- RLS service_role only

### 2. `GeminiBudgetGuardService` (nouveau service)
- `isAllowed()` : check `todayUsd < cap` OR override actif aujourd'hui
- `assertAllowed()` : throw `GeminiBudgetExceededError` si bloqué
- `getStatus()` : shape complet (today, monthToDate, capUsedPct, killSwitchActive, manualOverrideActive, overrideAt/reason, nextResetUtc)
- `manualOverride({ userId, reason })` / `clearOverride()`
- Cache 30s pour éviter SUM Supabase par LLM call

### 3. `ScannerLlmRouterService` modifié
- Injection `Optional<GeminiBudgetGuardService>`
- `assertAllowed()` appelé avant chaque `.call()` et `.callWithPro()`
- Throw propagé jusqu'au caller (fallback à `fallbackUsed=true`)

### 4. Endpoints `LisaController`
- `GET  /lisa/gemini-cost/status`
- `POST /lisa/gemini-cost/manual-override` body `{ reason?: string }`
- `POST /lisa/gemini-cost/clear-override`

### 5. Hooks React Query (`use-gemini-cost.ts`)
- `useGeminiCostStatus` — poll **30s**, `refetchIntervalInBackground=true`
- `useGeminiManualOverride`, `useGeminiClearOverride`

### 6. Composant `GeminiCostPanel` monté sur `/lisa`
- Barre de progression coût quotidien (vert/ambre/rouge selon %)
- Coût mensuel cumulé visible
- **Bouton "⚡ Relancer maintenant (bypass kill-switch)"** visible UNIQUEMENT si bloqué
- Champ texte raison (optionnel) avant override
- Bandeau info si override actif : timestamp + raison + bouton "Suspendre"
- Footer : rappelle que le tracking interne sous-déclare 5-50× la facturation Google réelle + lien vers Google AI Studio

## Comportement utilisateur

```
État normal :          🟢 OK $12 / $30 (40%)
Approche cap :         🟡 Attention $24 / $30 (80%)
Bloqué :               🔴 BLOQUÉ + [⚡ Relancer maintenant] visible
Override actif :       🔵 "Override manuel actif depuis HH:MM — Raison" + [Suspendre]
```

## Default hard cap

`$30/jour` (env `GEMINI_DAILY_HARD_CAP_USD` ajustable via Fly secret).  
Conservateur vu le ratio observé tracking interne / facturation : $30 interne ≈ $150-300 facturé Google.

## Tests

11/11 tests unitaires (`gemini-budget-guard.spec.ts`) :
- Hard cap par défaut + configurable + edge cases (négatif, NaN)
- `isAllowed` true/false selon cap et override
- `assertAllowed` throw correct
- `getStatus` aggregation Gemini-only (ignore Claude)
- `GeminiBudgetExceededError` shape

Typecheck `apps/api` + `apps/web` clean.

## Limitations connues (documentées)

1. **Tracking interne sous-déclaré** — `api_costs_daily` sous-estime massivement la facturation Google (5-50× observé fin mai). Le cap effectif réel dépend du ratio. À ajuster via env si déclenche trop tôt/tard.
2. **Pricing par-token non recalculé** — Tier 2 separate concern, nécessite update du `MultiVendorLlmRouter` dans `@smartvest/ai-analyst`. Roadmap futur.

## Roll-back

- `GEMINI_DAILY_HARD_CAP_USD=99999` désactive de facto le cap
- Removal de `GeminiBudgetGuardService` du provider list (injection Optional préserve comportement pré-PR)

## Plan post-merge

1. Migration `0177` appliquée auto au boot Fly
2. UI panel visible immédiatement sur `/lisa`
3. Surveiller cap effective sur 24-48h, ajuster `GEMINI_DAILY_HARD_CAP_USD` si nécessaire
4. Vérifier bouton "Relancer" fonctionne avec scénario test (lancer trade depuis état bloqué)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_