### PR TITLE
feat(cost): kill-switch grounding RiskManager (PR3, ~$150-200/mois économie)

### DIFF
--- a/apps/api/src/modules/lisa/services/research/gemini-risk-manager.service.ts
+++ b/apps/api/src/modules/lisa/services/research/gemini-risk-manager.service.ts
@@ -147,11 +147,34 @@ export class GeminiRiskManagerService {
     const rawConf = parseFloat(this.config.get<string>('GEMINI_RISK_MANAGER_AUTO_CLOSE_MIN_CONFIDENCE') ?? '0.8');
     this.autoCloseMinConfidence = Number.isFinite(rawConf) && rawConf >= 0 && rawConf <= 1.1 ? rawConf : 0.8;
     this.useMacroNews = (this.config.get<string>('GEMINI_RISK_MANAGER_USE_MACRO_NEWS') ?? 'false').toLowerCase() === 'true';
-    this.useGrounding = (this.config.get<string>('GEMINI_RISK_MANAGER_USE_GROUNDING') ?? 'false').toLowerCase() === 'true';
+
+    // PR3 cost-cut (31/05/2026) — kill-switch grounding hardcodé default ON.
+    // L'analyse coût-bénéfice 30/05 a montré :
+    //   - Coût grounding : ~$150-200/mois (Google facture $35/1000 queries au-delà
+    //     du quota gratuit 1500/jour ; observé 6920 queries/mois sur le 27/05)
+    //   - Bénéfice : 0 décision 'thesis_broken' déclenchée sur la période mesurable
+    //   - Verdict : pure perte sèche
+    //
+    // Le kill-switch force useGrounding=false même si le Fly secret
+    // GEMINI_RISK_MANAGER_USE_GROUNDING=true reste actif (économise une étape
+    // de manipulation Fly secrets). Pour réactiver volontairement après évaluation
+    // ROI, set GEMINI_RISK_MANAGER_GROUNDING_KILL_SWITCH=false ET garder
+    // GEMINI_RISK_MANAGER_USE_GROUNDING=true.
+    const groundingKillSwitch = (this.config.get<string>('GEMINI_RISK_MANAGER_GROUNDING_KILL_SWITCH') ?? 'true').toLowerCase() === 'true';
+    const rawGrounding = (this.config.get<string>('GEMINI_RISK_MANAGER_USE_GROUNDING') ?? 'false').toLowerCase() === 'true';
+    this.useGrounding = !groundingKillSwitch && rawGrounding;
+
     if (this.enabled) {
       this.logger.log(
         `[risk-manager] V2 ENABLED — auto-close conf>=${this.autoCloseMinConfidence} — macro=${this.useMacroNews} — grounding=${this.useGrounding} — cron */5min`,
       );
+      if (rawGrounding && groundingKillSwitch) {
+        this.logger.warn(
+          '[risk-manager] ⚠ GROUNDING_KILL_SWITCH active — env GEMINI_RISK_MANAGER_USE_GROUNDING=true ignoré ' +
+          '(PR3 cost-cut ~$150-200/mois sans bénéfice mesurable). Pour réactiver : set ' +
+          'GEMINI_RISK_MANAGER_GROUNDING_KILL_SWITCH=false',
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Contexte

Étude empirique 31/05 — bénéfice grounding RiskManager **= ZÉRO sur la période mesurable** :

| Métrique | Valeur |
|---|---:|
| Cycles RiskManager (14h post-recovery) | ~168 |
| Décisions `risk_manager_thesis_broken` | **0** |
| Closes par `exit_reason` contenant risk/thesis/broken | **0** |
| Coût grounding mois en cours | ~$150-200 |

**Historique** : `GEMINI_RISK_MANAGER_USE_GROUNDING` activé dans Fly secrets le **26/05 05:23 UTC** — exactement la veille du pic 180€/jour le 27/05.

## Approche

Kill-switch hardcodé code-side : `GEMINI_RISK_MANAGER_GROUNDING_KILL_SWITCH` (default `true`) qui **force `useGrounding=false`** même si `GEMINI_RISK_MANAGER_USE_GROUNDING=true` reste actif dans Fly secrets.

Avantages :
- Pas besoin de manipuler les Fly secrets manuellement
- Réactivation rapide possible (`GEMINI_RISK_MANAGER_GROUNDING_KILL_SWITCH=false`) si évaluation ROI ultérieure le justifie
- Log boot warn explicite quand le kill-switch override l'env actif

## Ce qui ne change PAS

- Le service `GeminiRiskManagerService` reste **actif** (cron 5min, Gemini Pro)
- L'analyse Gemini Pro sur input_news EODHD (déjà fourni en context) continue
- Seul le **search Google grounding** est neutralisé → économie immédiate sans dégradation de capacité

## Économie estimée

**~$150-200/mois** sur le grounding Google. Tracking via Google AI Studio billing.

## Roll-back

`GEMINI_RISK_MANAGER_GROUNDING_KILL_SWITCH=false` dans Fly secrets → grounding réactivé instantanément.

## Tests

6/6 tests existants `gemini-risk-manager.spec.ts` passent. Typecheck clean.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_