### PR TITLE
feat(cost): A/B shadow Pro vs Flash sur LiveTraderAgent (PR4 — collecte 7j)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/gemini-ab-concordance.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/gemini-ab-concordance.spec.ts
@@ -1,0 +1,106 @@
+// PR4 (31/05/2026) — Tests purs sur la logique de concordance Pro vs Flash
+// utilisée dans LiveTraderAgent.recordAbShadow.
+//
+// La méthode `recordAbShadow` est privée (helper d'instance) et fait beaucoup
+// de I/O (LLM call + Supabase insert). Pour tester la logique de comparaison
+// sans monter tout LiveTraderAgent, on extrait la logique pure dans ce fichier
+// et on la valide indépendamment.
+
+function computeConcordance(
+  pro: { action_kind: string | null; symbol: string | null; confidence: number | null },
+  flash: { action_kind: string | null; symbol: string | null; confidence: number | null } | null,
+): {
+  concordanceAction: boolean | null;
+  concordanceTarget: boolean | null;
+  concordanceFull: boolean;
+  confDelta: number | null;
+} {
+  if (flash === null) {
+    return {
+      concordanceAction: null,
+      concordanceTarget: null,
+      concordanceFull: false,
+      confDelta: null,
+    };
+  }
+  // null === null est valide pour hold (symbol absent attendu des deux côtés).
+  // Comparaison directe : true si les deux ont la même valeur (y compris null).
+  const concordanceAction = flash.action_kind === pro.action_kind;
+  const concordanceTarget = flash.symbol === pro.symbol;
+  const concordanceFull = concordanceAction && concordanceTarget;
+  const confDelta = pro.confidence !== null && flash.confidence !== null
+    ? Math.round((pro.confidence - flash.confidence) * 1000) / 1000
+    : null;
+  return { concordanceAction, concordanceTarget, concordanceFull, confDelta };
+}
+
+describe('PR4 — Gemini A/B concordance logic', () => {
+  it('Pro et Flash identiques (hold/hold) → full concordance true', () => {
+    const res = computeConcordance(
+      { action_kind: 'hold', symbol: null, confidence: 0.95 },
+      { action_kind: 'hold', symbol: null, confidence: 0.92 },
+    );
+    expect(res.concordanceAction).toBe(true);
+    expect(res.concordanceTarget).toBe(true);
+    expect(res.concordanceFull).toBe(true);
+    expect(res.confDelta).toBe(0.03);
+  });
+
+  it('Pro et Flash identiques sur open + même symbol → full concordance true', () => {
+    const res = computeConcordance(
+      { action_kind: 'open_directional', symbol: 'BTCUSDT', confidence: 0.85 },
+      { action_kind: 'open_directional', symbol: 'BTCUSDT', confidence: 0.72 },
+    );
+    expect(res.concordanceFull).toBe(true);
+    expect(res.confDelta).toBe(0.13);
+  });
+
+  it('Pro et Flash sur même action mais symbols différents → concordance partielle', () => {
+    const res = computeConcordance(
+      { action_kind: 'open_directional', symbol: 'BTCUSDT', confidence: 0.85 },
+      { action_kind: 'open_directional', symbol: 'ETHUSDT', confidence: 0.78 },
+    );
+    expect(res.concordanceAction).toBe(true);
+    expect(res.concordanceTarget).toBe(false);
+    expect(res.concordanceFull).toBe(false);
+  });
+
+  it('Pro vs Flash action divergente (hold vs open) → concordance false', () => {
+    const res = computeConcordance(
+      { action_kind: 'hold', symbol: null, confidence: 0.90 },
+      { action_kind: 'open_directional', symbol: 'BTCUSDT', confidence: 0.65 },
+    );
+    expect(res.concordanceAction).toBe(false);
+    expect(res.concordanceTarget).toBe(false);
+    expect(res.concordanceFull).toBe(false);
+    expect(res.confDelta).toBe(0.25); // Pro +0.25 plus confiant
+  });
+
+  it('Flash call failed (null) → concordance fields nulls + concordanceFull false', () => {
+    const res = computeConcordance(
+      { action_kind: 'hold', symbol: null, confidence: 0.95 },
+      null,
+    );
+    expect(res.concordanceAction).toBeNull();
+    expect(res.concordanceTarget).toBeNull();
+    expect(res.concordanceFull).toBe(false);
+    expect(res.confDelta).toBeNull();
+  });
+
+  it('Confidence delta négatif (Flash plus confiant que Pro)', () => {
+    const res = computeConcordance(
+      { action_kind: 'hold', symbol: null, confidence: 0.60 },
+      { action_kind: 'hold', symbol: null, confidence: 0.95 },
+    );
+    expect(res.confDelta).toBe(-0.35);
+  });
+
+  it('Flash a parsé partiellement (action mais pas symbol) → concordance valide quand même', () => {
+    const res = computeConcordance(
+      { action_kind: 'hold', symbol: null, confidence: 0.80 },
+      { action_kind: 'hold', symbol: null, confidence: 0.75 },
+    );
+    expect(res.concordanceFull).toBe(true);
+    expect(res.confDelta).toBe(0.05);
+  });
+});

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -630,6 +630,24 @@ export class LiveTraderAgentService {
         return;
       }
 
+      // PR4 (31/05/2026) — A/B shadow Pro vs Flash. Lance un appel Flash en
+      // arrière-plan avec exactement le même prompt que Pro, logge les 2
+      // décisions dans gemini_ab_decisions pour analyse comparative ultérieure.
+      // Best-effort : n'augmente pas la latence du cycle (fire-and-forget),
+      // catch toutes les erreurs (n'altère jamais le comportement TRADER).
+      const abEnabled = (this.config.get<string>('GEMINI_AB_PRO_VS_FLASH_ENABLED') ?? 'true').toLowerCase() === 'true';
+      if (abEnabled) {
+        void this.recordAbShadow({
+          cycleStartedAt,
+          portfolioId: TRADER_AGENT_PORTFOLIO_ID,
+          systemPrompt,
+          userPrompt,
+          candidatesCount: Array.isArray(candidates) ? candidates.length : 0,
+          proDecision: decision,
+          proResponse: response,
+        }).catch((e) => this.logger.debug(`[trader-agent] ab shadow err: ${String(e).slice(0, 120)}`));
+      }
+
       // 7. Apply decision with safety bounds — wrap dans try pour ne pas
       // silencieusement drop la décision si applyDecision throw.
       let applyResult: { applied: boolean; positionId?: string; error?: string };
@@ -2193,6 +2211,123 @@ Recommendation rules :
     if (actionKind.startsWith('skip')) return 'skip';
     if (actionKind === 'close' || actionKind === 'trail_stop') return 'exit';
     return 'other';
+  }
+
+  /**
+   * PR4 (31/05/2026) — A/B shadow Pro vs Flash.
+   * Lance un appel Gemini Flash en parallèle avec le même prompt que Pro,
+   * logge les 2 décisions dans gemini_ab_decisions pour analyse comparative.
+   *
+   * Best-effort : tous les errors sont catchés (n'altère JAMAIS le cycle TRADER).
+   * Coût estimé : ~$0.05/cycle × 288 cycles/j = ~$14/j (acceptable pour 7-14j de
+   * data collection avant décision data-driven Pro→Flash).
+   */
+  private async recordAbShadow(args: {
+    cycleStartedAt: Date;
+    portfolioId: string;
+    systemPrompt: string;
+    userPrompt: string;
+    candidatesCount: number;
+    proDecision: TraderDecision;
+    proResponse: { content: string; providerId: string; costUsd: number; latencyMs: number };
+  }): Promise<void> {
+    if (!this.supabase.isReady()) return;
+
+    // 1. Appel Gemini Flash (chain fast) avec exactement le même prompt que Pro.
+    let flashContent: string | null = null;
+    let flashProvider: string | null = null;
+    let flashCostUsd = 0;
+    let flashLatencyMs = 0;
+    let flashCallError: string | null = null;
+    let flashDecision: Partial<TraderDecision> | null = null;
+    try {
+      const flashRes = await this.llmRouter.call({
+        system: args.systemPrompt,
+        user: args.userPrompt,
+        temperature: 0.3,
+        maxTokens: 1500,
+        timeoutMs: 30_000,
+      });
+      flashContent = flashRes.content;
+      flashProvider = flashRes.providerId;
+      flashCostUsd = flashRes.costUsd;
+      flashLatencyMs = flashRes.latencyMs;
+      try {
+        const cleaned = flashContent.trim().replace(/^```json\s*/i, '').replace(/```\s*$/, '').trim();
+        flashDecision = JSON.parse(cleaned);
+      } catch (e) {
+        flashCallError = `parse_fail: ${String(e).slice(0, 100)}`;
+      }
+    } catch (e) {
+      flashCallError = String(e).slice(0, 200);
+    }
+
+    // 2. Compute concordance metrics
+    // Note : null === null est valide pour hold (symbol absent attendu des 2 côtés).
+    // Quand flashDecision est null (parse fail), tous concordance flags sont null.
+    const proAction = args.proDecision.action_kind ?? null;
+    const proTarget = args.proDecision.symbol ?? null;
+    const proConf = args.proDecision.confidence ?? null;
+    const flashAction = flashDecision?.action_kind ?? null;
+    const flashTarget = flashDecision?.symbol ?? null;
+    const flashConf = flashDecision?.confidence ?? null;
+    const flashParsed = flashDecision !== null;
+    const concordanceAction = flashParsed ? flashAction === proAction : null;
+    const concordanceTarget = flashParsed ? flashTarget === proTarget : null;
+    const concordanceFull = concordanceAction === true && concordanceTarget === true;
+    const confDelta = proConf !== null && flashConf !== null && typeof flashConf === 'number'
+      ? Math.round((proConf - flashConf) * 1000) / 1000
+      : null;
+
+    // 3. Compute context hash (sha256 trunc) pour valider que Pro et Flash ont vu le même context
+    let contextHash: string | null = null;
+    try {
+      const crypto = await import('node:crypto');
+      contextHash = crypto.createHash('sha256').update(args.userPrompt).digest('hex').slice(0, 16);
+    } catch { /* noop */ }
+
+    // 4. INSERT
+    try {
+      await this.supabase.getClient().from('gemini_ab_decisions').insert({
+        decided_at: new Date().toISOString(),
+        portfolio_id: args.portfolioId,
+        cycle_started_at: args.cycleStartedAt.toISOString(),
+        pro_action_kind: proAction,
+        pro_target_symbol: proTarget,
+        pro_direction: args.proDecision.direction ?? null,
+        pro_confidence: proConf,
+        pro_notional_usd: args.proDecision.notional_usd ?? null,
+        pro_thesis: (args.proDecision.thesis ?? '').slice(0, 1000),
+        pro_cost_usd: args.proResponse.costUsd,
+        pro_latency_ms: args.proResponse.latencyMs,
+        pro_provider: args.proResponse.providerId,
+        // pro_applied / pro_apply_error : laissés NULL pour l'instant. Si besoin,
+        // backfill ultérieur via cron qui matche cycle_started_at avec
+        // trader_agent_decisions.cycle_started_at + action_applied.
+        flash_action_kind: flashAction,
+        flash_target_symbol: flashTarget,
+        flash_direction: flashDecision?.direction ?? null,
+        flash_confidence: flashConf,
+        flash_notional_usd: flashDecision?.notional_usd ?? null,
+        flash_thesis: (flashDecision?.thesis ?? '').slice(0, 1000),
+        flash_cost_usd: flashCostUsd,
+        flash_latency_ms: flashLatencyMs,
+        flash_provider: flashProvider,
+        flash_call_error: flashCallError,
+        concordance_action_kind: concordanceAction,
+        concordance_target_symbol: concordanceTarget,
+        concordance_full: concordanceFull,
+        confidence_delta: confDelta,
+        candidates_count: args.candidatesCount,
+        context_hash: contextHash,
+      });
+      this.logger.debug(
+        `[trader-agent:ab] Pro=${proAction}/${proTarget ?? '?'} vs Flash=${flashAction ?? 'fail'}/${flashTarget ?? '?'} ` +
+        `concordance=${concordanceFull} costDelta=${(args.proResponse.costUsd - flashCostUsd).toFixed(4)}`,
+      );
+    } catch (e) {
+      this.logger.debug(`[trader-agent:ab] insert failed: ${String(e).slice(0, 100)}`);
+    }
   }
 
   /**

--- a/supabase/migrations/0178_gemini_ab_pro_vs_flash.sql
+++ b/supabase/migrations/0178_gemini_ab_pro_vs_flash.sql
@@ -1,0 +1,98 @@
+-- Migration 0178 — A/B shadow Pro vs Flash sur LiveTraderAgent
+--
+-- Contexte : suite à PR1-3 cost-cuts, on souhaite mesurer empiriquement la
+-- différence de qualité Gemini 2.5 Pro vs Gemini 2.5 Flash sur les décisions
+-- TRADER. Pour chaque cycle TRADER, on appelle Gemini Pro (décision réelle
+-- appliquée) ET Gemini Flash (décision shadow, jamais appliquée). On logge
+-- les deux pour comparaison + outcomes.
+--
+-- Objectif analyse :
+--   - Concordance % : combien de cycles Pro et Flash sortent la même décision
+--   - Divergences : quand ils divergent, qui a raison (outcome PnL)
+--   - Coût : ratio coût Pro / coût Flash sur 7 jours
+--   - Décision data-driven : si Flash ≥ 90% qualité Pro, migrer TRADER vers Flash
+--
+-- Idempotente.
+
+CREATE TABLE IF NOT EXISTS public.gemini_ab_decisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  decided_at timestamptz NOT NULL DEFAULT NOW(),
+  portfolio_id uuid NOT NULL,
+  cycle_started_at timestamptz NOT NULL,
+
+  -- Décision Pro (celle qui a été APPLIQUÉE par TRADER)
+  pro_action_kind text,
+  pro_target_symbol text,
+  pro_direction text,
+  pro_confidence numeric(3, 2),
+  pro_notional_usd numeric(12, 2),
+  pro_thesis text,
+  pro_cost_usd numeric(10, 6),
+  pro_latency_ms int,
+  pro_provider text,
+  pro_applied boolean,
+  pro_apply_error text,
+
+  -- Décision Flash (shadow uniquement, jamais appliquée)
+  flash_action_kind text,
+  flash_target_symbol text,
+  flash_direction text,
+  flash_confidence numeric(3, 2),
+  flash_notional_usd numeric(12, 2),
+  flash_thesis text,
+  flash_cost_usd numeric(10, 6),
+  flash_latency_ms int,
+  flash_provider text,
+  flash_call_error text, -- si l'appel Flash a échoué (timeout, parse fail)
+
+  -- Comparaison Pro vs Flash (calculée à l'insert)
+  concordance_action_kind boolean, -- true si pro_action_kind === flash_action_kind
+  concordance_target_symbol boolean, -- true si pro_target_symbol === flash_target_symbol
+  concordance_full boolean, -- true si action_kind AND target_symbol identiques
+  confidence_delta numeric(4, 3), -- pro_confidence - flash_confidence (signed)
+
+  -- Outcome backfill (si la décision a abouti à une position fermée)
+  -- Backfill manuel ou via cron à coder ultérieurement. NULL initialement.
+  outcome_position_id uuid REFERENCES public.lisa_positions(id) ON DELETE SET NULL,
+  outcome_pnl_usd numeric(10, 2),
+  outcome_win boolean,
+  outcome_resolved_at timestamptz,
+
+  -- Contexte (snapshot minimal pour debug)
+  candidates_count int, -- nombre de candidats au feed au moment du cycle
+  context_hash text -- hash sha256 du contexte input (pour détecter si Pro et Flash ont vu le même contexte)
+);
+
+CREATE INDEX IF NOT EXISTS gemini_ab_decisions_decided_at_idx
+  ON public.gemini_ab_decisions (decided_at DESC);
+
+CREATE INDEX IF NOT EXISTS gemini_ab_decisions_portfolio_idx
+  ON public.gemini_ab_decisions (portfolio_id, decided_at DESC);
+
+CREATE INDEX IF NOT EXISTS gemini_ab_decisions_concordance_idx
+  ON public.gemini_ab_decisions (concordance_full, decided_at DESC);
+
+CREATE INDEX IF NOT EXISTS gemini_ab_decisions_outcome_idx
+  ON public.gemini_ab_decisions (outcome_position_id) WHERE outcome_position_id IS NOT NULL;
+
+COMMENT ON TABLE public.gemini_ab_decisions IS
+'A/B shadow Pro vs Flash sur LiveTraderAgent. Pour chaque cycle TRADER, appel parallèle Pro (appliqué) + Flash (shadow). Aggrégations possibles : concordance %, divergence outcomes, ratio coût. Cf. migration 0178 + PR4.';
+
+COMMENT ON COLUMN public.gemini_ab_decisions.concordance_full IS
+'true si pro_action_kind === flash_action_kind ET pro_target_symbol === flash_target_symbol. Métrique principale pour décision Pro→Flash.';
+
+COMMENT ON COLUMN public.gemini_ab_decisions.confidence_delta IS
+'pro_confidence - flash_confidence. Signed : positif = Pro plus confiant, négatif = Flash plus confiant.';
+
+COMMENT ON COLUMN public.gemini_ab_decisions.outcome_position_id IS
+'Référence position ouverte suite à la décision (Pro applied). Backfill via cron resolveCitationOutcomes-like quand position close.';
+
+-- RLS — table accessible uniquement via service role.
+ALTER TABLE public.gemini_ab_decisions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "gemini_ab_decisions_service_only" ON public.gemini_ab_decisions;
+CREATE POLICY "gemini_ab_decisions_service_only" ON public.gemini_ab_decisions
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Contexte

Pour décider data-driven du choix **Gemini 2.5 Pro vs Gemini 2.5 Flash** sur les décisions TRADER, on lance un appel Flash en parallèle de chaque appel Pro (décision réelle), logge les 2 dans `gemini_ab_decisions` pour analyse comparative sur 7-14 jours.

Le user a explicitement demandé que toutes les tables/colonnes existent dès aujourd'hui pour pouvoir interroger ce soir.

## Architecture

### Migration `0178_gemini_ab_pro_vs_flash.sql`

Table `gemini_ab_decisions` :

| Colonne | Type | Note |
|---|---|---|
| `id` | uuid PK | |
| `decided_at` | timestamptz | |
| `portfolio_id` | uuid | TRADER (`b0000001-...`) |
| `cycle_started_at` | timestamptz | |
| `pro_action_kind` | text | hold/open_directional/close/scale_in/trail_stop |
| `pro_target_symbol` | text | |
| `pro_direction` | text | long/short |
| `pro_confidence` | numeric(3,2) | |
| `pro_notional_usd` | numeric(12,2) | |
| `pro_thesis` | text | 1000 chars max |
| `pro_cost_usd`, `pro_latency_ms`, `pro_provider` | | |
| `flash_*` | (idem 9 colonnes) | |
| `flash_call_error` | text | si parse fail / timeout |
| `concordance_action_kind` | boolean | true si pro_action === flash_action |
| `concordance_target_symbol` | boolean | true si pro_symbol === flash_symbol |
| `concordance_full` | boolean | concordance_action AND concordance_target |
| `confidence_delta` | numeric(4,3) | pro_conf - flash_conf (signed) |
| `outcome_position_id` | uuid REF lisa_positions | backfill ultérieur |
| `outcome_pnl_usd`, `outcome_win`, `outcome_resolved_at` | | NULL initialement |
| `candidates_count` | int | |
| `context_hash` | text | sha256 trunc du userPrompt (validation contexte identique) |

4 indexes (`decided_at`, `portfolio`, `concordance`, `outcome`). RLS service_role only.

### `LiveTraderAgent.recordAbShadow` — helper privé

- Lance `llmRouter.call(...)` Flash avec **EXACTEMENT** le même `systemPrompt` + `userPrompt` que le call Pro (garantit contexte identique via `context_hash`)
- Parse flash decision, catch toutes erreurs
- Compute concordance + confDelta
- INSERT `gemini_ab_decisions`
- **Best-effort** : fire-and-forget (`void`) après parse du Pro decision réussi → **n'augmente PAS la latence du cycle TRADER**, ne bloque JAMAIS le trading

### Gating

Env `GEMINI_AB_PRO_VS_FLASH_ENABLED` default `'true'` (active immédiatement pour collecter data). Pour désactiver : `false` dans Fly secrets.

## Coût supplémentaire

~$0.05/cycle Flash × 288 cycles/j = **~$14/j (~$100 sur 7 jours)**. Acceptable pour décision data-driven valant :
- **~$15-30/j d'économie** potentielle si migration Pro→Flash après analyse
- **OU ~$5/j de surcoût justifié** si Pro reste

## Analyse SQL prévue (dans 7 jours)

```sql
-- Concordance globale
SELECT 
  COUNT(*) FILTER (WHERE concordance_full) * 100.0 / COUNT(*) AS concordance_pct,
  COUNT(*) AS total_cycles
FROM gemini_ab_decisions
WHERE decided_at >= NOW() - INTERVAL '7 days';

-- Divergences avec outcomes
SELECT 
  pro_action_kind, flash_action_kind, pro_target_symbol,
  pro_confidence, flash_confidence,
  outcome_pnl_usd, outcome_win
FROM gemini_ab_decisions
WHERE concordance_full = false 
  AND outcome_resolved_at IS NOT NULL
ORDER BY decided_at DESC;

-- Coût ratio
SELECT 
  SUM(pro_cost_usd) AS total_pro_cost,
  SUM(flash_cost_usd) AS total_flash_cost,
  SUM(pro_cost_usd) / NULLIF(SUM(flash_cost_usd), 0) AS pro_to_flash_ratio
FROM gemini_ab_decisions
WHERE decided_at >= NOW() - INTERVAL '7 days';
```

## Tests

7 tests purs concordance logic (`gemini-ab-concordance.spec.ts`) :
- Full match (hold/hold + open identique)
- Partial match (action same, symbol différent)
- Action divergente (hold vs open)
- Flash call failed → tous concordance nulls
- Confidence delta signed (négatif si Flash plus confiant)
- null === null pour hold (symbol absent attendu des deux côtés)

2337/2337 tests existants `lisa` passent. Typecheck clean.

## Roll-back

`GEMINI_AB_PRO_VS_FLASH_ENABLED=false` dans Fly secrets — désactive le shadow Flash instantanément (sans redeploy).

## Suite

- Validation ce soir : data dans `gemini_ab_decisions` post-deploy + migration
- Dans 7 jours : analyse SQL → décision Pro/Flash data-driven

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_