### PR TITLE
fix(scanner): diagnostic warn pour binance fetch (12/30 cryptos)

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -1966,10 +1966,19 @@ export class TopGainersScannerService implements OnModuleInit {
       ...CRYPTO_PAIRS.map((s) => ({ symbol: s, assetClass: 'crypto_major' as const })),
       ...CRYPTO_ALTS.map((s) => ({ symbol: s, assetClass: 'crypto_alt' as const })),
     ];
+    // 31/05/2026 — diagnostic : on observait ~12/30 cryptos retournés en prod sans
+    // moyen de savoir lesquelles échouaient (ancien log debug + silent continue).
+    // On remonte à warn niveau cycle pour identifier les pairs délistées/renommées
+    // sur Binance, puis on nettoiera CRYPTO_ALTS à partir des warnings.
+    const nullSymbols: string[] = [];
+    const errorSymbols: string[] = [];
     for (const { symbol: pair, assetClass } of pairs) {
       try {
         const t = await this.binanceMarket.getTicker24h(pair);
-        if (!t) continue;
+        if (!t) {
+          nullSymbols.push(pair);
+          continue;
+        }
         out.push({
           symbol: pair,
           exchange: 'BINANCE',
@@ -1987,8 +1996,15 @@ export class TopGainersScannerService implements OnModuleInit {
           marketCap: CRYPTO_MARKET_CAP_USD[pair] ?? 0,
         });
       } catch (e) {
-        this.logger.debug(`[top-gainers] binance ${pair} error: ${String(e).slice(0, 80)}`);
+        errorSymbols.push(`${pair}:${String(e).slice(0, 60)}`);
       }
+    }
+    if (nullSymbols.length > 0 || errorSymbols.length > 0) {
+      this.logger.warn(
+        `[top-gainers] binance fetch summary: ${out.length}/${pairs.length} ok` +
+          (nullSymbols.length > 0 ? ` · null(${nullSymbols.length}): ${nullSymbols.join(',')}` : '') +
+          (errorSymbols.length > 0 ? ` · error(${errorSymbols.length}): ${errorSymbols.join(' | ')}` : ''),
+      );
     }
     return out;
   }


### PR DESCRIPTION
## Contexte

Depuis PR #504 (élargissement 10 majors → 30 crypto incluant 20 alts), seuls
**~12/30 candidats** remontent du scanner Binance — sans aucun log permettant
d'identifier les pairs en échec :

- `if (!t) continue;` silently skip (Binance retourne null pour pair inconnue)
- catch logué en `debug` (filtré en prod Fly, niveau info+ uniquement)

## Fix

Patch minimal de télémétrie :
- On accumule `nullSymbols[]` + `errorSymbols[]` par cycle
- Une seule ligne `warn` par cycle (summary, pas une ligne par symbol)
- Aucun changement comportemental

Format du log :

```
[top-gainers] binance fetch summary: 12/30 ok · null(17): RNDRUSDT,TIAUSDT,... · error(1): SUIUSDT:HTTP 451
```

## Plan post-merge

1. Auto-merge → Fly redeploy auto
2. Attendre 1-2 cycles scanner (≈ 5 min)
3. Copier les warnings Fly
4. Cleanup `CRYPTO_ALTS` (suppression des morts, garde les vivants)

## Test plan

- [x] Typecheck : 6 erreurs avant/après (pré-existantes dans `lisa.service.ts`, non liées)
- [x] Changement isolé à `fetchBinanceGainers` — pas de régression possible ailleurs
- [ ] Vérifier en prod après deploy que le warn s'imprime bien dans Fly logs

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_