### PR TITLE
fix(scanner): bypass geo-block Binance (12/30 → 30/30 alts)

### DIFF
--- a/apps/api/src/modules/lisa/services/binance-market.service.ts
+++ b/apps/api/src/modules/lisa/services/binance-market.service.ts
@@ -69,8 +69,14 @@ export interface BinanceFlowStats {
 @Injectable()
 export class BinanceMarketService {
   private readonly logger = new Logger(BinanceMarketService.name);
-  private readonly BASE_URL = 'https://api.binance.com';
-  private readonly FAPI_URL = 'https://fapi.binance.com';
+  // 31/05/2026 — api.binance.com renvoie HTTP 451 (geo-block) depuis Fly Paris (cdg).
+  // data-api.binance.vision est le CDN public officiel pour le market data spot (mêmes
+  // routes /api/v3/{ticker,klines,price}, pas d'auth, pas geo-restreint). Constat
+  // 30-31/05 : 18/20 alts ajoutées par PR #504 (NEAR/ATOM/UNI/ICP/APT/XLM/FIL/...)
+  // skip silencieusement via api.binance.com → null → continue. Sur data-api elles
+  // répondent toutes. Override possible via env BINANCE_BASE_URL si besoin.
+  private readonly BASE_URL = process.env.BINANCE_BASE_URL ?? 'https://data-api.binance.vision';
+  private readonly FAPI_URL = process.env.BINANCE_FAPI_URL ?? 'https://fapi.binance.com';
   private klinesCache = new Map<string, { data: BinanceCandle[]; asOf: number }>();
   // Bug #A (13/05/2026) — Cache séparé pour getKlinesRange. TTL 1h car un range
   // historique fermé [startTime, endTime] est immutable, pas besoin de refresh


### PR DESCRIPTION
## Root cause

PR #511 a posé le diagnostic : depuis PR #504 (élargissement 10 majors → 30 cryptos), seuls **12/30 candidats** remontent du scanner Binance.

Probe runtime du 31/05/2026 09:30 CEST :

| Endpoint | Code |
|---|---|
| `api.binance.com/api/v3/ticker/24hr?symbol=*` | **HTTP 451** (Unavailable For Legal Reasons) — geo-block depuis Fly Paris (cdg) |
| `data-api.binance.vision/api/v3/ticker/24hr?symbol=*` | **HTTP 200** sur les 21 paires testées |

`data-api.binance.vision` est le **CDN public officiel Binance** pour le market data spot — mêmes routes `/api/v3/{ticker,klines,price}`, pas d'auth, pas geo-restreint EU.

Les 18 alts qui skippaient (LTC, BCH, ETC, NEAR, ATOM, UNI, ICP, APT, XLM, FIL, ARB, OP, INJ, AAVE, SUI, TIA, RNDR, IMX) ne sont **ni délistées ni renommées** — juste bloquées par geo depuis Fly. Sur `data-api.binance.vision` elles répondent toutes avec `lastPrice` + `priceChangePercent` valides.

## Patch

`apps/api/src/modules/lisa/services/binance-market.service.ts` :
- `BASE_URL` → default `https://data-api.binance.vision` (override env `BINANCE_BASE_URL`)
- `FAPI_URL` inchangé par défaut, override env `BINANCE_FAPI_URL` (futures = endpoint séparé, hors scope)
- Adapter signé `packages/brokers/binance.adapter.ts` reste sur `api.binance.com` (orders/account = signed endpoints obligatoires) — dormant en l'état (`placeOrder` throw `NotSupportedError` per CLAUDE.md §6ter)

## Validation

- `tsc --noEmit` : 0 erreur dans le fichier touché (les 6 erreurs `lisa.service.ts` sur main sont pré-existantes, non liées)
- `crypto-pairs-pol-rebrand.spec.ts` : 16/16 ✅
- `crypto-universe-expanded.spec.ts` : 8/8 ✅

## Effet attendu post-deploy

- `[top-gainers] binance fetch summary: 30/30 ok` (plus de `null(18): LTC,BCH,...`)
- Effectif crypto scannable ×2.5 (12 → 30) → meilleure couverture sweet spot [3%, 8%] weekend/24-7
- Aucun gate qualité touché (KTOS / pump_score / persistence / path_eff intact)

## Rollback

Si régression imprévue : `fly secrets set BINANCE_BASE_URL=https://api.binance.com -a smartvest` → restore comportement d'avant.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_