### PR TITLE
fix(scanner): log toujours-on fetch binance + BASE_URL résolu

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -1999,13 +1999,18 @@ export class TopGainersScannerService implements OnModuleInit {
         errorSymbols.push(`${pair}:${String(e).slice(0, 60)}`);
       }
     }
-    if (nullSymbols.length > 0 || errorSymbols.length > 0) {
-      this.logger.warn(
-        `[top-gainers] binance fetch summary: ${out.length}/${pairs.length} ok` +
-          (nullSymbols.length > 0 ? ` · null(${nullSymbols.length}): ${nullSymbols.join(',')}` : '') +
-          (errorSymbols.length > 0 ? ` · error(${errorSymbols.length}): ${errorSymbols.join(' | ')}` : ''),
-      );
-    }
+    // 31/05/2026 — log toujours-on (anciennement conditionnel) après constat
+    // "0 crypto_alt persisté en 24h" alors que summary warn silencieux. Permet
+    // de différencier fetch-OK + downstream-gate-blocks vs fetch-KO en 1 cycle.
+    const majorsOk = out.filter((c) => c.assetClass === 'crypto_major').length;
+    const altsOk = out.filter((c) => c.assetClass === 'crypto_alt').length;
+    this.logger.log(
+      `[top-gainers] binance fetch: ${out.length}/${pairs.length} ok ` +
+        `(majors=${majorsOk}/${CRYPTO_PAIRS.length} alts=${altsOk}/${CRYPTO_ALTS.length}) ` +
+        `base=${process.env.BINANCE_BASE_URL ?? 'data-api.binance.vision[default]'}` +
+        (nullSymbols.length > 0 ? ` · null(${nullSymbols.length}): ${nullSymbols.join(',')}` : '') +
+        (errorSymbols.length > 0 ? ` · error(${errorSymbols.length}): ${errorSymbols.join(' | ')}` : ''),
+    );
     return out;
   }
 


### PR DESCRIPTION
## Constat critique

SQL prod 31/05 11:55 UTC :
```
SELECT asset_class, COUNT(DISTINCT symbol) AS distinct_symbols
FROM gainers_user_shadow_signals
WHERE created_at > NOW() - INTERVAL '24 hours' AND asset_class IN ('crypto_major','crypto_alt')
GROUP BY asset_class;

| asset_class  | distinct_symbols |
| crypto_major | 2                |
```

**0 distinct crypto_alt sur 24h**. Or `persistShadowSignalsBatch` persiste TOUS les candidats (ACCEPT + REJECT) sans filtre asset_class. Donc 0 alt persisté = 0 alt dans `candidates` = `fetchBinanceGainers` ne retourne pas les alts.

Mais le warn diag de PR #511 reste silencieux (conditionnel à `nullSymbols.length > 0 || errorSymbols.length > 0`). **2 hypothèses indistinguables sans plus de logs** :

| Hypothèse | Scénario | Probabilité |
|---|---|---|
| H1 | Alts répondent OK mais filtrées en aval | Faible (code path direct vérifié, aucun filtre asset_class entre fetch et persistence) |
| H2 | PR #512 non déployé / inopérant | Élevée |

## Patch minimal

Le log précédent était conditionnel — il ne disait rien quand fetch retournait 0 sans erreur. Maintenant :

```typescript
this.logger.log(
  `[top-gainers] binance fetch: ${out.length}/${pairs.length} ok ` +
    `(majors=${majorsOk}/${CRYPTO_PAIRS.length} alts=${altsOk}/${CRYPTO_ALTS.length}) ` +
    `base=${process.env.BINANCE_BASE_URL ?? 'data-api.binance.vision[default]'}` +
    (nullSymbols.length > 0 ? ` · null(${nullSymbols.length}): ${nullSymbols.join(',')}` : '') +
    (errorSymbols.length > 0 ? ` · error(${errorSymbols.length}): ${errorSymbols.join(' | ')}` : ''),
);
```

→ Loggé **à chaque cycle scanner** (~30s), niveau INFO (pas warn).

## Au prochain cycle post-deploy, le log dira

| Pattern | Interprétation | Action |
|---|---|---|
| `majors=10/10 alts=20/20` | Fetch OK, problème ailleurs | Creuser candidat path post-fetch |
| `majors=10/10 alts=2/20 · null(18): LTC,BCH,...` | Geo-block persiste | PR #512 inopérant, switch endpoint différent |
| `majors=10/10 alts=0/20 · base=https://api.binance.com` | PR #512 pas déployé | Force redeploy Fly |
| `majors=10/10 alts=0/20 · base=data-api.binance.vision[default]` | Code OK mais alts skip silencieux | Bug dans la loop, à creuser |

## Validation

- 0 erreur tsc nouvelle dans le fichier (les 6 lisa.service.ts pré-existantes notées PR #512/#513 inchangées)
- Aucune modif logique, juste log promu INFO + compteurs séparés majors/alts

## Effet sur les coûts logs

Cycle scanner ~30s → 1 ligne INFO/cycle = ~2880 lignes/jour. Négligeable vs les 350k lignes/jour économisées par PR #513.

⚠️ À reverter après diagnostic (mais utile à garder tant qu'on n'est pas sûr du 30/30).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_