### PR TITLE
chore(scripts): diagnostic scripts crypto alts (post PR #515)

### DIFF
--- a/scripts/q-binance-fetch-trace.ts
+++ b/scripts/q-binance-fetch-trace.ts
@@ -1,0 +1,76 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+  process.env.SUPABASE_SERVICE_ROLE_KEY || '',
+);
+
+async function main() {
+  console.log('=== 1. Toutes les asset_class dans gainers_user_shadow_signals 60min ===');
+  const { data: d1, error: e1 } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('asset_class')
+    .gte('created_at', new Date(Date.now() - 60 * 60_000).toISOString());
+  if (e1) console.error(e1.message);
+  else {
+    const counts: Record<string, number> = {};
+    (d1 ?? []).forEach(r => { counts[r.asset_class as string] = (counts[r.asset_class as string] ?? 0) + 1; });
+    console.log(counts);
+  }
+
+  console.log('\n=== 2. Tous les symbols (top 30 par count) 60min ===');
+  const { data: d2 } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('symbol,asset_class,decision,reject_reason')
+    .gte('created_at', new Date(Date.now() - 60 * 60_000).toISOString())
+    .limit(500);
+  const symCounts = new Map<string, { count: number; asset_class: string; decisions: Set<string>; rejects: Set<string> }>();
+  (d2 ?? []).forEach(r => {
+    const key = r.symbol as string;
+    const e = symCounts.get(key) ?? { count: 0, asset_class: r.asset_class as string, decisions: new Set(), rejects: new Set() };
+    e.count++;
+    e.decisions.add(r.decision as string);
+    if (r.reject_reason) e.rejects.add(r.reject_reason as string);
+    symCounts.set(key, e);
+  });
+  [...symCounts.entries()]
+    .sort((a, b) => b[1].count - a[1].count)
+    .slice(0, 30)
+    .forEach(([sym, s]) => {
+      console.log(`  ${sym.padEnd(15)} ${s.asset_class.padEnd(20)} count=${s.count} decisions=${[...s.decisions].join(',')} rejects=${[...s.rejects].join('|')}`);
+    });
+
+  console.log('\n=== 3. Toutes les tables top_gainers* / gainers* existantes ===');
+  const tables = [
+    'top_gainers_log',
+    'gainers_v1_shadow_signals',
+    'gainers_user_shadow_signals',
+    'gainers_persistence_log',
+  ];
+  for (const t of tables) {
+    const { count, error } = await sb.from(t).select('*', { count: 'exact', head: true }).gte('created_at', new Date(Date.now() - 60 * 60_000).toISOString());
+    console.log(`  ${t.padEnd(40)} 60min count=${count ?? 'ERROR:' + error?.message?.slice(0, 50)}`);
+  }
+
+  console.log('\n=== 4. top_gainers_log breakdown 30min par asset_class ===');
+  const { data: d4, error: e4 } = await sb
+    .from('top_gainers_log')
+    .select('symbol,asset_class')
+    .gte('created_at', new Date(Date.now() - 30 * 60_000).toISOString())
+    .limit(1000);
+  if (e4) console.log(`  ERROR: ${e4.message}`);
+  else {
+    const ac: Record<string, Set<string>> = {};
+    (d4 ?? []).forEach(r => {
+      const k = r.asset_class as string;
+      ac[k] = ac[k] ?? new Set();
+      ac[k].add(r.symbol as string);
+    });
+    Object.entries(ac).forEach(([k, syms]) => {
+      console.log(`  ${k.padEnd(20)} ${syms.size} distinct: ${[...syms].sort().slice(0, 20).join(', ')}${syms.size > 20 ? '...' : ''}`);
+    });
+  }
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/q-gainers-v1-shadow.ts
+++ b/scripts/q-gainers-v1-shadow.ts
@@ -1,0 +1,55 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+  process.env.SUPABASE_SERVICE_ROLE_KEY || '',
+);
+
+async function main() {
+  // 30 min window — post-deploy 11:07 UTC, we're at 11:17+
+  const since30 = new Date(Date.now() - 30 * 60_000).toISOString();
+
+  console.log('=== gainers_v1_shadow_signals 30min — schema discovery ===');
+  const { data: d0 } = await sb.from('gainers_v1_shadow_signals').select('*').limit(1);
+  console.log('Columns:', d0?.[0] ? Object.keys(d0[0]).join(', ') : '(empty)');
+
+  console.log('\n=== distinct symbols 30min ===');
+  const { data: d1 } = await sb
+    .from('gainers_v1_shadow_signals')
+    .select('symbol')
+    .gte('created_at', since30)
+    .limit(2000);
+  const syms = new Set((d1 ?? []).map(r => r.symbol as string));
+  console.log(`Total signals=${d1?.length}, distinct symbols=${syms.size}`);
+  console.log('Symbols:', [...syms].sort().join(', '));
+
+  console.log('\n=== top_gainers_log distinct symbols 30min ===');
+  const { data: d2 } = await sb
+    .from('top_gainers_log')
+    .select('symbol')
+    .gte('created_at', since30)
+    .limit(2000);
+  const syms2 = new Set((d2 ?? []).map(r => r.symbol as string));
+  console.log(`Total entries=${d2?.length}, distinct symbols=${syms2.size}`);
+  const altsTracked = ['LTCUSDT', 'BCHUSDT', 'ETCUSDT', 'NEARUSDT', 'ATOMUSDT', 'UNIUSDT', 'ICPUSDT', 'APTUSDT', 'XLMUSDT', 'FILUSDT', 'ARBUSDT', 'OPUSDT', 'INJUSDT', 'AAVEUSDT', 'SUIUSDT', 'TIAUSDT', 'RNDRUSDT', 'IMXUSDT'];
+  const altsFound = altsTracked.filter(a => syms2.has(a));
+  console.log(`Alts CRYPTO_ALTS dans top_gainers_log: ${altsFound.length}/18 — ${altsFound.join(', ') || '(aucun)'}`);
+  console.log(`All distinct: ${[...syms2].sort().slice(0, 50).join(', ')}${syms2.size > 50 ? '...' : ''}`);
+
+  console.log('\n=== gainers_persistence_log 30min ===');
+  const { data: d3 } = await sb
+    .from('gainers_persistence_log')
+    .select('*')
+    .gte('created_at', since30)
+    .limit(50);
+  if (d3?.[0]) {
+    console.log('Schema:', Object.keys(d3[0]).join(', '));
+    const syms3 = new Set(d3.map(r => (r as any).symbol as string));
+    console.log(`Distinct symbols=${syms3.size}: ${[...syms3].sort().join(', ')}`);
+  } else {
+    console.log('(empty)');
+  }
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Contexte

Scripts utilisés ce matin pour identifier le root cause de PR #515 (regex session-filter trop étroite, 0/18 alts persistés).

## Scripts ajoutés

**`scripts/q-binance-fetch-trace.ts`** — Compte les rows + breakdown par `asset_class` dans toutes les tables gainers_* (`top_gainers_log`, `gainers_v1_shadow_signals`, `gainers_user_shadow_signals`, `gainers_persistence_log`) sur fenêtres 30-60min. Utile pour différencier où les candidats sont/ne sont pas capturés.

**`scripts/q-gainers-v1-shadow.ts`** — Schema discovery + distinct symbols sur `gainers_v1_shadow_signals` (la vraie table de référence du scanner shadow). C'est cette table qui prouve définitivement que les 30 cryptos sont bien scannées.

## Usage

```bash
npx tsx scripts/q-gainers-v1-shadow.ts
```

**Attendu post-PR #515** (validé live à 11:18 UTC) :
```
=== distinct symbols 30min ===
Total signals=90, distinct symbols=30
Symbols: AAVEUSDT, ADAUSDT, APTUSDT, ARBUSDT, ATOMUSDT, AVAXUSDT, BCHUSDT,
BNBUSDT, BTCUSDT, DOGEUSDT, DOTUSDT, ETCUSDT, ETHUSDT, FILUSDT, ICPUSDT,
IMXUSDT, INJUSDT, LINKUSDT, LTCUSDT, NEARUSDT, OPUSDT, POLUSDT, RNDRUSDT,
SOLUSDT, SUIUSDT, TIAUSDT, TRXUSDT, UNIUSDT, XLMUSDT, XRPUSDT
```

## Apprentissage

`gainers_user_shadow_signals` (que j'avais initialement requêtée) est un subset filtré par `UserShadowSimulator`, pas la table de persistance scanner. Pour valider que le scanner fait son boulot, c'est `gainers_v1_shadow_signals` qu'il faut interroger.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_