### PR TITLE
feat(cost): A/B shadow 3-way Pro vs Flash vs Mistral Large 3 (étape 1)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -53,6 +53,7 @@ import { TopGainersScannerService } from './services/top-gainers-scanner.service
 import { GainersUserShadowService } from './services/gainers-user-shadow.service';
 import { ShadowSizingOrchestratorService } from './services/shadow-sizing-orchestrator.service';
 import { LiveTraderAgentService } from './services/live-trader-agent.service';
+import { MistralShadowService } from './services/mistral-shadow.service';
 import { MainScannerPostMortemService } from './services/main-scanner-postmortem.service';
 import { DailyDigestService } from './services/daily-digest.service';
 import { PushNotificationsService } from './services/push-notifications.service';
@@ -205,6 +206,10 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     // Live Trader Agent — portfolio dédié $10k piloté à 100% par Gemini Pro.
     // Cron 5min decision + cron 02:00 UTC post-mortem nightly + memory store.
     LiveTraderAgentService,
+    // MistralShadowService — A/B shadow 3-way (Pro/Flash/Mistral) pour mesurer
+    // concordance avant migration éventuelle TRADER vers Mistral Large 3 (74%
+    // moins cher que Gemini Pro). Activation MISTRAL_API_KEY + MISTRAL_SHADOW_ENABLED.
+    MistralShadowService,
     // MainScannerPostMortemService — apprentissage Gemini Pro sur le scanner gainers
     // (cron 02:30 UTC : analyse 24h × 4 portfolios → lessons macro-conditionnelles).
     MainScannerPostMortemService,

--- a/apps/api/src/modules/lisa/services/__tests__/mistral-shadow.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/mistral-shadow.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Smoke tests pour MistralShadowService.
+ * Couvre : disabled state (no key), HTTP success path, HTTP error path,
+ * timeout, parse failure. Réseau mocké via fetch global.
+ */
+import { ConfigService } from '@nestjs/config';
+import { MistralShadowService } from '../mistral-shadow.service';
+
+function mockConfig(values: Record<string, string | undefined>): ConfigService {
+  return {
+    get: <T>(key: string) => (values[key] as unknown) as T,
+  } as unknown as ConfigService;
+}
+
+describe('MistralShadowService', () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('isConfigured=false quand MISTRAL_SHADOW_ENABLED=false', () => {
+    const svc = new MistralShadowService(mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'false' }));
+    expect(svc.isConfigured()).toBe(false);
+  });
+
+  it('isConfigured=false quand MISTRAL_API_KEY absent (même si enabled)', () => {
+    const svc = new MistralShadowService(mockConfig({ MISTRAL_SHADOW_ENABLED: 'true' }));
+    expect(svc.isConfigured()).toBe(false);
+  });
+
+  it('isConfigured=true quand key + flag présents', () => {
+    const svc = new MistralShadowService(mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'true' }));
+    expect(svc.isConfigured()).toBe(true);
+  });
+
+  it('call() retourne error=not_configured sans throw quand disabled', async () => {
+    const svc = new MistralShadowService(mockConfig({}));
+    const r = await svc.call({ system: 's', user: 'u' });
+    expect(r.error).toBe('not_configured');
+    expect(r.content).toBeNull();
+    expect(r.costUsd).toBe(0);
+  });
+
+  it('call() HTTP 200 — calcul cost correct via pricing officiel Large 3 ($0.5 in / $1.5 out)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [{ message: { content: '{"action_kind":"hold","symbol":null,"confidence":0.5}' } }],
+        usage: { prompt_tokens: 2_000_000, completion_tokens: 1_000_000 },
+      }),
+    });
+    const svc = new MistralShadowService(mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'true' }));
+    const r = await svc.call({ system: 's', user: 'u' });
+    expect(r.error).toBeNull();
+    expect(r.content).toContain('hold');
+    expect(r.inputTokens).toBe(2_000_000);
+    expect(r.outputTokens).toBe(1_000_000);
+    // 2M × $0.5/M + 1M × $1.5/M = $1.00 + $1.50 = $2.50
+    expect(r.costUsd).toBeCloseTo(2.5, 5);
+    expect(r.providerId).toBe('mistral-large');
+  });
+
+  it('call() HTTP 429 → error capturé, pas de throw', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'rate limited',
+    });
+    const svc = new MistralShadowService(mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'true' }));
+    const r = await svc.call({ system: 's', user: 'u' });
+    expect(r.error).toContain('http_429');
+    expect(r.content).toBeNull();
+  });
+
+  it('call() fetch throws → error capturé sans crash', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const svc = new MistralShadowService(mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'true' }));
+    const r = await svc.call({ system: 's', user: 'u' });
+    expect(r.error).toContain('ECONNREFUSED');
+    expect(r.content).toBeNull();
+  });
+
+  it('call() empty content → error=empty_content', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ choices: [{ message: { content: null } }], usage: { prompt_tokens: 100, completion_tokens: 50 } }),
+    });
+    const svc = new MistralShadowService(mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'true' }));
+    const r = await svc.call({ system: 's', user: 'u' });
+    expect(r.error).toBe('empty_content');
+  });
+
+  it('call() request body contient model + messages + temperature', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ choices: [{ message: { content: '{}' } }], usage: { prompt_tokens: 10, completion_tokens: 5 } }),
+    });
+    global.fetch = fetchMock;
+    const svc = new MistralShadowService(mockConfig({ MISTRAL_API_KEY: 'sk-key-123', MISTRAL_SHADOW_ENABLED: 'true' }));
+    await svc.call({ system: 'sys-prompt', user: 'user-prompt', temperature: 0.7, maxTokens: 800 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.mistral.ai/v1/chat/completions');
+    expect((init as { headers: Record<string, string> }).headers.Authorization).toBe('Bearer sk-key-123');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body.model).toBe('mistral-large-latest');
+    expect(body.messages).toEqual([
+      { role: 'system', content: 'sys-prompt' },
+      { role: 'user', content: 'user-prompt' },
+    ]);
+    expect(body.temperature).toBe(0.7);
+    expect(body.max_tokens).toBe(800);
+  });
+});

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -34,6 +34,7 @@ import { LisaService } from './lisa.service';
 import { ScannerLessonsContextService } from './scanner-lessons-context.service';
 import { TopGainersScannerService } from './top-gainers-scanner.service';
 import { PushNotificationsService } from './push-notifications.service';
+import { MistralShadowService } from './mistral-shadow.service';
 import type { TopGainerCandidate } from '@smartvest/ai-analyst';
 
 const TRADER_AGENT_PORTFOLIO_ID = 'b0000001-0000-0000-0000-000000000001';
@@ -231,6 +232,10 @@ export class LiveTraderAgentService {
     private readonly topGainersScanner: TopGainersScannerService,
     @Optional() private readonly lessonsContext?: ScannerLessonsContextService,
     @Optional() private readonly pushNotifs?: PushNotificationsService,
+    // 31/05/2026 — A/B shadow 3-way avec Mistral Large 3.
+    // Optional : si MISTRAL_SHADOW_ENABLED=false ou MISTRAL_API_KEY absent,
+    // les colonnes mistral_* restent NULL dans gemini_ab_decisions.
+    @Optional() private readonly mistralShadow?: MistralShadowService,
   ) {}
 
   onModuleInit(): void {
@@ -2233,36 +2238,77 @@ Recommendation rules :
   }): Promise<void> {
     if (!this.supabase.isReady()) return;
 
-    // 1. Appel Gemini Flash (chain fast) avec exactement le même prompt que Pro.
+    // 1. Lance Flash + Mistral en parallèle (best-effort, n'altèrent jamais le cycle).
+    const flashPromise = this.llmRouter
+      .call({
+        system: args.systemPrompt,
+        user: args.userPrompt,
+        temperature: 0.3,
+        maxTokens: 1500,
+        timeoutMs: 30_000,
+      })
+      .then(r => ({ ok: true as const, ...r }))
+      .catch(e => ({ ok: false as const, error: String(e).slice(0, 200) }));
+
+    // 31/05/2026 — Mistral shadow 3-way (best-effort, désactivé tant que
+    // MISTRAL_SHADOW_ENABLED=false ou MISTRAL_API_KEY absent).
+    const mistralPromise = this.mistralShadow
+      ? this.mistralShadow.call({
+          system: args.systemPrompt,
+          user: args.userPrompt,
+          temperature: 0.3,
+          maxTokens: 1500,
+          timeoutMs: 30_000,
+        })
+      : Promise.resolve(null);
+
+    const [flashSettled, mistralSettled] = await Promise.all([flashPromise, mistralPromise]);
+
+    // 2. Parse Flash
     let flashContent: string | null = null;
     let flashProvider: string | null = null;
     let flashCostUsd = 0;
     let flashLatencyMs = 0;
     let flashCallError: string | null = null;
     let flashDecision: Partial<TraderDecision> | null = null;
-    try {
-      const flashRes = await this.llmRouter.call({
-        system: args.systemPrompt,
-        user: args.userPrompt,
-        temperature: 0.3,
-        maxTokens: 1500,
-        timeoutMs: 30_000,
-      });
-      flashContent = flashRes.content;
-      flashProvider = flashRes.providerId;
-      flashCostUsd = flashRes.costUsd;
-      flashLatencyMs = flashRes.latencyMs;
+    if (flashSettled.ok) {
+      flashContent = flashSettled.content;
+      flashProvider = flashSettled.providerId;
+      flashCostUsd = flashSettled.costUsd;
+      flashLatencyMs = flashSettled.latencyMs;
       try {
         const cleaned = flashContent.trim().replace(/^```json\s*/i, '').replace(/```\s*$/, '').trim();
         flashDecision = JSON.parse(cleaned);
       } catch (e) {
         flashCallError = `parse_fail: ${String(e).slice(0, 100)}`;
       }
-    } catch (e) {
-      flashCallError = String(e).slice(0, 200);
+    } else {
+      flashCallError = flashSettled.error;
     }
 
-    // 2. Compute concordance metrics
+    // 2b. Parse Mistral (3-way shadow). NULL si service désactivé ou clé absente.
+    let mistralProvider: string | null = null;
+    let mistralCostUsd = 0;
+    let mistralLatencyMs = 0;
+    let mistralCallError: string | null = null;
+    let mistralDecision: Partial<TraderDecision> | null = null;
+    if (mistralSettled) {
+      mistralProvider = mistralSettled.providerId;
+      mistralCostUsd = mistralSettled.costUsd;
+      mistralLatencyMs = mistralSettled.latencyMs;
+      if (mistralSettled.error) {
+        mistralCallError = mistralSettled.error;
+      } else if (mistralSettled.content) {
+        try {
+          const cleaned = mistralSettled.content.trim().replace(/^```json\s*/i, '').replace(/```\s*$/, '').trim();
+          mistralDecision = JSON.parse(cleaned);
+        } catch (e) {
+          mistralCallError = `parse_fail: ${String(e).slice(0, 100)}`;
+        }
+      }
+    }
+
+    // 3. Compute concordance metrics
     // Note : null === null est valide pour hold (symbol absent attendu des 2 côtés).
     // Quand flashDecision est null (parse fail), tous concordance flags sont null.
     const proAction = args.proDecision.action_kind ?? null;
@@ -2278,6 +2324,14 @@ Recommendation rules :
     const confDelta = proConf !== null && flashConf !== null && typeof flashConf === 'number'
       ? Math.round((proConf - flashConf) * 1000) / 1000
       : null;
+
+    // 3b. Concordance Pro vs Mistral
+    const mistralAction = mistralDecision?.action_kind ?? null;
+    const mistralTarget = mistralDecision?.symbol ?? null;
+    const mistralParsed = mistralDecision !== null;
+    const concordanceProMistralAction = mistralParsed ? mistralAction === proAction : null;
+    const concordanceProMistralTarget = mistralParsed ? mistralTarget === proTarget : null;
+    const concordanceProMistralFull = concordanceProMistralAction === true && concordanceProMistralTarget === true;
 
     // 3. Compute context hash (sha256 trunc) pour valider que Pro et Flash ont vu le même context
     let contextHash: string | null = null;
@@ -2320,10 +2374,27 @@ Recommendation rules :
         confidence_delta: confDelta,
         candidates_count: args.candidatesCount,
         context_hash: contextHash,
+        // Mistral 3-way shadow columns (31/05/2026)
+        mistral_action_kind: mistralAction,
+        mistral_target_symbol: mistralTarget,
+        mistral_direction: mistralDecision?.direction ?? null,
+        mistral_confidence: mistralDecision?.confidence ?? null,
+        mistral_notional_usd: mistralDecision?.notional_usd ?? null,
+        mistral_thesis: (mistralDecision?.thesis ?? '').slice(0, 1000),
+        mistral_cost_usd: mistralCostUsd,
+        mistral_latency_ms: mistralLatencyMs,
+        mistral_provider: mistralProvider,
+        mistral_call_error: mistralCallError,
+        concordance_pro_vs_mistral_action: concordanceProMistralAction,
+        concordance_pro_vs_mistral_target: concordanceProMistralTarget,
+        concordance_pro_vs_mistral_full: concordanceProMistralFull,
       });
+      const mistralLog = mistralProvider
+        ? ` vs Mistral=${mistralAction ?? (mistralCallError ? 'fail' : 'off')}/${mistralTarget ?? '?'} mConc=${concordanceProMistralFull} mCost=$${mistralCostUsd.toFixed(4)}`
+        : '';
       this.logger.debug(
         `[trader-agent:ab] Pro=${proAction}/${proTarget ?? '?'} vs Flash=${flashAction ?? 'fail'}/${flashTarget ?? '?'} ` +
-        `concordance=${concordanceFull} costDelta=${(args.proResponse.costUsd - flashCostUsd).toFixed(4)}`,
+        `concordance=${concordanceFull} costDelta=${(args.proResponse.costUsd - flashCostUsd).toFixed(4)}${mistralLog}`,
       );
     } catch (e) {
       this.logger.debug(`[trader-agent:ab] insert failed: ${String(e).slice(0, 100)}`);

--- a/apps/api/src/modules/lisa/services/mistral-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/mistral-shadow.service.ts
@@ -1,0 +1,144 @@
+/**
+ * MistralShadowService — adapter Mistral léger pour A/B shadow PR 31/05/2026.
+ *
+ * Pourquoi un service séparé (pas dans `packages/ai-analyst/src/llm/providers`) :
+ * ADR-001 a explicitement retiré Mistral du router principal pour simplifier
+ * la surface providers (Gemini chain → Claude Opus fallback ultime). On NE
+ * réintroduit PAS Mistral dans la chain prod — on le calle uniquement en
+ * shadow side-by-side avec Gemini Pro pour mesurer concordance/coût avant
+ * toute décision long-terme.
+ *
+ * Architecture :
+ *   - fetch direct vers https://api.mistral.ai/v1/chat/completions
+ *     (API OpenAI-compatible, pas besoin du SDK @mistralai/mistralai)
+ *   - 0 dépendance npm ajoutée
+ *   - Best-effort : tous les errors retournés dans `error`, jamais throw
+ *
+ * Pricing officiel 2026 (verified 31/05) :
+ *   - Mistral Large 3 (latest) : $0.50 / MTok input, $1.50 / MTok output
+ *
+ * Activation :
+ *   - MISTRAL_API_KEY (Fly secret) — sans cela, isConfigured() → false
+ *   - MISTRAL_SHADOW_ENABLED=true (default false par prudence) — flag explicite
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+const MISTRAL_API_URL = 'https://api.mistral.ai/v1/chat/completions';
+const MODEL_LARGE_LATEST = 'mistral-large-latest';
+const PRICE_INPUT_PER_M_LARGE = 0.50;
+const PRICE_OUTPUT_PER_M_LARGE = 1.50;
+
+export interface MistralShadowResult {
+  content: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+  providerId: string;
+  model: string;
+  error: string | null;
+}
+
+@Injectable()
+export class MistralShadowService {
+  private readonly logger = new Logger(MistralShadowService.name);
+  private readonly apiKey: string | undefined;
+  private readonly enabled: boolean;
+  private readonly model: string;
+
+  constructor(private readonly config: ConfigService) {
+    this.apiKey = this.config.get<string>('MISTRAL_API_KEY');
+    this.enabled = (this.config.get<string>('MISTRAL_SHADOW_ENABLED') ?? 'false').toLowerCase() === 'true';
+    this.model = this.config.get<string>('MISTRAL_SHADOW_MODEL') ?? MODEL_LARGE_LATEST;
+    if (this.enabled && !this.apiKey) {
+      this.logger.warn('[mistral-shadow] MISTRAL_SHADOW_ENABLED=true mais MISTRAL_API_KEY absent → service inerte');
+    } else if (this.enabled) {
+      this.logger.log(`[mistral-shadow] ENABLED — model=${this.model}`);
+    }
+  }
+
+  isConfigured(): boolean {
+    return this.enabled && !!this.apiKey;
+  }
+
+  /**
+   * Appel Mistral. Best-effort : ne throw jamais, retourne `error` non-null
+   * en cas d'échec pour que le caller puisse logger sans bloquer le cycle.
+   */
+  async call(params: {
+    system: string;
+    user: string;
+    temperature?: number;
+    maxTokens?: number;
+    timeoutMs?: number;
+  }): Promise<MistralShadowResult> {
+    const t0 = Date.now();
+    const result: MistralShadowResult = {
+      content: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      latencyMs: 0,
+      providerId: 'mistral-large',
+      model: this.model,
+      error: null,
+    };
+
+    if (!this.isConfigured()) {
+      result.error = 'not_configured';
+      result.latencyMs = Date.now() - t0;
+      return result;
+    }
+
+    try {
+      const res = await fetch(MISTRAL_API_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: this.model,
+          messages: [
+            { role: 'system', content: params.system },
+            { role: 'user', content: params.user },
+          ],
+          temperature: params.temperature ?? 0.3,
+          max_tokens: params.maxTokens ?? 1500,
+        }),
+        signal: AbortSignal.timeout(params.timeoutMs ?? 30_000),
+      });
+
+      result.latencyMs = Date.now() - t0;
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        result.error = `http_${res.status}: ${body.slice(0, 200)}`;
+        return result;
+      }
+
+      const data = (await res.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number };
+      };
+
+      result.content = data.choices?.[0]?.message?.content ?? null;
+      result.inputTokens = data.usage?.prompt_tokens ?? 0;
+      result.outputTokens = data.usage?.completion_tokens ?? 0;
+      result.costUsd =
+        (result.inputTokens / 1_000_000) * PRICE_INPUT_PER_M_LARGE +
+        (result.outputTokens / 1_000_000) * PRICE_OUTPUT_PER_M_LARGE;
+
+      if (!result.content) {
+        result.error = 'empty_content';
+      }
+
+      return result;
+    } catch (e) {
+      result.latencyMs = Date.now() - t0;
+      result.error = String(e).slice(0, 200);
+      return result;
+    }
+  }
+}

--- a/supabase/migrations/0179_mistral_shadow_columns.sql
+++ b/supabase/migrations/0179_mistral_shadow_columns.sql
@@ -1,0 +1,39 @@
+-- Migration 0179 — Extension A/B shadow avec Mistral Large 3
+--
+-- Contexte : suite à analyse cost comparison Mistral vs Gemini vs Anthropic
+-- (31/05/2026), Mistral Large 3 ressort à $0.5/$1.5 per MTok = 74% moins cher
+-- que Gemini 2.5 Pro pour qualité benchmarks équivalente. On souhaite valider
+-- empiriquement la concordance des décisions Pro vs Flash vs Mistral sur 7-14
+-- jours avant toute migration TRADER.
+--
+-- Le 3-way shadow réutilise la table existante `gemini_ab_decisions` (créée
+-- migration 0178). Ajout de colonnes mistral_* pour Mistral decision + 3
+-- colonnes concordance Pro vs Mistral.
+--
+-- ADR-001 reste valide : Mistral N'EST PAS dans le router principal. Le call
+-- vit dans MistralShadowService (apps/api), pas dans ai-analyst/llm/providers.
+-- Réintroduction conditionnelle (amender ADR-001 → ADR-007) UNIQUEMENT si
+-- shadow data montre concordance ≥ 85% sur 14j + différentiel coût significatif.
+--
+-- Idempotente.
+
+ALTER TABLE public.gemini_ab_decisions
+  ADD COLUMN IF NOT EXISTS mistral_action_kind text,
+  ADD COLUMN IF NOT EXISTS mistral_target_symbol text,
+  ADD COLUMN IF NOT EXISTS mistral_direction text,
+  ADD COLUMN IF NOT EXISTS mistral_confidence numeric(3, 2),
+  ADD COLUMN IF NOT EXISTS mistral_notional_usd numeric(12, 2),
+  ADD COLUMN IF NOT EXISTS mistral_thesis text,
+  ADD COLUMN IF NOT EXISTS mistral_cost_usd numeric(10, 6),
+  ADD COLUMN IF NOT EXISTS mistral_latency_ms int,
+  ADD COLUMN IF NOT EXISTS mistral_provider text,
+  ADD COLUMN IF NOT EXISTS mistral_call_error text,
+  ADD COLUMN IF NOT EXISTS concordance_pro_vs_mistral_action boolean,
+  ADD COLUMN IF NOT EXISTS concordance_pro_vs_mistral_target boolean,
+  ADD COLUMN IF NOT EXISTS concordance_pro_vs_mistral_full boolean;
+
+COMMENT ON COLUMN public.gemini_ab_decisions.mistral_action_kind IS
+'Mistral Large 3 decision (jamais appliquee — shadow uniquement). Permet 3-way comparison Pro vs Flash vs Mistral. Activation : MISTRAL_API_KEY + MISTRAL_SHADOW_ENABLED=true.';
+
+COMMENT ON COLUMN public.gemini_ab_decisions.concordance_pro_vs_mistral_full IS
+'True si Mistral et Pro sortent EXACTEMENT la meme action_kind ET target_symbol. NULL si Mistral parse failed ou disabled. Objectif analyse : si >= 85% concordance sur 14j, migration TRADER Pro -> Mistral economiserait ~74% du cout LLM.';


### PR DESCRIPTION
## Contexte (discussion 31/05 sur multi-portfolios + cost API comparison)

L'utilisateur planifie 4 portfolios horizon-différenciés ($10k scalp + $25k scalp+swing + $50k swing + $100k position) — tous architecturés TRADER-style (Gemini autonome) plutôt qu'avec Claude Opus (ratio coût/qualité jugé insuffisant).

Analyse pricing officielle 31/05 :

| Provider | Modèle | Input | Output | $/jour TRADER scaled |
|---|---|---|---|---|
| Anthropic | Claude Opus 4.7 | $5 | $25 | $20.79 |
| Google | Gemini 2.5 Pro **(actuel TRADER)** | $1.25 | $10 | $6.60 |
| 🇫🇷 Mistral | **Mistral Large 3** | $0.50 | $1.50 | **$1.71** (-74%) |

→ Mistral Large 3 = tier équivalent Gemini Pro pour 26% du coût, hébergé EU.

## Étape 1 (cette PR) : A/B shadow 3-way

Avant de migrer TRADER de Gemini Pro vers Mistral, mesurer **empiriquement la concordance des décisions** sur 7-14 jours de prod. Si Mistral et Gemini Pro sortent la même action_kind + symbol > 85% du temps, migration justifiée.

## Architecture

```
Cycle TRADER (toutes les 30s) :
  1. Gemini Pro → décision RÉELLEMENT APPLIQUÉE
  2. En parallèle (Promise.all, best-effort) :
     - Gemini Flash → shadow (déjà wiré PR #508)
     - Mistral Large 3 → shadow (NOUVEAU cette PR)
  3. INSERT row dans gemini_ab_decisions avec les 3 décisions + concordances
```

**Aucun impact prod** : Pro reste seul à décider. Les calls Flash + Mistral sont best-effort, errors capturées, n'altèrent jamais le cycle.

## Fichiers (5 changements)

| Type | Fichier | Description |
|---|---|---|
| Nouveau | `apps/api/src/modules/lisa/services/mistral-shadow.service.ts` | Adapter Mistral léger via fetch direct (API OpenAI-compatible, 0 dep npm ajoutée) |
| Nouveau | `apps/api/.../mistral-shadow.spec.ts` | 9 tests : disabled, config, success, 429, timeout, parse, body |
| Modifié | `live-trader-agent.service.ts` | Constructor @Optional MistralShadowService + recordAbShadow étendu 3-way |
| Modifié | `lisa.module.ts` | Register MistralShadowService |
| Nouveau | `supabase/migrations/0179_mistral_shadow_columns.sql` | ALTER TABLE gemini_ab_decisions ADD COLUMN mistral_* + concordance_pro_vs_mistral_* |

## ADR-001 respecté

ADR-001 a explicitement retiré Mistral du **router principal** (chain Gemini → Claude Opus fallback) pour simplifier la surface providers. Cette PR **ne touche pas** au router principal :

- Le service vit dans `apps/api/src/modules/lisa/services/` (pas dans `packages/ai-analyst/src/llm/providers/` où vivent les providers ADR-001)
- Mistral N'EST PAS appelable via `ScannerLlmRouterService`
- C'est uniquement un service "shadow" pour mesurer

Si analyse post-shadow montre concordance ≥ 85% → on amendera ADR-001 → ADR-007 pour réintroduire Mistral dans le router principal de manière formelle.

## Activation prod (post-deploy)

```bash
fly secrets set MISTRAL_API_KEY=sk-xxxx -a smartvest
fly secrets set MISTRAL_SHADOW_ENABLED=true -a smartvest
```

Sans ces secrets, comportement strictement identique à aujourd'hui (colonnes mistral_* restent NULL, Pro+Flash continuent comme avant).

## Coût additionnel

Avec MISTRAL_SHADOW_ENABLED=true, ~$0.0035/call × 50 calls/jour TRADER actuel = **~$0.17/jour additionnel** pendant la phase shadow (négligeable vs $6.60/jour Gemini Pro actuel).

## Tests

- ✅ 9/9 nouveaux MistralShadowService
- ✅ 7/7 existants gemini-ab-concordance (pas de régression)
- ✅ tsc --noEmit clean sur fichiers touchés

## Analyse post-deploy (après 7-14j de data)

```sql
SELECT
  COUNT(*) AS n,
  AVG(CASE WHEN concordance_full THEN 1 ELSE 0 END) AS flash_concord_pct,
  AVG(CASE WHEN concordance_pro_vs_mistral_full THEN 1 ELSE 0 END) AS mistral_concord_pct,
  SUM(pro_cost_usd) AS sum_pro_cost,
  SUM(flash_cost_usd) AS sum_flash_cost,
  SUM(mistral_cost_usd) AS sum_mistral_cost,
  AVG(pro_latency_ms) AS avg_pro_latency,
  AVG(mistral_latency_ms) AS avg_mistral_latency  -- Mistral Paris-hosted → potentiellement < Pro Fly Paris→US
FROM gainers_ab_decisions
WHERE decided_at > NOW() - INTERVAL '14 days'
  AND mistral_provider IS NOT NULL;
```

→ Si `mistral_concord_pct >= 0.85` et `avg_mistral_latency < avg_pro_latency` → décision data-driven de migrer TRADER vers Mistral.

## Hors scope (étapes suivantes)

- **Étape 2** : si Mistral concorde, migration TRADER Pro → Mistral (1 PR de 30 lignes : flip provider dans ScannerLlmRouter)
- **Étape 3** : application aux 3 nouveaux portfolios $25k/$50k/$100k
- **Étape 4** : amender ADR-001 → ADR-007 réintroduisant Mistral dans le router principal

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_