### PR TITLE
feat(cost): A/B shadow générique pour 4 call sites LLM périphériques

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -55,6 +55,7 @@ import { ShadowSizingOrchestratorService } from './services/shadow-sizing-orches
 import { LiveTraderAgentService } from './services/live-trader-agent.service';
 import { MistralShadowService } from './services/mistral-shadow.service';
 import { MistralLargeShadowService } from './services/mistral-large-shadow.service';
+import { LlmABShadowService } from './services/llm-ab-shadow.service';
 import { MainScannerPostMortemService } from './services/main-scanner-postmortem.service';
 import { DailyDigestService } from './services/daily-digest.service';
 import { PushNotificationsService } from './services/push-notifications.service';
@@ -213,6 +214,9 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     MistralShadowService,
     // PR #521 — 2e instance dédiée Mistral Large 3 (cheap tier) pour 4-way A/B
     MistralLargeShadowService,
+    // PR #523 — LlmABShadowService générique pour 4 call sites peripheriques
+    // (scanner_postmortem, strategy_coach, daily_brief, risk_monitor)
+    LlmABShadowService,
     // MainScannerPostMortemService — apprentissage Gemini Pro sur le scanner gainers
     // (cron 02:30 UTC : analyse 24h × 4 portfolios → lessons macro-conditionnelles).
     MainScannerPostMortemService,

--- a/apps/api/src/modules/lisa/services/__tests__/llm-ab-shadow.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/llm-ab-shadow.spec.ts
@@ -1,0 +1,313 @@
+/**
+ * Smoke tests pour LlmABShadowService (PR #523).
+ * Focus sur la logique métier critique : disabled flag, comparators, anti-doublon
+ * provider, best-effort sans throw.
+ */
+import { ConfigService } from '@nestjs/config';
+import { LlmABShadowService } from '../llm-ab-shadow.service';
+
+function mockConfig(values: Record<string, string | undefined>): ConfigService {
+  return {
+    get: <T>(key: string) => (values[key] as unknown) as T,
+  } as unknown as ConfigService;
+}
+
+function mockSupabase(insertedRows: unknown[] = []): {
+  isReady: () => boolean;
+  getClient: () => unknown;
+} {
+  return {
+    isReady: () => true,
+    getClient: () => ({
+      from: () => ({
+        insert: (row: unknown) => {
+          insertedRows.push(row);
+          return Promise.resolve({ error: null });
+        },
+      }),
+    }),
+  };
+}
+
+const mockLlmRouter = {
+  call: jest.fn(),
+  callWithPro: jest.fn(),
+};
+
+describe('LlmABShadowService (PR #523)', () => {
+  beforeEach(() => {
+    mockLlmRouter.call.mockReset();
+    mockLlmRouter.callWithPro.mockReset();
+  });
+
+  describe('enabled flag', () => {
+    it('default ENABLED=true sans flag explicite', () => {
+      const svc = new LlmABShadowService(
+        mockConfig({}),
+        mockSupabase() as never,
+        mockLlmRouter as never,
+      );
+      // Pas de getter exposé, on vérifie indirectement via recordShadow no-op
+      // (si disabled, recordShadow return immédiat sans appeler les shadows).
+      expect(svc).toBeDefined();
+    });
+
+    it('disabled si LLM_AB_SHADOW_ENABLED=false', async () => {
+      const inserted: unknown[] = [];
+      const svc = new LlmABShadowService(
+        mockConfig({ LLM_AB_SHADOW_ENABLED: 'false' }),
+        mockSupabase(inserted) as never,
+        mockLlmRouter as never,
+      );
+      await svc.recordShadow({
+        callSite: 'risk_monitor',
+        systemPrompt: 'sys',
+        userPrompt: 'user',
+        applied: { providerId: 'gemini-pro', content: 'hold', costUsd: 0.01, latencyMs: 100 },
+      });
+      // Disabled → no shadow calls, no insert
+      expect(mockLlmRouter.call).not.toHaveBeenCalled();
+      expect(mockLlmRouter.callWithPro).not.toHaveBeenCalled();
+      expect(inserted).toHaveLength(0);
+    });
+  });
+
+  describe('best-effort no throw', () => {
+    it('Promise rejection sur Flash → record OK avec error captured', async () => {
+      mockLlmRouter.call.mockRejectedValue(new Error('Flash API down'));
+      const inserted: unknown[] = [];
+      const svc = new LlmABShadowService(
+        mockConfig({ LLM_AB_SHADOW_ENABLED: 'true' }),
+        mockSupabase(inserted) as never,
+        mockLlmRouter as never,
+      );
+      await expect(
+        svc.recordShadow({
+          callSite: 'daily_brief',
+          systemPrompt: 'sys',
+          userPrompt: 'user',
+          applied: { providerId: 'gemini-pro', content: 'brief X', costUsd: 0.02, latencyMs: 200 },
+        }),
+      ).resolves.toBeUndefined();
+      expect(inserted).toHaveLength(1);
+      const row = inserted[0] as { shadows: Array<{ provider: string; error: string | null }> };
+      expect(row.shadows.find(s => s.provider === 'gemini-flash-lite')?.error).toContain('Flash API down');
+    });
+
+    it('Supabase insert error → no throw, just debug log', async () => {
+      mockLlmRouter.call.mockResolvedValue({
+        content: 'shadow content',
+        providerId: 'gemini-flash-lite',
+        costUsd: 0.001,
+        latencyMs: 50,
+        fallbackUsed: false,
+      });
+      const svc = new LlmABShadowService(
+        mockConfig({ LLM_AB_SHADOW_ENABLED: 'true' }),
+        {
+          isReady: () => true,
+          getClient: () => ({
+            from: () => ({ insert: () => Promise.reject(new Error('PG conn refused')) }),
+          }),
+        } as never,
+        mockLlmRouter as never,
+      );
+      await expect(
+        svc.recordShadow({
+          callSite: 'strategy_coach',
+          systemPrompt: 'sys',
+          userPrompt: 'user',
+          applied: { providerId: 'gemini-pro', content: 'reco', costUsd: 0.02, latencyMs: 200 },
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('Supabase non-ready → return early sans aucun shadow call', async () => {
+      const inserted: unknown[] = [];
+      const svc = new LlmABShadowService(
+        mockConfig({ LLM_AB_SHADOW_ENABLED: 'true' }),
+        {
+          isReady: () => false,
+          getClient: () => ({ from: () => ({ insert: () => { inserted.push({}); return Promise.resolve(); } }) }),
+        } as never,
+        mockLlmRouter as never,
+      );
+      await svc.recordShadow({
+        callSite: 'risk_monitor',
+        systemPrompt: 'sys',
+        userPrompt: 'user',
+        applied: { providerId: 'gemini-pro', content: 'X', costUsd: 0.01, latencyMs: 100 },
+      });
+      expect(mockLlmRouter.call).not.toHaveBeenCalled();
+      expect(inserted).toHaveLength(0);
+    });
+  });
+
+  describe('anti-doublon provider', () => {
+    it('applied=gemini-pro → skip Pro en shadow, appelle Flash via .call()', async () => {
+      mockLlmRouter.call.mockResolvedValue({
+        content: 'flash response',
+        providerId: 'gemini-flash-lite',
+        costUsd: 0.001,
+        latencyMs: 50,
+        fallbackUsed: false,
+      });
+      const inserted: unknown[] = [];
+      const svc = new LlmABShadowService(
+        mockConfig({ LLM_AB_SHADOW_ENABLED: 'true' }),
+        mockSupabase(inserted) as never,
+        mockLlmRouter as never,
+      );
+      await svc.recordShadow({
+        callSite: 'scanner_postmortem',
+        systemPrompt: 'sys',
+        userPrompt: 'user',
+        applied: { providerId: 'gemini-pro', content: 'X', costUsd: 0.02, latencyMs: 200 },
+      });
+      expect(mockLlmRouter.call).toHaveBeenCalledTimes(1);  // Flash shadow
+      expect(mockLlmRouter.callWithPro).not.toHaveBeenCalled();  // Pas de Pro shadow (déjà applied)
+    });
+
+    it('applied=gemini-flash-lite → skip Flash en shadow, appelle Pro via callWithPro', async () => {
+      mockLlmRouter.callWithPro.mockResolvedValue({
+        content: 'pro response',
+        providerId: 'gemini-pro',
+        costUsd: 0.02,
+        latencyMs: 800,
+        fallbackUsed: false,
+      });
+      const svc = new LlmABShadowService(
+        mockConfig({ LLM_AB_SHADOW_ENABLED: 'true' }),
+        mockSupabase() as never,
+        mockLlmRouter as never,
+      );
+      await svc.recordShadow({
+        callSite: 'daily_brief',
+        systemPrompt: 'sys',
+        userPrompt: 'user',
+        applied: { providerId: 'gemini-flash-lite', content: 'X', costUsd: 0.001, latencyMs: 50 },
+      });
+      expect(mockLlmRouter.callWithPro).toHaveBeenCalledTimes(1);
+      expect(mockLlmRouter.call).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('comparator', () => {
+    it('default comparator : normalize whitespace + lowercase + 200 chars', async () => {
+      mockLlmRouter.call.mockResolvedValue({
+        content: 'HOLD\n the position',  // case + whitespace differ vs 'hold the position'
+        providerId: 'gemini-flash-lite',
+        costUsd: 0.001,
+        latencyMs: 50,
+        fallbackUsed: false,
+      });
+      const inserted: unknown[] = [];
+      const svc = new LlmABShadowService(
+        mockConfig({ LLM_AB_SHADOW_ENABLED: 'true' }),
+        mockSupabase(inserted) as never,
+        mockLlmRouter as never,
+      );
+      await svc.recordShadow({
+        callSite: 'strategy_coach',
+        systemPrompt: 'sys',
+        userPrompt: 'user',
+        applied: { providerId: 'gemini-pro', content: 'hold the position', costUsd: 0.02, latencyMs: 200 },
+      });
+      const row = inserted[0] as { shadows: Array<{ provider: string; concordance_full: boolean }> };
+      const flashShadow = row.shadows.find(s => s.provider === 'gemini-flash-lite');
+      expect(flashShadow?.concordance_full).toBe(true);  // normalize → identique
+    });
+
+    it('custom comparator JSON-aware', async () => {
+      mockLlmRouter.call.mockResolvedValue({
+        content: '{"action_kind":"hold","extra":"X"}',
+        providerId: 'gemini-flash-lite',
+        costUsd: 0.001,
+        latencyMs: 50,
+        fallbackUsed: false,
+      });
+      const inserted: unknown[] = [];
+      const svc = new LlmABShadowService(
+        mockConfig({ LLM_AB_SHADOW_ENABLED: 'true' }),
+        mockSupabase(inserted) as never,
+        mockLlmRouter as never,
+      );
+      await svc.recordShadow({
+        callSite: 'strategy_coach',
+        systemPrompt: 'sys',
+        userPrompt: 'user',
+        applied: { providerId: 'gemini-pro', content: '{"action_kind":"hold","other":"Y"}', costUsd: 0.02, latencyMs: 200 },
+        comparator: (a, b) => {
+          const pa = JSON.parse(a);
+          const pb = JSON.parse(b);
+          return pa.action_kind === pb.action_kind;
+        },
+      });
+      const row = inserted[0] as { shadows: Array<{ provider: string; concordance_full: boolean }> };
+      expect(row.shadows.find(s => s.provider === 'gemini-flash-lite')?.concordance_full).toBe(true);
+    });
+
+    it('comparator throws → concordance_full = null (graceful)', async () => {
+      mockLlmRouter.call.mockResolvedValue({
+        content: 'not json',
+        providerId: 'gemini-flash-lite',
+        costUsd: 0.001,
+        latencyMs: 50,
+        fallbackUsed: false,
+      });
+      const inserted: unknown[] = [];
+      const svc = new LlmABShadowService(
+        mockConfig({ LLM_AB_SHADOW_ENABLED: 'true' }),
+        mockSupabase(inserted) as never,
+        mockLlmRouter as never,
+      );
+      await svc.recordShadow({
+        callSite: 'risk_monitor',
+        systemPrompt: 'sys',
+        userPrompt: 'user',
+        applied: { providerId: 'gemini-pro', content: 'X', costUsd: 0.02, latencyMs: 200 },
+        comparator: (a, _b) => { JSON.parse(a); return true; },  // throws
+      });
+      const row = inserted[0] as { shadows: Array<{ provider: string; concordance_full: boolean | null }> };
+      expect(row.shadows.find(s => s.provider === 'gemini-flash-lite')?.concordance_full).toBeNull();
+    });
+  });
+
+  describe('shadow row structure', () => {
+    it('insert contient call_site, applied_*, shadows[], concordance_summary, hashes', async () => {
+      mockLlmRouter.call.mockResolvedValue({
+        content: 'shadow',
+        providerId: 'gemini-flash-lite',
+        costUsd: 0.001,
+        latencyMs: 50,
+        fallbackUsed: false,
+      });
+      const inserted: Array<Record<string, unknown>> = [];
+      const svc = new LlmABShadowService(
+        mockConfig({ LLM_AB_SHADOW_ENABLED: 'true' }),
+        mockSupabase(inserted as never[]) as never,
+        mockLlmRouter as never,
+      );
+      await svc.recordShadow({
+        callSite: 'daily_brief',
+        portfolioId: 'b0000001-0000-0000-0000-000000000001',
+        systemPrompt: 'sys-prompt',
+        userPrompt: 'user-prompt',
+        applied: { providerId: 'gemini-pro', content: 'applied content', costUsd: 0.02, latencyMs: 200, parseOk: true },
+      });
+      const row = inserted[0];
+      expect(row.call_site).toBe('daily_brief');
+      expect(row.portfolio_id).toBe('b0000001-0000-0000-0000-000000000001');
+      expect(row.applied_provider).toBe('gemini-pro');
+      expect(row.applied_response_summary).toBe('applied content');
+      expect(row.applied_cost_usd).toBe(0.02);
+      expect(row.applied_latency_ms).toBe(200);
+      expect(row.applied_parse_ok).toBe(true);
+      expect(Array.isArray(row.shadows)).toBe(true);
+      expect((row.shadows as unknown[]).length).toBeGreaterThan(0);
+      expect(row.concordance_summary).toBeDefined();
+      expect(row.context_hash).toMatch(/^[a-f0-9]{16}$/);
+      expect(row.system_prompt_hash).toMatch(/^[a-f0-9]{16}$/);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/daily-catalyst-brief.service.ts
+++ b/apps/api/src/modules/lisa/services/daily-catalyst-brief.service.ts
@@ -22,11 +22,12 @@
  * SCANNER_LLM_ROUTER_ENABLED=true.
  */
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
+import { LlmABShadowService } from './llm-ab-shadow.service';
 import { EodhdEconomicEventsService } from './eodhd-economic-events.service';
 
 export interface DailyCatalystBrief {
@@ -76,6 +77,8 @@ export class DailyCatalystBriefService {
     private readonly supabase: SupabaseService,
     private readonly llm: ScannerLlmRouterService,
     private readonly economicEvents: EodhdEconomicEventsService,
+    // PR #523 — A/B shadow Pro/Flash/Mistral pour brief news
+    @Optional() private readonly llmABShadow?: LlmABShadowService,
   ) {
     this.enabled = (this.config.get<string>('GEMINI_DAILY_BRIEF_ENABLED') ?? 'false').toLowerCase() === 'true';
     if (this.enabled) this.logger.log('[daily-brief] enabled — cron 04:00 UTC daily');
@@ -129,6 +132,23 @@ export class DailyCatalystBriefService {
       this.logger.warn(`[daily-brief] could not parse JSON from llm content (len=${llmResult.content.length})`);
       return null;
     }
+
+    // PR #523 — A/B shadow fire-and-forget. Brief output = text JSON narrative.
+    // Default comparator (text normalize, first 200 chars) suffisant.
+    void this.llmABShadow?.recordShadow({
+      callSite: 'daily_brief',
+      systemPrompt: SYSTEM_PROMPT,
+      userPrompt,
+      applied: {
+        providerId: llmResult.providerId,
+        content: llmResult.content,
+        costUsd: llmResult.costUsd,
+        latencyMs: llmResult.latencyMs,
+        parseOk: brief !== null,
+      },
+      maxTokens: 1200,
+      temperature: 0.2,
+    });
 
     if (!this.supabase.isReady()) {
       this.logger.warn('[daily-brief] supabase not ready, skipping persist');

--- a/apps/api/src/modules/lisa/services/llm-ab-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/llm-ab-shadow.service.ts
@@ -1,0 +1,315 @@
+/**
+ * LlmABShadowService — service générique d'A/B shadow pour tous les call sites LLM.
+ *
+ * Complémente la table dédiée TRADER (`gemini_ab_decisions` via LiveTraderAgentService)
+ * en couvrant les 4 autres call sites Gemini :
+ *   - scanner_postmortem (cron 02:30 UTC, lessons generation)
+ *   - strategy_coach (cron hourly, recommendations)
+ *   - daily_brief (cron daily, news brief)
+ *   - risk_monitor (cron 5min sur positions ouvertes)
+ *
+ * Pattern d'usage dans chaque service caller :
+ *
+ *   const applied = await llmRouter.callWithPro({ system, user, ... });
+ *   // ... use applied.content ...
+ *
+ *   void llmABShadow.recordShadow({           // fire-and-forget
+ *     callSite: 'risk_monitor',
+ *     systemPrompt: system,
+ *     userPrompt: user,
+ *     applied,
+ *     comparator: (appliedText, shadowText) => normalize(appliedText) === normalize(shadowText),
+ *   });
+ *
+ * Best-effort : tous les errors capturés, n'altère JAMAIS le caller.
+ */
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { ScannerLlmRouterService } from './scanner-llm-router.service';
+import { MistralShadowService } from './mistral-shadow.service';
+import { MistralLargeShadowService } from './mistral-large-shadow.service';
+
+export type LlmABCallSite = 'scanner_postmortem' | 'strategy_coach' | 'daily_brief' | 'risk_monitor';
+
+export interface LlmABAppliedCall {
+  /** Provider effectivement utilisé par le service (ex: 'gemini-pro' ou 'gemini-flash-lite') */
+  providerId: string;
+  /** Contenu retourné par le provider */
+  content: string;
+  /** Coût USD de l'appel */
+  costUsd: number;
+  /** Latence wall-clock (ms) */
+  latencyMs: number;
+  /** True si le parse de la réponse (côté caller) a réussi */
+  parseOk?: boolean;
+}
+
+export interface LlmABRecordParams {
+  callSite: LlmABCallSite;
+  portfolioId?: string;
+  systemPrompt: string;
+  userPrompt: string;
+  applied: LlmABAppliedCall;
+  /**
+   * Comparator pour computer concordance. Reçoit (appliedContent, shadowContent),
+   * retourne true si "équivalent" selon les critères du caller (peut normaliser,
+   * parser JSON, etc.). Si non fourni, fallback à string equality après trim.
+   */
+  comparator?: (appliedContent: string, shadowContent: string) => boolean;
+  /**
+   * Si true, tente aussi Mistral Large 3 (cheap tier). Sinon seulement Flash + Medium.
+   * Useful pour limiter coût sur sites haute fréquence.
+   */
+  includeMistralLarge?: boolean;
+  /**
+   * Max tokens pour les shadows. Default 1500. Set plus bas pour sites avec
+   * sorties courtes (ex: risk_monitor verdict) pour économiser cost.
+   */
+  maxTokens?: number;
+  /** Override temperature pour shadows (default 0.3). */
+  temperature?: number;
+}
+
+interface ShadowResult {
+  provider: string;
+  cost_usd: number;
+  latency_ms: number;
+  response_summary: string | null;
+  error: string | null;
+  concordance_full: boolean | null;
+}
+
+@Injectable()
+export class LlmABShadowService {
+  private readonly logger = new Logger(LlmABShadowService.name);
+  private readonly enabled: boolean;
+  private readonly summaryMaxChars = 500;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+    private readonly llmRouter: ScannerLlmRouterService,
+    @Optional() private readonly mistralShadow?: MistralShadowService,
+    @Optional() private readonly mistralLargeShadow?: MistralLargeShadowService,
+  ) {
+    this.enabled = (this.config.get<string>('LLM_AB_SHADOW_ENABLED') ?? 'true').toLowerCase() === 'true';
+    if (!this.enabled) {
+      this.logger.warn('[llm-ab-shadow] DISABLED (LLM_AB_SHADOW_ENABLED=false) — no shadow calls will fire');
+    }
+  }
+
+  /**
+   * Best-effort recording. Ne throw jamais — tous errors capturés en log debug.
+   * Fire-and-forget : caller peut faire `void this.shadow.recordShadow(...)`.
+   */
+  async recordShadow(params: LlmABRecordParams): Promise<void> {
+    if (!this.enabled) return;
+    if (!this.supabase.isReady()) return;
+
+    try {
+      // Lance Flash + Mistral Medium en parallèle (best-effort).
+      // Si applied = Flash déjà (cas daily_brief utilisant llmRouter.call qui prend
+      // la chain fast Flash-Lite), on ne refait pas Flash en shadow — on ferait
+      // doublon. À la place on shadow uniquement Mistral + Pro.
+      const appliedIsFlashTier = params.applied.providerId.includes('flash');
+
+      const flashPromise = appliedIsFlashTier
+        ? Promise.resolve(null)  // skip — pas de doublon
+        : this.llmRouter
+            .call({
+              system: params.systemPrompt,
+              user: params.userPrompt,
+              temperature: params.temperature ?? 0.3,
+              maxTokens: params.maxTokens ?? 1500,
+              timeoutMs: 30_000,
+            })
+            .then(r => ({ ok: true as const, ...r }))
+            .catch(e => ({ ok: false as const, error: String(e).slice(0, 200) }));
+
+      // Si applied = Gemini Pro, on ne refait pas Pro en shadow (pas de doublon).
+      // Mais si applied = Flash (chain fast), on appelle Pro en shadow.
+      const proPromise = !appliedIsFlashTier
+        ? Promise.resolve(null)
+        : this.llmRouter
+            .callWithPro({
+              system: params.systemPrompt,
+              user: params.userPrompt,
+              temperature: params.temperature ?? 0.3,
+              maxTokens: params.maxTokens ?? 1500,
+              timeoutMs: 30_000,
+            })
+            .then(r => ({ ok: true as const, ...r }))
+            .catch(e => ({ ok: false as const, error: String(e).slice(0, 200) }));
+
+      const mistralPromise = this.mistralShadow
+        ? this.mistralShadow.call({
+            system: params.systemPrompt,
+            user: params.userPrompt,
+            temperature: params.temperature ?? 0.3,
+            maxTokens: params.maxTokens ?? 1500,
+            timeoutMs: 30_000,
+          })
+        : Promise.resolve(null);
+
+      const mistralLargePromise =
+        params.includeMistralLarge !== false && this.mistralLargeShadow
+          ? this.mistralLargeShadow.call({
+              system: params.systemPrompt,
+              user: params.userPrompt,
+              temperature: params.temperature ?? 0.3,
+              maxTokens: params.maxTokens ?? 1500,
+              timeoutMs: 30_000,
+            })
+          : Promise.resolve(null);
+
+      const [flashSettled, proSettled, mistralSettled, mistralLargeSettled] = await Promise.all([
+        flashPromise,
+        proPromise,
+        mistralPromise,
+        mistralLargePromise,
+      ]);
+
+      const comparator = params.comparator ?? this.defaultComparator;
+      const shadows: ShadowResult[] = [];
+      const concordanceSummary: Record<string, boolean | null> = {};
+
+      // Helper to convert a settled call to ShadowResult.
+      const toShadow = (
+        provider: string,
+        settled: { ok: true; content: string; providerId: string; costUsd: number; latencyMs: number } | { ok: false; error: string } | null,
+      ): ShadowResult | null => {
+        if (settled === null) return null;
+        if (!settled.ok) {
+          return {
+            provider,
+            cost_usd: 0,
+            latency_ms: 0,
+            response_summary: null,
+            error: settled.error,
+            concordance_full: null,
+          };
+        }
+        const concord = (() => {
+          try {
+            return comparator(params.applied.content, settled.content);
+          } catch {
+            return null;
+          }
+        })();
+        return {
+          provider: settled.providerId,
+          cost_usd: settled.costUsd,
+          latency_ms: settled.latencyMs,
+          response_summary: this.truncate(settled.content),
+          error: null,
+          concordance_full: concord,
+        };
+      };
+
+      const flashShadow = toShadow('gemini-flash-lite', flashSettled);
+      if (flashShadow) {
+        shadows.push(flashShadow);
+        concordanceSummary[flashShadow.provider] = flashShadow.concordance_full;
+      }
+
+      const proShadow = toShadow('gemini-pro', proSettled);
+      if (proShadow) {
+        shadows.push(proShadow);
+        concordanceSummary[proShadow.provider] = proShadow.concordance_full;
+      }
+
+      // Mistral instances retournent un format légèrement différent
+      const toMistralShadow = (
+        provider: string,
+        settled: { content: string | null; costUsd: number; latencyMs: number; providerId: string; error: string | null } | null,
+      ): ShadowResult | null => {
+        if (settled === null) return null;
+        if (settled.error) {
+          return {
+            provider,
+            cost_usd: settled.costUsd,
+            latency_ms: settled.latencyMs,
+            response_summary: null,
+            error: settled.error,
+            concordance_full: null,
+          };
+        }
+        if (!settled.content) return null;
+        const concord = (() => {
+          try {
+            return comparator(params.applied.content, settled.content);
+          } catch {
+            return null;
+          }
+        })();
+        return {
+          provider: settled.providerId,
+          cost_usd: settled.costUsd,
+          latency_ms: settled.latencyMs,
+          response_summary: this.truncate(settled.content),
+          error: null,
+          concordance_full: concord,
+        };
+      };
+
+      const mediumShadow = toMistralShadow('mistral-medium', mistralSettled);
+      if (mediumShadow) {
+        shadows.push(mediumShadow);
+        concordanceSummary[mediumShadow.provider] = mediumShadow.concordance_full;
+      }
+
+      const largeShadow = toMistralShadow('mistral-large', mistralLargeSettled);
+      if (largeShadow) {
+        shadows.push(largeShadow);
+        concordanceSummary[largeShadow.provider] = largeShadow.concordance_full;
+      }
+
+      // Compute hashes pour audit + drift detection
+      const crypto = await import('node:crypto');
+      const contextHash = crypto.createHash('sha256').update(params.userPrompt).digest('hex').slice(0, 16);
+      const systemPromptHash = crypto.createHash('sha256').update(params.systemPrompt).digest('hex').slice(0, 16);
+
+      await this.supabase.getClient().from('llm_ab_shadow_decisions').insert({
+        decided_at: new Date().toISOString(),
+        call_site: params.callSite,
+        portfolio_id: params.portfolioId ?? null,
+        applied_provider: params.applied.providerId,
+        applied_response_summary: this.truncate(params.applied.content),
+        applied_cost_usd: params.applied.costUsd,
+        applied_latency_ms: params.applied.latencyMs,
+        applied_parse_ok: params.applied.parseOk ?? null,
+        shadows: shadows,
+        concordance_summary: concordanceSummary,
+        context_hash: contextHash,
+        system_prompt_hash: systemPromptHash,
+      });
+
+      const concordances = Object.entries(concordanceSummary)
+        .map(([p, c]) => `${p}=${c === null ? '?' : c ? '✓' : '✗'}`)
+        .join(' ');
+      this.logger.debug(
+        `[llm-ab-shadow] ${params.callSite} applied=${params.applied.providerId} shadows=${shadows.length} ${concordances}`,
+      );
+    } catch (e) {
+      this.logger.debug(`[llm-ab-shadow] recordShadow ${params.callSite} failed: ${String(e).slice(0, 100)}`);
+    }
+  }
+
+  /**
+   * Comparator par défaut : normalise whitespace + lowercase + first 200 chars.
+   * Suffisant pour text responses (lessons, briefs, coach recommendations).
+   * Pour JSON/structured outputs (risk_monitor verdict), caller doit fournir
+   * son propre comparator parseur.
+   */
+  private defaultComparator(a: string, b: string): boolean {
+    const normalize = (s: string) =>
+      s.trim().toLowerCase().replace(/\s+/g, ' ').slice(0, 200);
+    return normalize(a) === normalize(b);
+  }
+
+  private truncate(s: string | null): string | null {
+    if (s === null) return null;
+    return s.length > this.summaryMaxChars ? s.slice(0, this.summaryMaxChars) + '…' : s;
+  }
+}

--- a/apps/api/src/modules/lisa/services/main-scanner-postmortem.service.ts
+++ b/apps/api/src/modules/lisa/services/main-scanner-postmortem.service.ts
@@ -24,12 +24,13 @@
  *   - TopGainersScanner signal_quality validation : idem
  */
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { CronJob } from 'cron';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
+import { LlmABShadowService } from './llm-ab-shadow.service';
 import { LisaService } from './lisa.service';
 
 const SCANNER_PORTFOLIO_IDS = [
@@ -126,6 +127,9 @@ export class MainScannerPostMortemService {
     private readonly llmRouter: ScannerLlmRouterService,
     private readonly lisa: LisaService,
     private readonly schedulerRegistry: SchedulerRegistry,
+    // PR #523 — A/B shadow contre Flash + Mistral Medium/Large pour comparer
+    // la qualité des lessons générées (cron 02:30 UTC daily, ~1 call/jour).
+    @Optional() private readonly llmABShadow?: LlmABShadowService,
   ) {}
 
   onModuleInit(): void {
@@ -280,6 +284,22 @@ export class MainScannerPostMortemService {
     this.logger.log(
       `[scanner-postmortem] Gemini provider=${response.providerId} latency=${response.latencyMs}ms cost=$${response.costUsd.toFixed(4)}`,
     );
+
+    // PR #523 — A/B shadow fire-and-forget contre Flash + Mistral Medium/Large.
+    // Cron 02:30 UTC quotidien → 1 call/jour, coût additionnel shadows ~$0.05/jour.
+    // Comparator default (text normalize) suffisant pour lessons text.
+    void this.llmABShadow?.recordShadow({
+      callSite: 'scanner_postmortem',
+      systemPrompt: POST_MORTEM_SYSTEM_PROMPT,
+      userPrompt: JSON.stringify(payload, null, 2),
+      applied: {
+        providerId: response.providerId,
+        content: response.content,
+        costUsd: response.costUsd,
+        latencyMs: response.latencyMs,
+      },
+      maxTokens: 8000,
+    });
 
     if (!response.content || response.content.trim().length === 0) {
       const errMsg = 'Gemini returned empty content (thinking tokens exhausted?)';

--- a/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
+++ b/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
@@ -24,7 +24,7 @@
  * Audit best-effort dans lisa_decision_log (kind='risk_monitor_action').
  */
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
@@ -32,6 +32,7 @@ import { MultiTimeframePersistenceService } from './multi-tf-persistence.service
 import { LisaService } from './lisa.service';
 import { DecisionLogService } from './decision-log.service';
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
+import { LlmABShadowService } from './llm-ab-shadow.service';
 import {
   evaluateThesisHealth,
   type RiskVerdict,
@@ -81,6 +82,8 @@ export class OpenPositionRiskMonitorService {
     private readonly mtfPersistence: MultiTimeframePersistenceService,
     private readonly decisionLog: DecisionLogService,
     private readonly llmRouter: ScannerLlmRouterService,
+    // PR #523 — A/B shadow Pro/Flash/Mistral pour verdicts risk monitor
+    @Optional() private readonly llmABShadow?: LlmABShadowService,
   ) {}
 
   onModuleInit(): void {
@@ -280,6 +283,32 @@ export class OpenPositionRiskMonitorService {
         return null;
       }
       this.logger.debug(`[risk-monitor] Gemini ${pos.symbol} score=${parsed.score.toFixed(2)} (${parsed.rationale})`);
+
+      // PR #523 — A/B shadow fire-and-forget. Verdict = score numérique 0-1.
+      // Comparator score-based : concordant si delta < 0.15 (5 levels equivalents).
+      void this.llmABShadow?.recordShadow({
+        callSite: 'risk_monitor',
+        portfolioId: pos.portfolio_id,
+        systemPrompt: GEMINI_VERDICT_SYSTEM_PROMPT,
+        userPrompt,
+        applied: {
+          providerId: resp.providerId,
+          content: resp.content,
+          costUsd: resp.costUsd,
+          latencyMs: resp.latencyMs,
+          parseOk: parsed !== null,
+        },
+        maxTokens: 120,
+        temperature: 0.2,
+        // Verdict score-based : tolérance 0.15 (échelle 0-1)
+        comparator: (a, b) => {
+          const pa = parseGeminiVerdict(a);
+          const pb = parseGeminiVerdict(b);
+          if (!pa || !pb) return false;
+          return Math.abs(pa.score - pb.score) < 0.15;
+        },
+      });
+
       return parsed.score;
     } catch (e) {
       this.logger.debug(`[risk-monitor] Gemini ${pos.symbol} exception: ${String(e).slice(0, 150)}`);

--- a/apps/api/src/modules/lisa/services/strategy-coach.service.ts
+++ b/apps/api/src/modules/lisa/services/strategy-coach.service.ts
@@ -21,6 +21,7 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 import { CronJob } from 'cron';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
+import { LlmABShadowService } from './llm-ab-shadow.service';
 import { PushNotificationsService } from './push-notifications.service';
 
 const SYSTEM_PROMPT = `Tu es Strategy Coach de LISA, un trader algo autonome basé sur Gemini Pro.
@@ -189,6 +190,8 @@ export class StrategyCoachService {
     private readonly llmRouter: ScannerLlmRouterService,
     private readonly schedulerRegistry: SchedulerRegistry,
     @Optional() private readonly pushNotifs?: PushNotificationsService,
+    // PR #523 — A/B shadow Pro/Flash/Mistral pour comparer recommandations coach
+    @Optional() private readonly llmABShadow?: LlmABShadowService,
   ) {}
 
   onModuleInit(): void {
@@ -289,6 +292,34 @@ export class StrategyCoachService {
       ? await this.llmRouter.callWithPro(llmCallParams)
       : await this.llmRouter.call(llmCallParams);
     const latencyMs = Date.now() - start;
+
+    // PR #523 — A/B shadow fire-and-forget. Coach output = JSON config_change
+    // → comparator JSON-aware (action_kind + first config field equal).
+    void this.llmABShadow?.recordShadow({
+      callSite: 'strategy_coach',
+      portfolioId: cfg.portfolio_id,
+      systemPrompt: SYSTEM_PROMPT,
+      userPrompt,
+      applied: {
+        providerId: res.providerId,
+        content: res.content,
+        costUsd: res.costUsd,
+        latencyMs,
+      },
+      maxTokens: 2048,
+      temperature: 0.4,
+      comparator: (a, b) => {
+        try {
+          const pa = this.parseJsonStrict(a);
+          const pb = this.parseJsonStrict(b);
+          if (!pa || !pb) return false;
+          // Compare action_kind (le critère le plus impactant)
+          return (pa as { action_kind?: string }).action_kind === (pb as { action_kind?: string }).action_kind;
+        } catch {
+          return false;
+        }
+      },
+    });
 
     const parsed = this.parseJsonStrict(res.content);
     if (!parsed) {

--- a/supabase/migrations/0181_llm_ab_shadow_decisions.sql
+++ b/supabase/migrations/0181_llm_ab_shadow_decisions.sql
@@ -1,0 +1,80 @@
+-- Migration 0181 — Table générique A/B shadow pour tous les call sites LLM
+--
+-- Contexte : suite à PR #519/520/521 (A/B shadow Pro/Flash/Mistral sur TRADER
+-- décisions), extension aux 4 autres call sites Gemini :
+--   1. Scanner Post-Mortem (cron 02:30 UTC daily, lessons generation)
+--   2. Strategy Coach (cron hourly, recommendations)
+--   3. Daily Catalyst Brief (cron daily, news brief)
+--   4. Open Position Risk Monitor (cron 5min sur positions ouvertes)
+--
+-- Différence avec gemini_ab_decisions (TRADER-specific) :
+--   - Cette table est générique avec call_site discriminator
+--   - Output JSONB au lieu de colonnes typées (chaque site a un format différent)
+--   - Une shadow = 1 row JSONB array element au lieu de N colonnes par provider
+--
+-- Permet :
+--   - Aggregation cross-site dans /admin/llm-cost-live
+--   - Comparaison concordance par site
+--   - Ajout d'un 5e site sans migration (juste passer le nom de call_site)
+--
+-- Idempotente.
+
+CREATE TABLE IF NOT EXISTS public.llm_ab_shadow_decisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  decided_at timestamptz NOT NULL DEFAULT NOW(),
+
+  -- Discriminator : permet aggregations par site
+  -- ('scanner_postmortem' | 'strategy_coach' | 'daily_brief' | 'risk_monitor')
+  call_site text NOT NULL,
+
+  -- Portfolio scope (NULL pour sites non-portfolio-scoped)
+  portfolio_id uuid,
+
+  -- Provider appliqué (celui dont la réponse a été utilisée par le service)
+  applied_provider text NOT NULL,
+  applied_response_summary text,  -- truncated à ~500 chars pour audit
+  applied_cost_usd numeric(10, 6),
+  applied_latency_ms int,
+  applied_parse_ok boolean,
+
+  -- Shadows : array JSONB des autres providers appelés en parallèle
+  -- Format : [{ "provider": "gemini-flash", "cost_usd": 0.002, "latency_ms": 1450,
+  --             "response_summary": "...", "error": null, "concordance_full": true }]
+  shadows jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+  -- Concordance per shadow (pre-computed pour query rapides)
+  -- Format : { "gemini-flash": true, "mistral-medium": true, "mistral-large": false }
+  concordance_summary jsonb,
+
+  -- Hashes pour valider que les shadows ont vu le même context que l'applied
+  context_hash text,  -- sha256(user_prompt).slice(0,16)
+  system_prompt_hash text,  -- sha256(system_prompt).slice(0,16) — détecte prompt drift
+
+  created_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_ab_shadow_decided_at ON public.llm_ab_shadow_decisions(decided_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_ab_shadow_call_site_decided_at ON public.llm_ab_shadow_decisions(call_site, decided_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_ab_shadow_portfolio_decided_at ON public.llm_ab_shadow_decisions(portfolio_id, decided_at DESC) WHERE portfolio_id IS NOT NULL;
+
+COMMENT ON TABLE public.llm_ab_shadow_decisions IS
+'A/B shadow comparison pour 4 call sites Gemini periphériques (PR #523). TRADER decisions restent dans gemini_ab_decisions (table dediee plus structuree). Permet decision data-driven : si Mistral Medium concorde >=85% avec Pro sur TOUS les sites pendant 7j, migration vers Mistral est validee globalement.';
+
+COMMENT ON COLUMN public.llm_ab_shadow_decisions.call_site IS
+'Discriminator: scanner_postmortem | strategy_coach | daily_brief | risk_monitor. Permet filtres + indexes. Extensible sans migration.';
+
+COMMENT ON COLUMN public.llm_ab_shadow_decisions.shadows IS
+'Array JSONB des providers shadows appeles en parallele. Chaque element : provider, cost_usd, latency_ms, response_summary, error, concordance_full. Format flexible permet ajouter des providers sans migration.';
+
+COMMENT ON COLUMN public.llm_ab_shadow_decisions.applied_response_summary IS
+'Truncated a ~500 chars. Pour audit forensique uniquement, pas pour replay (use case different de la replay infrastructure).';
+
+-- RLS — service_role only (table interne, pas exposee user-facing)
+ALTER TABLE public.llm_ab_shadow_decisions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "llm_ab_shadow_service_only" ON public.llm_ab_shadow_decisions;
+CREATE POLICY "llm_ab_shadow_service_only" ON public.llm_ab_shadow_decisions
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Contexte

Extension de l'A/B shadow comparison (PR #519/520/521 sur TRADER) aux **4 autres call sites Gemini** mentionnés par l'utilisateur :

| # | Site | Cron | Volume | Output format |
|---|---|---|---|---|
| 1 | `scanner_postmortem` | 02:30 UTC daily | 1 call/jour | JSON lessons |
| 2 | `strategy_coach` | hourly | ~24 calls/jour | JSON recommandations |
| 3 | `daily_brief` | 04:00 UTC daily | 1 call/jour | JSON brief news |
| 4 | `risk_monitor` | every 5min sur positions ouvertes | ~50 calls/jour | text verdict |

Permet décision data-driven exhaustive vendredi sur **TOUS** les call sites LLM, pas juste TRADER.

## Architecture générique (vs gemini_ab_decisions TRADER-specific)

```
Table : llm_ab_shadow_decisions
  ├── call_site discriminator (scanner_postmortem | strategy_coach | daily_brief | risk_monitor)
  ├── applied_provider + applied_response_summary + cost + latency
  ├── shadows JSONB array (extensible — ajout providers sans migration)
  ├── concordance_summary JSONB { "gemini-flash-lite": true, "mistral-medium": false, ... }
  ├── context_hash + system_prompt_hash (audit + drift detection)
  └── indexes : call_site, decided_at, portfolio_id
```

→ **Une seule table** pour les 4 sites + futur 5e/6e sans migration.

## Pattern d'usage (post-LLM-call dans chaque service)

```typescript
const applied = await llmRouter.callWithPro({ system, user });
// ... use applied.content ...

void this.llmABShadow?.recordShadow({           // fire-and-forget
  callSite: 'risk_monitor',
  systemPrompt: system,
  userPrompt: user,
  applied: { providerId, content, costUsd, latencyMs },
  comparator: (a, b) => mySemanticCompare(a, b),  // optional
});
```

## Comparators par site (concordance metrics)

| Site | Comparator | Logique |
|---|---|---|
| scanner_postmortem | default (text normalize) | Lessons textuels, comparaison string normalisée |
| strategy_coach | JSON-aware | Compare `action_kind` (le seul critère décisionnel) |
| daily_brief | default (text normalize) | Brief textuel narrative |
| risk_monitor | score-based | Tolérance 0.15 sur échelle 0-1 (5 niveaux équivalents) |

## Anti-doublon provider

- Si `applied=gemini-pro` (cas TRADER et autres avec Pro) → **skip Pro en shadow** (pas de re-call), appelle Flash en shadow
- Si `applied=gemini-flash-lite` (cas Daily Brief avec chain fast) → **skip Flash**, appelle Pro en **counterfactual** ("qu'aurait fait Pro ?")
- Mistral Medium + Large toujours appelés en parallèle (peu importe applied)

## Best-effort

Tous errors capturés (LLM API down, Supabase fail, comparator throws). **Ne throw JAMAIS** → impossible d'altérer le comportement du caller. Si tout pète, on a juste 0 row insérée et un debug log.

## Files (8 changements)

| Type | Fichier | Changement |
|---|---|---|
| Nouveau | `llm-ab-shadow.service.ts` | Service générique (~250 lignes) |
| Nouveau | `__tests__/llm-ab-shadow.spec.ts` | 11 tests (enabled, best-effort, anti-doublon, comparators, row structure) |
| Modifié | `lisa.module.ts` | Register `LlmABShadowService` |
| Modifié | `main-scanner-postmortem.service.ts` | DI @Optional + recordShadow() après Pro call |
| Modifié | `strategy-coach.service.ts` | DI + recordShadow() avec JSON comparator |
| Modifié | `daily-catalyst-brief.service.ts` | DI + recordShadow() après Flash call (Pro counterfactual) |
| Modifié | `open-position-risk-monitor.service.ts` | DI + recordShadow() avec score comparator |
| Nouveau | `0181_llm_ab_shadow_decisions.sql` | Migration table + indexes + RLS |

## Activation

Active par défaut au boot (`LLM_AB_SHADOW_ENABLED=true`). Désactivable :
```bash
fly secrets set LLM_AB_SHADOW_ENABLED=false -a smartvest  # kill switch
```

`MISTRAL_API_KEY` + `MISTRAL_SHADOW_ENABLED` + `MISTRAL_LARGE_SHADOW_ENABLED` déjà set par toi.

## Coût additionnel total

| Site | Volume × 3 shadows × $/call | $/jour |
|---|---|---|
| scanner_postmortem | 1 × 3 × ~$0.025 | $0.08 |
| strategy_coach | ~24 × 3 × ~$0.005 | $0.36 |
| daily_brief | 1 × 3 × ~$0.005 | $0.02 |
| risk_monitor | ~50 × 3 × ~$0.002 | $0.30 |
| **Total** | — | **~$0.75/jour** |

Coverage 4-way exhaustive des 4 sites pour <$25/mois.

## Tests

- ✅ 11/11 LlmABShadowService (enabled, best-effort sans throw, anti-doublon Pro/Flash, comparators default + custom + throws, row structure complète)
- ✅ tsc --noEmit clean sur tous les fichiers touchés
- ✅ Aucune régression sur les tests existants (LiveTraderAgent, gemini_ab_concordance, etc.)

## Analyse vendredi prochain (extension SQL)

```sql
SELECT call_site,
       COUNT(*) AS n,
       AVG(CASE WHEN (concordance_summary->>'gemini-flash-lite')::boolean THEN 1.0 ELSE 0.0 END)*100 AS pct_flash_match,
       AVG(CASE WHEN (concordance_summary->>'mistral-medium')::boolean THEN 1.0 ELSE 0.0 END)*100 AS pct_medium_match,
       AVG(CASE WHEN (concordance_summary->>'mistral-large')::boolean THEN 1.0 ELSE 0.0 END)*100 AS pct_large_match,
       SUM(applied_cost_usd) AS cost_applied_7d
FROM llm_ab_shadow_decisions
WHERE decided_at > NOW() - INTERVAL '7 days'
GROUP BY call_site
ORDER BY call_site;
```

→ Décision per-site possible : peut-être garder Pro sur strategy_coach (décisions complexes) mais migrer scanner_postmortem vers Medium 3.5 si concordance ≥ 90%. Granularité maximale.

## Hors scope (potentiel PR follow-up)

- Endpoint `/admin/llm-cost-live` étendu pour aggreger aussi `llm_ab_shadow_decisions` (actuellement seulement `gemini_ab_decisions`)
- UI panel comparatif 4-way × 4 sites (visualisation par site)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_