### PR TITLE
feat(lisa): panel UI temps réel coût LLM 4 providers × 5 sites

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -129,6 +129,136 @@ export class LisaController {
     return this.qwStats.recent(Number.isFinite(parsed) ? parsed : 50);
   }
 
+  /**
+   * PR #524 — Compteur LLM temps réel pour /lisa UI panel.
+   * Mêmes calculs que /admin/llm-cost-live mais user-auth scoped (pas d'admin token).
+   * Aggrège gemini_ab_decisions (TRADER) ET llm_ab_shadow_decisions (4 autres sites)
+   * → vue unifiée 4 providers × tous call sites.
+   */
+  @Get('llm-cost-live')
+  async getLlmCostLive(
+    @Headers() headers: Record<string, string>,
+    @Query('hours') hours?: string,
+  ): Promise<{
+    since: string;
+    until: string;
+    total_cost_usd: number;
+    total_cycles: number;
+    providers: Record<string, { calls: number; cost_usd: number; avg_latency_ms: number | null }>;
+    by_site: Array<{ call_site: string; cycles: number; cost_usd: number }>;
+  }> {
+    extractUserId(headers);
+
+    const now = new Date();
+    const since = hours
+      ? new Date(now.getTime() - Math.min(168, Math.max(1, Number(hours))) * 3600_000)
+      : new Date(now.toISOString().slice(0, 10) + 'T00:00:00Z');
+
+    const stats: Record<string, { sum_cost: number; sum_lat: number; n_lat: number; n_calls: number }> = {
+      'gemini-pro': { sum_cost: 0, sum_lat: 0, n_lat: 0, n_calls: 0 },
+      'gemini-flash': { sum_cost: 0, sum_lat: 0, n_lat: 0, n_calls: 0 },
+      'mistral-medium': { sum_cost: 0, sum_lat: 0, n_lat: 0, n_calls: 0 },
+      'mistral-large': { sum_cost: 0, sum_lat: 0, n_lat: 0, n_calls: 0 },
+    };
+    const bySite = new Map<string, { cycles: number; cost: number }>();
+
+    // 1. TRADER decisions (gemini_ab_decisions — colonnes typées)
+    const { data: trader } = await this.supabase
+      .getClient()
+      .from('gemini_ab_decisions')
+      .select('pro_cost_usd,flash_cost_usd,mistral_cost_usd,mistral_large_cost_usd,pro_latency_ms,flash_latency_ms,mistral_latency_ms,mistral_large_latency_ms')
+      .gte('decided_at', since.toISOString())
+      .limit(50_000);
+    const traderRows = (trader ?? []) as unknown as Array<Record<string, unknown>>;
+    let traderTotalCost = 0;
+    for (const r of traderRows) {
+      const accum = (key: string, cost: number, lat: number | null) => {
+        if (cost > 0 || (key === 'gemini-pro')) {
+          stats[key].n_calls += 1;
+          stats[key].sum_cost += cost;
+          traderTotalCost += cost;
+          if (lat !== null && lat > 0) { stats[key].sum_lat += lat; stats[key].n_lat += 1; }
+        }
+      };
+      accum('gemini-pro', Number(r.pro_cost_usd ?? 0), r.pro_latency_ms != null ? Number(r.pro_latency_ms) : null);
+      accum('gemini-flash', Number(r.flash_cost_usd ?? 0), r.flash_latency_ms != null ? Number(r.flash_latency_ms) : null);
+      accum('mistral-medium', Number(r.mistral_cost_usd ?? 0), r.mistral_latency_ms != null ? Number(r.mistral_latency_ms) : null);
+      accum('mistral-large', Number(r.mistral_large_cost_usd ?? 0), r.mistral_large_latency_ms != null ? Number(r.mistral_large_latency_ms) : null);
+    }
+    bySite.set('trader_decision', { cycles: traderRows.length, cost: traderTotalCost });
+
+    // 2. Other 4 sites (llm_ab_shadow_decisions — JSONB shadows array)
+    const { data: shadow } = await this.supabase
+      .getClient()
+      .from('llm_ab_shadow_decisions')
+      .select('call_site,applied_provider,applied_cost_usd,applied_latency_ms,shadows')
+      .gte('decided_at', since.toISOString())
+      .limit(50_000);
+    const shadowRows = (shadow ?? []) as unknown as Array<Record<string, unknown>>;
+    for (const r of shadowRows) {
+      const site = String(r.call_site);
+      const cost = Number(r.applied_cost_usd ?? 0);
+      const lat = r.applied_latency_ms != null ? Number(r.applied_latency_ms) : null;
+      const provider = String(r.applied_provider ?? '').includes('pro') ? 'gemini-pro' : 'gemini-flash';
+      stats[provider].n_calls += 1;
+      stats[provider].sum_cost += cost;
+      if (lat !== null && lat > 0) { stats[provider].sum_lat += lat; stats[provider].n_lat += 1; }
+
+      // Shadows array
+      let siteCost = cost;
+      for (const s of (r.shadows as Array<Record<string, unknown>>) ?? []) {
+        const sp = String(s.provider ?? '');
+        const sCost = Number(s.cost_usd ?? 0);
+        const sLat = s.latency_ms != null ? Number(s.latency_ms) : null;
+        if (sp.includes('flash')) {
+          stats['gemini-flash'].n_calls += 1;
+          stats['gemini-flash'].sum_cost += sCost;
+          if (sLat !== null && sLat > 0) { stats['gemini-flash'].sum_lat += sLat; stats['gemini-flash'].n_lat += 1; }
+        } else if (sp.includes('pro')) {
+          stats['gemini-pro'].n_calls += 1;
+          stats['gemini-pro'].sum_cost += sCost;
+          if (sLat !== null && sLat > 0) { stats['gemini-pro'].sum_lat += sLat; stats['gemini-pro'].n_lat += 1; }
+        } else if (sp === 'mistral-medium' || sp.startsWith('mistral-medium')) {
+          stats['mistral-medium'].n_calls += 1;
+          stats['mistral-medium'].sum_cost += sCost;
+          if (sLat !== null && sLat > 0) { stats['mistral-medium'].sum_lat += sLat; stats['mistral-medium'].n_lat += 1; }
+        } else if (sp === 'mistral-large' || sp.startsWith('mistral-large')) {
+          stats['mistral-large'].n_calls += 1;
+          stats['mistral-large'].sum_cost += sCost;
+          if (sLat !== null && sLat > 0) { stats['mistral-large'].sum_lat += sLat; stats['mistral-large'].n_lat += 1; }
+        }
+        siteCost += sCost;
+      }
+      const prev = bySite.get(site) ?? { cycles: 0, cost: 0 };
+      bySite.set(site, { cycles: prev.cycles + 1, cost: prev.cost + siteCost });
+    }
+
+    const providers: Record<string, { calls: number; cost_usd: number; avg_latency_ms: number | null }> = {};
+    let totalCost = 0;
+    for (const [k, s] of Object.entries(stats)) {
+      if (s.n_calls === 0) continue;
+      providers[k] = {
+        calls: s.n_calls,
+        cost_usd: Math.round(s.sum_cost * 10000) / 10000,
+        avg_latency_ms: s.n_lat > 0 ? Math.round(s.sum_lat / s.n_lat) : null,
+      };
+      totalCost += s.sum_cost;
+    }
+
+    return {
+      since: since.toISOString(),
+      until: now.toISOString(),
+      total_cost_usd: Math.round(totalCost * 10000) / 10000,
+      total_cycles: traderRows.length + shadowRows.length,
+      providers,
+      by_site: Array.from(bySite.entries()).map(([call_site, v]) => ({
+        call_site,
+        cycles: v.cycles,
+        cost_usd: Math.round(v.cost * 10000) / 10000,
+      })),
+    };
+  }
+
   @Get('risk-state/:portfolioId')
   getRiskState(
     @Headers() headers: Record<string, string>,

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -44,6 +44,7 @@ import { LiveTradingWizard } from '@/components/lisa/live-trading-wizard';
 import { useOperatingMode } from '@/hooks/use-operating-mode';
 import { AutopilotBudgetBadge } from '@/components/lisa/autopilot-budget-badge';
 import { GeminiCostPanel } from '@/components/lisa/gemini-cost-panel';
+import { LlmCostLivePanel } from '@/components/lisa/llm-cost-live-panel';
 import { RiskStateBanner } from '@/components/lisa/risk-state-banner';
 import { LisaDecisionLog } from '@/components/lisa/decision-log';
 import { MechanicalAgentCard } from '@/components/lisa/mechanical-agent-card';
@@ -686,6 +687,9 @@ export default function LisaPage() {
 
       {/* PR2 cost-cuts (H) — Panel coûts Gemini quotidien/mensuel + kill-switch */}
       <GeminiCostPanel />
+
+      {/* PR #524 — Compteur LLM temps réel 4 providers × 5 call sites */}
+      <LlmCostLivePanel />
 
       {/* LISA refonte A.3 — Section Gains (badges + reset display-only) */}
       {selectedPortfolioId && <GainsTracker portfolioId={selectedPortfolioId} />}

--- a/apps/web/src/components/lisa/llm-cost-live-panel.tsx
+++ b/apps/web/src/components/lisa/llm-cost-live-panel.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+/**
+ * LlmCostLivePanel — affiche le compteur LLM temps réel pour les 4 providers
+ * sur les 5 call sites SmartVest. Lit depuis /lisa/llm-cost-live (refresh 30s).
+ *
+ * Apparait dans la page /lisa, complète l'ancien compteur Gemini qui lisait
+ * api_costs_daily (aggregé en fin de journée UTC, "figé" intra-day).
+ */
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+interface ProviderStats {
+  calls: number;
+  cost_usd: number;
+  avg_latency_ms: number | null;
+}
+
+interface SiteStats {
+  call_site: string;
+  cycles: number;
+  cost_usd: number;
+}
+
+interface LlmCostLiveResponse {
+  since: string;
+  until: string;
+  total_cost_usd: number;
+  total_cycles: number;
+  providers: Record<string, ProviderStats>;
+  by_site: SiteStats[];
+}
+
+const PROVIDER_LABELS: Record<string, { label: string; color: string }> = {
+  'gemini-pro': { label: 'Gemini 2.5 Pro', color: 'bg-blue-500' },
+  'gemini-flash': { label: 'Gemini 2.5 Flash', color: 'bg-cyan-500' },
+  'mistral-medium': { label: 'Mistral Medium 3.5', color: 'bg-orange-500' },
+  'mistral-large': { label: 'Mistral Large 3', color: 'bg-amber-500' },
+};
+
+const SITE_LABELS: Record<string, string> = {
+  trader_decision: 'TRADER decisions',
+  scanner_postmortem: 'Scanner post-mortem',
+  strategy_coach: 'Strategy coach',
+  daily_brief: 'Daily catalyst brief',
+  risk_monitor: 'Risk monitor',
+};
+
+export function LlmCostLivePanel() {
+  const { data, isLoading, isError } = useQuery<LlmCostLiveResponse>({
+    queryKey: ['lisa', 'llm-cost-live'],
+    queryFn: () => apiFetch<LlmCostLiveResponse>('/lisa/llm-cost-live'),
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: true,
+    staleTime: 25_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+        <h3 className="mb-3 text-sm font-semibold text-gray-700">Coût LLM temps réel</h3>
+        <p className="text-xs text-gray-500">Chargement…</p>
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+        <h3 className="mb-3 text-sm font-semibold text-gray-700">Coût LLM temps réel</h3>
+        <p className="text-xs text-red-600">Erreur de chargement</p>
+      </div>
+    );
+  }
+
+  const since = new Date(data.since);
+  const fmtSince = since.toISOString().slice(11, 16) + ' UTC';
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="mb-3 flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold text-gray-700">Coût LLM temps réel</h3>
+        <span className="text-xs text-gray-500">depuis {fmtSince}</span>
+      </div>
+
+      <div className="mb-4 flex items-baseline justify-between border-b border-gray-100 pb-3">
+        <span className="text-2xl font-bold text-gray-900">${data.total_cost_usd.toFixed(2)}</span>
+        <span className="text-xs text-gray-500">{data.total_cycles} cycles</span>
+      </div>
+
+      <div className="space-y-2">
+        {Object.entries(data.providers).map(([key, p]) => {
+          const meta = PROVIDER_LABELS[key] ?? { label: key, color: 'bg-gray-400' };
+          const pct = data.total_cost_usd > 0 ? (p.cost_usd / data.total_cost_usd) * 100 : 0;
+          return (
+            <div key={key} className="flex items-center gap-3 text-xs">
+              <div className={`h-2 w-2 rounded-full ${meta.color}`} aria-hidden />
+              <span className="flex-1 font-medium text-gray-700">{meta.label}</span>
+              <span className="text-gray-500">{p.calls} calls</span>
+              <span className="w-16 text-right font-mono text-gray-900">${p.cost_usd.toFixed(3)}</span>
+              {p.avg_latency_ms !== null && (
+                <span className="w-14 text-right text-gray-500">{(p.avg_latency_ms / 1000).toFixed(1)}s</span>
+              )}
+              <span className="w-10 text-right text-gray-400">{pct.toFixed(0)}%</span>
+            </div>
+          );
+        })}
+      </div>
+
+      {data.by_site.length > 0 && (
+        <details className="mt-4 border-t border-gray-100 pt-3">
+          <summary className="cursor-pointer text-xs text-gray-600">Détail par call site ({data.by_site.length})</summary>
+          <div className="mt-2 space-y-1">
+            {data.by_site
+              .sort((a, b) => b.cost_usd - a.cost_usd)
+              .map((s) => (
+                <div key={s.call_site} className="flex items-center justify-between text-xs">
+                  <span className="text-gray-600">{SITE_LABELS[s.call_site] ?? s.call_site}</span>
+                  <span className="font-mono text-gray-900">
+                    ${s.cost_usd.toFixed(3)} ({s.cycles})
+                  </span>
+                </div>
+              ))}
+          </div>
+        </details>
+      )}
+
+      <p className="mt-3 text-[10px] text-gray-400">
+        Refresh 30s — source : gemini_ab_decisions + llm_ab_shadow_decisions (vs api_costs_daily figé EOD)
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problème (constat live ce soir)

L'ancien `GeminiCostPanel` dans `/lisa` lit `api_costs_daily` qui est **aggregé en fin de journée UTC** (updated_at = 06:02 UTC du lendemain). Pendant la journée, le compteur affiche **$0** alors que Pro/Flash/Mistral consomment en continu (~$3.82/jour mesuré ce soir sur 122 cycles TRADER).

## Fix

Nouveau `LlmCostLivePanel` qui consume `GET /lisa/llm-cost-live` (refresh 30s) et affiche en temps réel :
- **Total** cumulé depuis 00:00 UTC + nombre de cycles
- **Breakdown 4 providers** : Gemini Pro / Flash / Mistral Medium / Mistral Large
  - Calls, coût, latence moyenne, % de la dépense
- **Breakdown par call site** (collapsible) : TRADER, Scanner post-mortem, Strategy coach, Daily brief, Risk monitor

## Architecture

### Backend
```
GET /lisa/llm-cost-live              # since 00:00 UTC today
GET /lisa/llm-cost-live?hours=24     # sliding window
```

User-auth scoped (pas d'admin token, contrairement à `/admin/llm-cost-live` de PR #522 qui reste actif pour usage CLI/scripts).

Aggregation depuis **2 tables** en 1 call :
- `gemini_ab_decisions` (TRADER decisions, colonnes typées par provider — PR #519-521)
- `llm_ab_shadow_decisions` (4 autres sites, shadows JSONB array — PR #523)

### Frontend
`LlmCostLivePanel` component avec `react-query` polling 30s. Insert dans `/lisa/page.tsx` après `GeminiCostPanel`.

## Files (3 changements)

| Type | Fichier | Lignes |
|---|---|---|
| Modifié | `apps/api/src/modules/lisa/lisa.controller.ts` | +130 (endpoint aggregation) |
| Nouveau | `apps/web/src/components/lisa/llm-cost-live-panel.tsx` | +130 (React component) |
| Modifié | `apps/web/src/app/lisa/page.tsx` | +2 (import + insert) |

## Aperçu visuel attendu

```
┌─────────────────────────────────────────────────┐
│  Coût LLM temps réel        depuis 00:00 UTC    │
├─────────────────────────────────────────────────┤
│  $3.82                              122 cycles   │
├─────────────────────────────────────────────────┤
│  ● Gemini 2.5 Pro       122 calls $2.621 16.9s  69%│
│  ● Gemini 2.5 Flash     122 calls $0.201  1.5s   5%│
│  ● Mistral Medium 3.5    31 calls $0.781  5.9s  20%│
│  ● Mistral Large 3       26 calls $0.213    -    6%│
├─────────────────────────────────────────────────┤
│  ▶ Détail par call site (5)                     │
│                                                 │
│  Refresh 30s — source : ab_decisions tables     │
└─────────────────────────────────────────────────┘
```

## Tests

- ✅ tsc --noEmit clean front + back
- ✅ Aucune régression (panel UI read-only, lecture seule de tables existantes)
- ❌ Pas de test unitaire (panel UI sans logique métier critique — la logique d'aggregation backend est testable séparément si besoin)

## Hors scope

- Graphique time-series par hour (data dispo dans `gemini_ab_decisions.decided_at`)
- Concordance live panel (Pro vs Mistral % match) — pourrait être ajouté en follow-up tomorrow après accumulation 6-12h de data
- Suppression du vieux `GeminiCostPanel` (laissé pour rétrocompat — affiche $0 mais ne perturbe pas)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_