### PR TITLE
feat(scanner-postmortem): +1 cron 14:00 UTC (delta 12h) pré-US-open

### DIFF
--- a/apps/api/src/modules/lisa/services/main-scanner-postmortem.service.ts
+++ b/apps/api/src/modules/lisa/services/main-scanner-postmortem.service.ts
@@ -143,16 +143,29 @@ export class MainScannerPostMortemService {
     );
     if (this.enabled) {
       // Registration manuelle via SchedulerRegistry (pattern TopGainersScanner / LiveTraderAgent).
-      // Cron 02:30 UTC : après Trader Agent post-mortem (02:00) pour pas saturer Gemini Pro.
+      // 2 crons :
+      //   - 02:30 UTC : full 24h post US close (baseline). Génère lessons pour le jour suivant.
+      //   - 14:00 UTC : delta 12h post Asia+EU close (pré-US open). Propage lessons Asia/EU
+      //     fraîches dans le prompt Gemini AVANT que les patterns ne contaminent la session US.
+      //     Cadence alignée tempo TRADER scalp 5min (vs feedback loop 24h trop lent).
       try {
-        const job = new CronJob('30 2 * * *', () => {
+        const jobNightly = new CronJob('30 2 * * *', () => {
           this.runPostMortem(24).catch((e) =>
-            this.logger.error(`[scanner-postmortem] cron failed: ${String(e).slice(0, 200)}`),
+            this.logger.error(`[scanner-postmortem] cron 02:30 failed: ${String(e).slice(0, 200)}`),
           );
         });
-        this.schedulerRegistry.addCronJob('main-scanner-postmortem', job);
-        job.start();
-        this.logger.log('[scanner-postmortem] ENABLED — cron 02:30 UTC daily');
+        this.schedulerRegistry.addCronJob('main-scanner-postmortem', jobNightly);
+        jobNightly.start();
+
+        const jobMidday = new CronJob('0 14 * * *', () => {
+          this.runPostMortem(12).catch((e) =>
+            this.logger.error(`[scanner-postmortem] cron 14:00 failed: ${String(e).slice(0, 200)}`),
+          );
+        });
+        this.schedulerRegistry.addCronJob('main-scanner-postmortem-midday', jobMidday);
+        jobMidday.start();
+
+        this.logger.log('[scanner-postmortem] ENABLED — crons 02:30 UTC (24h) + 14:00 UTC (12h)');
       } catch (e) {
         this.logger.error(`[scanner-postmortem] cron register failed: ${String(e).slice(0, 200)}`);
       }


### PR DESCRIPTION
## Summary
- Ajoute un **2ème cron 14:00 UTC fenêtre 12h** sur `MainScannerPostMortemService` (en plus du 02:30 UTC fenêtre 24h existant).
- Objectif : propager les lessons Asia+EU **avant US open** au lieu d'attendre J+1 02:30 UTC.

## Pourquoi

Constat session du 31/05 — le feedback loop 24h actuel est désaccordé du tempo **TRADER scalp 5min** :
- Pattern toxique détecté en Asia (00-06 UTC) → continue en EU (07-15 UTC) → contamine US (14:30-21 UTC) → enfin corrigé J+1 à 02:30 UTC = **~24h perdues**.
- Avec 2 crons : Asia/EU patterns identifiés à 14:00 UTC → lessons dispo dans le prompt Gemini Pro pour US open → **délai max ~12h**.

## Détails techniques

| Cron | Fenêtre | Rôle |
|---|---|---|
| `30 2 * * *` (existant) | 24h | Baseline post US close, génère lessons J+1 |
| `0 14 * * *` (nouveau) | 12h | Delta Asia+EU pré-US-open |

Cron names distincts dans `SchedulerRegistry` : `main-scanner-postmortem` et `main-scanner-postmortem-midday`.

## Coût

~$0.10/jour additionnel pour Gemini Pro + 3 shadows (Flash + Medium 3.5 + Large 3) ≈ **+$0.40/jour** soit +10% sur le budget TRADER $4-5/j. Acceptable.

## Test plan
- [ ] CI typecheck + Jest verts
- [ ] Vérifier au prochain deploy : log `[scanner-postmortem] ENABLED — crons 02:30 UTC (24h) + 14:00 UTC (12h)`
- [ ] À 14:00 UTC J+1 : confirmer dans logs Fly que le cron fire (`[scanner-postmortem] running for window …`)
- [ ] Vérifier que `llm_ab_shadow_decisions` reçoit un row `call_site=scanner_postmortem` après le run 14:00

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_