### PR TITLE
feat(scanner): cross-portfolio dedupe opt-in via env (default OFF) — vraie diversification

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -2502,14 +2502,18 @@ export class TopGainersScannerService implements OnModuleInit {
       .eq('status', 'open');
     const openSymbols = new Set((openPositions ?? []).map((p) => String(p.symbol).toUpperCase()));
 
-    // Shadow sizing × cross-portfolio dedupe — règle métier 26/05 :
-    // Quand on scanne un des 3 portfolios shadow, on étend openSymbols aux
-    // positions ouvertes dans les AUTRES shadows + main pour éviter que les
-    // 4 portfolios ouvrent le MÊME ticker (effet "convoy" sur EL/VUZI/etc.).
-    // slotsAvailable reste calculé sur les positions de CE portfolio uniquement
-    // (chaque shadow garde son capacity propre).
+    // Cross-portfolio dedupe — opt-in via env (default OFF depuis 01/06/2026)
+    // pour permettre vraie diversification : les 4 portfolios peuvent prendre
+    // les MÊMES setups indépendamment → multiplie les lessons via outcomes
+    // observés sur sample plus large (MFE/MAE/capture par classe × sizing).
+    //
+    // Si GAINERS_CROSS_PORTFOLIO_DEDUPE_ENABLED=true, on revient au comportement
+    // précédent (anti-doublon entre shadows + main pour éviter "convoy"
+    // sur EL/VUZI). Slots dispo restent calculés par-portfolio dans tous les cas.
+    const crossDedupeEnabled =
+      (this.config.get<string>('GAINERS_CROSS_PORTFOLIO_DEDUPE_ENABLED') ?? 'false').toLowerCase() === 'true';
     const isShadowPortfolio = SHADOW_PORTFOLIO_IDS.has(portfolioId);
-    if (isShadowPortfolio) {
+    if (crossDedupeEnabled && isShadowPortfolio) {
       const dedupeIds = [...SHADOW_PORTFOLIO_IDS, MAIN_PORTFOLIO_ID_FOR_DEDUPE]
         .filter((id) => id !== portfolioId);
       const { data: crossOpens } = await this.supabase


### PR DESCRIPTION
## Summary

Désactive par défaut l'**anti-doublon cross-portfolio** entre les 4 portfolios (TRADER + HIGH + MIDDLE + SMALL) pour permettre une **vraie diversification**.

## Pourquoi

Audit 01/06 03:00 UTC a révélé que MIDDLE et SMALL n'ont pas ouvert les 2 KOSDAQ (216080.KQ + 241520.KQ) tradés par TRADER + HIGH parce que ces tickers étaient dans la liste dédupe quand MIDDLE/SMALL ont scanné 4s plus tard :

```
02:26:36  TRADER scanne   → accept 216080.KQ + 241520.KQ
02:26:41  HIGH scanne     → accept aussi
02:26:42-44  HIGH+TRADER ouvrent les positions
02:26:45  MIDDLE scanne   → ces 2 tickers dans openSymbols (cross-dedupe) → exclus
02:26:46  SMALL scanne    → idem
```

**Conséquence** : sample lessons réduit à 2 outcomes (TRADER+HIGH dupliqués) au lieu de 4 outcomes indépendants pour analyse (MFE/MAE/capture par portfolio sizing).

## Nouveau comportement

Les 4 portfolios peuvent prendre les MÊMES setups indépendamment → **4× plus de data** pour calibrer guards/seuils dans les lessons auto-générées.

## Garde-fous

- Slots dispo restent calculés **par-portfolio** (chacun respecte son `max_open_positions`)
- Sizing reste configuré par-portfolio (`gainers_position_pct`)
- **Réactivable** via Fly secret `GAINERS_CROSS_PORTFOLIO_DEDUPE_ENABLED=true` si l'effet "convoy" se manifeste à nouveau
- Le commentaire mentionne le contexte 26/05 (anti-convoy EL/VUZI) en cas de regression

## Test plan
- [ ] CI vert (typecheck + Jest)
- [ ] Après deploy : observer si les 4 portfolios ouvrent maintenant les mêmes setups Asia/EU/US
- [ ] Surveiller risk concentration : si effet "convoy" se manifeste (4 portfolios saignant simultanément sur le même bad setup), réactiver `GAINERS_CROSS_PORTFOLIO_DEDUPE_ENABLED=true`

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_