### PR TITLE
feat(llm-ab-shadow): comparators Jaccard daily_brief + postmortem — fix faux 0% concordance

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/llm-shadow-comparators.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/llm-shadow-comparators.spec.ts
@@ -1,0 +1,122 @@
+import { dailyBriefComparator, jaccardSimilarity, parseLooseJson, postmortemComparator } from '../llm-shadow-comparators';
+
+describe('llm-shadow-comparators', () => {
+  describe('jaccardSimilarity', () => {
+    it('returns 1 for 2 empty sets', () => {
+      expect(jaccardSimilarity(new Set(), new Set())).toBe(1);
+    });
+
+    it('returns 0 when one set is empty', () => {
+      expect(jaccardSimilarity(new Set(['a']), new Set())).toBe(0);
+    });
+
+    it('returns intersection/union for overlapping sets', () => {
+      // A={a,b,c}, B={b,c,d} → intersection={b,c}, union={a,b,c,d} → 2/4 = 0.5
+      expect(jaccardSimilarity(new Set(['a', 'b', 'c']), new Set(['b', 'c', 'd']))).toBe(0.5);
+    });
+
+    it('returns 1 for identical sets', () => {
+      expect(jaccardSimilarity(new Set(['a', 'b']), new Set(['a', 'b']))).toBe(1);
+    });
+  });
+
+  describe('parseLooseJson', () => {
+    it('parses plain JSON', () => {
+      expect(parseLooseJson('{"a": 1}')).toEqual({ a: 1 });
+    });
+
+    it('parses JSON in ```json fences', () => {
+      expect(parseLooseJson('```json\n{"a": 1}\n```')).toEqual({ a: 1 });
+    });
+
+    it('extracts first { ... } block', () => {
+      expect(parseLooseJson('Some prefix text {"a": 1} suffix')).toEqual({ a: 1 });
+    });
+
+    it('returns null for unparseable', () => {
+      expect(parseLooseJson('not json at all')).toBeNull();
+    });
+  });
+
+  describe('dailyBriefComparator', () => {
+    const briefA = `{
+      "date": "2026-06-01",
+      "macro_events": [
+        {"time_utc": "06:00", "event": "DE Retail Sales", "impact": "medium"},
+        {"time_utc": "09:00", "event": "EU Unemployment Rate", "impact": "high"},
+        {"time_utc": "14:00", "event": "US ISM Manufacturing PMI", "impact": "medium"}
+      ]
+    }`;
+
+    const briefBSimilar = `\`\`\`json
+{
+  "date": "2026-06-01",
+  "macro_events": [
+    {"time_utc":"06:00","event":"DE Retail Sales","impact":"medium"},
+    {"time_utc":"09:00","event":"EU Unemployment Rate","impact":"high"},
+    {"time_utc":"14:00","event":"US ISM Manufacturing PMI New Orders","impact":"medium"}
+  ]
+}
+\`\`\``;
+
+    const briefBDifferent = `{
+      "date": "2026-06-01",
+      "macro_events": [
+        {"time_utc": "10:00", "event": "JP GDP Quarterly", "impact": "high"},
+        {"time_utc": "12:00", "event": "CN Trade Balance", "impact": "medium"}
+      ]
+    }`;
+
+    it('returns true for substantially identical briefs (different formatting)', () => {
+      expect(dailyBriefComparator(briefA, briefBSimilar)).toBe(true);
+    });
+
+    it('returns false for fully different events', () => {
+      expect(dailyBriefComparator(briefA, briefBDifferent)).toBe(false);
+    });
+
+    it('returns false on unparseable input', () => {
+      expect(dailyBriefComparator(briefA, 'not json')).toBe(false);
+    });
+  });
+
+  describe('postmortemComparator', () => {
+    const postA = `{
+      "lessons": [
+        {"macro_condition": "TRAIL_STOP_CRYPTO", "lesson_text": "..."},
+        {"macro_condition": "MFE_TRIGGER", "lesson_text": "..."},
+        {"macro_condition": "KOSDAQ_SMALL", "lesson_text": "..."}
+      ]
+    }`;
+
+    const postBSimilar = `{
+      "lessons": [
+        {"macro_condition": "trail_stop_crypto", "lesson_text": "different text"},
+        {"macro_condition": "mfe_trigger", "lesson_text": "yet other text"},
+        {"macro_condition": "kosdaq_small", "lesson_text": "..."}
+      ]
+    }`;
+
+    const postBDifferent = `{
+      "lessons": [
+        {"macro_condition": "US_HOURLY_BLACKLIST", "lesson_text": "..."},
+        {"macro_condition": "EU_NEWS_SHOCK", "lesson_text": "..."}
+      ]
+    }`;
+
+    it('returns true for same macro_conditions (case-insensitive)', () => {
+      expect(postmortemComparator(postA, postBSimilar)).toBe(true);
+    });
+
+    it('returns false for different macro_conditions', () => {
+      expect(postmortemComparator(postA, postBDifferent)).toBe(false);
+    });
+
+    it('fallback tokens : returns false if no JSON parse', () => {
+      // Both unparseable → fallback tokens; long different texts → < 0.4 Jaccard
+      const textA = 'The first text discusses momentum trading strategies on Asian markets';
+      const textB = 'A completely different document about crypto futures arbitrage opportunities';
+      expect(postmortemComparator(textA, textB)).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/daily-catalyst-brief.service.ts
+++ b/apps/api/src/modules/lisa/services/daily-catalyst-brief.service.ts
@@ -28,6 +28,7 @@ import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
 import { LlmABShadowService } from './llm-ab-shadow.service';
+import { dailyBriefComparator } from './llm-shadow-comparators';
 import { EodhdEconomicEventsService } from './eodhd-economic-events.service';
 
 export interface DailyCatalystBrief {
@@ -133,8 +134,9 @@ export class DailyCatalystBriefService {
       return null;
     }
 
-    // PR #523 — A/B shadow fire-and-forget. Brief output = text JSON narrative.
-    // Default comparator (text normalize, first 200 chars) suffisant.
+    // PR #523 — A/B shadow fire-and-forget. Brief output = JSON macro events.
+    // Comparator sémantique Jaccard sur events[].event (default text-match donnait
+    // 0% concordance malgré contenu substantiellement identique, cf. audit 01/06).
     void this.llmABShadow?.recordShadow({
       callSite: 'daily_brief',
       systemPrompt: SYSTEM_PROMPT,
@@ -148,6 +150,7 @@ export class DailyCatalystBriefService {
       },
       maxTokens: 1200,
       temperature: 0.2,
+      comparator: dailyBriefComparator,
     });
 
     if (!this.supabase.isReady()) {

--- a/apps/api/src/modules/lisa/services/llm-shadow-comparators.ts
+++ b/apps/api/src/modules/lisa/services/llm-shadow-comparators.ts
@@ -1,0 +1,121 @@
+/**
+ * Comparators sémantiques pour LlmABShadowService.
+ *
+ * Le default comparator (string normalize + first 200 chars exact match) est
+ * trop strict pour comparer des outputs LLM structurés (JSON, listes d'events,
+ * lessons). Cas observé 01/06 : Mistral Medium 3.5 + Large 3 retournent une
+ * analyse macro events SUBSTANTIELLEMENT IDENTIQUE au primary Gemini mais le
+ * formatting JSON diffère (ordre champs, whitespace) → faux négatif 100%.
+ *
+ * Solution : extraire un set de tokens sémantiques et comparer Jaccard.
+ */
+
+/**
+ * Jaccard similarity entre 2 sets : |A∩B| / |A∪B|.
+ * Retourne 0 si les 2 sets sont vides.
+ */
+export function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1; // both empty → trivially concordant
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const item of a) if (b.has(item)) intersection++;
+  const union = a.size + b.size - intersection;
+  return intersection / union;
+}
+
+/**
+ * Extrait un set de tokens normalisés (lowercase, alphanumeric only) depuis un texte.
+ * Utile pour comparer du texte libre (lessons, recommendations narratives).
+ */
+function tokenize(text: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const word of text.toLowerCase().match(/[a-z0-9_]+/g) ?? []) {
+    if (word.length >= 3) tokens.add(word);
+  }
+  return tokens;
+}
+
+/**
+ * Tente de parser le JSON depuis un output LLM. Gère :
+ * - JSON brut
+ * - JSON dans ```json fences
+ * - JSON dans ```text fences
+ * - JSON wrapper avec préfixe textuel
+ */
+export function parseLooseJson(content: string): unknown | null {
+  if (!content) return null;
+  const trimmed = content.trim();
+
+  // Tentative 1 : JSON brut
+  try { return JSON.parse(trimmed); } catch { /* continue */ }
+
+  // Tentative 2 : extraire entre ``` fences
+  const fenceMatch = trimmed.match(/```(?:json|text)?\s*([\s\S]*?)\s*```/);
+  if (fenceMatch) {
+    try { return JSON.parse(fenceMatch[1].trim()); } catch { /* continue */ }
+  }
+
+  // Tentative 3 : find first { ... } block
+  const braceStart = trimmed.indexOf('{');
+  const braceEnd = trimmed.lastIndexOf('}');
+  if (braceStart !== -1 && braceEnd > braceStart) {
+    try { return JSON.parse(trimmed.slice(braceStart, braceEnd + 1)); } catch { /* continue */ }
+  }
+
+  return null;
+}
+
+/**
+ * Comparator pour daily_brief : extrait les noms d'events macro et compare Jaccard.
+ * Concordant si similarity >= 0.6 (60% des events partagés).
+ *
+ * Format attendu : { macro_events: [{ event: string, ... }, ...] }
+ */
+export function dailyBriefComparator(a: string, b: string): boolean {
+  const pa = parseLooseJson(a) as { macro_events?: Array<{ event?: string }> } | null;
+  const pb = parseLooseJson(b) as { macro_events?: Array<{ event?: string }> } | null;
+  if (!pa || !pb) return false;
+
+  const eventsA = new Set<string>();
+  const eventsB = new Set<string>();
+  for (const e of pa.macro_events ?? []) {
+    if (e.event) {
+      // Normalize : keep only keywords (3-letter codes + main words)
+      for (const word of e.event.toLowerCase().match(/[a-z]{3,}/g) ?? []) {
+        eventsA.add(word);
+      }
+    }
+  }
+  for (const e of pb.macro_events ?? []) {
+    if (e.event) {
+      for (const word of e.event.toLowerCase().match(/[a-z]{3,}/g) ?? []) {
+        eventsB.add(word);
+      }
+    }
+  }
+
+  return jaccardSimilarity(eventsA, eventsB) >= 0.6;
+}
+
+/**
+ * Comparator pour scanner_postmortem : extrait les keywords des lessons proposées
+ * et compare Jaccard. Concordant si similarity >= 0.5 (50% keywords partagés).
+ *
+ * Format flexible : tente { lessons: [...] } d'abord, fallback sur full text.
+ */
+export function postmortemComparator(a: string, b: string): boolean {
+  const pa = parseLooseJson(a) as { lessons?: Array<{ macro_condition?: string; lesson_text?: string }> } | null;
+  const pb = parseLooseJson(b) as { lessons?: Array<{ macro_condition?: string; lesson_text?: string }> } | null;
+
+  // Cas 1 : JSON structuré avec lessons[].macro_condition
+  if (pa?.lessons && pb?.lessons) {
+    const conditionsA = new Set(pa.lessons.map(l => (l.macro_condition || '').toUpperCase()).filter(Boolean));
+    const conditionsB = new Set(pb.lessons.map(l => (l.macro_condition || '').toUpperCase()).filter(Boolean));
+    return jaccardSimilarity(conditionsA, conditionsB) >= 0.5;
+  }
+
+  // Cas 2 : fallback texte → tokenize les premiers 800 chars (résumé exécutif)
+  const tokensA = tokenize(a.slice(0, 800));
+  const tokensB = tokenize(b.slice(0, 800));
+  return jaccardSimilarity(tokensA, tokensB) >= 0.4;
+}

--- a/apps/api/src/modules/lisa/services/main-scanner-postmortem.service.ts
+++ b/apps/api/src/modules/lisa/services/main-scanner-postmortem.service.ts
@@ -31,6 +31,7 @@ import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
 import { LlmABShadowService } from './llm-ab-shadow.service';
+import { postmortemComparator } from './llm-shadow-comparators';
 import { LisaService } from './lisa.service';
 
 const SCANNER_PORTFOLIO_IDS = [
@@ -300,7 +301,8 @@ export class MainScannerPostMortemService {
 
     // PR #523 — A/B shadow fire-and-forget contre Flash + Mistral Medium/Large.
     // Cron 02:30 UTC quotidien → 1 call/jour, coût additionnel shadows ~$0.05/jour.
-    // Comparator default (text normalize) suffisant pour lessons text.
+    // Comparator sémantique Jaccard sur lessons[].macro_condition (fallback tokens
+    // si JSON parse fail). Default text-match donnait 0% concordance.
     void this.llmABShadow?.recordShadow({
       callSite: 'scanner_postmortem',
       systemPrompt: POST_MORTEM_SYSTEM_PROMPT,
@@ -312,6 +314,7 @@ export class MainScannerPostMortemService {
         latencyMs: response.latencyMs,
       },
       maxTokens: 8000,
+      comparator: postmortemComparator,
     });
 
     if (!response.content || response.content.trim().length === 0) {


### PR DESCRIPTION
## Problème

Audit 01/06 04:00 UTC : la concordance globale sur `llm_ab_shadow_decisions` (25 rows, 4 call sites périphériques) tombait à **0%** sur Mistral Medium + Large 3.

**Cas concret daily_brief 04:00 UTC** — les 3 LLMs identifient les MÊMES events macro :

```
Applied (gemini-flash-lite) :  DE Retail Sales 06:00 medium, EU Unemployment 09:00 high, US ISM 14:00 medium...
Shadow Mistral Medium 3.5 :     ✅ EU Unemployment 09:00 high, ✅ US ISM 14:00 medium, ✅ Fed Kashkari...
Shadow Mistral Large 3 :        ✅ DE Retail Sales 06:00 medium, ✅ EU Unemployment 09:00 high, ✅ US ISM 14:00 medium...
```

Mais **concordance = false** sur les 3 shadows. Cause : le `defaultComparator` (`normalize(first 200 chars).toLowerCase() === ...`) échoue à cause de micro-différences JSON (ordre champs, whitespace, markdown fences) **alors que le contenu est substantiellement identique**.

## Fix

Ajout de `llm-shadow-comparators.ts` avec 2 comparators sémantiques Jaccard-based :

| Call site | Comparator | Seuil concordance |
|---|---|---|
| `daily_brief` | extrait keywords events[].event, Jaccard | ≥ 0.60 |
| `scanner_postmortem` | macro_condition des lessons[] (case-insensitive), Jaccard | ≥ 0.50 |

Helpers réutilisables exposés :
- `jaccardSimilarity(setA, setB)` — intersection/union
- `parseLooseJson(content)` — gère JSON brut, ` ```json` fences, embedded braces

## Pas modifié

- `risk_monitor` : a déjà un comparator score-based custom (`delta < 0.15`)
- `strategy_coach` : a déjà un comparator JSON `action_kind` custom

→ Si ces 2-là montrent des faux négatifs persistants après ce fix, PR follow-up. Pour l'instant on n'a observé que `daily_brief` et `scanner_postmortem` casser.

## Tests

```
14 nouveaux tests passent :
- jaccardSimilarity : 4 cas (vide, asymétrique, partiel, identique)
- parseLooseJson : 4 cas (raw, fences, embedded, unparseable)
- dailyBriefComparator : 3 cas (similar formatting, different events, unparseable)
- postmortemComparator : 3 cas (macro_conditions match, different, fallback tokens)
```

Typecheck : 6 errors TS pré-existantes inchangées.

## Test plan

- [ ] CI vert
- [ ] Après deploy : observer `llm_ab_shadow_decisions.concordance_summary` au prochain `daily_brief` (04:00 UTC J+1) et `scanner_postmortem` (02:30 UTC J+1). Attendu : `daily_brief` concordance Mistral Medium/Large monte de 0% → 50-80% sur events macro consensuels.
- [ ] Vérifier que les outputs RÉELS sont stockés dans `applied_response_summary` et `shadows[].response_summary` (déjà confirmé pre-PR).

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_