### PR TITLE
feat(llm-shadow): fix Pro maxTokens + boucle feedback "qui a raison ?" (risk_monitor accuracy)

### DIFF
--- a/apps/api/src/modules/admin/admin-llm-accuracy.controller.ts
+++ b/apps/api/src/modules/admin/admin-llm-accuracy.controller.ts
@@ -1,0 +1,48 @@
+/**
+ * Endpoint admin pour mesurer "qui a raison ?" sur les shadows LLM.
+ *
+ * Phase 1 : risk_monitor (PR #535). Compare le verdict_score de chaque LLM
+ * (Pro / Flash / Mistral Medium / Large) à l'outcome réel de la position
+ * (PnL %). Le LLM avec le Brier score le plus bas = le plus précis.
+ *
+ * Endpoint :
+ *   GET /admin/llm-accuracy?call_site=risk_monitor&days=14
+ *
+ * Auth : header x-admin-token.
+ */
+
+import { Controller, Get, Headers, HttpException, HttpStatus, Logger, Query } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { LlmAccuracyService } from '../lisa/services/llm-accuracy.service';
+
+@Controller('admin')
+export class AdminLlmAccuracyController {
+  private readonly logger = new Logger(AdminLlmAccuracyController.name);
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly accuracy: LlmAccuracyService,
+  ) {}
+
+  @Get('llm-accuracy')
+  async getAccuracy(
+    @Headers('x-admin-token') token: string | undefined,
+    @Query('call_site') callSite?: string,
+    @Query('days') daysRaw?: string,
+  ): Promise<unknown> {
+    const adminToken = this.config.get<string>('ADMIN_TOKEN');
+    if (adminToken && token !== adminToken) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+    const site = callSite ?? 'risk_monitor';
+    const days = Math.max(1, Math.min(90, parseInt(daysRaw ?? '14', 10) || 14));
+
+    try {
+      const result = await this.accuracy.computeAccuracy(site, days);
+      return result;
+    } catch (e) {
+      this.logger.error(`[llm-accuracy] compute failed: ${String(e).slice(0, 200)}`);
+      throw new HttpException(`Compute failed: ${String(e).slice(0, 200)}`, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -47,6 +47,7 @@ import { AdminScannerDebugController } from './admin-scanner-debug.controller';
 import { AdminMarketCloseReportsController } from './admin-market-close-reports.controller';
 import { AdminLessonAutoApplyController } from './admin-lesson-auto-apply.controller';
 import { AdminLlmCostLiveController } from './admin-llm-cost-live.controller';
+import { AdminLlmAccuracyController } from './admin-llm-accuracy.controller';
 
 @Module({
   imports: [SupabaseModule, forwardRef(() => LisaModule), GainersModule],
@@ -90,6 +91,8 @@ import { AdminLlmCostLiveController } from './admin-llm-cost-live.controller';
     AdminLessonAutoApplyController,
     // PR #522 — Compteur LLM TEMPS RÉEL (vs api_costs_daily qui flush EOD).
     AdminLlmCostLiveController,
+    // PR #535 — "Qui a raison ?" ranking par provider sur les shadows.
+    AdminLlmAccuracyController,
   ],
 })
 export class AdminModule {}

--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -56,6 +56,7 @@ import { LiveTraderAgentService } from './services/live-trader-agent.service';
 import { MistralShadowService } from './services/mistral-shadow.service';
 import { MistralLargeShadowService } from './services/mistral-large-shadow.service';
 import { LlmABShadowService } from './services/llm-ab-shadow.service';
+import { LlmAccuracyService } from './services/llm-accuracy.service';
 import { MainScannerPostMortemService } from './services/main-scanner-postmortem.service';
 import { DailyDigestService } from './services/daily-digest.service';
 import { PushNotificationsService } from './services/push-notifications.service';
@@ -217,6 +218,9 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     // PR #523 — LlmABShadowService générique pour 4 call sites peripheriques
     // (scanner_postmortem, strategy_coach, daily_brief, risk_monitor)
     LlmABShadowService,
+    // PR #535 — boucle feedback "qui a raison ?" sur les shadows : backfill outcomes
+    // depuis lisa_positions closed → Brier + correlation par provider → /admin/llm-accuracy
+    LlmAccuracyService,
     // MainScannerPostMortemService — apprentissage Gemini Pro sur le scanner gainers
     // (cron 02:30 UTC : analyse 24h × 4 portfolios → lessons macro-conditionnelles).
     MainScannerPostMortemService,

--- a/apps/api/src/modules/lisa/services/__tests__/llm-accuracy-helper.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/llm-accuracy-helper.spec.ts
@@ -1,0 +1,85 @@
+import { brierScore, pearsonCorrelation, directionalAccuracy, parseRiskVerdictScore } from '../llm-accuracy.helper';
+
+describe('llm-accuracy.helper', () => {
+  describe('brierScore', () => {
+    it('returns 0 for perfect predictions', () => {
+      expect(brierScore([1, 0, 1, 0], [1, 0, 1, 0])).toBe(0);
+    });
+
+    it('returns 1 for worst predictions', () => {
+      expect(brierScore([1, 0], [0, 1])).toBe(1);
+    });
+
+    it('returns 0.25 for baseline (always 0.5)', () => {
+      expect(brierScore([0.5, 0.5, 0.5, 0.5], [1, 0, 1, 0])).toBe(0.25);
+    });
+
+    it('returns null for empty', () => {
+      expect(brierScore([], [])).toBeNull();
+    });
+  });
+
+  describe('pearsonCorrelation', () => {
+    it('returns 1 for perfect positive linear', () => {
+      const r = pearsonCorrelation([1, 2, 3, 4], [10, 20, 30, 40]);
+      expect(r).toBeCloseTo(1, 5);
+    });
+
+    it('returns -1 for perfect negative linear', () => {
+      const r = pearsonCorrelation([1, 2, 3, 4], [40, 30, 20, 10]);
+      expect(r).toBeCloseTo(-1, 5);
+    });
+
+    it('returns null for constant series (variance=0)', () => {
+      expect(pearsonCorrelation([1, 1, 1], [2, 3, 4])).toBeNull();
+    });
+
+    it('returns null for too few samples', () => {
+      expect(pearsonCorrelation([1], [2])).toBeNull();
+    });
+  });
+
+  describe('directionalAccuracy', () => {
+    it('returns 1 when all directional matches', () => {
+      // 0.7 + 0.5%, 0.3 + (-1%), 0.8 + 2% → 3/3 matches (bullish ↔ positive)
+      // BUT directionalAccuracy considers score>0.5 as bullish strictly, so 0.5 = bearish
+      const r = directionalAccuracy([0.7, 0.3, 0.8], [0.5, -1, 2]);
+      expect(r).toBe(1);
+    });
+
+    it('returns 0 when all flipped', () => {
+      expect(directionalAccuracy([0.8, 0.2], [-1, 1])).toBe(0);
+    });
+
+    it('returns 0.5 for mixed', () => {
+      expect(directionalAccuracy([0.8, 0.2, 0.8, 0.2], [1, -1, -1, 1])).toBe(0.5);
+    });
+  });
+
+  describe('parseRiskVerdictScore', () => {
+    it('parses JSON brut score', () => {
+      expect(parseRiskVerdictScore('{"score": 0.5, "rationale": "..."}')).toBe(0.5);
+    });
+
+    it('parses JSON in ```json fences', () => {
+      expect(parseRiskVerdictScore('```json\n{"score": 0.7}\n```')).toBe(0.7);
+    });
+
+    it('parses score from text "score: 0.3"', () => {
+      expect(parseRiskVerdictScore('Le score est score: 0.3 mais rationale...')).toBe(0.3);
+    });
+
+    it('returns null for unparseable', () => {
+      expect(parseRiskVerdictScore('no score here')).toBeNull();
+    });
+
+    it('returns null for out-of-range score', () => {
+      expect(parseRiskVerdictScore('{"score": 1.5}')).toBeNull();
+    });
+
+    it('returns null for null/undefined', () => {
+      expect(parseRiskVerdictScore(null)).toBeNull();
+      expect(parseRiskVerdictScore(undefined)).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/llm-ab-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/llm-ab-shadow.service.ts
@@ -69,6 +69,11 @@ export interface LlmABRecordParams {
   maxTokens?: number;
   /** Override temperature pour shadows (default 0.3). */
   temperature?: number;
+  /**
+   * Identifier optionnel de l'objet évalué (e.g. lisa_positions.id pour
+   * risk_monitor). Permet le backfill outcome ultérieur par LlmAccuracyService.
+   */
+  targetId?: string;
 }
 
 interface ShadowResult {
@@ -281,6 +286,7 @@ export class LlmABShadowService {
         decided_at: new Date().toISOString(),
         call_site: params.callSite,
         portfolio_id: params.portfolioId ?? null,
+        target_id: params.targetId ?? null,
         applied_provider: params.applied.providerId,
         applied_response_summary: this.truncate(params.applied.content),
         applied_cost_usd: params.applied.costUsd,

--- a/apps/api/src/modules/lisa/services/llm-ab-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/llm-ab-shadow.service.ts
@@ -129,6 +129,13 @@ export class LlmABShadowService {
 
       // Si applied = Gemini Pro, on ne refait pas Pro en shadow (pas de doublon).
       // Mais si applied = Flash (chain fast), on appelle Pro en shadow.
+      //
+      // ⚠️ Gemini 2.5 Pro = modèle THINKING : consomme 1000-2000 tokens en
+      // reasoning AVANT de produire du content. Si maxTokens < 2000, tout
+      // passe en thinking → content vide. Floor 4000 pour Pro shadow
+      // (2000 thinking + 1500 content + buffer). Autres shadows (Flash,
+      // Mistral) gardent le maxTokens du caller car ils ne thinking pas.
+      const proMaxTokens = Math.max(params.maxTokens ?? 1500, 4000);
       const proPromise = !appliedIsFlashTier
         ? Promise.resolve(null)
         : this.llmRouter
@@ -136,7 +143,7 @@ export class LlmABShadowService {
               system: params.systemPrompt,
               user: params.userPrompt,
               temperature: params.temperature ?? 0.3,
-              maxTokens: params.maxTokens ?? 1500,
+              maxTokens: proMaxTokens,
               timeoutMs: 30_000,
             })
             .then(r => ({ ok: true as const, ...r }))

--- a/apps/api/src/modules/lisa/services/llm-accuracy.helper.ts
+++ b/apps/api/src/modules/lisa/services/llm-accuracy.helper.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure helpers pour mesurer la justesse des LLMs sur leurs verdicts shadow.
+ *
+ * Question : sur 100 risk_monitor calls, qui prédit le mieux le PnL réel
+ * de la position ? On compare verdict_score (0-1) au outcome_pnl_pct mesuré.
+ *
+ * Métriques :
+ *   - Brier score : Σ (score - outcome_binary)² / N — plus bas = meilleur
+ *   - Pearson correlation : corrélation linéaire entre score et pnl
+ *   - Accuracy directionnelle : % de fois où score>0.5 ↔ pnl>0
+ */
+
+/**
+ * Brier score = MSE entre la probabilité prédite et l'outcome binaire.
+ * - 0.0 = parfait (prédit 1.0 et outcome=1, ou prédit 0.0 et outcome=0)
+ * - 0.25 = baseline (prédit 0.5 → no information)
+ * - 1.0 = pire (prédit 1.0 et outcome=0)
+ *
+ * @param scores tableau de probabilités prédites [0, 1]
+ * @param outcomes tableau d'outcomes binaires {0, 1}
+ * @returns Brier score, ou null si arrays vides ou inégaux
+ */
+export function brierScore(scores: number[], outcomes: number[]): number | null {
+  if (scores.length === 0 || scores.length !== outcomes.length) return null;
+  let sum = 0;
+  for (let i = 0; i < scores.length; i++) {
+    const s = scores[i];
+    const o = outcomes[i];
+    if (s < 0 || s > 1) continue;
+    if (o !== 0 && o !== 1) continue;
+    sum += (s - o) ** 2;
+  }
+  return sum / scores.length;
+}
+
+/**
+ * Pearson correlation coefficient entre 2 séries.
+ * - +1.0 = corrélation linéaire parfaite positive
+ * -  0.0 = aucune relation
+ * - -1.0 = corrélation négative (LLM prédit l'inverse du réel)
+ *
+ * @returns r ∈ [-1, 1], ou null si arrays trop petits / variance nulle
+ */
+export function pearsonCorrelation(xs: number[], ys: number[]): number | null {
+  if (xs.length < 2 || xs.length !== ys.length) return null;
+  const n = xs.length;
+  const meanX = xs.reduce((s, v) => s + v, 0) / n;
+  const meanY = ys.reduce((s, v) => s + v, 0) / n;
+  let num = 0;
+  let denX = 0;
+  let denY = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = xs[i] - meanX;
+    const dy = ys[i] - meanY;
+    num += dx * dy;
+    denX += dx * dx;
+    denY += dy * dy;
+  }
+  const den = Math.sqrt(denX * denY);
+  if (den === 0) return null;
+  return num / den;
+}
+
+/**
+ * Accuracy directionnelle simple : % de fois où LLM et outcome ont le même sens.
+ * Considère que score > 0.5 = "bullish" et outcome > 0 = "win".
+ *
+ * @returns ratio dans [0, 1], ou null si array vide
+ */
+export function directionalAccuracy(scores: number[], outcomes: number[]): number | null {
+  if (scores.length === 0 || scores.length !== outcomes.length) return null;
+  let matches = 0;
+  for (let i = 0; i < scores.length; i++) {
+    const llmBullish = scores[i] > 0.5;
+    const realWin = outcomes[i] > 0;
+    if (llmBullish === realWin) matches++;
+  }
+  return matches / scores.length;
+}
+
+/**
+ * Parse un verdict risk_monitor sous forme JSON ({"score": 0.5, ...}) ou
+ * texte avec "score: 0.7" embedded. Retourne null si pas extractible.
+ */
+export function parseRiskVerdictScore(content: string | null | undefined): number | null {
+  if (!content) return null;
+  // 1. Tentative JSON brut
+  try {
+    const parsed = JSON.parse(content);
+    if (typeof parsed?.score === 'number') {
+      const s = parsed.score;
+      if (s >= 0 && s <= 1) return s;
+    }
+  } catch { /* continue */ }
+
+  // 2. Tentative JSON dans ```json fences
+  const fence = content.match(/```(?:json|text)?\s*([\s\S]*?)\s*```/);
+  if (fence) {
+    try {
+      const parsed = JSON.parse(fence[1].trim());
+      if (typeof parsed?.score === 'number' && parsed.score >= 0 && parsed.score <= 1) {
+        return parsed.score;
+      }
+    } catch { /* continue */ }
+  }
+
+  // 3. Tentative regex "score: 0.5" / "score":0.5
+  const m = content.match(/["\s]?score["\s]?\s*[:=]\s*(\d+(?:\.\d+)?)/);
+  if (m) {
+    const s = parseFloat(m[1]);
+    if (s >= 0 && s <= 1) return s;
+  }
+
+  return null;
+}

--- a/apps/api/src/modules/lisa/services/llm-accuracy.service.ts
+++ b/apps/api/src/modules/lisa/services/llm-accuracy.service.ts
@@ -1,0 +1,207 @@
+/**
+ * LlmAccuracyService — boucle de feedback "qui a raison ?" sur les shadows LLM.
+ *
+ * Phase 1 : risk_monitor. Pour chaque position fermée, backfill les rows
+ * llm_ab_shadow_decisions correspondantes (target_id=position.id) avec :
+ *   - outcome_pnl_pct : PnL réel %
+ *   - outcome_label   : win / loss / breakeven
+ *
+ * Ensuite computeAccuracy() agrège par provider : Brier score + Pearson
+ * correlation entre verdict_score et outcome_pnl_pct.
+ *
+ * Endpoint : GET /admin/llm-accuracy?call_site=risk_monitor&days=14
+ *
+ * Phase 2 (PR follow-up) : étendre aux 3 autres call sites.
+ */
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { SupabaseService } from '../../supabase/supabase.service';
+import {
+  brierScore,
+  pearsonCorrelation,
+  directionalAccuracy,
+  parseRiskVerdictScore,
+} from './llm-accuracy.helper';
+
+interface ShadowEntry {
+  provider: string;
+  response_summary: string | null;
+}
+
+interface ShadowRow {
+  id: string;
+  applied_provider: string;
+  applied_response_summary: string | null;
+  shadows: ShadowEntry[] | null;
+  outcome_pnl_pct: number | null;
+  outcome_label: string | null;
+}
+
+export interface ProviderAccuracy {
+  provider: string;
+  n: number;
+  brier: number | null;
+  correlation: number | null;
+  directional_accuracy: number | null;
+  avg_score: number | null;
+  avg_outcome_pct: number | null;
+}
+
+export interface CallSiteAccuracy {
+  call_site: string;
+  window_days: number;
+  total_samples: number;
+  resolved_samples: number;
+  by_provider: ProviderAccuracy[];
+  verdict: string;
+}
+
+@Injectable()
+export class LlmAccuracyService {
+  private readonly logger = new Logger(LlmAccuracyService.name);
+
+  constructor(@Optional() private readonly supabase?: SupabaseService) {}
+
+  /**
+   * Appelé par MechanicalTradingService.closePosition après le close DB.
+   * Backfill toutes les shadow rows risk_monitor associées à cette position.
+   *
+   * @param positionId  lisa_positions.id
+   * @param pnlPct      PnL réalisé en % (positif = win, négatif = loss)
+   */
+  async linkPositionOutcome(positionId: string, pnlPct: number): Promise<void> {
+    if (!this.supabase?.isReady()) return;
+    const label = pnlPct > 0.05 ? 'win' : pnlPct < -0.05 ? 'loss' : 'breakeven';
+    try {
+      const { error } = await this.supabase
+        .getClient()
+        .from('llm_ab_shadow_decisions')
+        .update({
+          outcome_pnl_pct: pnlPct,
+          outcome_label: label,
+          outcome_resolved_at: new Date().toISOString(),
+        })
+        .eq('target_id', positionId)
+        .is('outcome_resolved_at', null);
+      if (error) {
+        this.logger.debug(`[llm-accuracy] backfill ${positionId.slice(0, 8)} failed: ${error.message}`);
+      }
+    } catch (e) {
+      this.logger.debug(`[llm-accuracy] backfill ${positionId.slice(0, 8)} exception: ${String(e).slice(0, 100)}`);
+    }
+  }
+
+  /**
+   * Compute accuracy metrics par provider pour un call_site donné sur les
+   * N derniers jours. Ne prend que les rows avec outcome_resolved_at set.
+   */
+  async computeAccuracy(callSite: string, days: number): Promise<CallSiteAccuracy> {
+    if (!this.supabase?.isReady()) {
+      return {
+        call_site: callSite,
+        window_days: days,
+        total_samples: 0,
+        resolved_samples: 0,
+        by_provider: [],
+        verdict: 'supabase not ready',
+      };
+    }
+
+    const since = new Date(Date.now() - days * 24 * 3600_000).toISOString();
+    const { data: rows, error } = await this.supabase
+      .getClient()
+      .from('llm_ab_shadow_decisions')
+      .select('id, applied_provider, applied_response_summary, shadows, outcome_pnl_pct, outcome_label')
+      .eq('call_site', callSite)
+      .gte('created_at', since);
+    if (error || !rows) {
+      return {
+        call_site: callSite,
+        window_days: days,
+        total_samples: 0,
+        resolved_samples: 0,
+        by_provider: [],
+        verdict: `query failed: ${error?.message ?? 'unknown'}`,
+      };
+    }
+
+    const totalSamples = rows.length;
+    const resolved = rows.filter((r: ShadowRow) => r.outcome_pnl_pct !== null);
+    if (resolved.length === 0) {
+      return {
+        call_site: callSite,
+        window_days: days,
+        total_samples: totalSamples,
+        resolved_samples: 0,
+        by_provider: [],
+        verdict: `no resolved outcomes yet (need positions to close)`,
+      };
+    }
+
+    // Phase 1 : risk_monitor only — extract score via parseRiskVerdictScore.
+    // (Phase 2 : autres call sites auront leur propre extracteur.)
+    const extractScore = callSite === 'risk_monitor' ? parseRiskVerdictScore : () => null;
+
+    // Aggregate per provider
+    const byProvider = new Map<string, { scores: number[]; outcomesPct: number[]; outcomesBin: number[] }>();
+    const ensure = (p: string) => {
+      if (!byProvider.has(p)) byProvider.set(p, { scores: [], outcomesPct: [], outcomesBin: [] });
+      return byProvider.get(p)!;
+    };
+
+    for (const r of resolved as ShadowRow[]) {
+      const outcomePct = Number(r.outcome_pnl_pct);
+      const outcomeBin = outcomePct > 0 ? 1 : 0;
+
+      // Applied provider
+      const appliedScore = extractScore(r.applied_response_summary);
+      if (appliedScore !== null) {
+        const b = ensure(r.applied_provider);
+        b.scores.push(appliedScore);
+        b.outcomesPct.push(outcomePct);
+        b.outcomesBin.push(outcomeBin);
+      }
+
+      // Shadow providers
+      for (const s of r.shadows ?? []) {
+        const sScore = extractScore(s.response_summary);
+        if (sScore !== null) {
+          const b = ensure(s.provider);
+          b.scores.push(sScore);
+          b.outcomesPct.push(outcomePct);
+          b.outcomesBin.push(outcomeBin);
+        }
+      }
+    }
+
+    const byProviderArr: ProviderAccuracy[] = [];
+    for (const [provider, b] of byProvider.entries()) {
+      byProviderArr.push({
+        provider,
+        n: b.scores.length,
+        brier: brierScore(b.scores, b.outcomesBin),
+        correlation: pearsonCorrelation(b.scores, b.outcomesPct),
+        directional_accuracy: directionalAccuracy(b.scores, b.outcomesPct),
+        avg_score: b.scores.length > 0 ? b.scores.reduce((s, v) => s + v, 0) / b.scores.length : null,
+        avg_outcome_pct:
+          b.outcomesPct.length > 0 ? b.outcomesPct.reduce((s, v) => s + v, 0) / b.outcomesPct.length : null,
+      });
+    }
+
+    // Sort by Brier (lower = better)
+    byProviderArr.sort((a, b) => (a.brier ?? Infinity) - (b.brier ?? Infinity));
+    const best = byProviderArr[0];
+    const verdict =
+      best && best.brier !== null
+        ? `${best.provider} is best on ${callSite} (Brier=${best.brier.toFixed(3)}, n=${best.n}/${resolved.length} samples ${days}d)`
+        : `insufficient resolved samples for ranking (n=${resolved.length})`;
+
+    return {
+      call_site: callSite,
+      window_days: days,
+      total_samples: totalSamples,
+      resolved_samples: resolved.length,
+      by_provider: byProviderArr,
+      verdict,
+    };
+  }
+}

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -13,7 +13,8 @@
  * passe en mode défensif (fermetures uniquement, plus d'ouvertures).
  */
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { LlmAccuracyService } from './llm-accuracy.service';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import Decimal from 'decimal.js';
 import { randomUUID } from 'node:crypto';
@@ -219,6 +220,7 @@ export class MechanicalTradingService {
     private readonly sanityR5: SanityR5Service,
     private readonly qw3Warmup: Qw3WarmupExtendedService,
     private readonly assetClassKelly: AssetClassKellyConfigService,
+    @Optional() private readonly llmAccuracy?: LlmAccuracyService,
   ) {}
 
   /**
@@ -3107,6 +3109,14 @@ export class MechanicalTradingService {
       pos.direction as string,
       realizedPnl.toNumber(),
     ).catch((e) => this.logger.debug(`pattern feedback failed: ${String(e).slice(0, 100)}`));
+
+    // PR #535 — boucle feedback LLM accuracy : backfill outcome sur les
+    // shadow rows risk_monitor associées à cette position (target_id=id).
+    // Permet ensuite computeAccuracy() de mesurer Brier + correlation par
+    // provider. Fire-and-forget — ne bloque jamais le close.
+    this.llmAccuracy
+      ?.linkPositionOutcome(positionId, pnlPct)
+      .catch((e) => this.logger.debug(`[llm-accuracy] hook failed: ${String(e).slice(0, 100)}`));
 
     await this.decisionLog.append({
       portfolioId: pos.portfolio_id as string,

--- a/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
+++ b/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
@@ -289,6 +289,7 @@ export class OpenPositionRiskMonitorService {
       void this.llmABShadow?.recordShadow({
         callSite: 'risk_monitor',
         portfolioId: pos.portfolio_id,
+        targetId: pos.id, // permet backfill outcome quand position ferme (LlmAccuracyService)
         systemPrompt: GEMINI_VERDICT_SYSTEM_PROMPT,
         userPrompt,
         applied: {

--- a/supabase/migrations/0182_llm_ab_shadow_outcomes.sql
+++ b/supabase/migrations/0182_llm_ab_shadow_outcomes.sql
@@ -1,0 +1,41 @@
+-- Migration 0182 — Backfill outcomes pour llm_ab_shadow_decisions
+--
+-- Permet de répondre à la question "qui des 4 LLMs a raison?" en liant chaque
+-- shadow decision à un outcome mesurable (position fermée pour risk_monitor,
+-- événements pour daily_brief, etc.).
+--
+-- Phase 1 (cette migration) : risk_monitor uniquement. Chaque shadow row peut
+-- pointer vers une lisa_positions.id ; quand la position ferme, on backfill
+-- outcome_pnl_pct + outcome_label.
+--
+-- Phase 2 (PR follow-up) : étendre aux 3 autres call sites avec leur propre
+-- ground truth (lessons applied → J+1 outcomes, brief events → market move, etc.)
+
+ALTER TABLE public.llm_ab_shadow_decisions
+  ADD COLUMN IF NOT EXISTS target_id UUID NULL,
+  ADD COLUMN IF NOT EXISTS outcome_pnl_pct NUMERIC NULL,
+  ADD COLUMN IF NOT EXISTS outcome_label TEXT NULL,
+  ADD COLUMN IF NOT EXISTS outcome_resolved_at TIMESTAMPTZ NULL;
+
+ALTER TABLE public.llm_ab_shadow_decisions
+  DROP CONSTRAINT IF EXISTS llm_ab_shadow_outcome_label_chk;
+ALTER TABLE public.llm_ab_shadow_decisions
+  ADD CONSTRAINT llm_ab_shadow_outcome_label_chk
+  CHECK (outcome_label IS NULL OR outcome_label IN ('win', 'loss', 'breakeven'));
+
+CREATE INDEX IF NOT EXISTS idx_llm_ab_shadow_target_id
+  ON public.llm_ab_shadow_decisions(target_id)
+  WHERE target_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_llm_ab_shadow_unresolved
+  ON public.llm_ab_shadow_decisions(call_site, created_at)
+  WHERE outcome_resolved_at IS NULL AND target_id IS NOT NULL;
+
+COMMENT ON COLUMN public.llm_ab_shadow_decisions.target_id IS
+  'Lien optionnel vers l''objet évalué (e.g. lisa_positions.id pour risk_monitor). Permet le backfill outcome.';
+COMMENT ON COLUMN public.llm_ab_shadow_decisions.outcome_pnl_pct IS
+  'PnL final % de l''objet évalué (risk_monitor: position closed pnl).';
+COMMENT ON COLUMN public.llm_ab_shadow_decisions.outcome_label IS
+  'Catégorie outcome : win / loss / breakeven.';
+COMMENT ON COLUMN public.llm_ab_shadow_decisions.outcome_resolved_at IS
+  'Quand l''outcome a été résolu et backfillé.';


### PR DESCRIPTION
## 2 changements complémentaires sur la pipeline shadow LLM

### Partie 1 — Fix maxTokens Gemini Pro shadow (commit 1)

**Bug** : sur 23 calls (22 risk_monitor + 1 daily_brief), le shadow `gemini-pro` a `response_summary = ""` malgré un cost effectif ~$0.002 par call.

**Cause** : Gemini 2.5 Pro est un modèle THINKING qui consomme 1000-2000 tokens en reasoning AVANT de produire du content. Les callers passaient `maxTokens=120` (risk_monitor) ou `1200` (daily_brief) — Pro consommait tout en thinking et retournait content vide.

**Fix** : floor 4000 maxTokens spécifiquement pour Pro shadow (budget thinking + content + buffer). Pas d'impact sur Flash/Mistral.

### Partie 2 — Boucle feedback "qui a raison ?" (commit 2)

Question fondamentale identifiée : aujourd'hui on mesure "qui dit quoi" (concordance) mais pas "qui prédit correctement". 1er pas pour répondre.

**Architecture phase 1 (risk_monitor)** :

```
Position ouverte (T0)
  ↓
risk_monitor évalue → score 0.5 / 0.3 / 0.7 par LLM
  ↓ shadow row avec target_id = position.id
Position fermée (T1)
  ↓
closePosition() → linkPositionOutcome(position.id, pnlPct)
  ↓ UPDATE outcome_pnl_pct + outcome_label
  ↓
GET /admin/llm-accuracy?call_site=risk_monitor&days=14
  → Brier score + Pearson correlation + directional accuracy par provider
  → Verdict : "gemini-pro is best on risk_monitor (Brier=0.12, n=87)"
```

**Composants** :
- Migration 0182 : ALTER llm_ab_shadow_decisions ADD target_id + outcome_*
- `llm-accuracy.helper.ts` : pure functions brier / pearson / directional / parseRiskVerdictScore
- `LlmAccuracyService` : linkPositionOutcome + computeAccuracy
- Hook `closePosition` dans MechanicalTradingService (fire-and-forget)
- Caller risk_monitor passe `targetId: pos.id`
- Admin endpoint `GET /admin/llm-accuracy?call_site=&days=`

**Phase 2 (PR follow-up)** : étendre à scanner_postmortem / daily_brief / strategy_coach avec ground truth dédiée à chaque call site.

## Tests

- 11 tests llm-ab-shadow existants : verts (typecheck OK 6 errors pré-existants)
- 17 tests llm-accuracy-helper : verts (Brier, correlation, directional, parseRiskVerdictScore × edge cases)

## Coût additionnel

~$0.005 par call Pro shadow × 22 risk_monitor/jour ≈ **$0.11/jour**. Acceptable vs valeur de répondre objectivement à "qui prédit le mieux".

## Test plan
- [ ] CI vert
- [ ] Migration 0182 appliquée (workflow Apply Supabase migrations)
- [ ] Après deploy : prochain risk_monitor (5 min) → shadow gemini-pro a `response_summary` non vide
- [ ] Quand 1ère position ferme → vérifier `llm_ab_shadow_decisions.outcome_pnl_pct` backfillé
- [ ] Après 10-20 positions fermées → `curl /admin/llm-accuracy?call_site=risk_monitor` retourne verdict avec ranking

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk