### PR TITLE
feat(trader): consume daily_catalyst_brief in prompt — comparer interprétation news Pro vs Mistral

### DIFF
--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -205,6 +205,20 @@ CONTEXTE NEWS (input \`news_recent\` — eodhd dernières 2h) :
 - Évite d'ouvrir 5 minutes avant un événement \`macro.upcomingEvents\`
   (FOMC, CPI, NFP) : volatilité non-directionnelle
 
+DAILY CATALYST BRIEF (input \`daily_brief\` — généré 04:00 UTC, scope 24h, peut être null) :
+- \`macro_events[]\` : événements EU/US/Asia datés avec impact (high/medium/low)
+  → Si l'heure courante est dans la fenêtre ±15 min d'un event \`impact=high\`,
+    HOLD plutôt qu'open_directional (volatilité non-directionnelle, gap risk)
+- \`tickers_to_watch[]\` : tickers identifiés comme catalystes du jour
+  → Si un candidat scanner matche un ticker_to_watch → bonus conviction +0.05
+- \`tickers_to_avoid[]\` : tickers à éviter (post-event drift, regulatory risk)
+  → Si un candidat matche → conf max 0.60 (reject implicit)
+- \`sectors_in_focus[]\` : secteurs où chercher en priorité
+  → Si plusieurs candidats équivalents, privilégier celui dans un sector_in_focus
+- \`summary\` : 2-3 phrases résumé jour. Cite-le dans ton thesis si tu fais un trade
+  dirigé par un event listé (e.g. "Pre-CPI defensive positioning per daily brief").
+- Si \`daily_brief = null\` (brief non généré, < 24h après reset, etc.) : ignore ce bloc.
+
 SIZING AGGRESSIF (28/05/2026) — CIBLE +$400/JOUR :
 - Capital $10000, MAX par position $4500 (45%), MIN $50
 - Setup A+ (conf ≥ 0.85, persistence=1.0, lesson winning_pattern qui match, news favorable)
@@ -491,6 +505,10 @@ export class LiveTraderAgentService {
         this.fetchMiddleReference(),
         // AUTO-CORRECTION DYNAMIQUE (29/05) — self-reflection sur dernières 5 décisions
         this.computeSelfReflection(),
+        // PR #536 — daily catalyst brief (cron 04:00 UTC) : événements macro du jour
+        // + sectors in focus + tickers to watch/avoid. Permet à Pro/Mistral d'interpréter
+        // les news EU CPI / US ISM / Fed speeches en contexte vs réagir post-event.
+        this.fetchLatestDailyBrief(),
       ]);
       const candidates = settled[0].status === 'fulfilled' ? settled[0].value : [];
       const macro = settled[1].status === 'fulfilled' ? settled[1].value : { note: 'macro_fetch_failed' };
@@ -499,8 +517,9 @@ export class LiveTraderAgentService {
       const crossScannerLessons = settled[4].status === 'fulfilled' ? (settled[4].value as string) : '';
       const middleReference = settled[5].status === 'fulfilled' ? (settled[5].value as string) : '';
       const selfReflection = settled[6].status === 'fulfilled' ? (settled[6].value as string) : '';
+      const dailyBrief = settled[7].status === 'fulfilled' ? settled[7].value : null;
       const fetchFailures = settled
-        .map((s, i) => s.status === 'rejected' ? `${['candidates','macro','news','memory','lessons','middle_ref','self_reflect'][i]}=${String(s.reason).slice(0,80)}` : null)
+        .map((s, i) => s.status === 'rejected' ? `${['candidates','macro','news','memory','lessons','middle_ref','self_reflect','daily_brief'][i]}=${String(s.reason).slice(0,80)}` : null)
         .filter((x) => x !== null);
       if (fetchFailures.length > 0) {
         this.logger.warn(`[trader-agent] fetch partial failures: ${fetchFailures.join(' | ')}`);
@@ -547,6 +566,9 @@ export class LiveTraderAgentService {
         candidates,
         macro,
         news_recent: news,
+        // PR #536 — Daily catalyst brief (cron 04:00 UTC) avec events macro + tickers focus.
+        // Format JSON pour facilité du LLM à parser/citer. Null si pas de brief du jour.
+        daily_brief: dailyBrief,
         constraints: {
           max_concentration_usd: dynamicMaxConcentration,
           max_open_positions: 5,
@@ -1600,6 +1622,41 @@ Recommendation rules :
       .order('published_at', { ascending: false })
       .limit(n);
     return (data ?? []) as object[];
+  }
+
+  /**
+   * PR #536 — Récupère le daily_catalyst_brief le plus récent (cron 04:00 UTC).
+   * Retourne le payload brut (macro_events, tickers_to_watch/avoid, sectors)
+   * pour injection directe dans le user_prompt JSON du LLM décideur.
+   *
+   * Ne retourne null que si :
+   *   - brief absent dans lisa_decision_log
+   *   - brief > 24h (stale, on évite de polluer le prompt avec données obsolètes)
+   *
+   * Le brief existe en N copies (1 par portfolio gainers actif) mais le contenu
+   * est identique → on prend la première row trouvée.
+   */
+  private async fetchLatestDailyBrief(): Promise<object | null> {
+    const since24h = new Date(Date.now() - 24 * 60 * 60_000).toISOString();
+    const { data, error } = await this.supabase.getClient()
+      .from('lisa_decision_log')
+      .select('payload, timestamp')
+      .eq('kind', 'daily_catalyst_brief')
+      .gte('timestamp', since24h)
+      .order('timestamp', { ascending: false })
+      .limit(1);
+    if (error || !data || data.length === 0) return null;
+    const p = data[0].payload as Record<string, unknown>;
+    // Strip llm metadata, garde uniquement la substance pour le décideur
+    return {
+      date: p.date,
+      macro_events: p.macro_events,
+      tickers_to_watch: p.tickers_to_watch,
+      tickers_to_avoid: p.tickers_to_avoid,
+      sectors_in_focus: p.sectors_in_focus,
+      summary: p.summary,
+      generated_at: data[0].timestamp,
+    };
   }
 
   private async fetchActiveMemory(n: number): Promise<Array<{ lesson_kind: string; lesson_text: string; confidence: number }>> {

--- a/scripts/asia-open-snapshot-full.ts
+++ b/scripts/asia-open-snapshot-full.ts
@@ -1,0 +1,75 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const cutoff = '2026-06-01T00:00:00Z';
+  const nullify = (s: any) => (s === '' || s == null ? null : s);
+  const eq = (a: any, b: any, c: any, d: any) => nullify(a) === nullify(c) && nullify(b) === nullify(d);
+
+  // 1. TRADER cycles + concordance
+  const { data: cycles } = await sb
+    .from('gemini_ab_decisions')
+    .select('decided_at, pro_action_kind, pro_target_symbol, flash_action_kind, flash_target_symbol, mistral_action_kind, mistral_target_symbol, mistral_large_action_kind, mistral_large_target_symbol')
+    .gte('decided_at', cutoff).order('decided_at', { ascending: false });
+
+  let actions=0, holds=0, nF=0, mF=0, nM=0, mM=0, nL=0, mL=0;
+  for (const r of cycles ?? []) {
+    if (r.pro_action_kind === 'hold' && !nullify(r.pro_target_symbol)) holds++; else actions++;
+    if (r.flash_action_kind) { nF++; if (eq(r.pro_action_kind, r.pro_target_symbol, r.flash_action_kind, r.flash_target_symbol)) mF++; }
+    if (r.mistral_action_kind) { nM++; if (eq(r.pro_action_kind, r.pro_target_symbol, r.mistral_action_kind, r.mistral_target_symbol)) mM++; }
+    if (r.mistral_large_action_kind) { nL++; if (eq(r.pro_action_kind, r.pro_target_symbol, r.mistral_large_action_kind, r.mistral_large_target_symbol)) mL++; }
+  }
+  console.log(`=== TRADER (depuis 00:00 UTC) — ${cycles?.length ?? 0} cycles ===`);
+  console.log(`actions=${actions} holds=${holds}`);
+  console.log(`Pro=Flash: ${mF}/${nF} = ${nF?((mF/nF)*100).toFixed(1):'—'}%`);
+  console.log(`Pro=Med3.5: ${mM}/${nM} = ${nM?((mM/nM)*100).toFixed(1):'—'}%`);
+  console.log(`Pro=Large3: ${mL}/${nL} = ${nL?((mL/nL)*100).toFixed(1):'—'}%`);
+
+  // 2. LLM_AB_SHADOW (les 4 call sites peripheriques)
+  const { data: shadows, count } = await sb
+    .from('llm_ab_shadow_decisions')
+    .select('*', { count: 'exact' })
+    .gte('created_at', cutoff)
+    .order('created_at', { ascending: false });
+  console.log(`\n=== LLM_AB_SHADOW (4 call sites périph) — ${count ?? 0} rows depuis 00:00 UTC ===`);
+  if (shadows && shadows.length > 0) {
+    const bySite: Record<string, any[]> = {};
+    for (const r of shadows) { const s = r.call_site || '?'; (bySite[s] = bySite[s] || []).push(r); }
+    for (const [site, rows] of Object.entries(bySite)) {
+      console.log(`\n  ${site} (${rows.length} calls):`);
+      for (const r of rows.slice(0, 5)) {
+        const t = r.created_at?.slice(11,19);
+        const shadowsArr = r.shadows ?? [];
+        const summary = shadowsArr.map((s: any) => `${s.provider}:${s.concordant ? '✓' : '✗'}`).join(' ');
+        console.log(`    ${t}  ${r.applied_provider} → ${summary}`);
+      }
+    }
+    // Concordance globale par provider
+    console.log(`\n  Concordance globale shadows (tous sites) :`);
+    const conc: Record<string, { n: number; m: number }> = {};
+    for (const r of shadows) {
+      for (const s of (r.shadows ?? [])) {
+        const k = s.provider;
+        if (!conc[k]) conc[k] = { n: 0, m: 0 };
+        conc[k].n++;
+        if (s.concordant) conc[k].m++;
+      }
+    }
+    for (const [k, v] of Object.entries(conc)) console.log(`    ${k}: ${v.m}/${v.n} = ${((v.m/v.n)*100).toFixed(1)}%`);
+  } else {
+    console.log('Encore vide.');
+  }
+
+  // 3. Positions open
+  const { data: openPos } = await sb.from('paper_trades').select('opened_at, symbol, side, entry_price, size_usd, portfolio_id').is('exit_timestamp', null);
+  console.log(`\n=== POSITIONS OUVERTES = ${openPos?.length ?? 0} ===`);
+  for (const p of (openPos ?? [])) {
+    console.log(`  ${p.opened_at?.slice(0,16)?.replace('T',' ')}  ${p.symbol} ${p.side} $${p.size_usd}`);
+  }
+
+  // 4. Gainers candidates
+  const { count: gainersCount } = await sb.from('gainers_user_shadow_signals').select('*', { count: 'exact', head: true }).gte('detected_at', cutoff);
+  console.log(`\n=== Gainers candidats détectés = ${gainersCount ?? 0} ===`);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/snap-post-event.ts
+++ b/scripts/snap-post-event.ts
@@ -1,0 +1,64 @@
+/**
+ * Snapshot post-event macro. Compare les decisions TRADER (Pro vs Flash vs
+ * Mistral Medium vs Large) sur les cycles ±15 min après un event critique.
+ *
+ * Usage : npx tsx scripts/snap-post-event.ts <event_time_utc> <event_name>
+ * Exemple : npx tsx scripts/snap-post-event.ts 2026-06-01T09:00:00Z "EU CPI"
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const eventUtc = process.argv[2] ?? new Date().toISOString();
+  const eventName = process.argv[3] ?? 'unknown event';
+  const windowStart = new Date(new Date(eventUtc).getTime() - 5 * 60_000).toISOString();
+  const windowEnd = new Date(new Date(eventUtc).getTime() + 30 * 60_000).toISOString();
+
+  console.log(`═══ SNAP POST-EVENT : ${eventName} @ ${eventUtc.slice(11,16)} UTC ═══`);
+  console.log(`Window : ${windowStart.slice(11,16)} → ${windowEnd.slice(11,16)} UTC\n`);
+
+  const nullify = (s: any) => (s === '' || s == null ? null : s);
+
+  // TRADER cycles dans la fenêtre
+  const { data: cycles } = await sb
+    .from('gemini_ab_decisions')
+    .select('decided_at, pro_action_kind, pro_target_symbol, pro_confidence, pro_thesis, flash_action_kind, flash_target_symbol, mistral_action_kind, mistral_target_symbol, mistral_large_action_kind, mistral_large_target_symbol, pro_applied, candidates_count')
+    .gte('decided_at', windowStart)
+    .lte('decided_at', windowEnd)
+    .order('decided_at', { ascending: true });
+
+  console.log(`TRADER cycles dans la fenêtre : ${cycles?.length ?? 0}\n`);
+
+  for (const r of cycles ?? []) {
+    const t = r.decided_at?.slice(11, 19);
+    const pro = `${r.pro_action_kind}/${nullify(r.pro_target_symbol) ?? '-'}`;
+    const fl = r.flash_action_kind ? `${r.flash_action_kind}/${nullify(r.flash_target_symbol) ?? '-'}` : '—';
+    const md = r.mistral_action_kind ? `${r.mistral_action_kind}/${nullify(r.mistral_target_symbol) ?? '-'}` : '—';
+    const lg = r.mistral_large_action_kind ? `${r.mistral_large_action_kind}/${nullify(r.mistral_large_target_symbol) ?? '-'}` : '—';
+
+    // Mark divergences
+    const allSame = pro === fl && pro === md && pro === lg;
+    const marker = allSame ? '  ' : '⚡';
+    console.log(`${marker} ${t}  Pro=${pro.padEnd(22)} Flash=${fl.padEnd(22)} Med=${md.padEnd(22)} Lg=${lg}`);
+
+    if (!allSame && r.pro_thesis) {
+      console.log(`     Pro thesis: ${(r.pro_thesis as string).slice(0, 150)}`);
+    }
+  }
+
+  // Positions ouvertes/fermées dans la fenêtre
+  const { data: opens } = await sb
+    .from('lisa_positions')
+    .select('symbol, entry_price, entry_notional_usd, portfolio_id, entry_timestamp, status, exit_timestamp, exit_price, realized_pnl_usd, exit_reason')
+    .gte('entry_timestamp', windowStart)
+    .lte('entry_timestamp', windowEnd);
+  if (opens && opens.length > 0) {
+    console.log(`\n📈 POSITIONS OUVERTES DANS LA FENÊTRE (${opens.length}):`);
+    for (const p of opens) {
+      const port = (p.portfolio_id as string)?.slice(0,8);
+      console.log(`  ${p.entry_timestamp?.slice(11,16)} ${port} ${p.symbol} entry=$${p.entry_price} notional=$${p.entry_notional_usd}  status=${p.status} ${p.realized_pnl_usd ? `pnl=$${p.realized_pnl_usd}` : ''}`);
+    }
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Problème

Audit 01/06 04:00 UTC : le `daily_catalyst_brief` (cron 04:00 UTC) était généré + stocké dans `lisa_decision_log` (4 rows/jour, 1 par portfolio gainers) mais **JAMAIS consommé** par TRADER ni les autres déciders LLM.

Conséquence : Pro / Flash / Mistral Medium / Large réagissaient uniquement à la **price action POST-event**, sans contexte sur les events macro à venir. Impossible de comparer leur "interprétation" des news.

## Fix

1. Nouveau fetch `fetchLatestDailyBrief()` dans `LiveTraderAgentService` :
   - Lit la dernière row `lisa_decision_log` `kind=daily_catalyst_brief` < 24h
   - Strip llm metadata, garde `macro_events` + `tickers_to_watch/avoid` + `sectors_in_focus` + `summary`

2. Inject dans le `user_prompt` JSON (nouveau champ `daily_brief`). Disponible pour Pro (applied) ET Mistral Medium/Large (shadows via mêmes prompts).

3. Documentation dans `SYSTEM_PROMPT_BASE` — bloc dédié sur l'usage du brief :
   ```
   DAILY CATALYST BRIEF :
   - HOLD si ±15 min d'un event high-impact (gap risk)
   - Bonus +0.05 conviction si candidate matche ticker_to_watch
   - Reject implicit (conf max 0.60) si match ticker_to_avoid
   - Privilégier sectors_in_focus en cas d'égalité
   - Cite le summary dans le thesis si trade dirigé par event
   ```

## Effet attendu

Au prochain cycle TRADER (5 min après deploy), Pro + Mistral Medium + Large recevront le brief du jour dans leur prompt → leurs décisions sur les cycles autour de **09:00 UTC** (EU CPI) et **14:00 UTC** (US ISM) seront maintenant comparables en termes d'interprétation des news.

## Couplage avec PR #534

PR #534 (mergée) ajoute la boucle feedback outcome → Brier/correlation par provider. Avec cette PR, on pourra ex-post mesurer **qui a interprété correctement chaque event** :

- À 08:55 UTC pre-EU-CPI : Pro dit HOLD, Mistral Med dit open_directional → divergence
- À 09:05 UTC post-EU-CPI : marché bouge dans un sens
- À 10:00 UTC : si la position serait gagnante → Mistral avait raison sur l'interprétation

## Bonus scripts

- `scripts/snap-post-event.ts` : Compare les decisions Pro / Mistral sur les cycles ±5 min après un event. Usage : `npx tsx scripts/snap-post-event.ts 2026-06-01T09:00:00Z "EU CPI"`

## Test plan
- [ ] CI vert (typecheck 6 errors pré-existants inchangés)
- [ ] Après deploy : prochain cycle TRADER doit logger fetch daily_brief OK (pas null)
- [ ] À 09:00 UTC + 14:00 UTC : observer divergences Pro vs Mistral via snap-post-event.ts
- [ ] Vérifier que les thesis Pro/Mistral citent maintenant le brief ("Pre-CPI defensive positioning per daily brief", etc.)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_