### PR TITLE
fix(portfolio-chart): skip trade markers in snapshot gaps > 30min

### DIFF
--- a/apps/web/src/components/lisa/portfolio-chart.tsx
+++ b/apps/web/src/components/lisa/portfolio-chart.tsx
@@ -203,35 +203,51 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
     const positions = positionsQuery.data ?? [];
     const minT = chartData[0].t;
     const maxT = chartData[chartData.length - 1].t;
+    // PR #541 fix — Skip markers qui tombent dans un GAP de snapshots > 30 min.
+    // Sans ce guard, le fallback `chartData[last].value` faisait que tous les
+    // trades dans un gap (e.g. 32h sans snapshot entre 30/05 23:50 et 01/06 06:55
+    // suite à redémarrage Fly cette nuit) prenaient TOUS la même valeur Y, ce qui
+    // empilait visuellement les 6 dots au même point sur le graph "Évolution
+    // capital" (bug constaté 01/06 matin).
+    const MAX_INTERPOLATION_GAP_MS = 30 * 60 * 1000;
     const closed = positions.filter((p) => {
       if (p.status === 'open' || !p.exitTimestamp) return false;
       const t = new Date(p.exitTimestamp).getTime();
       return t >= minT && t <= maxT;
     });
-    return closed.map((p) => {
-      const t = new Date(p.exitTimestamp!).getTime();
-      // Interpolation linéaire entre les 2 points de chartData entourant t
-      let value = chartData[chartData.length - 1].value;
-      for (let i = 0; i < chartData.length - 1; i++) {
-        const a = chartData[i];
-        const b = chartData[i + 1];
-        if (t >= a.t && t <= b.t) {
-          const ratio = b.t === a.t ? 0 : (t - a.t) / (b.t - a.t);
-          value = a.value + (b.value - a.value) * ratio;
-          break;
+    return closed
+      .map((p) => {
+        const t = new Date(p.exitTimestamp!).getTime();
+        // Cherche les 2 chartData points qui encadrent t. Si gap > threshold,
+        // l'interpolation est non fiable → on skip le marker (retourne null).
+        let interpolatedValue: number | null = null;
+        for (let i = 0; i < chartData.length - 1; i++) {
+          const a = chartData[i];
+          const b = chartData[i + 1];
+          if (t >= a.t && t <= b.t) {
+            const gap = b.t - a.t;
+            if (gap > MAX_INTERPOLATION_GAP_MS) {
+              // t tombe dans un trou snapshots > 30 min — pas fiable
+              break;
+            }
+            const ratio = b.t === a.t ? 0 : (t - a.t) / (b.t - a.t);
+            interpolatedValue = a.value + (b.value - a.value) * ratio;
+            break;
+          }
         }
-      }
-      const pnlUsd = parseFloat(p.realizedPnlUsd ?? '0') || 0;
-      return {
-        t,
-        value,
-        symbol: p.symbol,
-        pnlUsd,
-        pnlPct: p.realizedPnlPct ?? 0,
-        win: pnlUsd > 0,
-        exitReason: (p.exitReason ?? p.status).slice(0, 40),
-      };
-    });
+        if (interpolatedValue === null) return null;
+        const pnlUsd = parseFloat(p.realizedPnlUsd ?? '0') || 0;
+        return {
+          t,
+          value: interpolatedValue,
+          symbol: p.symbol,
+          pnlUsd,
+          pnlPct: p.realizedPnlPct ?? 0,
+          win: pnlUsd > 0,
+          exitReason: (p.exitReason ?? p.status).slice(0, 40),
+        };
+      })
+      .filter((m): m is TradeMarker => m !== null);
   }, [chartData, positionsQuery.data]);
   const winMarkers = useMemo(() => tradeMarkers.filter((m) => m.win), [tradeMarkers]);
   const lossMarkers = useMemo(() => tradeMarkers.filter((m) => !m.win), [tradeMarkers]);


### PR DESCRIPTION
## Problème

Bug observé 01/06 matin sur le graph "Évolution du capital" (capture user) : les 6 trades fermés (4 perdants + 2 gagnants) étaient tous **empilés au même point Y=$10000** sur la première date du graph, au lieu d'être distribués à leurs dates d'exit respectives. Récurrence du bug constaté le 26 mai.

## Root cause

Le cron `lisa-portfolio-snapshot` a connu **un trou de ~32h** cette nuit (30/05 23:50 → 01/06 06:55), causé par les redémarrages Fly successifs pendant les 9 PRs mergées.

Dans `portfolio-chart.tsx:tradeMarkers`, l'interpolation cherchait les 2 chartData points encadrant chaque `exit_timestamp`. Si `t` tombait dans le gap de 32h, **AUCUN intervalle** n'était trouvé → fallback `chartData[last].value` (valeur dernière du graph) était utilisée. Tous les markers se retrouvaient donc à la même valeur Y.

## Fix

Détecte les gaps > 30 min entre 2 chartData points adjacents. Si `t` tombe dans un tel gap, marker = `null` (filtré out). Plus honnête : marker manquant > marker au mauvais endroit.

```typescript
const MAX_INTERPOLATION_GAP_MS = 30 * 60 * 1000;
// ...
if (t >= a.t && t <= b.t) {
  const gap = b.t - a.t;
  if (gap > MAX_INTERPOLATION_GAP_MS) {
    break; // t dans un trou snapshots — pas fiable, skip
  }
  // ...
}
```

## Effet visuel attendu

- Si gap snapshots → markers correspondants invisibles (au lieu d'empilés au mauvais Y)
- Plus de fausse impression que tous les trades sont au même endroit
- Les snapshots cohérents (sans gap) continuent d'afficher leurs markers normalement

## Follow-up (out of scope)

Le vrai fix long terme = combler les snapshots manquants côté backend (script backfill ou cron "detect gap + interpolate"). Cette PR est le hotfix front pour rendre le graph cohérent en attendant.

## Test plan
- [ ] CI vert (web typecheck OK : 0 erreur)
- [ ] Après deploy : graph "Évolution du capital" ne montre plus les 6 dots empilés au même point
- [ ] Pour les trades dans des zones avec snapshots continus (≤ 30 min gap), markers visibles à leurs vrais positions

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_