### PR TITLE
⚡ feat(risk-monitor): cadence 5min→2min (Mistral free tier)

### DIFF
--- a/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
+++ b/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
@@ -105,7 +105,11 @@ export class OpenPositionRiskMonitorService {
     }
   }
 
-  @Cron(CronExpression.EVERY_5_MINUTES, { name: 'open-position-risk-monitor', timeZone: 'UTC' })
+  // PR #542 — Cadence augmentée 5→2 min pour cut losses plus rapidement.
+  // Mistral free tier supporte largement (~75k tokens/min limite, on est <5k/min).
+  // Impact P&L attendu : sur les setups perdants, exit ~3 min plus tôt = limite
+  // les drawdowns post-MFE (cf. capture rate négatif TRADER -45% sur sample).
+  @Cron('0 */2 * * * *', { name: 'open-position-risk-monitor', timeZone: 'UTC' })
   async runCycle(): Promise<void> {
     if (!this.enabled) return;
     if (!this.supabase.isReady()) return;


### PR DESCRIPTION
## PR 1/4 — Cadence augmentée Mistral free tier

Risk monitor cycle **5 min → 2 min**. Cut losses plus rapidement sur positions en drawdown post-MFE.

## Impact attendu

Sur le sample TRADER récent : capture rate médian **-45%** → beaucoup de pertes viennent de positions tenues 4-5 min trop longtemps après le MFE peak. Avec risk monitor à 2 min, exit ~3 min plus tôt = limite le giveback.

## Coût

**$0** — Mistral Medium free tier 1G tokens/mois supporte ce 2.5× augmentation. On passe d'environ 5% → 12% du quota.

## Tests
- Typecheck OK 0 erreur

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_