### PR TITLE
⚡ feat(trader-agent): top candidates 20→50

### DIFF
--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -496,7 +496,7 @@ export class LiveTraderAgentService {
       // en allSettled pour qu'un échec individuel (DB query fail, API down) ne
       // stoppe pas le cycle entier. Fallback aux valeurs vides en cas de fail.
       const settled = await Promise.allSettled([
-        this.fetchTopCandidates(20),
+        this.fetchTopCandidates(50),  // PR #544 — élargi 20→50 pour catch pépites position #30+ (cf. commentaire L1462)
         this.fetchMacroContext(),
         this.fetchRecentNews(10),
         this.fetchActiveMemory(1000),


### PR DESCRIPTION
## PR 3/4 — Top candidates 20 → 50

Le commentaire L1462 existant note : *"RWS.LSE que MAIN a pris étaient enterrés position #30-50, hors top 20"*. Pépites cachées qu'on rate.

Maintenant Mistral voit **50 candidats** par cycle au lieu de 20.

## Coût

**$0** — ~3000 tokens additionnels par cycle, négligeable vs 1G/mois.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_