### PR TITLE
feat(shadow-sizing): audit kill/restart dans lisa_decision_log

### DIFF
--- a/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
@@ -26,12 +26,13 @@
  * pas de crash. Cron tourne tous les 30 min sans dépendance.
  */
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
 import { LisaService } from './lisa.service';
+import { DecisionLogService } from './decision-log.service';
 
 const SHADOW_PORTFOLIOS = [
   { id: 'a0000001-0000-0000-0000-000000000001', name: 'high'   as const, posCount: 3,  posUsd: 3500 },
@@ -142,6 +143,9 @@ export class ShadowSizingOrchestratorService {
     private readonly supabase: SupabaseService,
     private readonly llmRouter: ScannerLlmRouterService,
     private readonly lisa: LisaService,
+    // PR #547 — audit traçable des décisions LLM sur shadow sizing dans
+    // lisa_decision_log (visible côté UI). Optional pour back-compat tests.
+    @Optional() private readonly decisionLog?: DecisionLogService,
   ) {}
 
   onModuleInit(): void {
@@ -875,6 +879,26 @@ export class ShadowSizingOrchestratorService {
       }
     } catch (e) {
       applyError = String(e).slice(0, 200);
+    }
+
+    // PR #547 — Audit lisa_decision_log explicit pour kill/restart (les actions
+    // les plus impactantes). Visible côté UI. Le shadow_sizing_autotune_log
+    // garde l'audit complet structuré (tous decision_kind).
+    if (this.decisionLog && (decision.action_kind === 'kill' || decision.action_kind === 'restart')) {
+      await this.decisionLog
+        .append({
+          portfolioId: target.portfolioId,
+          kind: applied
+            ? `shadow_sizing_${decision.action_kind}_applied`
+            : `shadow_sizing_${decision.action_kind}_failed`,
+          summary: applied
+            ? `🤖 [SHADOW_SIZING] ${decision.action_kind.toUpperCase()} ${target.profileName} APPLIED (LLM conf=${decision.confidence?.toFixed(2)})`
+            : `🤖 [SHADOW_SIZING] ${decision.action_kind} ${target.profileName} FAILED: ${applyError ?? 'unknown'}`,
+          rationale: decision.rationale ?? '(no rationale from LLM)',
+          payload: { decision, applied, applyError, profile_name: target.profileName },
+          triggeredBy: 'autopilot_cron',
+        })
+        .catch((e) => this.logger.debug(`[shadow-sizing] decision_log append failed: ${String(e).slice(0, 100)}`));
     }
 
     await this.logAutoTune({

--- a/scripts/check-shadow-log.ts
+++ b/scripts/check-shadow-log.ts
@@ -1,0 +1,13 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+async function main() {
+  const { count, error } = await sb.from('shadow_sizing_autotune_log').select('*', { count: 'exact', head: true });
+  console.log('shadow_sizing_autotune_log:', count, error?.message);
+  if (count !== null) {
+    const { data } = await sb.from('shadow_sizing_autotune_log').select('*').order('created_at', { ascending: false }).limit(3);
+    if (data?.[0]) console.log('cols:', Object.keys(data[0]).join(', '));
+    for (const r of data ?? []) console.log(`  ${r.created_at?.slice(0,19)} ${r.profile_name} ${r.decision_kind} applied=${r.action_applied} ${(r.rationale as string)?.slice(0,100)}`);
+  }
+}
+main().catch(e => console.error(e));

--- a/scripts/q-shadow-log-final.ts
+++ b/scripts/q-shadow-log-final.ts
@@ -1,0 +1,15 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+async function main() {
+  const { data } = await sb.from('shadow_sizing_autotune_log').select('decided_at, profile_name, decision_kind, trigger_metric, action_applied, rationale')
+    .eq('profile_name', 'high')
+    .gte('decided_at', '2026-06-01T06:00:00Z')
+    .order('decided_at', { ascending: false }).limit(15);
+  console.log(`HIGH today logs since 06:00 UTC: ${data?.length}`);
+  for (const r of data ?? []) {
+    console.log(`\n${r.decided_at?.slice(11,19)} ${r.decision_kind} trigger=${r.trigger_metric} applied=${r.action_applied}`);
+    console.log(`  ${(r.rationale as string)?.slice(0, 250)}`);
+  }
+}
+main().catch(e => console.error(e));

--- a/scripts/q-shadow-log-today.ts
+++ b/scripts/q-shadow-log-today.ts
@@ -1,0 +1,15 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+async function main() {
+  const { data } = await sb.from('shadow_sizing_autotune_log').select('*')
+    .eq('profile_name', 'high')
+    .gte('created_at', '2026-06-01T00:00:00Z')
+    .order('created_at', { ascending: false }).limit(10);
+  console.log(`HIGH autotune logs today: ${data?.length}`);
+  for (const r of data ?? []) {
+    console.log(`\n${r.created_at?.slice(11,19)} kind=${r.decision_kind} trigger=${r.trigger_metric} applied=${r.action_applied}`);
+    console.log(`  rationale: ${(r.rationale as string)?.slice(0, 250)}`);
+  }
+}
+main().catch(e => console.error(e));

--- a/scripts/q-shadow-log2.ts
+++ b/scripts/q-shadow-log2.ts
@@ -1,0 +1,15 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+async function main() {
+  const { data, error } = await sb.from('shadow_sizing_autotune_log').select('*')
+    .gte('created_at', '2026-06-01T00:00:00Z')
+    .order('created_at', { ascending: false }).limit(20);
+  console.log('err:', error?.message, 'count:', data?.length);
+  if (data?.[0]) console.log('cols:', Object.keys(data[0]).join(', '));
+  for (const r of data ?? []) {
+    console.log(`\n${r.created_at?.slice(11,19)} profile=${r.profile_name} kind=${r.decision_kind} trigger=${r.trigger_metric} applied=${r.action_applied}`);
+    console.log(`  ${(r.rationale as string)?.slice(0,200)}`);
+  }
+}
+main().catch(e => console.error(e));

--- a/scripts/q-shadow-log3.ts
+++ b/scripts/q-shadow-log3.ts
@@ -1,0 +1,9 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+async function main() {
+  const { data } = await sb.from('shadow_sizing_autotune_log').select('*').limit(2);
+  if (data?.[0]) console.log('cols:', Object.keys(data[0]).join(', '));
+  console.log(JSON.stringify(data?.[0], null, 2)?.slice(0, 500));
+}
+main().catch(e => console.error(e));


### PR DESCRIPTION
## Follow-up audit kill switch shadow sizing

Suite à l'investigation 01/06 où HIGH a été killed (`SHADOW_GEMINI_KILL`) sans trace lisible dans `lisa_decision_log` (juste un UPDATE silencieux + audit dans table dédiée `shadow_sizing_autotune_log`).

## Fix

Ajoute un append dans `lisa_decision_log` à chaque action KILL ou RESTART décidée par le LLM :

```typescript
kind: 'shadow_sizing_kill_applied' | 'shadow_sizing_restart_applied'
summary: '🤖 [SHADOW_SIZING] KILL HIGH APPLIED (LLM conf=0.85)'
rationale: <le rationale complet du LLM> ← le critique
payload: { decision, applied, applyError, profile_name }
```

## Scope

Limité aux **KILL et RESTART** (actions les plus impactantes / visibles UI). Les autres (raise_sizing, lower_sizing, tune_tp_sl) gardent l'audit `shadow_sizing_autotune_log` existant pour ne pas spammer.

## Impact

- ✅ UI `/lisa/decisions` affichera désormais les kills/restarts avec rationale
- ✅ Grep facile : `kind ILIKE '%shadow_sizing%kill%'`
- ✅ Permet de retracer le seuil pratiqué par Mistral en pratique (drawdown vs cycles consécutifs vs fees ratio)

## Garde-fous

- `DecisionLogService` injecté `@Optional()` pour back-compat
- Best-effort `.catch()` → ne bloque jamais le kill effectif
- Audit existant `shadow_sizing_autotune_log` préservé (double-écriture)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_