### PR TITLE
fix(mistral-cost): zéro-out costUsd en free tier (default true)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/mistral-large-shadow.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/mistral-large-shadow.spec.ts
@@ -65,7 +65,7 @@ describe('MistralLargeShadowService (PR #521 cheap tier)', () => {
       }),
     });
     const svc = new MistralLargeShadowService(
-      mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_LARGE_SHADOW_ENABLED: 'true' }),
+      mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_LARGE_SHADOW_ENABLED: 'true', MISTRAL_FREE_TIER: 'false' }),
     );
     const r = await svc.call({ system: 's', user: 'u' });
     expect(r.error).toBeNull();

--- a/apps/api/src/modules/lisa/services/__tests__/mistral-shadow.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/mistral-shadow.spec.ts
@@ -55,7 +55,7 @@ describe('MistralShadowService', () => {
         usage: { prompt_tokens: 2_000_000, completion_tokens: 1_000_000 },
       }),
     });
-    const svc = new MistralShadowService(mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'true' }));
+    const svc = new MistralShadowService(mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'true', MISTRAL_FREE_TIER: 'false' }));
     const r = await svc.call({ system: 's', user: 'u' });
     expect(r.error).toBeNull();
     expect(r.content).toContain('hold');
@@ -77,7 +77,7 @@ describe('MistralShadowService', () => {
       }),
     });
     const svc = new MistralShadowService(
-      mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'true', MISTRAL_SHADOW_MODEL: 'mistral-large-latest' }),
+      mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'true', MISTRAL_SHADOW_MODEL: 'mistral-large-latest', MISTRAL_FREE_TIER: 'false' }),
     );
     const r = await svc.call({ system: 's', user: 'u' });
     // Large 3 = $0.50 in + $1.50 out → 2M × $0.50 + 1M × $1.50 = $1.00 + $1.50 = $2.50
@@ -96,12 +96,29 @@ describe('MistralShadowService', () => {
       }),
     });
     const svc = new MistralShadowService(
-      mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'true', MISTRAL_SHADOW_MODEL: 'magistral-medium-latest' }),
+      mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'true', MISTRAL_SHADOW_MODEL: 'magistral-medium-latest', MISTRAL_FREE_TIER: 'false' }),
     );
     const r = await svc.call({ system: 's', user: 'u' });
     // Magistral Medium = $2 in + $5 out → 1M × $2 + 1M × $5 = $7
     expect(r.costUsd).toBeCloseTo(7, 5);
     expect(r.providerId).toBe('magistral-medium');
+  });
+
+  it('call() free tier default — costUsd=0 même avec gros volume tokens', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [{ message: { content: '{}' } }],
+        usage: { prompt_tokens: 2_000_000, completion_tokens: 1_000_000 },
+      }),
+    });
+    // Par défaut MISTRAL_FREE_TIER=true → coût zéro malgré tokens
+    const svc = new MistralShadowService(mockConfig({ MISTRAL_API_KEY: 'sk-test', MISTRAL_SHADOW_ENABLED: 'true' }));
+    const r = await svc.call({ system: 's', user: 'u' });
+    expect(r.costUsd).toBe(0);
+    expect(r.inputTokens).toBe(2_000_000);
+    expect(r.outputTokens).toBe(1_000_000);
   });
 
   it('call() HTTP 429 → error capturé, pas de throw', async () => {

--- a/apps/api/src/modules/lisa/services/mistral-large-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/mistral-large-shadow.service.ts
@@ -44,14 +44,16 @@ export class MistralLargeShadowService {
   private readonly logger = new Logger(MistralLargeShadowService.name);
   private readonly apiKey: string | undefined;
   private readonly enabled: boolean;
+  private readonly freeTier: boolean;
 
   constructor(private readonly config: ConfigService) {
     this.apiKey = this.config.get<string>('MISTRAL_API_KEY');
     this.enabled = (this.config.get<string>('MISTRAL_LARGE_SHADOW_ENABLED') ?? 'false').toLowerCase() === 'true';
+    this.freeTier = (this.config.get<string>('MISTRAL_FREE_TIER') ?? 'true').toLowerCase() === 'true';
     if (this.enabled && !this.apiKey) {
       this.logger.warn('[mistral-large-shadow] ENABLED=true mais MISTRAL_API_KEY absent → service inerte');
     } else if (this.enabled) {
-      this.logger.log(`[mistral-large-shadow] ENABLED — model=${MODEL_LARGE_LATEST}`);
+      this.logger.log(`[mistral-large-shadow] ENABLED — model=${MODEL_LARGE_LATEST} freeTier=${this.freeTier}`);
     }
   }
 
@@ -119,9 +121,15 @@ export class MistralLargeShadowService {
       result.content = data.choices?.[0]?.message?.content ?? null;
       result.inputTokens = data.usage?.prompt_tokens ?? 0;
       result.outputTokens = data.usage?.completion_tokens ?? 0;
-      result.costUsd =
-        (result.inputTokens / 1_000_000) * PRICE_INPUT_PER_M +
-        (result.outputTokens / 1_000_000) * PRICE_OUTPUT_PER_M;
+      // En free tier (default), coût réel = 0 (Experiment plan Mistral 1B tok/mois).
+      // Cf. mistral-shadow.service.ts pour la rationale et MISTRAL_FREE_TIER env.
+      if (this.freeTier) {
+        result.costUsd = 0;
+      } else {
+        result.costUsd =
+          (result.inputTokens / 1_000_000) * PRICE_INPUT_PER_M +
+          (result.outputTokens / 1_000_000) * PRICE_OUTPUT_PER_M;
+      }
 
       if (!result.content) {
         result.error = 'empty_content';

--- a/apps/api/src/modules/lisa/services/mistral-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/mistral-shadow.service.ts
@@ -89,15 +89,17 @@ export class MistralShadowService {
   private readonly apiKey: string | undefined;
   private readonly enabled: boolean;
   private readonly model: string;
+  private readonly freeTier: boolean;
 
   constructor(private readonly config: ConfigService) {
     this.apiKey = this.config.get<string>('MISTRAL_API_KEY');
     this.enabled = (this.config.get<string>('MISTRAL_SHADOW_ENABLED') ?? 'false').toLowerCase() === 'true';
     this.model = this.config.get<string>('MISTRAL_SHADOW_MODEL') ?? MODEL_MEDIUM_LATEST;
+    this.freeTier = (this.config.get<string>('MISTRAL_FREE_TIER') ?? 'true').toLowerCase() === 'true';
     if (this.enabled && !this.apiKey) {
       this.logger.warn('[mistral-shadow] MISTRAL_SHADOW_ENABLED=true mais MISTRAL_API_KEY absent → service inerte');
     } else if (this.enabled) {
-      this.logger.log(`[mistral-shadow] ENABLED — model=${this.model}`);
+      this.logger.log(`[mistral-shadow] ENABLED — model=${this.model} freeTier=${this.freeTier}`);
     }
   }
 
@@ -175,10 +177,18 @@ export class MistralShadowService {
       result.outputTokens = data.usage?.completion_tokens ?? 0;
       // Pricing model-aware : lookup par prefixe pour matcher la facturation
       // Mistral reelle (Medium != Large != Magistral != Ministral).
-      const pricing = lookupPricing(this.model);
-      result.costUsd =
-        (result.inputTokens / 1_000_000) * pricing.input +
-        (result.outputTokens / 1_000_000) * pricing.output;
+      // En free tier (default), coût réel = 0 — pas de facturation Mistral
+      // sur la "Experiment plan" (1B tokens/mois). On garde les token counts
+      // pour les stats d'usage mais on zéro-out le costUsd pour ne pas polluer
+      // le widget /lisa/llm-cost-live avec du théorique payant.
+      if (this.freeTier) {
+        result.costUsd = 0;
+      } else {
+        const pricing = lookupPricing(this.model);
+        result.costUsd =
+          (result.inputTokens / 1_000_000) * pricing.input +
+          (result.outputTokens / 1_000_000) * pricing.output;
+      }
 
       if (!result.content) {
         result.error = 'empty_content';


### PR DESCRIPTION
## Bug

Widget `/lisa/llm-cost-live` affichait Mistral Medium = **$2.815** + Mistral Large = **$0.648** alors qu'on est en **free tier Mistral** (Experiment plan 1B tokens/mois = $0 réel).

## Cause

`MistralShadowService.call()` appliquait le pricing officiel payant ($1.50/$7.50 par MTok Medium, $0.50/$1.50 Large) à chaque call et stockait dans `gemini_ab_decisions.mistral_cost_usd`. Le widget sommait ces théoriques.

## Fix

Env `MISTRAL_FREE_TIER` (default `true`) qui zero-out `result.costUsd` tout en gardant `inputTokens/outputTokens` pour les stats.

- Nouveaux cycles → Mistral à $0 dans le widget
- Rows déjà en DB aujourd'hui restent jusqu'au rollover 00:00 UTC (pas de backfill rétroactif)
- Pour passer en paid plus tard : `MISTRAL_FREE_TIER=false` dans Fly secrets

## Impact widget

Avant : Mistral Medium 48% / Mistral Large 11% (faux)  
Après (demain 00:00 UTC) : Mistral 0% — total réel ≈ **$2.4/jour** (Gemini Pro + Flash uniquement)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_