### PR TITLE
fix(lessons-impact): blacklist section headers + skip si lesson_id null

### DIFF
--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -2213,10 +2213,27 @@ Recommendation rules :
   // quel win-rate, sur 30j ?"
 
   /**
+   * Markers techniques / section headers / labels du prompt — PAS des lessons.
+   * Cités fréquemment par Mistral en écho au system prompt, ils polluent
+   * scanner_lesson_citations s'ils ne sont pas filtrés (cf. audit 01/06 :
+   * 287 citations / 0 résolues, dont [OPEN_POSITIONS]=1, [KELLY_STANDARD]=1,
+   * [AUTO_CORRECTION_DYNAMIQUE]=1, [DATA_QUALITY_DEGRADED]=2, etc.).
+   */
+  private static readonly INFRA_MARKERS = new Set<string>([
+    // Markers infra bas-niveau
+    'DIAGNOSTIC', 'SANITY_BOUND', 'KILL_SWITCH', 'HT_BYPASS', 'HT_EXCEPTION',
+    // Section headers / labels du prompt
+    'OPEN_POSITIONS', 'POSITIONS_OUVERTES', 'DATA_QUALITY_DEGRADED',
+    'KELLY_STANDARD', 'PUMP_SCORE', 'AUTO_CORRECTION_DYNAMIQUE',
+    'MODE_DEFENSIF', 'MODE_DÉFENSIF',
+    // Catégories rhétoriques génériques (pas des lessons identifiées)
+    'ANTI-PATTERN', 'ANTI-REVENGE',
+  ]);
+
+  /**
    * Extrait les markers [XXX] d'une thèse LLM. Dédupliqué.
    * Pattern : crochets, début majuscule, 3-40 chars [A-Z0-9_+-].
-   * Ignore les markers techniques bas-niveau (DIAGNOSTIC, SANITY_BOUND, etc.)
-   * qui ne sont pas des lessons — uniquement les markers > 6 chars.
+   * Filtre les markers infra/headers (cf. INFRA_MARKERS).
    */
   private parseLessonMarkers(thesis: string): string[] {
     if (!thesis || thesis.length === 0) return [];
@@ -2225,8 +2242,7 @@ Recommendation rules :
     let m: RegExpExecArray | null;
     while ((m = re.exec(thesis)) !== null) {
       const marker = m[1];
-      // Filtre out les markers infra (pas des lessons)
-      if (['DIAGNOSTIC', 'SANITY_BOUND', 'KILL_SWITCH', 'HT_BYPASS', 'HT_EXCEPTION'].includes(marker)) continue;
+      if (LiveTraderAgentService.INFRA_MARKERS.has(marker)) continue;
       set.add(marker);
     }
     return [...set];
@@ -2250,19 +2266,29 @@ Recommendation rules :
     if (markers.length === 0) return;
 
     const client = this.supabase.getClient();
-    // Résolution lesson_id par marker (1 query par marker, OK pour volume faible)
+    // Résolution lesson_id par marker (match exact case-insensitive sur lesson_kind).
+    // Skip l'insert si pas de match en DB — évite la pollution "Marker non mappé"
+    // qui dominait scanner_lesson_citations (audit 01/06: 287 cit / 0 mappées).
+    // Les markers cités sans match sont loggés pour identifier les lessons
+    // que TRADER invente mais qui ne sont pas registrées en DB.
     const rows: Array<Record<string, unknown>> = [];
+    const skipped: string[] = [];
     for (const marker of markers) {
       const { data: lesson } = await client
         .from('scanner_lessons')
         .select('id')
-        .ilike('lesson_kind', `%${marker}%`)
+        .ilike('lesson_kind', marker)
         .eq('is_active', true)
         .order('confidence', { ascending: false })
         .limit(1)
         .maybeSingle();
+      const lessonId = (lesson as { id?: string } | null)?.id ?? null;
+      if (!lessonId) {
+        skipped.push(marker);
+        continue;
+      }
       rows.push({
-        lesson_id: (lesson as { id?: string } | null)?.id ?? null,
+        lesson_id: lessonId,
         marker_text: `[${marker}]`,
         portfolio_id: TRADER_AGENT_PORTFOLIO_ID,
         decision_decided_at: args.cycleStartedAt.toISOString(),
@@ -2275,12 +2301,18 @@ Recommendation rules :
         thesis_excerpt: args.thesis.slice(0, 300),
       });
     }
+    if (skipped.length > 0) {
+      this.logger.debug(
+        `[trader-agent] skipped ${skipped.length} unregistered markers: ${skipped.join(',')}`,
+      );
+    }
+    if (rows.length === 0) return;
     const { error } = await client.from('scanner_lesson_citations').insert(rows);
     if (error) {
       this.logger.warn(`[trader-agent] insertLessonCitations failed: ${error.message}`);
     } else {
       this.logger.debug(
-        `[trader-agent] inserted ${rows.length} citations (markers: ${markers.join(',')})`,
+        `[trader-agent] inserted ${rows.length} citations (mapped: ${rows.length}/${markers.length})`,
       );
     }
   }


### PR DESCRIPTION
## Audit 01/06 — Lessons Impact Tracker

UI affichait **287 citations / 0 résolues / 100% "Marker non mappé à scanner_lessons"**.

### Root causes

1. **Parser trop permissif** : `parseLessonMarkers` filtrait seulement 5 markers infra. Section headers du prompt comme `OPEN_POSITIONS`, `KELLY_STANDARD`, `PUMP_SCORE`, `DATA_QUALITY_DEGRADED`, `AUTO_CORRECTION_DYNAMIQUE`, `ANTI-PATTERN`, `POSITIONS_OUVERTES` étaient comptés comme lessons.

2. **Match trop loose** : `ILIKE '%marker%'` sur `scanner_lessons.lesson_kind`. La plupart des markers cités n'avaient aucun row correspondant → lignes insérées avec `lesson_id=null` polluant la table.

### Fix

- **`INFRA_MARKERS` étendu** (15 markers, vs 5 avant) — blacklist explicite des section headers / labels / pseudo-markers
- **Match exact case-insensitive** (`ilike('lesson_kind', marker)` sans `%`)
- **Skip insert si lesson_id null** + log debug pour audit "ce que TRADER invente vs registré"

### Impact

| Avant | Après |
|---|---|
| 287 citations / 0 résolues | Seules les **vraies lessons** registrées en DB |
| 17 markers dont 11 polluants | Filtrage explicite des section headers |
| Tracker illisible | UI clean : "X citations · Y appliquées · W/L · PnL" par lesson réelle |

### Backfill (manuel, optionnel)

Les 287 rows existants resteront dans la fenêtre 30j puis disparaîtront naturellement. Pour cleanup immédiat :

```sql
DELETE FROM scanner_lesson_citations WHERE lesson_id IS NULL;
```

### Out of scope

- Outcome resolution sur `hold`/`skip` : déjà cohérent (pas de trade = pas de W/L). La métrique "résolues" reste pertinente uniquement pour les `open`.
- Investigation `PULLBACK_WAIT_KTOS_LESSON` (208 citations en 30j) : à voir si registré dans `scanner_lessons` post-fix, sinon Mistral hallucine et il faut soit l'ajouter en DB soit traquer pourquoi le LLM le génère.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_