### PR TITLE
chore(logs): silence 404 sur portfolios migrés (58439d86)

### DIFF
--- a/apps/api/src/common/all-exceptions.filter.ts
+++ b/apps/api/src/common/all-exceptions.filter.ts
@@ -14,6 +14,19 @@ import type { Request, Response } from 'express';
  * affichés côté client n'exposent rien de la cause racine dans les logs
  * Railway — rendant le debug impossible en prod.
  */
+
+/**
+ * IDs de portfolios supprimés/migrés en DB mais encore polled par des clients
+ * (cache navigateur sur device tiers, anciens bookmarks, ancien deploy Vercel).
+ * On retourne toujours 404 (correct sémantiquement) mais on demote le log à
+ * DEBUG pour stopper la pollution Fly logs (~2 req/s sans valeur).
+ *
+ * Cf. 30/05/2026 — portfolio MAIN 58439d86 migré vers TRADER b0000001.
+ */
+const KNOWN_MIGRATED_PORTFOLIO_IDS = [
+  '58439d86-3f20-4a60-82a4-307f3f252bc2', // ex-MAIN → b0000001 (30/05/2026)
+];
+
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {
   private readonly logger = new Logger('HTTP');
@@ -40,9 +53,13 @@ export class AllExceptionsFilter implements ExceptionFilter {
     // valeur (l'erreur est côté client, pas une vraie défaillance serveur).
     // Stack trace + level=error réservés aux 5xx ; 4xx = warn sans stack.
     const isServerError = status >= 500;
+    const url = req.url ?? '';
+    const isKnownMigratedPortfolio = status === 404 && KNOWN_MIGRATED_PORTFOLIO_IDS.some((id) => url.includes(id));
     const log = isServerError
       ? this.logger.error.bind(this.logger)
-      : this.logger.warn.bind(this.logger);
+      : isKnownMigratedPortfolio
+        ? this.logger.debug.bind(this.logger)
+        : this.logger.warn.bind(this.logger);
     log(
       `${req.method} ${req.url} → ${status} — ${String(message)}`,
       isServerError && exception instanceof Error ? exception.stack : undefined,


### PR DESCRIPTION
## Bruit observé

`GET /lisa/positions/58439d86-...` toutes les ~2s → `404 — Portfolio introuvable` × WARN level → pollution Fly logs.

## Investigation

- ✅ Pas de référence hardcoded à `58439d86` dans le frontend (`apps/web/src/`)
- ✅ DB clean : aucune row `portfolios` avec cet ID (vérifié via Supabase)
- ✅ `usePortfolios()` retourne 5 portfolios sains, aucun avec ID mort
- ✅ Pas de `persistQueryClient` / `localStorage` qui caching l'ID
- ✅ Service worker = push-only, pas un fetch interceptor
- ❌ User a refresh la tab — bruit persiste

→ **Source externe** : autre device de l'user, vieux bookmark, ancien preview Vercel, ou monitoring tiers. Non bloquant pour le système.

## Fix

Demote WARN → DEBUG dans `AllExceptionsFilter` quand `req.url` contient un ID de portfolio migré connu. Status HTTP 404 inchangé (correct sémantiquement).

```ts
const KNOWN_MIGRATED_PORTFOLIO_IDS = [
  '58439d86-3f20-4a60-82a4-307f3f252bc2', // ex-MAIN → b0000001 (30/05/2026)
];
```

Liste extensible si d'autres portfolios sont supprimés à l'avenir.

## Impact

- ~2 req/s × WARN supprimées = logs Fly lisibles
- Aucun risque de masquer un vrai bug (404 sur un ID inconnu reste WARN)
- HTTP response 404 inchangée — le client externe finira par se taire (cache TTL ou user clear)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_