### PR TITLE
fix(migration-0183): wrap DELETE dans DO block

### DIFF
--- a/supabase/migrations/0183_cleanup_orphan_lesson_citations.sql
+++ b/supabase/migrations/0183_cleanup_orphan_lesson_citations.sql
@@ -18,6 +18,13 @@
 --
 -- Idempotent : DELETE WHERE lesson_id IS NULL → 0 rows si déjà appliquée
 -- (PR #549 garantit qu'aucune nouvelle ligne avec lesson_id=null ne sera créée).
+--
+-- Wrapping DO block obligatoire : la Management API Supabase rejette les
+-- DELETE-only statements (pas de SELECT result) avec exit code 1 sur le
+-- workflow apply-supabase-migrations. Run précédent failed avec ce SQL en
+-- DELETE direct — applied manuellement via service role + tracker upsert.
 
-DELETE FROM scanner_lesson_citations
-WHERE lesson_id IS NULL;
+DO $$
+BEGIN
+  DELETE FROM scanner_lesson_citations WHERE lesson_id IS NULL;
+END $$;


### PR DESCRIPTION
## Bug CI

Workflow `apply-supabase-migrations.yml` a failed avec exit code 1 sur 0183. La Management API Supabase rejette les DELETE-only statements (attend un SELECT result).

## État actuel

✅ Migration **déjà appliquée manuellement** via service role :
- 308 orphan rows supprimées
- `_smartvest_migrations` upserted avec filename + sha256 → 0183 marqué applied

## Fix

Wrap DELETE dans `DO $$ BEGIN ... END $$;` qui produit un void result accepté par la Management API. Idempotent.

```sql
DO $$
BEGIN
  DELETE FROM scanner_lesson_citations WHERE lesson_id IS NULL;
END $$;
```

Le filename est déjà en tracker → futures runs SKIP. Cette PR est défensive au cas où le tracker row serait supprimé.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_