### PR TITLE
fix: migration 0184 lesson kinds + risk-monitor 1min + Mistral throughput note

### DIFF
--- a/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
+++ b/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
@@ -105,11 +105,13 @@ export class OpenPositionRiskMonitorService {
     }
   }
 
-  // PR #542 — Cadence augmentée 5→2 min pour cut losses plus rapidement.
-  // Mistral free tier supporte largement (~75k tokens/min limite, on est <5k/min).
-  // Impact P&L attendu : sur les setups perdants, exit ~3 min plus tôt = limite
-  // les drawdowns post-MFE (cf. capture rate négatif TRADER -45% sur sample).
-  @Cron('0 */2 * * * *', { name: 'open-position-risk-monitor', timeZone: 'UTC' })
+  // PR #542 — Cadence 5→2 min pour cut losses plus rapidement.
+  // 01/06 PR follow-up — 2→1 min : user veut suivi minute-par-minute des positions
+  // ouvertes pour décisions Mistral optimales (objectif : gain net positif).
+  // Limite : 60 calls/h × 4 portfolios × ~3-5k tok/call ≈ 12-20k TPM, OK sur
+  // mistral-medium-2505 (375k TPM, 0.42 rps) — passer à ce snapshot via
+  // MISTRAL_SHADOW_MODEL si on reste sur free tier 50k TPM. Cf. PR notes.
+  @Cron('0 */1 * * * *', { name: 'open-position-risk-monitor', timeZone: 'UTC' })
   async runCycle(): Promise<void> {
     if (!this.enabled) return;
     if (!this.supabase.isReady()) return;

--- a/supabase/migrations/0184_decision_log_kinds_lesson_auto_apply.sql
+++ b/supabase/migrations/0184_decision_log_kinds_lesson_auto_apply.sql
@@ -1,0 +1,60 @@
+-- 0184_decision_log_kinds_lesson_auto_apply.sql
+--
+-- Étend CHECK constraint lisa_decision_log.kind pour les 2 kinds insérés par
+-- LessonAutoApplyService (lesson-auto-apply.service.ts:336-356).
+--
+-- Bug observé 01/06/2026 vers 10:07 UTC : ~8 WARN par cycle
+--   "decision_log insert failed: violates check constraint lisa_decision_log_kind_check"
+-- Cause : le service écrit kind='lesson_auto_applied' ou 'lesson_needs_manual_review'
+-- mais ces 2 kinds n'avaient jamais été ajoutés à la constraint (oubli historique
+-- lors du déploiement du service).
+--
+-- Impact pré-fix : aucune trace lisa_decision_log de l'auto-apply des lessons.
+-- Le service exécutait l'action (UPDATE config) mais l'audit était silencieusement
+-- rejeté. Visible dans logs Fly mais pas dans /lisa/decisions UI.
+--
+-- Idempotent : DROP IF EXISTS + recréation avec liste complète existante 0164
+-- + 2 nouveaux kinds.
+
+ALTER TABLE public.lisa_decision_log
+  DROP CONSTRAINT IF EXISTS lisa_decision_log_kind_check;
+
+ALTER TABLE public.lisa_decision_log
+  ADD CONSTRAINT lisa_decision_log_kind_check
+  CHECK (kind IN (
+    -- Original 0043
+    'proposal_generated', 'proposal_approved', 'proposal_rejected',
+    'position_opened', 'position_closed', 'position_resized',
+    'thesis_invalidated', 'risk_limit_breached', 'kill_switch_triggered',
+    'autopilot_cycle_started', 'autopilot_cycle_completed',
+    'market_regime_changed', 'analog_matched', 'user_override',
+    -- Autopilot extensions
+    'autopilot_cycle_completed_error', 'proposal_cooldown_active',
+    'autopilot_paused', 'autopilot_resumed', 'autopilot_disabled',
+    'autopilot_auto_approve_expired',
+    -- Mechanical agent
+    'mechanical_open', 'mechanical_close_stop', 'mechanical_close_target',
+    'mechanical_close_invalidated', 'mechanical_skip', 'mechanical_override_applied',
+    -- Hedge
+    'hedge_recommendation',
+    -- P5-EXEC visibility
+    'position_skipped_duplicate_symbol', 'position_skipped_insufficient_cash',
+    'position_skipped_fallback_price', 'proposal_capped_by_max_positions',
+    -- P19β shadow
+    'gainer_shadow_466', 'gainer_shadow_566',
+    -- 0118 observabilité
+    'position_open_failed',
+    -- 0119 adaptive selectivity
+    'adaptive_status_changed', 'adaptive_adjustment_applied',
+    'adaptive_restore_applied', 'adaptive_kill_switch_triggered',
+    -- 0156 PR #398 — Daily catalyst brief Gemini
+    'daily_catalyst_brief',
+    -- 0158 — OpenPositionRiskMonitorService audit
+    'risk_monitor_action',
+    -- 0164 — Gemini V2 RiskManager + OpportunityScout (25/05/2026)
+    'risk_manager_thesis_broken',
+    'opportunity_scout_opened',
+    -- 0184 NEW — LessonAutoApplyService (audit auto-apply lessons)
+    'lesson_auto_applied',
+    'lesson_needs_manual_review'
+  ));


### PR DESCRIPTION
## 3 actions liées dans une PR

### 🔴 Bug 1 — `lisa_decision_log_kind_check` violation

**Constat** (logs 01/06 10:07 UTC) : 8 WARN/cycle
```
decision_log insert failed: violates check constraint lisa_decision_log_kind_check
```

**Cause** : `LessonAutoApplyService.logDecision()` écrit `kind='lesson_auto_applied'` ou `'lesson_needs_manual_review'`, mais ces 2 kinds n'ont jamais été ajoutés à la CHECK constraint (oubli au déploiement du service).

**Impact** : aucune trace UI `/lisa/decisions` des auto-apply lessons depuis le déploiement du service. Pure perte d'audit.

**Fix** : migration 0184 ajoute les 2 kinds en bottom de la liste 0164.

### ⚡ Bug 2 — Suivi temps réel positions ouvertes (user request)

`OpenPositionRiskMonitorService` cron `0 */2 * * * *` → `0 */1 * * * *`

User : « je veux que Mistral puisse suivre à la minute chaque position ouverte et prendre la bonne décision pour avoir toujours un gain net positif ».

Charge estimée : 4 portfolios × 60 calls/h × 3-5k tok = ~12-20k TPM en pointe.

### ⚠️ Note 3 — Rate limit Mistral 429 (pas dans cette PR, action Fly secret)

Le 429 observé n'est PAS lié au budget €. Doc Mistral 01/06 :

| Modèle | TPM | RPS | TPmois |
|---|---|---|---|
| `mistral-medium-3-5` (actuel, alias `mistral-medium-latest`) | **50k** | **1.00** | 4M |
| `mistral-medium-2505` (snapshot précédent) | **375k** | 0.42 | illimité |

**Action conseillée** (à appliquer côté Fly) :
```bash
fly secrets set MISTRAL_SHADOW_MODEL=mistral-medium-2505 -a smartvest
```

→ 7.5× plus de throughput, indispensable pour soutenir le 1min cron + scanner cycles + shadows.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_