### PR TITLE
fix(risk-monitor): rollback 1min → 2min (PR #554 saturait Mistral)

### DIFF
--- a/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
+++ b/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
@@ -106,12 +106,12 @@ export class OpenPositionRiskMonitorService {
   }
 
   // PR #542 — Cadence 5→2 min pour cut losses plus rapidement.
-  // 01/06 PR follow-up — 2→1 min : user veut suivi minute-par-minute des positions
-  // ouvertes pour décisions Mistral optimales (objectif : gain net positif).
-  // Limite : 60 calls/h × 4 portfolios × ~3-5k tok/call ≈ 12-20k TPM, OK sur
-  // mistral-medium-2505 (375k TPM, 0.42 rps) — passer à ce snapshot via
-  // MISTRAL_SHADOW_MODEL si on reste sur free tier 50k TPM. Cf. PR notes.
-  @Cron('0 */1 * * * *', { name: 'open-position-risk-monitor', timeZone: 'UTC' })
+  // PR #554 a tenté 2→1 min mais saturait Mistral rate limit (0.42 rps tier
+  // mistral-medium-2505 vs ~40 calls/min effectifs = 60% over limit). Logs Fly
+  // 01/06 11:00-12:30 UTC : 429 systématiques + fallback Gemini Pro à chaque
+  // cycle = pollution + coût LLM.
+  // 01/06 14h — Rollback 1→2 min : on reste dans le rate limit Mistral.
+  @Cron('0 */2 * * * *', { name: 'open-position-risk-monitor', timeZone: 'UTC' })
   async runCycle(): Promise<void> {
     if (!this.enabled) return;
     if (!this.supabase.isReady()) return;


### PR DESCRIPTION
## Rollback risk-monitor cron 1min → 2min

PR #554 a baissé le cron à 1min pour suivi positions « minute-par-minute » mais ça sature le rate limit Mistral :

| | Valeur |
|---|---|
| Cycles/min | 1 |
| Open positions moyennes | ~10 |
| LLM calls/position/cycle | ~4 (composite + shadows) |
| **Total calls/min** | **~40** |
| Mistral rate limit (`mistral-medium-2505`) | **25/min** (0.42 rps) |
| **Saturation** | **+60%** |

→ 429 systématique observé dans logs Fly 11:00-12:30 UTC + fallback Gemini Pro forcé à chaque cycle = pollution log + coût Gemini Pro inutile.

## Trade-off accepté

- ❌ Perte du suivi minute-par-minute des positions
- ✅ Mistral fonctionnel sans pollution 429
- ✅ Pas de coût Gemini Pro fallback
- ✅ Risk monitor 2min reste suffisant pour cut losses (vs 5min original)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_