### PR TITLE
fix(scanner): sort+filter refund_1d_p sur TOUS exchanges (Asia hit rate 18% → ~100%)

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.eodhd.spec.ts
@@ -146,28 +146,29 @@ describe('fetchEodhdScreener — URL construction (P18c regression guard)', () =
     expect(decoded).not.toContain('limit=20');
   });
 
-  it('P19s++ HOTFIX — non-US exchanges build URL with UPPERCASE + NO 1d return filter', async () => {
-    // P19s++ (30/04/2026 08:10 UTC) — `change_p` n'est PAS un valid filter
-    // field per EODHD doc (c'est le nom dans la RÉPONSE seulement). Ça
-    // causait HTTP 422 sur LSE/MC/KO/HK :
-    //     {"errors":{"filters.1.field":["The selected filters.1.field is invalid."]}}
-    // Fix : DROP le filter 1d return pour non-US, post-filter client-side.
+  it('non-US exchanges build URL with UPPERCASE + refund_1d_p>3 filter + sort desc (post-01/06 fix)', async () => {
+    // Audit 01/06/2026 — Confirmation live EODHD : `refund_1d_p` est filtrable
+    // ET sortable sur TOUS les exchanges (KO/KQ/SHG/SHE/NSE/TW). L'hypothèse
+    // historique P19s++ "non-US n'a pas de données refund_1d_p" était fausse.
+    //
+    // Sans sort+filter, le scanner paginait dans un ordre arbitraire et ratait
+    // 82% des EODHD Asia top gainers (4/22 hit rate observé 01/06). Cf. commit
+    // de fix pour détails.
+    //
+    // change_p reste interdit (n'est PAS un filter field valide — c'est le nom
+    // de la RÉPONSE).
     const svc = makeService();
-    // P20a: corrected EODHD codes — T (Tokyo), SHG (Shanghai), SHE (Shenzhen)
-    const exchanges = ['T', 'HK', 'KO', 'SHG', 'SHE', 'TO', 'AS', 'NSE', 'BSE', 'AU'];
+    const exchanges = ['T', 'HK', 'KO', 'KQ', 'SHG', 'SHE', 'TO', 'AS', 'NSE', 'BSE', 'AU'];
     for (const ex of exchanges) {
       capturedUrl = undefined;
       await (svc as any).fetchEodhdScreener(ex, 'test-key');
       expect(capturedUrl).toBeDefined();
       const decoded = decodeURIComponent(capturedUrl!);
-      // Exchange UPPERCASE
       expect(decoded).toContain(`["exchange","=","${ex}"]`);
-      // P19s++ : pas de filter 1d return (ni change_p, ni refund_1d_p)
       expect(decoded).not.toMatch(/\["change_p","[<>=]"/);
-      expect(decoded).not.toMatch(/\["refund_1d_p","[<>=]"/);
-      // market_cap conservé (valid filter)
+      expect(decoded).toContain('["refund_1d_p",">",3]');
       expect(decoded).toContain('["market_capitalization",">",50000000]');
-      expect(decoded).not.toMatch(/[?&]sort=/);
+      expect(decoded).toMatch(/[?&]sort=refund_1d_p\.desc/);
       expect(decoded).not.toContain('avgvol_50d');
     }
   });

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.multi-exchange.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.multi-exchange.spec.ts
@@ -69,22 +69,17 @@ describe('fetchEodhdScreener — multi-exchange UPPERCASE + changeField (P19s+ r
     global.fetch = realFetch;
   });
 
-  it('passes UPPERCASE exchange + change_p for non-US (LSE) to EODHD screener', async () => {
+  it('passes UPPERCASE exchange + refund_1d_p>3 filter + sort desc for non-US (LSE) (post-01/06 fix)', async () => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('lse', 'test_key');
     expect(capturedUrl).toBeDefined();
     const decoded = decodeURIComponent(capturedUrl!);
-    // Exchange filter doit contenir "LSE" (UPPERCASE), pas "lse"
     expect(decoded).toContain('"LSE"');
     expect(decoded).not.toContain('"lse"');
-    // P19s++ HOTFIX : pas de filter 1d return pour non-US (rejected as
-    // invalid filter field by EODHD validator). Post-filter client-side.
-    // PR #557 — refund_1d_p en filter rejeté EODHD pour non-US (P19s+ regression).
-    // Sort param refund_1d_p activé UNIQUEMENT pour US (Laravel validator EODHD
-    // rejette sort sur non-US per test historique P19s).
-    expect(decoded).not.toContain('"refund_1d_p"');
+    // Audit 01/06 : refund_1d_p filtrable+sortable sur tous exchanges (test live).
+    expect(decoded).toContain('["refund_1d_p",">",3]');
     expect(decoded).not.toContain('"change_p"');
-    expect(decoded).not.toContain('sort=');
+    expect(decoded).toMatch(/[?&]sort=refund_1d_p\.desc/);
   });
 
   it('passes UPPERCASE exchange + refund_1d_p for US to EODHD screener', async () => {
@@ -100,18 +95,14 @@ describe('fetchEodhdScreener — multi-exchange UPPERCASE + changeField (P19s+ r
     expect(decoded).not.toContain('change_p');
   });
 
-  it('handles already-uppercase input (idempotent) — XETRA passes through', async () => {
+  it('handles already-uppercase input (idempotent) — XETRA passes through with new filter+sort', async () => {
     const svc = makeService();
     await (svc as any).fetchEodhdScreener('XETRA', 'test_key');
     const decoded = decodeURIComponent(capturedUrl!);
     expect(decoded).toContain('"XETRA"');
-    // P19s++ : pas de filter 1d return pour non-US
-    // PR #557 — refund_1d_p en filter rejeté EODHD pour non-US (P19s+ regression).
-    // Sort param refund_1d_p activé UNIQUEMENT pour US (Laravel validator EODHD
-    // rejette sort sur non-US per test historique P19s).
-    expect(decoded).not.toContain('"refund_1d_p"');
+    expect(decoded).toContain('["refund_1d_p",">",3]');
     expect(decoded).not.toContain('"change_p"');
-    expect(decoded).not.toContain('sort=');
+    expect(decoded).toMatch(/[?&]sort=refund_1d_p\.desc/);
   });
 
   it.each([
@@ -123,19 +114,19 @@ describe('fetchEodhdScreener — multi-exchange UPPERCASE + changeField (P19s+ r
     ['to', 'TO'],   // Toronto
     ['as', 'AS'],   // Amsterdam
     ['nse', 'NSE'], // India NSE
-  ])('non-US exchange "%s" sent as "%s" without 1d return filter (post-filter client-side)', async (input, expected) => {
+  ])('non-US exchange "%s" sent as "%s" with refund_1d_p>3 filter + sort desc (post-01/06 fix)', async (input, expected) => {
+    // Audit 01/06/2026 — `refund_1d_p` filtrable+sortable sur Asia exchanges
+    // confirmé live (KO/KQ/SHG/SHE/NSE/TW). Hypothèse historique P19s++ "non-US
+    // sans données refund_1d_p" était fausse. Sans sort+filter, le scanner
+    // ratait 82% des EODHD top gainers (4/22 hit rate observé).
+    // change_p reste interdit (filter field invalide, c'est le nom de la réponse).
     const svc = makeService();
     await (svc as any).fetchEodhdScreener(input, 'test_key');
     const decoded = decodeURIComponent(capturedUrl!);
     expect(decoded).toContain(`"${expected}"`);
-    // P19s++ : pas de filter 1d return (rejected by EODHD validator pour non-US)
-    // PR #557 — refund_1d_p en filter rejeté EODHD pour non-US (P19s+ regression).
-    // Sort param refund_1d_p activé UNIQUEMENT pour US (Laravel validator EODHD
-    // rejette sort sur non-US per test historique P19s).
-    expect(decoded).not.toContain('"refund_1d_p"');
+    expect(decoded).toContain('["refund_1d_p",">",3]');
     expect(decoded).not.toContain('"change_p"');
-    expect(decoded).not.toContain('sort=');
-    // market_capitalization filter conservé
+    expect(decoded).toMatch(/[?&]sort=refund_1d_p\.desc/);
     expect(decoded).toContain('market_capitalization');
   });
 });

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -1737,29 +1737,27 @@ export class TopGainersScannerService implements OnModuleInit {
   private async fetchEodhdScreener(exchange: string, apiKey: string): Promise<TopGainerCandidate[]> {
     const exUpper = exchange.toUpperCase();
     const isUs = exUpper === 'US';
-    // P19s++ (30/04/2026 08:10 UTC HOTFIX) — Revert `change_p` filter qui
-    // causait HTTP 422 sur LSE/MC/KO/HK :
-    //     {"errors":{"filters.1.field":["The selected filters.1.field is invalid."]}}
-    // EODHD doc officielle confirme : `change_p` n'est PAS un valid filter
-    // field — c'est le nom dans la RÉPONSE seulement. Les seuls valid filter
-    // fields pour 1d return sont `refund_1d_p`, `refund_5d_p`, `refund_ytd_p`.
-    // Mais `refund_1d_p` ne semble pas avoir de données pour la plupart des
-    // marchés non-US.
+    // Audit 01/06/2026 — Confirmation live EODHD : `refund_1d_p` est filtrable
+    // ET sortable sur TOUS les exchanges (US/KO/KQ/SHG/SHE/NSE/TW), pas juste US.
+    // L'hypothèse historique "non-US n'a pas de données refund_1d_p" était fausse
+    // (ou EODHD l'a fixée depuis P19s++).
     //
-    // Stratégie multi-exchange :
-    //   - US      : keep `refund_1d_p > 3` filter (validé prod)
-    //   - non-US  : DROP le filter 1d return entirely. Filtre seulement par
-    //               exchange + market_capitalization. Post-filter changePct
-    //               appliqué client-side via mapEodhdRow + filter ci-dessous
-    //               (la valeur change_p existe dans la RÉPONSE, juste pas
-    //               comme filter input).
+    // Symptôme observé 01/06 sur top_gainers_log + gainers_user_shadow_signals :
+    // sur 22 EODHD Asia top gainers (live screener via clé prod), le scanner
+    // n'en voyait que 4 (18% hit rate). Cause : sans `sort=` explicite, EODHD
+    // renvoie les rows dans un ordre arbitraire (premier hit Korea = 002170
+    // Samyang à -3.73%). Les vraies pépites (037560.KO LG HelloVision +30%) sont
+    // à offset 200-299 — le scanner cape à ~250 par exchange et les manquait.
+    //
+    // Fix : ajouter le filter `refund_1d_p > 3` + `sort=refund_1d_p.desc` pour
+    // TOUS les exchanges. Effet : page 1 = top gainers (037560.KO +30%, 066570.KO
+    // +29.9%, 454910.KO +29.95%, etc.), plus de gaspillage de pagination sur des
+    // small caps en perte.
     const filtersList: Array<[string, string, string | number]> = [
       ['exchange', '=', exUpper],
+      ['refund_1d_p', '>', 3],
+      ['market_capitalization', '>', 50_000_000],
     ];
-    if (isUs) {
-      filtersList.push(['refund_1d_p', '>', 3]);
-    }
-    filtersList.push(['market_capitalization', '>', 50_000_000]);
     const filters = encodeURIComponent(JSON.stringify(filtersList));
 
     // PR #352 — Pagination screener pour étendre l'univers à 3000 tickers.
@@ -1810,8 +1808,13 @@ export class TopGainersScannerService implements OnModuleInit {
         // PR #557 avait utilisé le mauvais format → US screener 100 % cassé
         // (ok=0/fail=2 sur 6h, 0 ticker US dans top_gainers_log depuis deploy).
         // Format correct documenté inline ligne 1696 : `refund_1d_p.desc`.
-        // Restreint à US car non-US n'a pas le filter refund_1d_p (cf. P19s+ ligne 1710).
-        const sortParam = isUs ? '&sort=refund_1d_p.desc' : '';
+        //
+        // Update 01/06 soir — étendu à TOUS les exchanges (US + non-US). Audit
+        // live confirme que refund_1d_p est filtrable+sortable sur Asia (KO/KQ/
+        // SHG/SHE/NSE/TW). Cf. filtre ligne 1758 (`refund_1d_p > 3`). Sans cette
+        // extension, Asia pagine en ordre arbitraire et rate les top movers
+        // (037560.KO LG HelloVision +30%, 454910.KO Doosan Robotics +30%).
+        const sortParam = '&sort=refund_1d_p.desc';
         const url = `https://eodhd.com/api/screener?api_token=${encodeURIComponent(apiKey)}&filters=${filters}${sortParam}&limit=${pageSize}&offset=${offset}&fmt=json`;
         const tStart = Date.now();
         const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });


### PR DESCRIPTION
## Summary

Le scanner EODHD non-US n'utilisait ni `sort` ni filtre `refund_1d_p` → ordre arbitraire, pagination cape ~250 par exchange, vraies pépites ratées.

**Audit live 01/06/2026** :
- 22 EODHD Asia top gainers (live screener) → scanner SmartVest n'en voyait que 4 (18%)
- 037560.KO LG HelloVision (+30%), 454910.KO Doosan Robotics (+30%), 108490.KQ Robotis (+24%), etc. : 0 row dans `gainers_user_shadow_signals` 24h, **jamais touchés**
- Premier hit Korea sans sort = 002170 Samyang à **-3.73%** → cap pagination épuisé sur small caps en perte avant d'atteindre les top movers à l'offset 200-299

## Fix

Ajouter `refund_1d_p > 3` (filter) + `sort=refund_1d_p.desc` (URL) pour **tous** les exchanges (US déjà OK, juste étendu à non-US).

Confirmation live via clé prod : `refund_1d_p` est filtrable + sortable sur KO/KQ/SHG/SHE/NSE/TW. L'hypothèse historique P19s++ "non-US n'a pas de données refund_1d_p" était fausse.

## Effet attendu cycle Asia 00-06 UTC

| Avant | Après |
|---|---|
| Page 1 = small caps random −5% | Page 1 = top gainers +30% |
| Cap 250 → manque LG/Samsung/Doosan | Cap 250 → couvre tous les +3% movers |
| 18% hit rate sur EODHD top 22 | ~100% hit rate (limit by cap pagination) |
| ~5 calls EODHD par exchange pour 0 résultat utile | ~1 call par exchange suffit |

Bonus : coût EODHD réduit (moins de pages fetchées pour atteindre les bons candidats).

## Non couvert (Fix #2 séparé)

Tokyo (.T) et Hong Kong (.HK) restent absents. Testé live JPX/JP/TYO/TKS/T/TSE → tous 0 rows EODHD. Pas dans `exchanges-list` officiel EODHD. Options :
- TwelveData Pro $229/mo (couvre TSE + HKEX + Korea + China + Singapore + Taiwan)
- Yahoo Finance (gratuit, déjà intégré comme fallback intraday, nécessite refacto pipeline scanner)
- EODHD addon Japan/HK (à vérifier disponibilité)

→ Décision business à part.

## Test plan
- [ ] CI typecheck vert
- [ ] CI Jest vert
- [ ] Post-deploy : observer logs Fly `[top-gainers] screener KO fetched N mapped in 1 pages` (était 4-5 pages)
- [ ] Post-deploy : observer `top_gainers_log` après 1er cycle Asia (00-06 UTC) → présence de 037560.KO / 454910.KO / 108490.KQ / etc.
- [ ] Observer baisse calls EODHD screener (cf. `eodhd_request_log` 24h vs 24h pré-deploy)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_