### PR TITLE
feat(admin): /admin/llm-router-probe — diagnostic Mistral primary runtime

### DIFF
--- a/apps/api/src/modules/admin/admin-llm-router-probe.controller.ts
+++ b/apps/api/src/modules/admin/admin-llm-router-probe.controller.ts
@@ -1,0 +1,109 @@
+/**
+ * /admin/llm-router-probe — diagnostic LLM router runtime state + test call.
+ *
+ * Créé 02/06/2026 03:30 UTC suite à constat 998 calls Gemini Flash-Lite vs
+ * 1 seul Mistral en 48h alors que LLM_PRIMARY_PROVIDER=mistral-medium est
+ * censé être set. Endpoint diagnostique pour confirmer :
+ *   1. Valeur runtime de LLM_PRIMARY_PROVIDER lue par le service
+ *   2. Si MistralShadowService a été injecté (DI Optional)
+ *   3. Résultat d'un test call effectif → providerId retourné
+ *
+ * Permet de répondre en 1 GET à "Mistral primary est-il réellement actif ?"
+ */
+
+import { Controller, Get, Headers, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ScannerLlmRouterService } from '../lisa/services/scanner-llm-router.service';
+
+@Controller('admin/llm-router-probe')
+export class AdminLlmRouterProbeController {
+  private readonly logger = new Logger(AdminLlmRouterProbeController.name);
+
+  constructor(
+    private readonly router: ScannerLlmRouterService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Get()
+  async probe(@Headers('x-admin-token') providedToken: string | undefined) {
+    this.assertAdmin(providedToken);
+
+    const envValue = this.config.get<string>('LLM_PRIMARY_PROVIDER') ?? null;
+    const runtimeValue = this.router.getPrimaryProvider();
+    const mistralInjected = this.router.hasMistralShadow();
+    const routerEnabled = this.router.isEnabled();
+
+    let testCall: Record<string, unknown> = { skipped: 'router_not_enabled' };
+    if (routerEnabled) {
+      try {
+        const t0 = Date.now();
+        const res = await this.router.call({
+          system: 'You are a test responder. Reply with exactly the word PING.',
+          user: 'probe',
+          temperature: 0,
+          maxTokens: 10,
+          timeoutMs: 8000,
+        });
+        testCall = {
+          provider_id: res.providerId,
+          content: res.content.slice(0, 50),
+          fallback_used: res.fallbackUsed,
+          latency_ms: res.latencyMs,
+          cost_usd: res.costUsd,
+          total_latency_ms: Date.now() - t0,
+        };
+      } catch (e) {
+        testCall = {
+          error: String(e instanceof Error ? e.message : e).slice(0, 300),
+        };
+      }
+    }
+
+    return {
+      env_LLM_PRIMARY_PROVIDER: envValue,
+      runtime_primaryProvider: runtimeValue,
+      mistral_shadow_injected: mistralInjected,
+      router_enabled: routerEnabled,
+      test_call: testCall,
+      interpretation: this.interpret(envValue, runtimeValue, mistralInjected, testCall),
+    };
+  }
+
+  private interpret(
+    envValue: string | null,
+    runtime: string,
+    mistralInjected: boolean,
+    testCall: Record<string, unknown>,
+  ): string {
+    if (envValue !== 'mistral-medium' && runtime !== 'mistral-medium') {
+      return 'LLM_PRIMARY_PROVIDER pas set OU pas effectif sur la machine — Mistral ne peut pas être primary.';
+    }
+    if (!mistralInjected) {
+      return 'MistralShadowService non injecté — vérifier providers du module lisa.';
+    }
+    const tcProvider = String((testCall as { provider_id?: string }).provider_id ?? '');
+    if (tcProvider.includes('mistral')) {
+      return 'OK : Mistral primary actif et test call OK.';
+    }
+    if (tcProvider.includes('gemini')) {
+      return 'Mistral path entré mais a fail (catch fallback Gemini). Vérifier MISTRAL_API_KEY / MISTRAL_SHADOW_MODEL / throttle.';
+    }
+    return 'Status indéterminé — inspecter le test_call ci-dessus.';
+  }
+
+  private assertAdmin(providedToken: string | undefined): void {
+    const expected = this.config.get<string>('ADMIN_TOKEN');
+    if (!expected || expected.length === 0) {
+      throw new HttpException(
+        { message: 'Endpoint disabled (ADMIN_TOKEN not configured)', code: 'ADMIN_DISABLED' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+    if (providedToken !== expected) {
+      throw new HttpException(
+        { message: 'Invalid admin token', code: 'ADMIN_FORBIDDEN' },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -24,6 +24,7 @@ import { AdminMigrationsController } from './admin-migrations.controller';
 import { AdminSupabaseQueryController } from './admin-supabase-query.controller';
 import { AdminLogsController } from './admin-logs.controller';
 import { AdminEodhdStatusController } from './admin-eodhd-status.controller';
+import { AdminLlmRouterProbeController } from './admin-llm-router-probe.controller';
 import { AdminTdProbeController } from './admin-td-probe.controller';
 import { AdminGainersStatusController } from './admin-gainers-status.controller';
 import { AdminGainersBaselineController } from './admin-gainers-baseline.controller';
@@ -57,6 +58,7 @@ import { AdminLearningLoopAuditController } from './admin-learning-loop-audit.co
     AdminSupabaseQueryController,
     AdminLogsController,
     AdminEodhdStatusController,
+    AdminLlmRouterProbeController,
     AdminTdProbeController,
     AdminGainersStatusController,
     AdminGainersBaselineController,

--- a/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
+++ b/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
@@ -111,6 +111,16 @@ export class ScannerLlmRouterService {
     return this.router !== null;
   }
 
+  /** Expose la valeur runtime de LLM_PRIMARY_PROVIDER (debug admin). */
+  getPrimaryProvider(): string {
+    return this.primaryProvider;
+  }
+
+  /** True si MistralShadowService a été injecté (DI optional). */
+  hasMistralShadow(): boolean {
+    return this.mistralShadow != null;
+  }
+
   /**
    * Appel LLM via la chain rapide (Flash Lite → Opus). Pour les tâches simples /
    * volumineuses (scanner, screening, classification).


### PR DESCRIPTION
## Summary

Constat 998 calls Gemini Flash-Lite vs 1 seul Mistral en 48h sur `llm_ab_shadow_decisions`, alors que `LLM_PRIMARY_PROVIDER=mistral-medium` est censé être posé sur Fly. Code path Mistral primary EST câblé dans `scanner-llm-router.service.ts:127` mais ne s'active manifestement pas en prod.

Ajout endpoint diagnostic qui répond en 1 GET aux 3 questions critiques :

1. La var `LLM_PRIMARY_PROVIDER` est-elle effectivement lue par le service au boot (vs default `gemini-pro`) ?
2. `MistralShadowService` est-il injecté (DI Optional) ?
3. Que retourne réellement un appel test du router ? (`provider_id` effectif)

## Usage

```bash
curl -sS https://smartvest.fly.dev/admin/llm-router-probe \
  -H "x-admin-token: $ADMIN_TOKEN" | jq
```

Retour :
```json
{
  "env_LLM_PRIMARY_PROVIDER": "mistral-medium",
  "runtime_primaryProvider": "mistral-medium",
  "mistral_shadow_injected": true,
  "router_enabled": true,
  "test_call": {
    "provider_id": "mistral-medium-2505",
    "content": "PING",
    "fallback_used": false,
    "latency_ms": 850,
    "cost_usd": 0
  },
  "interpretation": "OK : Mistral primary actif et test call OK."
}
```

3 scénarios de fail diagnostiqués :
- `env` null → secret pas posé sur Fly
- `mistral_shadow_injected=false` → DI échoue
- `test_call.provider_id` contient `gemini` alors que `runtime_primaryProvider=mistral-medium` → Mistral throw silencieusement, fallback Gemini

## Coût

~$0.0001 par probe (1 test call). Gated `ADMIN_TOKEN`.

## Test plan
- [ ] CI typecheck vert
- [ ] CI Jest vert
- [ ] Post-deploy : `curl /admin/llm-router-probe` retourne le diagnostic

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_