### PR TITLE
hotfix: export ScannerLlmRouterService from LisaModule (fix boot crash #562)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -361,6 +361,7 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     LisaService,
     DecisionLogService,
     DebateGateMetricsStore,
+    ScannerLlmRouterService,
     RealtimePriceService,
     EodhdTechnicalService,
     EodhdIntradayService,


### PR DESCRIPTION
🚨 **HOTFIX URGENT — site DOWN.**

PR #562 a ajouté `AdminLlmRouterProbeController` qui dépend de `ScannerLlmRouterService`, mais ce service n'était pas exporté depuis `LisaModule`. Boot NestJS crash :

```
Nest can't resolve dependencies of the AdminLlmRouterProbeController (?, ConfigService).
Please make sure that the argument ScannerLlmRouterService at index [0]
is available in the AdminModule context.
```

Machine Fly crashloope 10× puis abandonne → app indisponible depuis ~04:21 UTC.

## Fix

Ajouter `ScannerLlmRouterService` au tableau `exports` de `LisaModule` (déjà dans `providers`). 1 ligne.

## Test plan
- [ ] CI typecheck ✅ vert
- [ ] CI Jest ✅
- [ ] Post-deploy Fly : `/version` et `/health` répondent 200
- [ ] `curl /admin/llm-router-probe` retourne le diagnostic Mistral

À MERGER ASAP.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_