### PR TITLE
feat(scanner): Phase 1 — composite ranking framework (env-gated)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/composite-ranker.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/composite-ranker.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests Composite Ranker — Phase 1 du refactor scanner.
+ * Vérifie que les sweet-spot candidates rankent au-dessus des paraboliques.
+ */
+
+import {
+  computeCompositeScore,
+  rankByCompositeScore,
+  parseCompositeWeights,
+  DEFAULT_COMPOSITE_WEIGHTS,
+} from '../composite-ranker.helper';
+
+describe('Composite Ranker', () => {
+  describe('parseCompositeWeights', () => {
+    it('parses valid CSV string', () => {
+      const w = parseCompositeWeights('0.5,0.2,0.15,0.1,0.05');
+      expect(w.w1_sweetSpot).toBe(0.5);
+      expect(w.w2_volume).toBe(0.2);
+      expect(w.w3_notAtPeak).toBe(0.15);
+      expect(w.w4_mcap).toBe(0.1);
+      expect(w.w5_parabolicPenalty).toBe(0.05);
+    });
+
+    it('returns DEFAULT on empty string', () => {
+      expect(parseCompositeWeights('')).toEqual(DEFAULT_COMPOSITE_WEIGHTS);
+      expect(parseCompositeWeights(undefined)).toEqual(DEFAULT_COMPOSITE_WEIGHTS);
+    });
+
+    it('returns DEFAULT on invalid input (wrong count)', () => {
+      expect(parseCompositeWeights('0.5,0.5')).toEqual(DEFAULT_COMPOSITE_WEIGHTS);
+    });
+
+    it('returns DEFAULT on negative value', () => {
+      expect(parseCompositeWeights('-0.1,0.2,0.3,0.2,0.4')).toEqual(DEFAULT_COMPOSITE_WEIGHTS);
+    });
+  });
+
+  describe('computeCompositeScore', () => {
+    it('sweet-spot candidate (5%, vol 2x, not at peak) scores HIGHER than parabolic (+30% at peak)', () => {
+      const sweetSpot = {
+        changePct: 5,
+        close: 100,
+        high: 105,        // closeToHigh = 0.952 (un peu sous le peak)
+        volume: 2_000_000,
+        avgVol50d: 1_000_000,
+        marketCap: 5_000_000_000, // 5B
+      };
+      const parabolic = {
+        changePct: 30,
+        close: 130,
+        high: 130,        // closeToHigh = 1 (au peak)
+        volume: 5_000_000,
+        avgVol50d: 1_000_000,
+        marketCap: 5_000_000_000,
+      };
+      const sweetScore = computeCompositeScore(sweetSpot);
+      const parabolicScore = computeCompositeScore(parabolic);
+      expect(sweetScore).toBeGreaterThan(parabolicScore);
+    });
+
+    it('parabolic 30% gets STRONG penalty (mostly negative score component)', () => {
+      const parabolic = {
+        changePct: 30,
+        close: 130,
+        high: 130,
+        volume: 2_000_000,
+        avgVol50d: 1_000_000,
+        marketCap: 5_000_000_000,
+      };
+      const score = computeCompositeScore(parabolic);
+      // Avec penalty pleine (changePct >= 25 → penalty=1), score doit être bas
+      // Sans le bonus volume/mcap, ce serait carrément négatif
+      expect(score).toBeLessThan(0.3);
+    });
+
+    it('higher volume ratio → higher score (all else equal)', () => {
+      const base = { changePct: 5, close: 100, high: 105, marketCap: 5_000_000_000, avgVol50d: 1_000_000 };
+      const lowVol = computeCompositeScore({ ...base, volume: 500_000 });
+      const highVol = computeCompositeScore({ ...base, volume: 2_000_000 });
+      expect(highVol).toBeGreaterThan(lowVol);
+    });
+
+    it('not-at-peak bonus higher when closeToHigh < 1', () => {
+      const base = { changePct: 5, marketCap: 5_000_000_000, volume: 2_000_000, avgVol50d: 1_000_000 };
+      const atPeak = computeCompositeScore({ ...base, close: 100, high: 100 }); // closeToHigh = 1
+      const notAtPeak = computeCompositeScore({ ...base, close: 95, high: 100 }); // closeToHigh = 0.95
+      expect(notAtPeak).toBeGreaterThan(atPeak);
+    });
+
+    it('larger mcap → small bonus (preference liquidité)', () => {
+      const base = { changePct: 5, close: 100, high: 105, volume: 2_000_000, avgVol50d: 1_000_000 };
+      const smallCap = computeCompositeScore({ ...base, marketCap: 50_000_000 }); // 50M
+      const largeCap = computeCompositeScore({ ...base, marketCap: 10_000_000_000 }); // 10B
+      expect(largeCap).toBeGreaterThan(smallCap);
+    });
+
+    it('handles null/missing fields safely (no NaN)', () => {
+      const empty = {
+        changePct: 0,
+        close: 0,
+        high: 0,
+        volume: 0,
+        avgVol50d: 0,
+        marketCap: 0,
+      };
+      const score = computeCompositeScore(empty);
+      expect(Number.isFinite(score)).toBe(true);
+    });
+  });
+
+  describe('rankByCompositeScore', () => {
+    it('re-trie : sweet-spot AVANT parabolique', () => {
+      const candidates = [
+        { symbol: 'PARA.KO', changePct: 30, close: 130, high: 130, volume: 2_000_000, avgVol50d: 1_000_000, marketCap: 5_000_000_000 },
+        { symbol: 'SWEET.US', changePct: 5, close: 100, high: 105, volume: 2_000_000, avgVol50d: 1_000_000, marketCap: 5_000_000_000 },
+        { symbol: 'PARA2.KO', changePct: 25, close: 125, high: 125, volume: 1_500_000, avgVol50d: 1_000_000, marketCap: 5_000_000_000 },
+      ] as Parameters<typeof rankByCompositeScore>[0];
+      const ranked = rankByCompositeScore(candidates);
+      expect(ranked[0].symbol).toBe('SWEET.US');
+      expect(ranked[ranked.length - 1].symbol).toMatch(/PARA/);
+    });
+
+    it('ne supprime AUCUN candidat (longueur preservée)', () => {
+      const candidates = [
+        { symbol: 'A', changePct: 5, close: 100, high: 100, volume: 1000, avgVol50d: 1000, marketCap: 1e9 },
+        { symbol: 'B', changePct: 10, close: 100, high: 100, volume: 1000, avgVol50d: 1000, marketCap: 1e9 },
+        { symbol: 'C', changePct: 15, close: 100, high: 100, volume: 1000, avgVol50d: 1000, marketCap: 1e9 },
+      ] as Parameters<typeof rankByCompositeScore>[0];
+      const ranked = rankByCompositeScore(candidates);
+      expect(ranked).toHaveLength(3);
+    });
+
+    it('preserve les objets originaux (pas de mutation)', () => {
+      const original = { symbol: 'X', changePct: 5, close: 100, high: 100, volume: 1000, avgVol50d: 1000, marketCap: 1e9 };
+      const ranked = rankByCompositeScore([original as Parameters<typeof rankByCompositeScore>[0][number]]);
+      expect(ranked[0]).toBe(original); // même référence
+    });
+
+    it('liste vide → vide', () => {
+      expect(rankByCompositeScore([])).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/composite-ranker.helper.ts
+++ b/apps/api/src/modules/lisa/services/composite-ranker.helper.ts
@@ -1,0 +1,136 @@
+/**
+ * Composite Ranker — Phase 1 du refactor scanner (Option C).
+ *
+ * Re-classe les candidats remontés par EODHD screener selon un score composite
+ * au lieu du tri brut `refund_1d_p.desc` qui ne ramène que les paraboliques.
+ *
+ * Score = w1·sweetSpotProximity + w2·volumeStrength + w3·notAtPeakBonus
+ *       + w4·mcapTier - w5·parabolicPenalty
+ *
+ *   sweetSpotProximity : 1 = au sweet-spot 3-8% changePct, 0 = très loin
+ *   volumeStrength     : clamp(volumeRatio / 2, 0, 1) — surge volume = signal
+ *   notAtPeakBonus     : 1 - closeToHighRatio — plus on est sous le high, plus on respire
+ *   mcapTier           : tier 0 (<100M) à 1 (>10B), préférence mid/large pour liquidité
+ *   parabolicPenalty   : pénalité forte si changePct > 12% (= au-delà du sweet-spot)
+ *
+ * Architecture additive : remplace UNIQUEMENT l'ordre des candidats. Tous les
+ * candidats remontés par EODHD restent dans la liste, juste mieux triés.
+ * Mistral voit les mêmes fields, juste dans un ordre différent.
+ *
+ * Gated par env SCANNER_COMPOSITE_RANKING_ENABLED (default OFF) → zero risque
+ * de régression. Si OFF, tri inchangé par refund_1d_p desc.
+ *
+ * Poids paramétrables via SCANNER_COMPOSITE_WEIGHTS (CSV 5 valeurs).
+ *
+ * Pas d'effet sur le set de candidats envoyés au TRADER — juste le top-N change.
+ */
+
+import type { TopGainerCandidate } from '@smartvest/ai-analyst';
+
+/** Poids du score composite. Somme libre (le score est utilisé pour ranking, pas pour seuil absolu). */
+export interface CompositeWeights {
+  w1_sweetSpot: number;
+  w2_volume: number;
+  w3_notAtPeak: number;
+  w4_mcap: number;
+  w5_parabolicPenalty: number;
+}
+
+export const DEFAULT_COMPOSITE_WEIGHTS: CompositeWeights = {
+  w1_sweetSpot: 0.30,
+  w2_volume: 0.25,
+  w3_notAtPeak: 0.20,
+  w4_mcap: 0.10,
+  w5_parabolicPenalty: 0.15,
+};
+
+/** Parse "0.3,0.25,0.2,0.1,0.15" en CompositeWeights. Fallback DEFAULT si invalide. */
+export function parseCompositeWeights(raw: string | undefined): CompositeWeights {
+  if (!raw || raw.trim().length === 0) return DEFAULT_COMPOSITE_WEIGHTS;
+  const parts = raw.split(',').map((p) => Number(p.trim()));
+  if (parts.length !== 5 || parts.some((p) => !Number.isFinite(p) || p < 0)) {
+    return DEFAULT_COMPOSITE_WEIGHTS;
+  }
+  return {
+    w1_sweetSpot: parts[0],
+    w2_volume: parts[1],
+    w3_notAtPeak: parts[2],
+    w4_mcap: parts[3],
+    w5_parabolicPenalty: parts[4],
+  };
+}
+
+/** Sweet-spot proximity: cloche centrée sur 5.5% (= milieu du range gagnant 3-8%). */
+function sweetSpotProximity(changePct: number): number {
+  if (!Number.isFinite(changePct)) return 0;
+  const target = 5.5;
+  const sigma = 3; // largeur de la cloche : tolère 3-8 confortablement
+  const z = (changePct - target) / sigma;
+  return Math.max(0, Math.exp(-(z * z) / 2));
+}
+
+/** Volume strength: clamp volumeRatio/2 à [0,1]. RVOL 2x = score max. */
+function volumeStrength(volumeRatio: number | null | undefined): number {
+  if (volumeRatio == null || !Number.isFinite(volumeRatio)) return 0;
+  return Math.max(0, Math.min(1, volumeRatio / 2));
+}
+
+/** Not-at-peak bonus: 1 - closeToHighRatio. Plus on est sous le high, plus on a de marge. */
+function notAtPeakBonus(closeToHighRatio: number | null | undefined): number {
+  if (closeToHighRatio == null || !Number.isFinite(closeToHighRatio)) return 0;
+  return Math.max(0, Math.min(1, 1 - closeToHighRatio));
+}
+
+/** Mcap tier: 0 si <100M, 0.5 si 100M-1B, 1 si >1B. Préférence liquidité. */
+function mcapTier(marketCap: number | null | undefined): number {
+  if (marketCap == null || !Number.isFinite(marketCap) || marketCap <= 0) return 0;
+  if (marketCap >= 1_000_000_000) return 1;
+  if (marketCap >= 100_000_000) return 0.5;
+  return 0;
+}
+
+/** Parabolic penalty: 0 si <8%, ramp up vers 1 à 25%. Tue les Korean limit-up +30%. */
+function parabolicPenalty(changePct: number): number {
+  if (!Number.isFinite(changePct)) return 0;
+  if (changePct <= 8) return 0;
+  if (changePct >= 25) return 1;
+  return (changePct - 8) / 17; // linéaire entre 8 et 25
+}
+
+/** Compute le score composite d'un candidat. Retourne valeur dans ~[-0.15, 0.85]. */
+export function computeCompositeScore(
+  c: { changePct?: number; close?: number; high?: number; volume?: number; avgVol50d?: number; marketCap?: number },
+  weights: CompositeWeights = DEFAULT_COMPOSITE_WEIGHTS,
+): number {
+  const changePct = c.changePct ?? 0;
+  const close = c.close ?? 0;
+  const high = c.high ?? close;
+  const volumeRatio = (c.avgVol50d ?? 0) > 0 ? (c.volume ?? 0) / (c.avgVol50d ?? 1) : null;
+  const closeToHighRatio = high > 0 ? close / high : null;
+
+  const score =
+    weights.w1_sweetSpot * sweetSpotProximity(changePct)
+    + weights.w2_volume * volumeStrength(volumeRatio)
+    + weights.w3_notAtPeak * notAtPeakBonus(closeToHighRatio)
+    + weights.w4_mcap * mcapTier(c.marketCap)
+    - weights.w5_parabolicPenalty * parabolicPenalty(changePct);
+
+  return score;
+}
+
+/**
+ * Re-rank une liste de candidats par score composite (décroissant).
+ * Les candidats avec score plus haut viennent en premier.
+ *
+ * Ne supprime AUCUN candidat — juste re-trie. Préserve l'objet original
+ * (immutable pour le caller).
+ */
+export function rankByCompositeScore(
+  candidates: TopGainerCandidate[],
+  weights: CompositeWeights = DEFAULT_COMPOSITE_WEIGHTS,
+): TopGainerCandidate[] {
+  return [...candidates]
+    .map((c) => ({ c, score: computeCompositeScore(c, weights) }))
+    .sort((a, b) => b.score - a.score)
+    .map(({ c }) => c);
+}

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -26,6 +26,7 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 import { EodhdLoggerService } from './eodhd-logger.service';
 // PR #345 — filtres TwelveData (Supertrend US + RSI crypto)
 import { TwelveDataService, type MarketMover } from './twelve-data.service';
+import { rankByCompositeScore, parseCompositeWeights } from './composite-ranker.helper';
 import { evaluateTwelveDataFilters } from './twelve-data-scanner-filters';
 import { QwDecisionLoggerService } from '../quick-wins/qw-decision-logger.service';
 import { CronJob } from 'cron';
@@ -1701,6 +1702,26 @@ export class TopGainersScannerService implements OnModuleInit {
         // candidat dans le shadow batch). Conservateur — le coût réel est >=1.
         this.logger.log(`[top-gainers] ${formatFilterLog(filter, 1)}`);
       }
+    }
+
+    // Phase 1 refactor scanner — Composite Ranking (env-gated, default OFF).
+    // Re-trie les candidats par score composite au lieu du tri brut
+    // refund_1d_p.desc (qui ne ramène que les paraboliques). Architecture
+    // additive : aucun candidat supprimé, juste re-ordre. Cf. composite-
+    // ranker.helper.ts pour la formule.
+    //
+    // Si flag OFF : ordre inchangé (tri exchange-level refund_1d_p.desc).
+    // Si flag ON  : sweet-spot (3-8% changePct) rankent au-dessus des
+    // paraboliques (>12%) → Mistral voit les bons candidats en premier.
+    const rankingEnabled = (this.config.get<string>('SCANNER_COMPOSITE_RANKING_ENABLED') ?? 'false').toLowerCase() === 'true';
+    if (rankingEnabled) {
+      const weights = parseCompositeWeights(this.config.get<string>('SCANNER_COMPOSITE_WEIGHTS'));
+      const before = finalCandidates.length > 0 ? `${finalCandidates[0].symbol}(${finalCandidates[0].changePct?.toFixed(1)}%)` : 'empty';
+      finalCandidates = rankByCompositeScore(finalCandidates, weights);
+      const after = finalCandidates.length > 0 ? `${finalCandidates[0].symbol}(${finalCandidates[0].changePct?.toFixed(1)}%)` : 'empty';
+      this.logger.log(
+        `[top-gainers] composite ranking applied — top1 before=${before} after=${after} weights=${JSON.stringify(weights)}`,
+      );
     }
 
     // P19s++ — Cache fill (TTL 15min). Permet aux UI polls et au cron scanner


### PR DESCRIPTION
## Phase 1/5 — Refactor scanner Option C

Premier étage du refactor visant à débloquer Mistral (0 trade depuis activation 5h matin).

## Problème adressé

Audit ce matin :
- Scanner sort=`refund_1d_p.desc` → ramène uniquement les paraboliques (Korean limit-up +30%, Shanghai +20%)
- Mistral applique correctement `PULLBACK_WAIT_KTOS_LESSON` → hold systématique
- **0 trade en 6h** parce que sweet-spot 3-8% (lesson `aa6eda5f` WR-positive historique) jamais remonté

## Solution Phase 1

**Re-tri client-side par score composite** APRÈS le fetch EODHD :

```
score = w1·sweetSpotProximity (cloche centrée 5.5%, sigma 3)
      + w2·volumeStrength (volumeRatio/2 clampé [0,1])
      + w3·notAtPeakBonus (1 - closeToHighRatio)
      + w4·mcapTier (0 if <100M, 0.5 if 100M-1B, 1 if >1B)
      - w5·parabolicPenalty (ramp linéaire 8% → 25%)
```

Défaut weights : `0.30, 0.25, 0.20, 0.10, 0.15` (configurable env CSV).

## Architecture additive (ZÉRO régression)

- Aucun candidat supprimé (univers EODHD inchangé)
- Re-tri seulement → Mistral reçoit les mêmes 50 candidats mais dans un ordre différent
- Gated par `SCANNER_COMPOSITE_RANKING_ENABLED` (default OFF) → comportement identique à actuel si flag OFF
- Activation : `fly secrets set SCANNER_COMPOSITE_RANKING_ENABLED=true -a smartvest`

## Effet attendu si flag ON

Cycle scanner Asia, avant :
```
top 50 = [37560.KO +30%, 66575.KO +29.9%, 90360.KQ +30%, ...] → Mistral hold (paraboliques)
```

Cycle scanner Asia, après :
```
top 50 = [SWEET.XYZ +5.2% vol2x, ..., 37560.KO +30%] → Mistral pourra trouver des opens
```

Mistral garde son veto final (lessons + risk gates) → max risk = il hold quand même = état actuel.

## Test plan
- [x] CI typecheck vert
- [x] 14 nouveaux tests unitaires composite-ranker (sweet-spot > parabolique, no mutation, etc.)
- [x] 165 tests scanner existants restent verts
- [ ] Post-deploy, flag reste OFF → tri identique vérifié
- [ ] Activer flag → observer log "composite ranking applied — top1 before=X after=Y"
- [ ] Mesurer si Mistral ouvre des trades sweet-spot

## Phases suivantes (refactor Option C)

- Phase 2 : time-series momentum (gradient %/min, accel) → enrichissement candidats
- Phase 3 : bucket classification (sweet_spot_rising / peak_parabolic) + system prompt update
- Phase 4 : A/B shadow comparator v1 vs v2
- Phase 5 : ML classifier `p_rise_next_3min` (optionnel)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_