### PR TITLE
feat(scanner): Phase 2 — momentum analyzer + bucket classification (env-gated, OFF)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/momentum-analyzer.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/momentum-analyzer.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests Momentum Analyzer — Phase 2 du refactor scanner.
+ * Vérifie que les métriques distinguent rising / stalled / reversing.
+ */
+
+import { computeMomentumMetrics, classifyBucket, type Candle } from '../momentum-analyzer.helper';
+
+/** Helper : génère une candle synthétique. */
+function candle(ts: number, close: number, volume = 1000, range = 0.5): Candle {
+  return {
+    timestamp: ts,
+    open: close - range / 2,
+    high: close + range / 2,
+    low: close - range / 2,
+    close,
+    volume,
+  };
+}
+
+describe('Momentum Analyzer', () => {
+  describe('computeMomentumMetrics', () => {
+    it('returns NEUTRAL on empty input', () => {
+      const m = computeMomentumMetrics([]);
+      expect(m.sampleSize).toBe(0);
+      expect(m.risingScore).toBe(0.5);
+    });
+
+    it('returns NEUTRAL on insufficient candles (<3)', () => {
+      const m = computeMomentumMetrics([candle(0, 100), candle(60, 101)]);
+      expect(m.sampleSize).toBe(0);
+    });
+
+    it('rising trend (close monotone increasing): gradient positif, risingScore > 0.6', () => {
+      const candles = [
+        candle(0, 100, 1000),
+        candle(60, 101, 1100),
+        candle(120, 102, 1200),
+        candle(180, 103, 1300),
+        candle(240, 104, 1400),
+        candle(300, 105, 1500),
+      ];
+      const m = computeMomentumMetrics(candles);
+      expect(m.gradientPctPerMin).toBeGreaterThan(0);
+      expect(m.risingScore).toBeGreaterThan(0.55);
+    });
+
+    it('falling trend: gradient négatif, risingScore < 0.4', () => {
+      const candles = [
+        candle(0, 105),
+        candle(60, 104),
+        candle(120, 103),
+        candle(180, 102),
+        candle(240, 101),
+        candle(300, 100),
+      ];
+      const m = computeMomentumMetrics(candles);
+      expect(m.gradientPctPerMin).toBeLessThan(0);
+      expect(m.risingScore).toBeLessThan(0.45);
+    });
+
+    it('flat / stalled: gradient ≈ 0, risingScore proche de 0.5', () => {
+      const candles = [
+        candle(0, 100),
+        candle(60, 100.1),
+        candle(120, 99.9),
+        candle(180, 100),
+        candle(240, 100.05),
+        candle(300, 100),
+      ];
+      const m = computeMomentumMetrics(candles);
+      expect(Math.abs(m.gradientPctPerMin)).toBeLessThan(0.05);
+      expect(m.risingScore).toBeGreaterThan(0.4);
+      expect(m.risingScore).toBeLessThan(0.7);
+    });
+
+    it('accelerating (slow start, fast end): acceleration positive', () => {
+      const candles = [
+        candle(0, 100),
+        candle(60, 100.1),
+        candle(120, 100.2),
+        candle(180, 101),
+        candle(240, 102),
+        candle(300, 103.5),
+      ];
+      const m = computeMomentumMetrics(candles);
+      expect(m.acceleration).toBeGreaterThan(0);
+    });
+
+    it('decelerating (fast start, slow end): acceleration négative', () => {
+      const candles = [
+        candle(0, 100),
+        candle(60, 101.5),
+        candle(120, 102.5),
+        candle(180, 103),
+        candle(240, 103.1),
+        candle(300, 103.2),
+      ];
+      const m = computeMomentumMetrics(candles);
+      expect(m.acceleration).toBeLessThan(0);
+    });
+
+    it('volume surge: volumeMomentum > 1', () => {
+      const candles = [
+        candle(0, 100, 1000),
+        candle(60, 101, 1000),
+        candle(120, 102, 1100),
+        candle(180, 103, 2000),
+        candle(240, 104, 3000),
+        candle(300, 105, 4000),
+      ];
+      const m = computeMomentumMetrics(candles);
+      expect(m.volumeMomentum).toBeGreaterThan(1.5);
+    });
+
+    it('handles unsorted input (sorts by timestamp)', () => {
+      const candles = [
+        candle(300, 105),
+        candle(0, 100),
+        candle(180, 103),
+        candle(60, 101),
+        candle(240, 104),
+        candle(120, 102),
+      ];
+      const m = computeMomentumMetrics(candles);
+      expect(m.gradientPctPerMin).toBeGreaterThan(0);
+      expect(m.sampleSize).toBe(6);
+    });
+
+    it('handles zero/null first close safely', () => {
+      const candles = [
+        candle(0, 0),
+        candle(60, 100),
+        candle(120, 101),
+      ];
+      const m = computeMomentumMetrics(candles);
+      expect(Number.isFinite(m.gradientPctPerMin)).toBe(true);
+    });
+  });
+
+  describe('classifyBucket', () => {
+    const baseRising = { gradientPctPerMin: 0.05, acceleration: 0.02, volumeMomentum: 1.2, verticalityScore: 0.3, risingScore: 0.7, sampleSize: 6 };
+    const baseReversing = { gradientPctPerMin: -0.15, acceleration: -0.05, volumeMomentum: 0.8, verticalityScore: 0.5, risingScore: 0.3, sampleSize: 6 };
+
+    it('sweet_spot_rising : changePct ∈ [3,12] + risingScore > 0.55', () => {
+      expect(classifyBucket(5, 0.9, baseRising)).toBe('sweet_spot_rising');
+    });
+
+    it('peak_parabolic : changePct > 12 + closeToHigh > 0.95', () => {
+      expect(classifyBucket(20, 0.99, baseRising)).toBe('peak_parabolic');
+    });
+
+    it('early_mover : changePct ∈ [0.5,3] + accel positive', () => {
+      expect(classifyBucket(1.5, 0.9, baseRising)).toBe('early_mover');
+    });
+
+    it('reversing : gradient < -0.1 quelle que soit changePct', () => {
+      expect(classifyBucket(5, 0.9, baseReversing)).toBe('reversing');
+    });
+
+    it('stalled : tout le reste (sweet-spot mais momentum faible)', () => {
+      const stalled = { ...baseRising, risingScore: 0.5, gradientPctPerMin: 0.01 };
+      expect(classifyBucket(5, 0.9, stalled)).toBe('stalled');
+    });
+  });
+});

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -1684,6 +1684,10 @@ Recommendation rules :
       volumeRatio,
       kellyMaxNotional,
       sweetSpotEntry,
+      // Phase 2 refactor scanner — momentum + bucket (présents si
+      // SCANNER_MOMENTUM_ANALYSIS_ENABLED=true côté scanner, sinon undefined).
+      ...(c.momentum ? { momentum: c.momentum } : {}),
+      ...(c.bucket ? { bucket: c.bucket } : {}),
     };
   }
 

--- a/apps/api/src/modules/lisa/services/momentum-analyzer.helper.ts
+++ b/apps/api/src/modules/lisa/services/momentum-analyzer.helper.ts
@@ -1,0 +1,166 @@
+/**
+ * Momentum Analyzer — Phase 2 du refactor scanner Option C.
+ *
+ * Analyse time-series sur les dernières candles intraday d'un candidat :
+ *   - gradientPctPerMin  : vitesse moyenne de progression (% par minute)
+ *   - acceleration       : changement de vitesse récente vs ancienne
+ *   - volumeMomentum     : ratio volume récent vs volume earlier
+ *   - verticalityScore   : pump vertical vs progression échelonnée
+ *   - risingScore        : score composite 0-1 résumant la dynamique
+ *
+ * Le risingScore permet à Mistral de distinguer :
+ *   - "rising 5%" (= gradient positif, volume montant, accel positive)
+ *   - "stalled at 5%" (= gradient proche de 0)
+ *   - "rolling over from 8%" (= gradient négatif récent après hausse)
+ *
+ * Pure helpers : reçoivent un tableau de candles (timestamp + ohlcv) et
+ * retournent les métriques. Aucun appel réseau ici — le caller fetch les
+ * candles séparément (intraday-router ou EODHD).
+ */
+
+export interface Candle {
+  timestamp: number; // unix epoch seconds
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface MomentumMetrics {
+  /** Gradient moyen (% par minute) sur la fenêtre complète. Positif = rising, négatif = falling. */
+  gradientPctPerMin: number;
+  /** Différence gradient(récent 1/3) - gradient(ancien 1/3). Positif = en accélération. */
+  acceleration: number;
+  /** volume_recent_third / volume_earlier_third. >1 = momentum volume monte, <1 = descend. */
+  volumeMomentum: number;
+  /** Score 0-1 : 1 = pump vertical (range high-low concentré dans peu de candles), 0 = progression douce. */
+  verticalityScore: number;
+  /** Score composite 0-1 résumant la dynamique. Utilisé comme signal LLM. */
+  risingScore: number;
+  /** Nombre de candles utilisées (pour debug / sanity). */
+  sampleSize: number;
+}
+
+const NEUTRAL_METRICS: MomentumMetrics = {
+  gradientPctPerMin: 0,
+  acceleration: 0,
+  volumeMomentum: 1,
+  verticalityScore: 0,
+  risingScore: 0.5,
+  sampleSize: 0,
+};
+
+/**
+ * Computes momentum metrics from a series of intraday candles.
+ *
+ * Conventions :
+ *  - candles triées par timestamp CROISSANT (plus ancien → plus récent)
+ *  - retourne NEUTRAL si <3 candles (échantillon insuffisant)
+ *  - le risingScore est dans [0, 1] :
+ *      0   = clairement reversing (gradient négatif fort)
+ *      0.5 = idle / neutre
+ *      1   = clairement rising (gradient + accel + volume tous positifs)
+ */
+export function computeMomentumMetrics(candles: Candle[]): MomentumMetrics {
+  if (!Array.isArray(candles) || candles.length < 3) return { ...NEUTRAL_METRICS };
+
+  // Trie défensivement par timestamp
+  const sorted = [...candles].sort((a, b) => a.timestamp - b.timestamp);
+  const n = sorted.length;
+  const first = sorted[0];
+  const last = sorted[n - 1];
+  const spanMin = Math.max(1, (last.timestamp - first.timestamp) / 60);
+
+  // 1. Gradient global (% par min) sur la fenêtre entière
+  const gradientPctPerMin = first.close > 0
+    ? ((last.close - first.close) / first.close) * 100 / spanMin
+    : 0;
+
+  // 2. Acceleration : gradient récent (tiers final) - gradient ancien (tiers initial)
+  const third = Math.floor(n / 3);
+  const earlySlice = sorted.slice(0, Math.max(2, third));
+  const recentSlice = sorted.slice(n - Math.max(2, third));
+  const earlyGradient = computeSliceGradient(earlySlice);
+  const recentGradient = computeSliceGradient(recentSlice);
+  const acceleration = recentGradient - earlyGradient;
+
+  // 3. Volume momentum : volume récent / volume ancien
+  const earlyVol = earlySlice.reduce((s, c) => s + c.volume, 0) / Math.max(1, earlySlice.length);
+  const recentVol = recentSlice.reduce((s, c) => s + c.volume, 0) / Math.max(1, recentSlice.length);
+  const volumeMomentum = earlyVol > 0 ? recentVol / earlyVol : 1;
+
+  // 4. Verticality : range (high-low) / nombre de candles non-doji
+  // Un pump vertical concentre le mouvement dans peu de candles.
+  const maxHigh = Math.max(...sorted.map((c) => c.high));
+  const minLow = Math.min(...sorted.map((c) => c.low));
+  const totalRange = maxHigh - minLow;
+  const movingCandles = sorted.filter((c) => Math.abs(c.close - c.open) / Math.max(1e-9, c.open) > 0.001).length;
+  const verticalityScore = totalRange > 0 && movingCandles > 0
+    ? Math.min(1, totalRange / minLow / Math.max(1, movingCandles) * 100)
+    : 0;
+
+  // 5. Rising score composite (0-1)
+  //   gradient positif fort → contribution +
+  //   acceleration positive → contribution +
+  //   volume momentum > 1   → contribution +
+  //   verticality élevée    → contribution - (= pump-and-dump)
+  const gradComp = sigmoid(gradientPctPerMin * 4); // sensible à ±0.25%/min
+  const accelComp = sigmoid(acceleration * 4);
+  const volComp = sigmoid((volumeMomentum - 1) * 2); // 1 = neutre, >1 = bonus
+  const vertPenalty = Math.max(0, Math.min(1, verticalityScore));
+  const risingScore = Math.max(0, Math.min(1,
+    0.40 * gradComp
+    + 0.30 * accelComp
+    + 0.20 * volComp
+    - 0.10 * vertPenalty
+    + 0.20 // base : si tout neutre on est à 0.5
+  ));
+
+  return {
+    gradientPctPerMin,
+    acceleration,
+    volumeMomentum,
+    verticalityScore,
+    risingScore,
+    sampleSize: n,
+  };
+}
+
+/** Sigmoid logistique pour mapper R → (0,1). */
+function sigmoid(x: number): number {
+  if (!Number.isFinite(x)) return 0.5;
+  if (x > 10) return 1;
+  if (x < -10) return 0;
+  return 1 / (1 + Math.exp(-x));
+}
+
+/** Gradient (%/min) sur une tranche : (close_last - close_first) / close_first / span_min × 100. */
+function computeSliceGradient(slice: Candle[]): number {
+  if (slice.length < 2) return 0;
+  const first = slice[0];
+  const last = slice[slice.length - 1];
+  const spanMin = Math.max(1, (last.timestamp - first.timestamp) / 60);
+  if (first.close <= 0) return 0;
+  return ((last.close - first.close) / first.close) * 100 / spanMin;
+}
+
+/**
+ * Classifie un candidat en bucket selon les métriques (utilisé Phase 3).
+ * Exposé ici pour facilité de test, mais le bucket est computé Phase 3.
+ */
+export function classifyBucket(
+  changePct: number,
+  closeToHighRatio: number,
+  metrics: MomentumMetrics,
+): 'sweet_spot_rising' | 'peak_parabolic' | 'early_mover' | 'stalled' | 'reversing' {
+  // Reversing : gradient récent négatif sur fenêtre récente
+  if (metrics.gradientPctPerMin < -0.1) return 'reversing';
+  // Peak parabolic : changePct élevé + au peak
+  if (changePct > 12 && closeToHighRatio > 0.95) return 'peak_parabolic';
+  // Sweet spot rising : changePct entre 3 et 12 + dynamique positive
+  if (changePct >= 3 && changePct <= 12 && metrics.risingScore > 0.55) return 'sweet_spot_rising';
+  // Early mover : petit move avec accel positive (peut décoller)
+  if (changePct >= 0.5 && changePct < 3 && metrics.acceleration > 0) return 'early_mover';
+  return 'stalled';
+}

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -27,6 +27,7 @@ import { EodhdLoggerService } from './eodhd-logger.service';
 // PR #345 — filtres TwelveData (Supertrend US + RSI crypto)
 import { TwelveDataService, type MarketMover } from './twelve-data.service';
 import { rankByCompositeScore, parseCompositeWeights } from './composite-ranker.helper';
+import { computeMomentumMetrics, classifyBucket, type Candle as MomentumCandle } from './momentum-analyzer.helper';
 import { evaluateTwelveDataFilters } from './twelve-data-scanner-filters';
 import { QwDecisionLoggerService } from '../quick-wins/qw-decision-logger.service';
 import { CronJob } from 'cron';
@@ -1724,11 +1725,110 @@ export class TopGainersScannerService implements OnModuleInit {
       );
     }
 
+    // Phase 2 refactor scanner — Momentum Analysis (env-gated, default OFF).
+    // Pour les top-N candidats post-ranking, fetch les candles intraday récentes
+    // (5m × 12 = ~1h) et calcule {gradientPctPerMin, acceleration, volumeMomentum,
+    // verticalityScore, risingScore} + classifyBucket(). Permet à Mistral de
+    // distinguer "rising 5%" vs "stalled at 5%" vs "rolling over from 8%".
+    //
+    // Coût : N fetches intraday (EODHD ou Binance) par cycle. Cap top-N pour
+    // borner. Échecs silencieux → candidat sans `momentum`/`bucket` (back-compat).
+    const momentumEnabled = (this.config.get<string>('SCANNER_MOMENTUM_ANALYSIS_ENABLED') ?? 'false').toLowerCase() === 'true';
+    if (momentumEnabled) {
+      const topN = Number(this.config.get<string>('SCANNER_MOMENTUM_TOP_N') ?? '20');
+      finalCandidates = await this.enrichTopNWithMomentum(finalCandidates, topN);
+    }
+
     // P19s++ — Cache fill (TTL 15min). Permet aux UI polls et au cron scanner
     // de partager la même fetch sans re-frapper EODHD.
     this.allCandidatesCache = { candidates: finalCandidates, asOf: now.getTime() };
     this.recordFetchAllCandidates(finalCandidates.length, false);
     return finalCandidates;
+  }
+
+  /**
+   * Phase 2 refactor scanner — Enrichit les top-N candidats avec momentum
+   * time-series. Fetch les candles intraday récentes (5m × 12 ≈ 1h) puis
+   * calcule les métriques via computeMomentumMetrics() + classifyBucket().
+   *
+   * Concurrence : cap 5 fetches en parallèle pour éviter de saturer EODHD/Binance.
+   * Échecs silencieux : si le fetch ou le compute échoue, le candidat retourne
+   * sans `momentum`/`bucket` (back-compat, Mistral le verra comme avant).
+   *
+   * Crypto → BinanceMarketService.getKlines (openTime ms → timestamp sec normalisé).
+   * Equities → EodhdIntradayService.getCandles (timestamp déjà en secondes).
+   */
+  private async enrichTopNWithMomentum(
+    candidates: TopGainerCandidate[],
+    topN: number,
+  ): Promise<TopGainerCandidate[]> {
+    if (candidates.length === 0) return candidates;
+    const head = candidates.slice(0, topN);
+    const tail = candidates.slice(topN);
+
+    const enriched: TopGainerCandidate[] = [];
+    const CONCURRENCY = 5;
+    for (let i = 0; i < head.length; i += CONCURRENCY) {
+      const batch = head.slice(i, i + CONCURRENCY);
+      const results = await Promise.all(
+        batch.map(async (c) => {
+          try {
+            const candles = await this.fetchMomentumCandles(c);
+            if (!candles || candles.length < 3) return c;
+            const metrics = computeMomentumMetrics(candles);
+            const closeToHighRatio = c.high > 0 ? c.close / c.high : 0;
+            const bucket = classifyBucket(c.changePct ?? 0, closeToHighRatio, metrics);
+            return { ...c, momentum: metrics, bucket };
+          } catch (e) {
+            this.logger.debug(`[momentum] ${c.symbol} enrich failed: ${String(e).slice(0, 80)}`);
+            return c;
+          }
+        }),
+      );
+      enriched.push(...results);
+    }
+
+    const enrichedCount = enriched.filter((c) => c.momentum).length;
+    if (enrichedCount > 0) {
+      const sample = enriched.slice(0, 3).map((c) => {
+        if (!c.momentum) return `${c.symbol}:none`;
+        return `${c.symbol}:bucket=${c.bucket}/rising=${c.momentum.risingScore.toFixed(2)}`;
+      }).join(' ');
+      this.logger.log(`[top-gainers] momentum enriched ${enrichedCount}/${head.length} top-N — sample: ${sample}`);
+    }
+
+    return [...enriched, ...tail];
+  }
+
+  /**
+   * Fetch candles intraday pour un candidat. Crypto → Binance 5m × 12.
+   * Equity → EODHD intraday 5m × 12. Normalise le timestamp en secondes.
+   */
+  private async fetchMomentumCandles(c: TopGainerCandidate): Promise<MomentumCandle[] | null> {
+    const isCrypto = c.assetClass === 'crypto_major' || c.assetClass === 'crypto_alt';
+    if (isCrypto) {
+      const klines = await this.binanceMarket.getKlines(c.symbol, '5m', 12);
+      if (!klines || klines.length === 0) return null;
+      return klines.map((k) => ({
+        timestamp: Math.floor(k.openTime / 1000),
+        open: k.open,
+        high: k.high,
+        low: k.low,
+        close: k.close,
+        volume: k.volume,
+      }));
+    }
+    if (!this.eodhdIntraday) return null;
+    const series = await this.eodhdIntraday.getCandles(c.symbol, '5m', 12);
+    if (!series || series.candles.length === 0) return null;
+    return series.candles.map((cd) => ({
+      timestamp: cd.timestamp,
+      open: cd.open,
+      high: cd.high,
+      low: cd.low,
+      close: cd.close,
+      volume: cd.volume,
+    }));
   }
 
   /**

--- a/packages/ai-analyst/src/strategies/top-gainers-filter.ts
+++ b/packages/ai-analyst/src/strategies/top-gainers-filter.ts
@@ -123,6 +123,17 @@ export interface TopGainerCandidate {
   volume: number;
   avgVol50d: number;
   marketCap: number;
+  /** Phase 2 refactor scanner — métriques momentum time-series (optionnelles). */
+  momentum?: {
+    gradientPctPerMin: number;
+    acceleration: number;
+    volumeMomentum: number;
+    verticalityScore: number;
+    risingScore: number;
+    sampleSize: number;
+  };
+  /** Phase 2/3 refactor — bucket classification ('sweet_spot_rising', 'peak_parabolic', etc.). */
+  bucket?: 'sweet_spot_rising' | 'peak_parabolic' | 'early_mover' | 'stalled' | 'reversing';
 }
 
 export interface TopGainerEvaluation {


### PR DESCRIPTION
## Pourquoi

Phase 1 (composite ranking, #565) ré-ordonne les candidats mais ne dit pas à Mistral si un candidat 5 % est en train de **monter**, de **stagner** ou de **retracer**. Phase 2 ajoute les métriques time-series qui permettent cette distinction.

## Quoi

- `momentum-analyzer.helper.ts` — pure helper :
  - `computeMomentumMetrics(candles)` → `{ gradientPctPerMin, acceleration, volumeMomentum, verticalityScore, risingScore, sampleSize }`
  - `classifyBucket(changePct, closeToHighRatio, metrics)` → `'sweet_spot_rising' | 'peak_parabolic' | 'early_mover' | 'stalled' | 'reversing'`
- `TopGainerCandidate` : champs optionnels `momentum` + `bucket` (back-compat total)
- `TopGainersScannerService.enrichTopNWithMomentum()` :
  - Fetch candles intraday `5m × 12` (≈ 1 h) — Binance pour crypto, EODHD intraday pour equities
  - Calcule les métriques + classify, attache aux candidats
  - Concurrence cap 5 fetches parallèles, échecs silencieux (back-compat)
- `LiveTraderAgentService.enrichCandidateWithMath` : forward `momentum`/`bucket` si présents → Mistral voit le `risingScore` + `bucket` dans son user prompt JSON
- Tests : 15 specs momentum-analyzer (gradient/accel/volume/buckets/edge cases)

## Gating

- `SCANNER_MOMENTUM_ANALYSIS_ENABLED=true` (default `false`)
- `SCANNER_MOMENTUM_TOP_N=20` (default `20`)

**Sans le flag : zero impact runtime.** `finalCandidates` inchangé.

## Coût

- ≤ 20 fetches intraday/cycle quand activé (5m × 12 candles par symbole)
- Concurrence 5 parallèle → ~3 s overhead max

## Test plan

- [x] `momentum-analyzer.spec.ts` (15 tests, ✅ verts)
- [x] `composite-ranker.spec.ts` (14 tests, ✅ verts — Phase 1 non régressée)
- [x] `top-gainers-scanner.*.spec.ts` (165 tests, ✅ verts)
- [x] `tsc --noEmit` clean
- [ ] Post-merge : vérifier deploy Fly avec health 200, flag OFF (zero impact attendu)
- [ ] Activation `SCANNER_MOMENTUM_ANALYSIS_ENABLED=true` en suivi séparé après baseline shadow

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_