### PR TITLE
feat(scanner): Phase 4 — momentum shadow comparator (A/B logging, env-gated, OFF)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/scanner-momentum-shadow.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/scanner-momentum-shadow.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests Scanner Momentum Shadow — Phase 4 du refactor scanner.
+ * Vérifie agrégation bucket distribution + résolution chosen.
+ */
+
+import { summarizeMomentumDecisions, ShadowCandidate } from '../scanner-momentum-shadow.helper';
+
+function cand(symbol: string, opts: Partial<ShadowCandidate> = {}): ShadowCandidate {
+  return {
+    symbol,
+    exchange: 'US',
+    close: 100,
+    high: 105,
+    changePct: 5,
+    volume: 1_000_000,
+    avgVol50d: 500_000,
+    marketCap: 1e9,
+    ...opts,
+  };
+}
+
+describe('Scanner Momentum Shadow', () => {
+  it('counts candidates total + with momentum', () => {
+    const candidates = [
+      cand('AAA', { momentum: { gradientPctPerMin: 0.1, acceleration: 0.05, volumeMomentum: 1.5, verticalityScore: 0.2, risingScore: 0.75, sampleSize: 6 }, bucket: 'sweet_spot_rising' }),
+      cand('BBB'), // pas de momentum
+      cand('CCC', { momentum: { gradientPctPerMin: -0.15, acceleration: -0.05, volumeMomentum: 0.8, verticalityScore: 0.5, risingScore: 0.25, sampleSize: 6 }, bucket: 'reversing' }),
+    ];
+    const s = summarizeMomentumDecisions(candidates, null);
+    expect(s.candidatesTotal).toBe(3);
+    expect(s.candidatesWithMomentum).toBe(2);
+  });
+
+  it('bucket distribution agrège correctement', () => {
+    const candidates = [
+      cand('A', { bucket: 'sweet_spot_rising' }),
+      cand('B', { bucket: 'sweet_spot_rising' }),
+      cand('C', { bucket: 'peak_parabolic' }),
+      cand('D', { bucket: 'stalled' }),
+      cand('E'), // unclassified
+    ];
+    const s = summarizeMomentumDecisions(candidates, null);
+    expect(s.bucketDistribution).toEqual({
+      sweet_spot_rising: 2,
+      peak_parabolic: 1,
+      stalled: 1,
+      unclassified: 1,
+    });
+  });
+
+  it('topByRising trié par risingScore desc, max 5', () => {
+    const candidates = Array.from({ length: 8 }, (_, i) =>
+      cand(`S${i}`, {
+        momentum: { gradientPctPerMin: 0.1, acceleration: 0.01, volumeMomentum: 1, verticalityScore: 0.1, risingScore: i / 10, sampleSize: 6 },
+        bucket: 'sweet_spot_rising',
+      }),
+    );
+    const s = summarizeMomentumDecisions(candidates, null);
+    expect(s.topByRising).toHaveLength(5);
+    expect(s.topByRising[0].risingScore).toBe(0.7); // i=7
+    expect(s.topByRising[4].risingScore).toBe(0.3); // i=3
+  });
+
+  it('resolves chosenSymbol → chosenBucket / chosenRisingScore', () => {
+    const candidates = [
+      cand('TARGET', {
+        changePct: 5.5,
+        momentum: { gradientPctPerMin: 0.1, acceleration: 0.02, volumeMomentum: 1.2, verticalityScore: 0.2, risingScore: 0.72, sampleSize: 6 },
+        bucket: 'sweet_spot_rising',
+      }),
+      cand('OTHER'),
+    ];
+    const s = summarizeMomentumDecisions(candidates, 'TARGET');
+    expect(s.chosenSymbol).toBe('TARGET');
+    expect(s.chosenBucket).toBe('sweet_spot_rising');
+    expect(s.chosenRisingScore).toBe(0.72);
+    expect(s.chosenChangePct).toBe(5.5);
+  });
+
+  it('chosenSymbol absent du pool → tous nullables', () => {
+    const candidates = [cand('AAA', { bucket: 'sweet_spot_rising' })];
+    const s = summarizeMomentumDecisions(candidates, 'UNKNOWN');
+    expect(s.chosenSymbol).toBe('UNKNOWN');
+    expect(s.chosenBucket).toBeNull();
+    expect(s.chosenRisingScore).toBeNull();
+  });
+
+  it('Phase 2 OFF (zéro momentum) — summary valide, baseline A/B utilisable', () => {
+    const candidates = [cand('A'), cand('B'), cand('C')];
+    const s = summarizeMomentumDecisions(candidates, null);
+    expect(s.candidatesTotal).toBe(3);
+    expect(s.candidatesWithMomentum).toBe(0);
+    expect(s.bucketDistribution).toEqual({ unclassified: 3 });
+    expect(s.topByRising).toEqual([]);
+  });
+
+  it('liste vide → summary safe', () => {
+    const s = summarizeMomentumDecisions([], null);
+    expect(s.candidatesTotal).toBe(0);
+    expect(s.candidatesWithMomentum).toBe(0);
+    expect(s.bucketDistribution).toEqual({});
+    expect(s.topByRising).toEqual([]);
+    expect(s.chosenSymbol).toBeNull();
+  });
+});

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -36,6 +36,7 @@ import { TopGainersScannerService } from './top-gainers-scanner.service';
 import { PushNotificationsService } from './push-notifications.service';
 import { MistralShadowService } from './mistral-shadow.service';
 import { MistralLargeShadowService } from './mistral-large-shadow.service';
+import { summarizeMomentumDecisions } from './scanner-momentum-shadow.helper';
 import type { TopGainerCandidate } from '@smartvest/ai-analyst';
 
 const TRADER_AGENT_PORTFOLIO_ID = 'b0000001-0000-0000-0000-000000000001';
@@ -796,6 +797,28 @@ export class LiveTraderAgentService {
         });
       } catch (e) {
         this.logger.error(`[trader-agent] logDecision failed (cycle ran but trace lost): ${String(e).slice(0, 200)}`);
+      }
+
+      // Phase 4 refactor scanner — Momentum Shadow Comparator (env-gated, default OFF).
+      // Capture bucket distribution + chosen bucket dans lisa_decision_log pour analyse
+      // offline : winRate par bucket, A/B Phase 2 ON vs OFF. Aucun effet sur la décision.
+      const shadowEnabled = (this.config.get<string>('SCANNER_AB_SHADOW_ENABLED') ?? 'false').toLowerCase() === 'true';
+      if (shadowEnabled) {
+        try {
+          const chosenSymbol = decision.action_kind === 'open_directional' ? (decision.symbol ?? null) : null;
+          const summary = summarizeMomentumDecisions(candidates as Array<Record<string, unknown>>, chosenSymbol);
+          await this.supabase.getClient().from('lisa_decision_log').insert({
+            portfolio_id: TRADER_AGENT_PORTFOLIO_ID,
+            kind: 'scanner_momentum_shadow',
+            payload: {
+              cycle_started_at: cycleStartedAt.toISOString(),
+              action_kind: decision.action_kind,
+              ...summary,
+            },
+          });
+        } catch (e) {
+          this.logger.debug(`[trader-agent] momentum shadow log failed: ${String(e).slice(0, 120)}`);
+        }
       }
 
       // LISA refonte B.1 — parse markers thèse + insert citations

--- a/apps/api/src/modules/lisa/services/scanner-momentum-shadow.helper.ts
+++ b/apps/api/src/modules/lisa/services/scanner-momentum-shadow.helper.ts
@@ -1,0 +1,112 @@
+/**
+ * Scanner Momentum Shadow Comparator — Phase 4 du refactor scanner.
+ *
+ * Capture la distribution des buckets dans le pool de candidats fed à TRADER +
+ * le bucket choisi par Mistral. Permet l'analyse offline :
+ *   - Quels buckets Mistral préfère-t-il (sweet_spot_rising vs peak_parabolic) ?
+ *   - Quel est le winRate par bucket sur N jours ?
+ *   - Le composite ranking + momentum aide-t-il vs legacy refund_1d_p.desc ?
+ *
+ * Aucun effet sur la décision — pur logging. Persistance via decision_log
+ * (kind='scanner_momentum_shadow').
+ *
+ * Gating env : SCANNER_AB_SHADOW_ENABLED (default OFF). Marche que Phase 2 soit
+ * ON ou OFF — si OFF, candidatesWithMomentum=0 (utile pour A/B baseline).
+ */
+
+/**
+ * Shape minimal d'un candidat post-enrichCandidateWithMath. On ne dépend pas
+ * de TopGainerCandidate ici car le caller (TRADER) manipule la version
+ * enrichie `Record<string, unknown>` dans laquelle momentum/bucket sont
+ * forwardés par enrichCandidateWithMath (Phase 2).
+ */
+export interface ShadowCandidate {
+  symbol?: unknown;
+  changePct?: unknown;
+  bucket?: unknown;
+  momentum?: { risingScore?: unknown } | unknown;
+  [key: string]: unknown;
+}
+
+export interface MomentumShadowSummary {
+  /** Total candidats dans le pool fed à TRADER ce cycle. */
+  candidatesTotal: number;
+  /** Combien ont un champ `momentum` peuplé (= Phase 2 ON + fetch OK). */
+  candidatesWithMomentum: number;
+  /** Distribution des buckets (count par bucket). */
+  bucketDistribution: Record<string, number>;
+  /** Top 5 candidats par risingScore (debug + spot-check). */
+  topByRising: Array<{ symbol: string; bucket: string | null; risingScore: number; changePct: number }>;
+  /** Symbole choisi par Mistral, si action_kind = open_directional. */
+  chosenSymbol: string | null;
+  /** Bucket du symbole choisi (null si Mistral a hold ou si Phase 2 OFF). */
+  chosenBucket: string | null;
+  /** risingScore du symbole choisi (null si Phase 2 OFF). */
+  chosenRisingScore: number | null;
+  /** changePct du symbole choisi. */
+  chosenChangePct: number | null;
+}
+
+/**
+ * Construit un MomentumShadowSummary à partir du pool de candidats + de la
+ * décision Mistral (symbol choisi, ou null si hold).
+ */
+export function summarizeMomentumDecisions(
+  candidates: ShadowCandidate[],
+  chosenSymbol: string | null,
+): MomentumShadowSummary {
+  const getRising = (c: ShadowCandidate): number | null => {
+    const m = c.momentum as { risingScore?: unknown } | undefined;
+    if (!m || typeof m.risingScore !== 'number') return null;
+    return m.risingScore;
+  };
+  const getBucket = (c: ShadowCandidate): string | null =>
+    typeof c.bucket === 'string' ? c.bucket : null;
+  const getSymbol = (c: ShadowCandidate): string =>
+    typeof c.symbol === 'string' ? c.symbol : '';
+  const getChangePct = (c: ShadowCandidate): number | null =>
+    typeof c.changePct === 'number' ? c.changePct : null;
+
+  const candidatesTotal = candidates.length;
+  const candidatesWithMomentum = candidates.filter((c) => getRising(c) !== null).length;
+
+  const bucketDistribution: Record<string, number> = {};
+  for (const c of candidates) {
+    const b = getBucket(c) ?? 'unclassified';
+    bucketDistribution[b] = (bucketDistribution[b] ?? 0) + 1;
+  }
+
+  const topByRising = [...candidates]
+    .filter((c) => getRising(c) !== null)
+    .sort((a, b) => (getRising(b) ?? 0) - (getRising(a) ?? 0))
+    .slice(0, 5)
+    .map((c) => ({
+      symbol: getSymbol(c),
+      bucket: getBucket(c),
+      risingScore: Math.round((getRising(c) ?? 0) * 100) / 100,
+      changePct: Math.round((getChangePct(c) ?? 0) * 100) / 100,
+    }));
+
+  let chosenBucket: string | null = null;
+  let chosenRisingScore: number | null = null;
+  let chosenChangePct: number | null = null;
+  if (chosenSymbol) {
+    const match = candidates.find((c) => getSymbol(c) === chosenSymbol);
+    if (match) {
+      chosenBucket = getBucket(match);
+      chosenRisingScore = getRising(match);
+      chosenChangePct = getChangePct(match);
+    }
+  }
+
+  return {
+    candidatesTotal,
+    candidatesWithMomentum,
+    bucketDistribution,
+    topByRising,
+    chosenSymbol,
+    chosenBucket,
+    chosenRisingScore,
+    chosenChangePct,
+  };
+}


### PR DESCRIPTION
## Pourquoi

- Phase 2 (#566) : attache `momentum` + `bucket` aux candidats.
- Phase 3 (#567) : explique à Mistral comment lire ces champs.
- Phase 4 (ce PR) : capture la **distribution des buckets** dans le pool + le **bucket choisi** par Mistral, pour analyse offline.

Permet de répondre par SQL aux questions :
- Quel bucket Mistral préfère-t-il (`sweet_spot_rising` vs `peak_parabolic` vs `early_mover`) ?
- Quel `winRate` par bucket sur N jours (join `lisa_decision_log` × `lisa_positions`) ?
- Le composite ranking + momentum aide-t-il vs legacy `refund_1d_p.desc` ? (A/B comparant cycles avec Phase 2 ON vs OFF)

## Quoi

- `scanner-momentum-shadow.helper.ts` :
  - `summarizeMomentumDecisions(candidates, chosenSymbol) → MomentumShadowSummary`
  - Champs : `candidatesTotal`, `candidatesWithMomentum`, `bucketDistribution` (count par bucket), `topByRising` (top 5 par risingScore), `chosenSymbol/Bucket/RisingScore/ChangePct`
- `LiveTraderAgentService` cycle : après `logDecision` principal, si flag activé, insère row `lisa_decision_log` `kind='scanner_momentum_shadow'` avec le summary
- Tests : 7 specs (counts, distribution, topByRising sort+cap, chosen resolution, chosen-not-in-pool, Phase 2 OFF baseline, liste vide)

## Gating

- `SCANNER_AB_SHADOW_ENABLED=true` (default `false`)

Marche que Phase 2 soit ON ou OFF (baseline A/B utilisable). Aucune migration : utilise `lisa_decision_log` existant (`kind='scanner_momentum_shadow'`, `payload` JSONB).

## Requête SQL d'analyse (post-collecte)

```sql
-- winRate par bucket choisi sur les 7 derniers jours
SELECT
  payload->>'chosenBucket' as bucket,
  COUNT(*) as n_decisions,
  COUNT(*) FILTER (WHERE p.realized_pnl_usd > 0) as n_wins,
  ROUND(100.0 * COUNT(*) FILTER (WHERE p.realized_pnl_usd > 0) / NULLIF(COUNT(p.id), 0), 1) as win_rate_pct,
  ROUND(AVG(p.realized_pnl_usd)::numeric, 2) as avg_pnl_usd
FROM lisa_decision_log dl
LEFT JOIN lisa_positions p ON p.symbol = dl.payload->>'chosenSymbol'
  AND p.entry_timestamp >= dl.timestamp::timestamptz
  AND p.entry_timestamp < dl.timestamp::timestamptz + interval '5 minutes'
WHERE dl.kind = 'scanner_momentum_shadow'
  AND dl.timestamp >= now() - interval '7 days'
  AND dl.payload->>'chosenSymbol' IS NOT NULL
GROUP BY 1
ORDER BY 4 DESC NULLS LAST;
```

## Test plan

- [x] `tsc --noEmit` clean
- [x] 201 tests verts (scanner + trader-agent + 4 helpers Phase 1-4)
- [ ] Post-merge : vérifier deploy Fly health 200, flag OFF → aucun changement
- [ ] Activation `SCANNER_MOMENTUM_ANALYSIS_ENABLED=true` + `SCANNER_AB_SHADOW_ENABLED=true` ensuite, collecter 24-72h de shadow logs, puis décision GO/NOGO sur full prod

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_