### PR TITLE
fix(scanner): Phase 1-bis — preserve composite order in fetchTopCandidates

### DIFF
--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -1602,7 +1602,18 @@ Recommendation rules :
         const pool = tradeable.length > 0
           ? tradeable
           : candidates.filter((c) => (c.changePct ?? 0) <= feedMax);
-        const sorted = [...pool].sort((a, b) => (b.changePct ?? 0) - (a.changePct ?? 0));
+        // Phase 1-bis refactor scanner — Si composite ranking actif côté scanner,
+        // PRÉSERVER l'ordre du pool (déjà rangé par composite score décroissant
+        // dans fetchAllCandidates). Sans ce check, le sort changePct DESC ci-dessous
+        // écrase tout le travail Phase 1 et Mistral voit à nouveau les paraboliques
+        // en premier. Bug observé 02/06 09:21 UTC après deploy Phase 1-4 :
+        //   "composite ranking applied — top1=M44.XETRA(5.5%)"
+        //   "trader-agent hold — all candidates parabolic >13%"
+        // Cause : sort DESC re-mettait SDR.AU(10.9%) avant M44.XETRA(5.5%).
+        const rankingEnabled = (this.config.get<string>('SCANNER_COMPOSITE_RANKING_ENABLED') ?? 'false').toLowerCase() === 'true';
+        const sorted = rankingEnabled
+          ? pool
+          : [...pool].sort((a, b) => (b.changePct ?? 0) - (a.changePct ?? 0));
         if (sorted.length > 0) {
           this.logger.debug(
             `[trader-agent] feed: ${candidates.length} scanned → ${sorted.length} in band [${feedMin},${feedMax}]% → top ${Math.min(n, sorted.length)} (capital=$${currentCapital.toFixed(0)})`,


### PR DESCRIPTION
## Bug observé en prod 02/06 09:21 UTC après deploy Phase 1-4

```
[top-gainers] composite ranking applied — top1=M44.XETRA(5.5%) (sweet-spot)
[trader-agent] hold — all candidates are in a parabolic state with changePct >13%
```

**Contradiction frontale.** Le composite ranking dit "top1 = sweet-spot 5.5 %", mais Mistral (via Gemini fallback) voit "tous les candidats à >13 %".

## Cause racine

`fetchTopCandidates` re-sortait DESC sur `changePct` après le composite ranking, écrasant tout le travail Phase 1 :

```ts
// AVANT (live-trader-agent.service.ts:1605)
const sorted = [...pool].sort((a, b) => (b.changePct ?? 0) - (a.changePct ?? 0));
return sorted.slice(0, n)...
```

→ Mistral voyait à nouveau les paraboliques en premier comme avant le refactor. Le log `composite ranking applied` était cosmétique, aucun effet réel sur les décisions.

## Fix

Si `SCANNER_COMPOSITE_RANKING_ENABLED=true`, préserver l'ordre du pool (déjà rangé par composite score décroissant dans `fetchAllCandidates`). Sinon legacy sort DESC sur changePct.

```ts
const rankingEnabled = (this.config.get<string>('SCANNER_COMPOSITE_RANKING_ENABLED') ?? 'false').toLowerCase() === 'true';
const sorted = rankingEnabled
  ? pool
  : [...pool].sort((a, b) => (b.changePct ?? 0) - (a.changePct ?? 0));
```

## Effet attendu post-merge

Au prochain cycle TRADER, Mistral verra le top-50 dans l'ordre composite (sweet-spot d'abord, paraboliques en queue de liste) au lieu de l'ordre `changePct DESC`. Les décisions devraient enfin refléter le re-ranking Phase 1.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 201 tests verts (scanner + trader-agent + helpers Phase 1-4)
- [ ] Post-merge : vérifier au cycle suivant que le log `[trader-agent] feed: ...` contient bien un top-1 sweet-spot vs parabolique
- [ ] Confirmer que Mistral cite `[BUCKET=...]` dans sa thesis (Phase 3 prompt block)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_