### PR TITLE
fix(health): scanner-pulse fallback sur trader_agent_decisions en mode gainers

### DIFF
--- a/apps/api/src/modules/health/__tests__/scanner-pulse.spec.ts
+++ b/apps/api/src/modules/health/__tests__/scanner-pulse.spec.ts
@@ -17,7 +17,14 @@ function makeRes() {
   };
 }
 
-function makeSupabase(opts: { hasPortfolio: boolean; lastCycleTs: string | null; cfgErr?: string; logErr?: string }) {
+function makeSupabase(opts: {
+  hasPortfolio: boolean;
+  lastCycleTs: string | null;
+  cfgErr?: string;
+  logErr?: string;
+  traderTs?: string | null;
+  traderErr?: string;
+}) {
   return {
     getClient: () => ({
       from: (table: string) => {
@@ -32,6 +39,21 @@ function makeSupabase(opts: { hasPortfolio: boolean; lastCycleTs: string | null;
                       error: opts.cfgErr ? { message: opts.cfgErr } : null,
                     }),
                   }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === 'trader_agent_decisions') {
+          // Fallback chain post-fix 02/06 : .select().order().limit() — sans .eq().
+          return {
+            select: () => ({
+              order: () => ({
+                limit: async () => ({
+                  data: opts.traderErr
+                    ? null
+                    : (opts.traderTs ? [{ cycle_started_at: opts.traderTs }] : []),
+                  error: opts.traderErr ? { message: opts.traderErr } : null,
                 }),
               }),
             }),
@@ -117,6 +139,51 @@ describe('ScannerPulseController.getPulse', () => {
     const res = makeRes();
     const r = await ctrl.getPulse(res as any);
     expect(r.status).toBe('idle');
+    expect(res.statusCode).toBe(200);
+  });
+
+  // Fix 02/06/2026 — En mode strategy_mode='gainers', autopilot Lisa LLM skip et
+  // n'écrit plus `autopilot_cycle_completed`. Le pulse doit fallback sur le
+  // dernier `trader_agent_decisions.cycle_started_at` pour ne pas être stale à tort.
+  it('fallback trader_agent_decisions si autopilot stale mais trader cycle frais', async () => {
+    const staleAutopilot = new Date(Date.now() - 30 * 60_000).toISOString(); // 30min ago
+    const freshTrader = new Date(Date.now() - 60_000).toISOString(); // 1min ago
+    const ctrl = new ScannerPulseController(
+      makeSupabase({ hasPortfolio: true, lastCycleTs: staleAutopilot, traderTs: freshTrader }),
+      cfgService(),
+    );
+    const res = makeRes();
+    const r = await ctrl.getPulse(res as any);
+    expect(r.status).toBe('healthy');
+    expect(res.statusCode).toBe(200);
+    expect((r as any).age_sec).toBeLessThan(120);
+  });
+
+  it('stale 503 si autopilot stale ET trader_agent_decisions stale aussi', async () => {
+    const staleAutopilot = new Date(Date.now() - 30 * 60_000).toISOString();
+    const staleTrader = new Date(Date.now() - 25 * 60_000).toISOString();
+    const ctrl = new ScannerPulseController(
+      makeSupabase({ hasPortfolio: true, lastCycleTs: staleAutopilot, traderTs: staleTrader }),
+      cfgService(),
+    );
+    const res = makeRes();
+    const r = await ctrl.getPulse(res as any);
+    expect(r.status).toBe('stale');
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('autopilot null + trader cycle frais → healthy (mode gainers pure)', async () => {
+    const freshTrader = new Date(Date.now() - 60_000).toISOString();
+    const ctrl = new ScannerPulseController(
+      makeSupabase({ hasPortfolio: true, lastCycleTs: null, traderTs: freshTrader }),
+      cfgService(),
+    );
+    const res = makeRes();
+    const r = await ctrl.getPulse(res as any);
+    // lastCycleTs=null → premier short-circuit "healthy" car le code retourne healthy
+    // dès que rows vide. La fallback trader n'est pas exercée dans ce cas (acceptable :
+    // l'autopilot n'a juste jamais cyclé, le pulse considère "premier boot prod").
+    expect(r.status).toBe('healthy');
     expect(res.statusCode).toBe(200);
   });
 });

--- a/apps/api/src/modules/health/scanner-pulse.controller.ts
+++ b/apps/api/src/modules/health/scanner-pulse.controller.ts
@@ -90,7 +90,35 @@ export class ScannerPulseController {
       return { status: 'idle', last_cycle_at: null, age_sec: null, max_age_sec: maxAgeSec };
     }
 
-    const lastTs = rows && rows.length > 0 ? rows[0].timestamp : null;
+    let lastTs: string | null = rows && rows.length > 0 ? rows[0].timestamp : null;
+
+    // Fix 02/06/2026 — En mode strategy_mode='gainers', l'autopilot Lisa LLM skip
+    // ("Lisa LLM cycle skipped") et n'écrit donc plus `autopilot_cycle_completed`.
+    // Le pulse devenait stale même si le TRADER cron tournait normalement toutes
+    // les 2min via `trader_agent_decisions`. Bug observé 02/06 09:25 UTC : pulse
+    // stale 21h alors que les logs montraient des cycles scanner à 07:21/07:22.
+    // Fallback : si pas de marker autopilot récent, prendre le plus récent
+    // `trader_agent_decisions.cycle_started_at` comme preuve d'activité.
+    const lastAutopilotAgeSec = lastTs
+      ? Math.floor((Date.now() - new Date(lastTs).getTime()) / 1000)
+      : Number.MAX_SAFE_INTEGER;
+    if (lastAutopilotAgeSec > maxAgeSec) {
+      const { data: traderRows, error: traderErr } = await client
+        .from('trader_agent_decisions')
+        .select('cycle_started_at')
+        .order('cycle_started_at', { ascending: false })
+        .limit(1);
+      if (!traderErr && traderRows && traderRows.length > 0) {
+        const traderTs = (traderRows[0] as { cycle_started_at?: string }).cycle_started_at ?? null;
+        if (traderTs) {
+          const traderAgeSec = Math.floor((Date.now() - new Date(traderTs).getTime()) / 1000);
+          // Prend le plus récent des deux signaux (autopilot OU trader-agent).
+          if (lastTs == null || traderAgeSec < lastAutopilotAgeSec) {
+            lastTs = traderTs;
+          }
+        }
+      }
+    }
     if (!lastTs) {
       // Jamais cyclé (premier boot prod) — on tolère, le 1er cycle va venir.
       return { status: 'healthy', last_cycle_at: null, age_sec: null, max_age_sec: maxAgeSec };


### PR DESCRIPTION
## Bug

`/health/scanner-pulse` retournait `status=stale` avec `age_sec=75918` (21h) alors que le scanner cron tournait toutes les 5min (vu logs 07:21, 07:22 UTC).

## Cause

Le pulse cherchait uniquement le marker `autopilot_cycle_completed` dans `lisa_decision_log`. En mode `strategy_mode='gainers'`, l'autopilot Lisa LLM skip (`"Lisa LLM cycle skipped"`) et n'écrit donc plus ce marker. Le TRADER cron tourne via son propre cron `*/2 * * * *` et écrit dans `trader_agent_decisions`, hors du pulse legacy.

Le healthcheck Fly aurait dû tuer la machine sur ce signal — perte de la zombie-detection.

## Fix

Si `autopilot_cycle_completed` est stale (> `SCANNER_PULSE_MAX_AGE_MIN`), fallback sur le plus récent `trader_agent_decisions.cycle_started_at`. Prend le plus récent des deux comme `last_cycle_at`.

## Test plan

- [x] tsc clean
- [ ] Post-merge : `curl https://smartvest.fly.dev/health/scanner-pulse` doit retourner `status=healthy` avec `age_sec < 300`

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_