### PR TITLE
feat(scanner-llm): option SCANNER_MISTRAL_FALLBACK_USE_FAST (carte secours, default OFF)

### DIFF
--- a/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
+++ b/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
@@ -220,7 +220,24 @@ export class ScannerLlmRouterService {
         this.logger.warn(
           `[scanner-llm] Mistral primary failed → fallback vers Gemini Pro. err=${String(e).slice(0, 200)}`,
         );
-        // tombe sur Gemini Pro ci-dessous
+        // 02/06/2026 — Si SCANNER_MISTRAL_FALLBACK_USE_FAST=true, on saute la chain
+        // Pro et on tombe directement sur le fast chain (Gemini Flash-Lite). Économie
+        // ~46× vs Pro ($0.001 vs $0.046 par cycle). Cas d'usage : pendant un incident
+        // Mistral prolongé (clé révoquée, support en cours) pour minimiser le coût
+        // sans dégrader l'UX trader. Flash-Lite reste capable des décisions standard.
+        const useFastFallback = (this.config.get<string>('SCANNER_MISTRAL_FALLBACK_USE_FAST') ?? 'false').toLowerCase() === 'true';
+        if (useFastFallback && this.router) {
+          this.logger.log('[scanner-llm] SCANNER_MISTRAL_FALLBACK_USE_FAST=true → skip Gemini Pro, use fast chain');
+          const res = await this.router.call(params);
+          return {
+            content: res.content,
+            providerId: `${res.providerId}-mistral-fallback-fast`,
+            costUsd: res.costUsd,
+            latencyMs: res.latencyMs,
+            fallbackUsed: true,
+          };
+        }
+        // tombe sur Gemini Pro ci-dessous (comportement legacy)
       }
     }
 


### PR DESCRIPTION
## Pourquoi

Pendant l'incident Mistral en cours (clé 401, support contacté), `callWithPro` fallback sur **Gemini Pro** à $0.046/cycle ≈ **$33/jour** silencieusement. Acceptable court terme mais coûteux si l'incident dure.

Ce PR ajoute une **option opt-in** pour, pendant un incident Mistral prolongé, sauter Gemini Pro et tomber directement sur la **fast chain (Gemini Flash-Lite)** à $0.001/cycle = **~46× moins cher**.

## Quoi

- Nouveau secret env : `SCANNER_MISTRAL_FALLBACK_USE_FAST` (default `false`)
- Si `true` ET Mistral fail : skip Gemini Pro, route directement vers `router.call()` (fast chain Flash-Lite)
- `providerId` taggé `*-mistral-fallback-fast` pour traçabilité dans `trader_agent_decisions`
- Logs explicites : `[scanner-llm] SCANNER_MISTRAL_FALLBACK_USE_FAST=true → skip Gemini Pro, use fast chain`

## Default OFF — strictement opt-in

Sans toi qui sets le secret à `true`, **zero changement** vs comportement actuel (Mistral fail → Gemini Pro). PR safe à merger comme carte de secours dans le tiroir.

## Quand activer

- Mistral down >5-7 jours et le coût Gemini Pro commence à peser
- Trader décisions standard (pas A++ critique)
- **JAMAIS en permanence** — Pro reste préférable pour le raisonnement multi-facteurs

## Filets de sécurité aval

Même si Flash-Lite ouvre un trade médiocre, les protections en aval restent actives :
- RiskMonitor Gemini Pro (close auto > confidence 0.8)
- Macro veto Gemini
- Stops mécaniques TP/SL absolus

## Test plan

- [x] tsc clean
- [ ] Post-merge : flag reste OFF par défaut, vérifier que les logs Mistral fail → Gemini Pro continuent comme avant

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_