### PR TITLE
fix(trader): unblock XETRA mid/large caps + add 25 crypto fallback prices

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -3783,10 +3783,41 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
   private getFallbackPrice(symbol: string): string | null {
     const s = symbol.toUpperCase().replace('-', '');
     const prices: Record<string, string> = {
-      // Crypto
+      // Crypto majors (CRYPTO_PAIRS)
       'BTC': '79000', 'BTCUSDT': '79000', 'BTCSPOT': '79000', 'BTCUSD': '79000',
       'ETH': '1800', 'ETHUSDT': '1800', 'ETHSPOT': '1800',
-      'SOL': '130', 'BNB': '550', 'XRP': '2.1', 'ADA': '0.7',
+      'SOL': '130', 'SOLUSDT': '130',
+      'BNB': '550', 'BNBUSDT': '550',
+      'XRP': '2.1', 'XRPUSDT': '2.1',
+      'ADA': '0.7', 'ADAUSDT': '0.7',
+      // Crypto alts (CRYPTO_ALTS) — Bug observé 02/06 : ICPUSDT pump 4/6
+      // persistence score=0.67 mais skip cause `fallback_unknown`. Ces
+      // fallbacks débloquent les opens crypto quand Binance temporairement
+      // indispo. Prix indicatifs juin 2026, à recalibrer trimestriellement.
+      'DOT': '7', 'DOTUSDT': '7',
+      'POL': '0.30', 'POLUSDT': '0.30', 'MATIC': '0.30', 'MATICUSDT': '0.30',
+      'AVAX': '40', 'AVAXUSDT': '40',
+      'LINK': '18', 'LINKUSDT': '18',
+      'DOGE': '0.15', 'DOGEUSDT': '0.15',
+      'SHIB': '0.000020', 'SHIBUSDT': '0.000020',
+      'TRX': '0.15', 'TRXUSDT': '0.15',
+      'ATOM': '7', 'ATOMUSDT': '7',
+      'LTC': '90', 'LTCUSDT': '90',
+      'UNI': '7', 'UNIUSDT': '7',
+      'AAVE': '115', 'AAVEUSDT': '115',
+      'ARB': '0.70', 'ARBUSDT': '0.70',
+      'OP': '1.5', 'OPUSDT': '1.5',
+      'SUI': '1.3', 'SUIUSDT': '1.3',
+      'APT': '7', 'APTUSDT': '7',
+      'SEI': '0.45', 'SEIUSDT': '0.45',
+      'TIA': '5', 'TIAUSDT': '5',
+      'BCH': '400', 'BCHUSDT': '400',
+      'INJ': '14', 'INJUSDT': '14',
+      'NEAR': '5', 'NEARUSDT': '5',
+      'ICP': '7', 'ICPUSDT': '7',
+      'STX': '1.5', 'STXUSDT': '1.5',
+      'FIL': '4', 'FILUSDT': '4',
+      'IMX': '1', 'IMXUSDT': '1',
       // Métaux & matières premières
       'GOLD': '3300', 'GC': '3300', 'GLD': '310', 'IAU': '50',
       'SILVER': '33', 'SLV': '31', 'SI': '33',

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -2170,12 +2170,32 @@ Si momentum/bucket absents (Phase 2 désactivée ou fetch échoué), ignore ces 
       // LISA refonte A.4 — Cap dynamique 45% du capital actuel (composé).
       const dynamicCap = Math.round((await this.fetchCurrentCapital()) * 0.45);
       const notional = Math.max(MIN_NOTIONAL_USD, Math.min(dynamicCap, decision.notional_usd));
-      // XETRA small-cap blacklist (28/05/2026) — 2 incidents : SNG.XETRA -$35
-      // (gap SL slippage) + QH9.XETRA -$132 (gap -12% non capté par polling SL).
-      // XETRA small-caps notionnel < $3000 = liquidité trop mince pour gérer
-      // les gaps intra-session. Bloque pour Trader Agent.
-      if (decision.symbol.endsWith('.XETRA') && notional < 3000) {
-        return { applied: false, error: 'XETRA small-cap blacklist (notional <$3000) — anti-gap risk' };
+      // XETRA notional gate (28/05/2026, recalibré 02/06/2026 logs cycle 10:26-10:28).
+      //
+      // Origine : 2 incidents SNG.XETRA -$35 + QH9.XETRA -$132 sur small-caps
+      // peu liquides. Gate initial $3000 min anti-gap.
+      //
+      // Bug observé 02/06 : MSF.XETRA (Münchener Rück, mid-cap €60B) bloqué
+      // 2 cycles d'affilée avec notional=$1300 (= Kelly cap HORS_TRAJ sizing×0.7).
+      // Le LLM décide open conf=0.80 mais apply rejected → trade perdu.
+      //
+      // Fix : bypass le gate pour les mid/large caps XETRA (marketCap >= $5B).
+      // Le gap-and-fade qui motivait le gate n'affecte que les small-caps peu
+      // liquides. Mid/large caps comme MSF (Munich Re), SAP, SIEMENS, ALV, BMW
+      // ont un orderbook suffisant pour absorber un notional $1000-3000.
+      // Le min absolu reste $1000 pour éviter dust trades.
+      if (decision.symbol.endsWith('.XETRA')) {
+        const sym = decision.symbol.toUpperCase();
+        const candidate = candidates.find((c) => String(c.symbol ?? '').toUpperCase() === sym);
+        const mcap = Number(candidate?.marketCap ?? 0);
+        const isMidLargeCap = mcap >= 5_000_000_000; // $5B
+        const minNotional = isMidLargeCap ? 1000 : 3000;
+        if (notional < minNotional) {
+          return {
+            applied: false,
+            error: `XETRA notional gate (mcap=${(mcap / 1e9).toFixed(1)}B, ${isMidLargeCap ? 'mid/large' : 'small'}-cap min=$${minNotional})`,
+          };
+        }
       }
 
       // ASIA OPENING SUFFIX BAN (28/05/2026 soirée, MFE/MAE 3w n=250 asia_equity).


### PR DESCRIPTION
## 2 trous identifiés dans logs prod cycle 10:26-10:28 UTC

### TROU D — XETRA mid/large caps bloquées (applyDecision)

```
[trader-agent] ⚠️ open_directional MSF.XETRA conf=0.80 — applyResult.applied=false
reason='XETRA small-cap blacklist (notional <$3000) — anti-gap risk'
```

**Cause** : le gate $3000 min calibré 28/05 sur 2 incidents small-caps (SNG -$35, QH9 -$132) bloque maintenant **MSF.XETRA (Münchener Rück, mid-cap €60B)** à $1300 (Kelly cap HORS_TRAJ × 0.7). Le LLM décide open 2 cycles d'affilée, apply rejected à chaque fois.

**Fix** : marketCap >= $5B → min $1000 (mid/large cap, orderbook profond, pas de gap risk). Sinon (small-cap) → min $3000 préservé.

```ts
const mcap = Number(candidate?.marketCap ?? 0);
const isMidLargeCap = mcap >= 5_000_000_000;
const minNotional = isMidLargeCap ? 1000 : 3000;
```

### TROU E — Crypto alts bloqués par fallback_unknown

```
ICPUSDT persistence=4/6 score=0.67 pathEff=0.26 → OPEN
[scanner-llm:signal] ICPUSDT pass=true signal_quality=0.75
[ERROR] No fallback known for ICPUSDT — returning sentinel '0' with source='fallback_unknown'
[top-gainers] ICPUSDT: invalid live price 0 → skip
```

**Cause** : `getFallbackPrice()` ne connaissait que 6 cryptos (BTC, ETH, SOL, BNB, XRP, ADA). Les 24 autres `CRYPTO_ALTS` tombaient en `fallback_unknown` quand Binance temporairement indispo → opens perdus systématiquement.

**Fix** : ajout fallback pour 25 cryptos majors+alts : DOT, MATIC/POL, AVAX, LINK, DOGE, SHIB, TRX, ATOM, LTC, UNI, AAVE, ARB, OP, SUI, APT, SEI, TIA, BCH, INJ, NEAR, ICP, STX, FIL, IMX. Prix indicatifs juin 2026.

## Impact estimé

- **TROU D fix** : +1-2 opens XETRA mid/large caps/jour pendant HORS_TRAJ
- **TROU E fix** : +3-8 opens crypto/jour pendant pump alt-season

## Test plan

- [x] `tsc --noEmit` clean
- [x] **1443 tests verts** (toute la suite lisa + trader-agent)
- [ ] Post-merge : vérifier au prochain cycle qu'un candidat XETRA mid-cap est applied=true (icône ✅) et qu'un crypto alt en pump n'est plus skip "invalid live price 0"

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_