### PR TITLE
fix(trader): forward marketCap dans enrichCandidateWithMath → unblock XETRA mid/large

### DIFF
--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -1712,6 +1712,11 @@ Recommendation rules :
       close,
       high,
       exchange: c.exchange,
+      // Fix 02/06/2026 cycle 11:16 — forward marketCap pour permettre au gate
+      // XETRA notional (applyDecision) de distinguer mid/large cap (mcap≥$5B,
+      // min $1000) des small-caps (min $3000). Sans ce field, candidate.marketCap
+      // est undefined → traité small-cap → MSF.XETRA (€60B) bloqué à $1300.
+      marketCap: c.marketCap,
       // P-KTOS enrichment fields :
       pumpScore,
       closeToHighRatio,


### PR DESCRIPTION
## Bug observé cycle 11:16 UTC après deploy Trou D (sha ec755a6 à 11:08)

```
11:16:36 [trader-agent] ⚠️ open_directional MSF.XETRA conf=0.80 — HORS_TRAJECTOIRE
```

MSF.XETRA reste `⚠️ apply rejected` malgré le fix bypass marketCap≥$5B livré dans PR #573.

## Cause racine

`enrichCandidateWithMath()` retourne l'objet **sans le field `marketCap`**. Donc dans `applyDecision` :

```ts
const candidate = candidates.find((c) => String(c.symbol ?? '').toUpperCase() === sym);
const mcap = Number(candidate?.marketCap ?? 0); // ← undefined → 0
const isMidLargeCap = mcap >= 5_000_000_000;    // → false
const minNotional = isMidLargeCap ? 1000 : 3000; // → 3000 (small-cap)
```

→ MSF (Munich Re, €60B) traité comme small-cap → $1300<$3000 → rejected.

## Fix

Ajout `marketCap: c.marketCap` dans le return statement de `enrichCandidateWithMath`. 5 lignes.

## Test plan

- [x] tsc clean
- [ ] Post-merge : vérifier au prochain cycle TRADER que MSF.XETRA passe à `✅ applied=true` (icône change)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_