### PR TITLE
feat(trader-agent): bridge scanner gates + audit closed_choppy LLM gate

### DIFF
--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -1562,6 +1562,22 @@ Recommendation rules :
   }
 
   private async fetchTopCandidates(n: number): Promise<object[]> {
+    // 02/06/2026 — Scanner-bridge enforcement.
+    // Quand TRADER_ARBITRATION_ENABLED=true, le scanner Gainers INSERT ses candidats
+    // approuvés (post-gates persistence + path_eff + debate + Mistral LLM gate)
+    // dans `scanner_proposals`. Le TRADER LLM doit décider UNIQUEMENT parmi ceux-là —
+    // pas de bypass via fetchAllCandidates() (qui retourne la pool brute pré-gates,
+    // d'où LIN.PA/SBMO/MSF.XETRA ouverts sans validation gate observés 02/06).
+    // Règle métier user : "l'agent trader ne doit sélectionner que parmi ce que lui
+    // propose le scanner gainers, jamais autrement".
+    const arbitrationEnabled = (this.config.get<string>('TRADER_ARBITRATION_ENABLED') ?? 'false').toLowerCase() === 'true';
+    if (arbitrationEnabled) {
+      this.logger.debug(
+        '[trader-agent] TRADER_ARBITRATION_ENABLED=true → fetchTopCandidates returns [] (LLM uses scanner_proposals only)',
+      );
+      return [];
+    }
+
     // COMMIT 1 (29/05) — Lecture directe du cache scanner pour avoir des candidats
     // FRAIS (le snapshot table gainers_persistence_log était peuplé uniquement par
     // l'UI dashboard → jusqu'à 7h de retard). Avec topGainersScanner injecté, on

--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -2069,6 +2069,24 @@ export class MechanicalTradingService {
                   this.logger.warn(`[choppy-exit-llm-gate] ${pos.symbol} validation threw — fail-OPEN, proceed close. err=${String(e).slice(0, 150)}`);
                   return { approved: true, reason: 'llm_gate_exception_fail_open' };
                 });
+                // 02/06/2026 — Audit trace approve+reject (avant : silencieux côté approve,
+                // impossible de tracer après coup pourquoi closed_choppy a tiré sur NESF.LSE).
+                await this.decisionLog.append({
+                  portfolioId: portfolioIdChoppy,
+                  kind: approval.approved ? 'choppy_exit_llm_approved' : 'choppy_exit_llm_blocked',
+                  summary: `[CHOPPY_LLM_GATE] ${pos.symbol} ${approval.approved ? 'APPROVED' : 'BLOCKED'} — ${approval.reason}`,
+                  rationale: approval.reason,
+                  payload: {
+                    symbol: pos.symbol,
+                    position_id: pos.id,
+                    age_min: Math.round(ageMin * 10) / 10,
+                    peak_pnl_pct: Math.round(peakPnlPct * 100) / 100,
+                    monotonicity: Math.round(mono * 100) / 100,
+                    approved: approval.approved,
+                    llm_reason: approval.reason,
+                  },
+                  triggeredBy: 'mechanical_cron',
+                }).catch(() => { /* non-bloquant */ });
                 if (!approval.approved) {
                   this.logger.log(
                     `[choppy-exit-llm-gate] ${pos.symbol} CLOSE BLOCKED by LLM — ${approval.reason} (re-eval next cycle 60s)`,


### PR DESCRIPTION
## Summary

**Bug fix (OPEN)** — Le Live Trader Agent (LLM Gemini Pro/Mistral) appelait `fetchAllCandidates()` directement → court-circuitait les gates du scanner Gainers (persistence, path_eff, debate, Mistral LLM gate PR #540). Observé 02/06 : LIN.PA, SBMO.AS, MSF.XETRA ouverts sans validation gate, dont LIN.PA fermée à -1.88% (SL hit).

Fix : quand `TRADER_ARBITRATION_ENABLED=true` (déjà ON en prod), `fetchTopCandidates` retourne `[]` → le LLM décide UNIQUEMENT parmi les `scanner_proposals` injectées en aval (post-gates). Bridge minimal, réversible via env. Conforme à la règle métier user : *"l'agent trader ne doit sélectionner que parmi ce que lui propose le scanner gainers, jamais autrement"*.

**Improvement (CLOSE)** — Trace audit `closed_choppy` LLM gate (PR #545). Avant : silencieux côté approve, impossible de tracer pourquoi NESF.LSE a été closed à -0.22% en 11 min (le LLM a-t-il été appelé ? approuvé ?). Maintenant : `decisionLog.append` pour approve ET reject avec contexte (`symbol`, `peakPnl`, `monotonicity`, `ageMin`, `llm_reason`).

**Hors scope** (follow-up) :
- SL reste 100% mécanique (backtest sur 15 SL hits : 73% rebound à entry < 60min mais médiane PnL si held = -0.24%, sample biaisé)
- Advisories TP/trail asynchrones via Live Trader Agent (nécessite migration nouvelle table)
- Tuning trailing breakeven 0.5% → 0.3% (DB update, hors PR code)

## Test plan
- [x] `npm run typecheck` — clean
- [x] `jest top-gainers-scanner|scanner-llm-router|mechanical-trading|live-trader-agent` — 23 suites / 220 tests verts
- [ ] Post-deploy : injection vrai positif + faux positif dans `scanner_proposals` pour observer comportement TRADER agent
- [ ] Monitor 24h `lisa_decision_log` kind=`choppy_exit_llm_approved`/`choppy_exit_llm_blocked` pour vérifier que PR #545 trace bien

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_