### PR TITLE
feat(taxonomy): setup_kind + regime_at_entry classifier déterministe v1

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -100,6 +100,8 @@ import {
   computeVenueFeeDetail,
   filterTickersForFetch,
   formatFilterLog,
+  classifySetup,
+  type SetupClassifierInput,
 } from '@smartvest/ai-analyst';
 import { TickerBlacklistService } from './ticker-blacklist.service';
 import { CorrelationGuardService } from './correlation-guard.service';
@@ -5226,6 +5228,41 @@ export class TopGainersScannerService implements OnModuleInit {
       tf30m: persistence.tf30m,
       tf1h: persistence.tf1h,
     };
+
+    // Step 3 chain (02/06/2026) — Classification setup + régime au moment de l'open.
+    // Pure function, idempotente. Fallback graceful sur features disponibles
+    // (TopGainerCandidate + persistence Phase 8 + pathQuality P9-UX +
+    // momentum Phase 2 + bucket Phase 3). V2 ajoutera VWAP/EMA/ATR/ADX/RSI.
+    // Cast vers PersistenceWithPath (pathQuality est runtime-only, cf.
+    // multi-tf-persistence.service.ts:101 — type mismatch historique du
+    // codebase, fix typing graduel hors scope).
+    const persistenceWithPath = persistence as PersistenceResult & {
+      pathQuality?: { overallEfficiency?: number };
+    };
+    const classifierInput: SetupClassifierInput = {
+      changePct: cand.changePct,
+      close: cand.close,
+      high: cand.high,
+      volume: cand.volume,
+      avgVol50d: cand.avgVol50d,
+      persistenceScore: persistence.persistenceScore,
+      ...(persistenceWithPath.pathQuality?.overallEfficiency !== undefined
+        ? { pathEfficiency: persistenceWithPath.pathQuality.overallEfficiency }
+        : {}),
+      ...(cand.momentum
+        ? {
+            momentum: {
+              gradientPctPerMin: cand.momentum.gradientPctPerMin,
+              acceleration: cand.momentum.acceleration,
+              verticalityScore: cand.momentum.verticalityScore,
+              risingScore: cand.momentum.risingScore,
+            },
+          }
+        : {}),
+      ...(cand.bucket ? { bucket: cand.bucket } : {}),
+    };
+    const setupClassification = classifySetup(classifierInput);
+
     const insertRow: Record<string, unknown> = {
       user_id: userId,
       portfolio_id: portfolioId,
@@ -5242,6 +5279,10 @@ export class TopGainersScannerService implements OnModuleInit {
       persistence_score_at_entry: String(persistence.persistenceScore.toFixed(2)),
       persistence_count_at_entry: persistence.persistenceCount,
       tf_changes_at_entry: tfChanges,
+      // Step 3 chain — setup taxonomy (cf. migration 0187 + setup-classifier.ts)
+      setup_kind: setupClassification.setup_kind,
+      regime_at_entry: setupClassification.regime_at_entry,
+      classifier_version: setupClassification.classifier_version,
     };
     // PR #4 — features + p_win + model_version persistés pour boucle apprentissage
     if (pWinMeta) {

--- a/packages/ai-analyst/src/index.ts
+++ b/packages/ai-analyst/src/index.ts
@@ -24,6 +24,7 @@ export * from './strategies/top-gainers-filter';
 export * from './strategies/multi-tf-persistence';
 export * from './strategies/logistic-regression';
 export * from './strategies/empirical-law';
+export * from './strategies/setup-classifier';
 export * from './strategies/path-quality';
 export * from './strategies/bootstrap-ci';
 export * from './backtest/engine';

--- a/packages/ai-analyst/src/strategies/__tests__/setup-classifier.spec.ts
+++ b/packages/ai-analyst/src/strategies/__tests__/setup-classifier.spec.ts
@@ -1,0 +1,388 @@
+/**
+ * Tests SetupClassifier — couvre les 8 setup_kind + 3 régimes + edge cases
+ * dégradation gracieuse selon features disponibles.
+ *
+ * Sources de design pour les seuils :
+ *   - Zarattini SSRN 4729284 (ORB Sharpe 2.81 sur Stocks-in-Play)
+ *   - Agent 5 pseudocode (recherche web 02/06/2026)
+ *   - Marton & Cakir SSRN 4290787 (Hurst)
+ */
+import {
+  classifySetup,
+  CLASSIFIER_VERSION,
+  type SetupClassifierInput,
+} from '../setup-classifier';
+
+// Baseline input minimaliste — features manquent (v1 fallback path)
+function baseInput(overrides: Partial<SetupClassifierInput> = {}): SetupClassifierInput {
+  return {
+    changePct: 3.0,
+    close: 100,
+    high: 100.5,
+    volume: 1_000_000,
+    avgVol50d: 500_000,
+    persistenceScore: 0.5,
+    ...overrides,
+  };
+}
+
+describe('classifySetup — sortie type contract', () => {
+  it('retourne classifier_version v1', () => {
+    expect(classifySetup(baseInput()).classifier_version).toBe(CLASSIFIER_VERSION);
+  });
+
+  it('retourne setup_kind et regime_at_entry non vides', () => {
+    const r = classifySetup(baseInput());
+    expect(r.setup_kind).toBeTruthy();
+    expect(r.regime_at_entry).toBeTruthy();
+  });
+
+  it('renseigne features_used pour audit', () => {
+    const r = classifySetup(baseInput());
+    expect(Array.isArray(r.features_used)).toBe(true);
+  });
+});
+
+describe('classifySetup — features avancées (path v2 / agent 5)', () => {
+  it('ORB_BREAKOUT : window <60min + volSpike + closeToHigh ≥ 0.99', () => {
+    const r = classifySetup(
+      baseInput({
+        close: 100,
+        high: 100, // closeToHigh = 1
+        volume: 1_000_000,
+        avgVol50d: 500_000, // volRatio = 2
+        minutesSinceMarketOpen: 30,
+      }),
+    );
+    expect(r.setup_kind).toBe('ORB_BREAKOUT');
+  });
+
+  it('VWAP_RECLAIM : above VWAP, dist<0.3 ATR, trendUp, volSpike', () => {
+    const r = classifySetup(
+      baseInput({
+        close: 100.05,
+        high: 100.06,
+        vwap: 99.8,
+        atr: 1.0,
+        ema9: 100.1,
+        ema21: 100.0,
+        volume: 1_000_000,
+        avgVol50d: 500_000,
+        minutesSinceMarketOpen: 120, // hors fenêtre ORB
+      }),
+    );
+    expect(r.setup_kind).toBe('VWAP_RECLAIM');
+  });
+
+  it('VWAP_FADE : below VWAP, dist<0.3 ATR, !trendUp', () => {
+    const r = classifySetup(
+      baseInput({
+        changePct: -0.5,
+        close: 99,
+        vwap: 100,
+        atr: 5,
+        ema9: 99,
+        ema21: 100,
+        minutesSinceMarketOpen: 120,
+      }),
+    );
+    expect(r.setup_kind).toBe('VWAP_FADE');
+  });
+
+  it('MOMENTUM_BREAKOUT : ADX>25 + trendUp + volSpike', () => {
+    const r = classifySetup(
+      baseInput({
+        changePct: 3.0,
+        adx: 30,
+        volume: 2_000_000,
+        avgVol50d: 500_000,
+        minutesSinceMarketOpen: 120,
+      }),
+    );
+    expect(r.setup_kind).toBe('MOMENTUM_BREAKOUT');
+  });
+
+  it('TREND_PULLBACK : ADX 20-25 + trendUp + persistence>0.5', () => {
+    const r = classifySetup(
+      baseInput({
+        changePct: 1.5,
+        adx: 22,
+        persistenceScore: 0.7,
+        minutesSinceMarketOpen: 180,
+        volume: 600_000, // pas de spike pour exclure MOMENTUM_BREAKOUT
+      }),
+    );
+    expect(r.setup_kind).toBe('TREND_PULLBACK');
+  });
+
+  it('MEAN_REVERSION : ADX<20 + RSI extreme', () => {
+    const r = classifySetup(
+      baseInput({
+        adx: 15,
+        rsi: 25,
+        minutesSinceMarketOpen: 180,
+      }),
+    );
+    expect(r.setup_kind).toBe('MEAN_REVERSION');
+  });
+
+  it('GAP_FADE : gap >2% + early session + !volSpike', () => {
+    const r = classifySetup(
+      baseInput({
+        close: 103,
+        prevClose: 100,
+        volume: 400_000,
+        avgVol50d: 500_000,
+        minutesSinceMarketOpen: 15,
+      }),
+    );
+    expect(r.setup_kind).toBe('GAP_FADE');
+  });
+
+  it('CHOP_NOISE : pas de signature reconnaissable', () => {
+    const r = classifySetup(
+      baseInput({
+        changePct: 0.2,
+        adx: 22, // entre les seuils
+        rsi: 50, // pas extreme
+        minutesSinceMarketOpen: 180,
+        volume: 500_000,
+        avgVol50d: 500_000, // volRatio = 1 (pas de spike)
+        persistenceScore: 0.3, // sous persistence threshold trend_pullback
+      }),
+    );
+    expect(r.setup_kind).toBe('CHOP_NOISE');
+  });
+});
+
+describe('classifySetup — fallback v1 sur momentum/bucket (features SmartVest natives)', () => {
+  it('momentum.verticality>0.7 + risingScore>0.7 + volSpike → MOMENTUM_BREAKOUT', () => {
+    const r = classifySetup(
+      baseInput({
+        momentum: {
+          gradientPctPerMin: 0.8,
+          acceleration: 0.02,
+          verticalityScore: 0.85,
+          risingScore: 0.85,
+        },
+        volume: 1_000_000,
+        avgVol50d: 500_000,
+      }),
+    );
+    expect(r.setup_kind).toBe('MOMENTUM_BREAKOUT');
+  });
+
+  it('momentum.acceleration < -0.005 + persistence>0.5 + changePct>0 → TREND_PULLBACK', () => {
+    const r = classifySetup(
+      baseInput({
+        changePct: 2.0,
+        persistenceScore: 0.65,
+        momentum: {
+          gradientPctPerMin: 0.3,
+          acceleration: -0.01, // décélération
+          verticalityScore: 0.4,
+          risingScore: 0.6,
+        },
+      }),
+    );
+    expect(r.setup_kind).toBe('TREND_PULLBACK');
+  });
+
+  it('momentum reversal (gradient<0 + accel<0) → MEAN_REVERSION', () => {
+    const r = classifySetup(
+      baseInput({
+        changePct: -0.3,
+        momentum: {
+          gradientPctPerMin: -0.4,
+          acceleration: -0.02,
+          verticalityScore: 0.3,
+          risingScore: 0.2,
+        },
+      }),
+    );
+    expect(r.setup_kind).toBe('MEAN_REVERSION');
+  });
+
+  it('bucket Phase 3 = sweet_spot_rising → TREND_PULLBACK', () => {
+    const r = classifySetup(baseInput({ bucket: 'sweet_spot_rising' }));
+    expect(r.setup_kind).toBe('TREND_PULLBACK');
+  });
+
+  it('bucket peak_parabolic → MOMENTUM_BREAKOUT', () => {
+    const r = classifySetup(baseInput({ bucket: 'peak_parabolic' }));
+    expect(r.setup_kind).toBe('MOMENTUM_BREAKOUT');
+  });
+
+  it('bucket reversing → MEAN_REVERSION', () => {
+    const r = classifySetup(baseInput({ bucket: 'reversing' }));
+    expect(r.setup_kind).toBe('MEAN_REVERSION');
+  });
+
+  it('bucket stalled → CHOP_NOISE', () => {
+    const r = classifySetup(baseInput({ bucket: 'stalled' }));
+    expect(r.setup_kind).toBe('CHOP_NOISE');
+  });
+
+  it('aucune feature riche → CHOP_NOISE par défaut', () => {
+    const r = classifySetup(baseInput());
+    expect(r.setup_kind).toBe('CHOP_NOISE');
+  });
+});
+
+describe('classifySetup — regime_at_entry classification (3 buckets)', () => {
+  describe('path v2 (avec ADX)', () => {
+    it('TREND_PORTEUR : ADX>25 + persistence>0.55 + verticality>0.5', () => {
+      const r = classifySetup(
+        baseInput({
+          adx: 30,
+          persistenceScore: 0.7,
+          momentum: {
+            gradientPctPerMin: 0.5,
+            acceleration: 0.01,
+            verticalityScore: 0.6,
+            risingScore: 0.7,
+          },
+        }),
+      );
+      expect(r.regime_at_entry).toBe('TREND_PORTEUR');
+    });
+
+    it('VOLATILE_CHOPPY : pathEfficiency<0.4', () => {
+      const r = classifySetup(
+        baseInput({
+          adx: 22,
+          pathEfficiency: 0.25,
+        }),
+      );
+      expect(r.regime_at_entry).toBe('VOLATILE_CHOPPY');
+    });
+
+    it('RANGE_CALME : ADX<20', () => {
+      const r = classifySetup(baseInput({ adx: 15, persistenceScore: 0.3 }));
+      expect(r.regime_at_entry).toBe('RANGE_CALME');
+    });
+  });
+
+  describe('path v1 (fallback persistence + path_eff)', () => {
+    it('VOLATILE_CHOPPY : pathEfficiency<0.4 (priorité haute)', () => {
+      const r = classifySetup(
+        baseInput({ pathEfficiency: 0.2, persistenceScore: 0.7 }),
+      );
+      expect(r.regime_at_entry).toBe('VOLATILE_CHOPPY');
+    });
+
+    it('TREND_PORTEUR : persistence>=0.55 + path>=0.6 + verticality<0.85', () => {
+      const r = classifySetup(
+        baseInput({
+          persistenceScore: 0.7,
+          pathEfficiency: 0.75,
+          momentum: {
+            gradientPctPerMin: 0.4,
+            acceleration: 0.01,
+            verticalityScore: 0.5, // pas parabolic
+            risingScore: 0.7,
+          },
+        }),
+      );
+      expect(r.regime_at_entry).toBe('TREND_PORTEUR');
+    });
+
+    it('TREND_PORTEUR : sans path mais persistence>=0.55', () => {
+      const r = classifySetup(baseInput({ persistenceScore: 0.7 }));
+      expect(r.regime_at_entry).toBe('TREND_PORTEUR');
+    });
+
+    it('RANGE_CALME : persistence<0.55, pas de path<0.4', () => {
+      const r = classifySetup(baseInput({ persistenceScore: 0.4 }));
+      expect(r.regime_at_entry).toBe('RANGE_CALME');
+    });
+
+    it('TREND_PORTEUR exclu si verticality≥0.85 (pump parabolic)', () => {
+      const r = classifySetup(
+        baseInput({
+          persistenceScore: 0.7,
+          pathEfficiency: 0.8,
+          momentum: {
+            gradientPctPerMin: 1.5,
+            acceleration: 0.05,
+            verticalityScore: 0.95, // parabolic
+            risingScore: 0.9,
+          },
+        }),
+      );
+      // verticality élevée invalide TREND_PORTEUR fallback v1
+      expect(r.regime_at_entry).toBe('RANGE_CALME');
+    });
+  });
+});
+
+describe('classifySetup — edge cases robustesse', () => {
+  it('avgVol50d=0 ne plante pas', () => {
+    const r = classifySetup(baseInput({ avgVol50d: 0 }));
+    expect(r.setup_kind).toBeTruthy();
+  });
+
+  it('high=0 ne plante pas (closeToHigh=0)', () => {
+    const r = classifySetup(baseInput({ high: 0 }));
+    expect(r.setup_kind).toBeTruthy();
+  });
+
+  it('toutes features optionnelles undefined → fallback graceful', () => {
+    const r = classifySetup({
+      changePct: 5,
+      close: 100,
+      high: 100,
+      volume: 1_000_000,
+      avgVol50d: 500_000,
+      persistenceScore: 0.5,
+    });
+    expect(['CHOP_NOISE', 'MOMENTUM_BREAKOUT', 'TREND_PULLBACK', 'ORB_BREAKOUT', 'MEAN_REVERSION']).toContain(r.setup_kind);
+    expect(['TREND_PORTEUR', 'RANGE_CALME', 'VOLATILE_CHOPPY']).toContain(r.regime_at_entry);
+  });
+
+  it('classification idempotente (même input → même output)', () => {
+    const input = baseInput({ adx: 30, volume: 2_000_000, avgVol50d: 500_000 });
+    const r1 = classifySetup(input);
+    const r2 = classifySetup(input);
+    expect(r1.setup_kind).toBe(r2.setup_kind);
+    expect(r1.regime_at_entry).toBe(r2.regime_at_entry);
+  });
+});
+
+describe('classifySetup — priorité ordering (ORB > VWAP > ADX > GAP > fallback)', () => {
+  it('ORB prend la priorité même si VWAP + ADX présents', () => {
+    const r = classifySetup(
+      baseInput({
+        minutesSinceMarketOpen: 20,
+        close: 100,
+        high: 100,
+        volume: 2_000_000,
+        avgVol50d: 500_000,
+        vwap: 99,
+        atr: 1,
+        ema9: 100.5,
+        ema21: 99.8,
+        adx: 30,
+      }),
+    );
+    expect(r.setup_kind).toBe('ORB_BREAKOUT');
+  });
+
+  it('VWAP prend la priorité sur ADX si ORB exclu', () => {
+    const r = classifySetup(
+      baseInput({
+        minutesSinceMarketOpen: 120, // hors ORB window
+        close: 100.05,
+        high: 100.06, // closeToHigh proche 1, mais ORB skip car >60min
+        vwap: 99.85, // distVwapAtr = 0.20
+        atr: 1,
+        ema9: 100.2,
+        ema21: 100.0,
+        volume: 1_000_000,
+        avgVol50d: 500_000,
+        adx: 30,
+      }),
+    );
+    expect(r.setup_kind).toBe('VWAP_RECLAIM');
+  });
+});

--- a/packages/ai-analyst/src/strategies/setup-classifier.ts
+++ b/packages/ai-analyst/src/strategies/setup-classifier.ts
@@ -1,0 +1,272 @@
+/**
+ * SetupClassifier — classification déterministe v1 des trades intraday au open.
+ *
+ * Step 3 du chain post-PR #577. Recherche web 02/06/2026 :
+ *   - Zarattini SSRN 4729284 — ORB Stocks-in-Play, Sharpe 2.81
+ *   - Marton & Cakir SSRN 4290787 — Hurst + SuperTrend intraday
+ *   - Lopez de Prado SSRN 3517595 — Clustered Feature Importance
+ *   - Dalton "Markets in Profile" — initiative vs responsive, 80% rule
+ *   - Bookmap — absorption/exhaustion, CVD divergence (caveat : crypto only)
+ *
+ * Architecture :
+ *   - 8 setup_kind (cross-cutting, niveau-2 shadow tant que n<100/cellule)
+ *   - 3 regime_at_entry opérationnels (niveau-1 sizing × asset_class = 12 cellules)
+ *   - Pure function — pas de DB, pas de LLM, pas de réseau
+ *   - Features OPTIONNELLES tolérées : fallback en cascade selon disponibilité
+ *
+ * Limite v1 :
+ *   - Pas de VWAP/EMA/ATR/ADX/RSI computés à l'open (besoin candles fetch dédié)
+ *   - CVD/flow exclu (équités EODHD 5m sans tape granulaire — Agent 2 caveat)
+ *   - Hurst 15m sur fenêtre courte = bruité (Marton & Cakir : Kalman filter v2)
+ *   - Classifier dégrade gracieusement : si features riches absentes, mappe via
+ *     persistence + path_eff + momentum + bucket Phase 3 déjà calculés.
+ */
+
+export type SetupKind =
+  | 'ORB_BREAKOUT'
+  | 'VWAP_RECLAIM'
+  | 'VWAP_FADE'
+  | 'MOMENTUM_BREAKOUT'
+  | 'TREND_PULLBACK'
+  | 'MEAN_REVERSION'
+  | 'GAP_FADE'
+  | 'CHOP_NOISE';
+
+export type RegimeAtEntry = 'TREND_PORTEUR' | 'RANGE_CALME' | 'VOLATILE_CHOPPY';
+
+export const CLASSIFIER_VERSION = 'v1' as const;
+
+/**
+ * Input features pour classification. Required = toujours disponible dans
+ * TopGainerCandidate au moment de l'open. Optional = features avancées à fournir
+ * si computées en upstream (v2 : VWAP/EMA/ATR/ADX/RSI via candles 1m/5m).
+ */
+export interface SetupClassifierInput {
+  /** % de variation 1m au open. */
+  changePct: number;
+  /** Prix close au open. */
+  close: number;
+  /** High intraday observé jusqu'au open. */
+  high: number;
+  /** Volume 1m au open. */
+  volume: number;
+  /** Volume moyen 50 jours (proxy liquidity baseline). */
+  avgVol50d: number;
+
+  /** Persistence score multi-TF (P8). Fraction TFs positifs [0..1]. */
+  persistenceScore: number;
+  /** Path efficiency [0..1] (P9-UX). Indicateur smooth vs choppy. */
+  pathEfficiency?: number;
+
+  /** Momentum Phase 2 scanner (optionnel). */
+  momentum?: {
+    /** Gradient %/min. */
+    gradientPctPerMin: number;
+    /** Accélération (positif = pump, négatif = décélération). */
+    acceleration: number;
+    /** Score [0..1] verticality (pump parabolique vs sweet). */
+    verticalityScore: number;
+    /** Score [0..1] rising (trend confirmation). */
+    risingScore: number;
+  };
+  /** Bucket Phase 3 (optionnel). */
+  bucket?: 'sweet_spot_rising' | 'peak_parabolic' | 'early_mover' | 'stalled' | 'reversing';
+
+  // Optional advanced indicators (v2 : à wirer quand VWAP/EMA/ATR computés à l'open)
+  /** VWAP intraday. */
+  vwap?: number;
+  /** EMA 9 bars. */
+  ema9?: number;
+  /** EMA 21 bars. */
+  ema21?: number;
+  /** ATR 14 bars. */
+  atr?: number;
+  /** ADX 14 bars (force trend [0..100]). */
+  adx?: number;
+  /** RSI 14 bars [0..100]. */
+  rsi?: number;
+  /** Prix close veille (pour gap). */
+  prevClose?: number;
+  /** Minutes depuis l'open du marché (pour ORB priority). */
+  minutesSinceMarketOpen?: number;
+}
+
+export interface SetupClassifierOutput {
+  setup_kind: SetupKind;
+  regime_at_entry: RegimeAtEntry;
+  classifier_version: typeof CLASSIFIER_VERSION;
+  /** Liste des features qui ont contribué à la décision (audit / debug). */
+  features_used: string[];
+}
+
+/**
+ * Classifie un setup au moment de l'open. Pure function, idempotente.
+ *
+ * Ordre de priorité (Agent 5 + adaptation features SmartVest) :
+ *   1. ORB priority dans 60 premières min de session (si features avancées dispo)
+ *   2. VWAP-based (RECLAIM / FADE) si VWAP + ATR fournis
+ *   3. ADX-based (MOMENTUM_BREAKOUT / TREND_PULLBACK / MEAN_REVERSION) si ADX
+ *   4. GAP_FADE si prevClose fourni
+ *   5. Fallback v1 : utilise momentum/bucket/persistence/path_eff pour mapping
+ *      grossier mais reproductible (la majorité des opens SmartVest passent ici).
+ *
+ * Si features insuffisantes pour toute classification → CHOP_NOISE.
+ */
+export function classifySetup(f: SetupClassifierInput): SetupClassifierOutput {
+  const featuresUsed: string[] = [];
+  const volRatio = f.avgVol50d > 0 ? f.volume / f.avgVol50d : 1;
+  const volSpike = volRatio > 1.5;
+  const closeToHigh = f.high > 0 ? f.close / f.high : 0;
+
+  // ─── SETUP_KIND classification ───────────────────────────────────────────
+
+  let setup_kind: SetupKind = 'CHOP_NOISE';
+
+  // 1. ORB priority dans 60 premières min — exige minutesSinceMarketOpen + volSpike
+  if (
+    setup_kind === 'CHOP_NOISE' &&
+    f.minutesSinceMarketOpen !== undefined &&
+    f.minutesSinceMarketOpen <= 60 &&
+    volSpike &&
+    closeToHigh >= 0.99
+  ) {
+    setup_kind = 'ORB_BREAKOUT';
+    featuresUsed.push('orb_window', 'volSpike', 'closeToHigh');
+  }
+
+  // 2. VWAP-based — exige vwap + atr
+  if (
+    setup_kind === 'CHOP_NOISE' &&
+    f.vwap !== undefined &&
+    f.atr !== undefined &&
+    f.atr > 0
+  ) {
+    const aboveVWAP = f.close > f.vwap;
+    const distVwapAtr = Math.abs(f.close - f.vwap) / f.atr;
+    const trendUp =
+      f.ema9 !== undefined && f.ema21 !== undefined
+        ? f.ema9 > f.ema21 && f.close > f.ema21
+        : f.changePct > 0;
+    if (aboveVWAP && distVwapAtr < 0.3 && trendUp && volSpike) {
+      setup_kind = 'VWAP_RECLAIM';
+      featuresUsed.push('vwap_reclaim');
+    } else if (!aboveVWAP && distVwapAtr < 0.3 && !trendUp) {
+      setup_kind = 'VWAP_FADE';
+      featuresUsed.push('vwap_fade');
+    }
+  }
+
+  // 3. ADX-based
+  if (setup_kind === 'CHOP_NOISE' && f.adx !== undefined) {
+    const trendUp = f.changePct > 0;
+    if (f.adx > 25 && trendUp && volSpike) {
+      setup_kind = 'MOMENTUM_BREAKOUT';
+      featuresUsed.push('adx_momentum');
+    } else if (
+      f.adx > 20 &&
+      trendUp &&
+      f.persistenceScore > 0.5
+    ) {
+      setup_kind = 'TREND_PULLBACK';
+      featuresUsed.push('adx_pullback');
+    } else if (
+      f.adx < 20 &&
+      f.rsi !== undefined &&
+      (f.rsi < 30 || f.rsi > 70)
+    ) {
+      setup_kind = 'MEAN_REVERSION';
+      featuresUsed.push('adx_meanrev');
+    }
+  }
+
+  // 4. GAP_FADE — exige prevClose + early session
+  if (setup_kind === 'CHOP_NOISE' && f.prevClose !== undefined && f.prevClose > 0) {
+    const gapPct = (f.close - f.prevClose) / f.prevClose;
+    if (
+      Math.abs(gapPct) > 0.02 &&
+      (f.minutesSinceMarketOpen === undefined || f.minutesSinceMarketOpen < 30) &&
+      !volSpike
+    ) {
+      setup_kind = 'GAP_FADE';
+      featuresUsed.push('gap_fade');
+    }
+  }
+
+  // 5. Fallback v1 — utilise features SmartVest natives (momentum Phase 2, bucket Phase 3)
+  if (setup_kind === 'CHOP_NOISE' && f.momentum) {
+    const m = f.momentum;
+    if (m.verticalityScore > 0.7 && m.risingScore > 0.7 && volSpike) {
+      setup_kind = 'MOMENTUM_BREAKOUT';
+      featuresUsed.push('momentum_breakout');
+    } else if (m.acceleration < -0.005 && f.persistenceScore > 0.5 && f.changePct > 0) {
+      setup_kind = 'TREND_PULLBACK';
+      featuresUsed.push('momentum_decel_pullback');
+    } else if (m.gradientPctPerMin < 0 && m.acceleration < 0) {
+      setup_kind = 'MEAN_REVERSION';
+      featuresUsed.push('momentum_reversal');
+    }
+  }
+  if (setup_kind === 'CHOP_NOISE' && f.bucket) {
+    // Phase 3 bucket → setup_kind mapping (fallback coarse)
+    const bucketMap: Record<NonNullable<SetupClassifierInput['bucket']>, SetupKind> = {
+      sweet_spot_rising: 'TREND_PULLBACK',
+      peak_parabolic: 'MOMENTUM_BREAKOUT',
+      early_mover: 'MOMENTUM_BREAKOUT',
+      stalled: 'CHOP_NOISE',
+      reversing: 'MEAN_REVERSION',
+    };
+    setup_kind = bucketMap[f.bucket];
+    if (setup_kind !== 'CHOP_NOISE') featuresUsed.push(`bucket_${f.bucket}`);
+  }
+
+  // ─── REGIME_AT_ENTRY classification ──────────────────────────────────────
+  // Cascade : préférer ADX + Hurst si dispo, sinon fallback persistence + path_eff.
+
+  let regime_at_entry: RegimeAtEntry = 'RANGE_CALME';
+
+  if (f.adx !== undefined) {
+    // Path avancé v2 — ADX + persistence
+    const verticality = f.momentum?.verticalityScore ?? 0.5;
+    if (f.adx > 25 && f.persistenceScore > 0.55 && verticality > 0.5) {
+      regime_at_entry = 'TREND_PORTEUR';
+      featuresUsed.push('regime_adx_trend');
+    } else if (
+      f.pathEfficiency !== undefined && f.pathEfficiency < 0.4
+    ) {
+      regime_at_entry = 'VOLATILE_CHOPPY';
+      featuresUsed.push('regime_choppy_pathEff');
+    } else if (f.adx < 20) {
+      regime_at_entry = 'RANGE_CALME';
+      featuresUsed.push('regime_range_lowAdx');
+    } else {
+      regime_at_entry = 'RANGE_CALME';
+      featuresUsed.push('regime_default');
+    }
+  } else {
+    // Fallback v1 — persistence + path_eff + momentum
+    const pathEff = f.pathEfficiency;
+    const verticality = f.momentum?.verticalityScore;
+
+    if (pathEff !== undefined && pathEff < 0.4) {
+      regime_at_entry = 'VOLATILE_CHOPPY';
+      featuresUsed.push('regime_choppy_v1');
+    } else if (
+      f.persistenceScore >= 0.55 &&
+      (pathEff === undefined || pathEff >= 0.6) &&
+      (verticality === undefined || verticality < 0.85)
+    ) {
+      regime_at_entry = 'TREND_PORTEUR';
+      featuresUsed.push('regime_trend_v1');
+    } else {
+      regime_at_entry = 'RANGE_CALME';
+      featuresUsed.push('regime_range_v1');
+    }
+  }
+
+  return {
+    setup_kind,
+    regime_at_entry,
+    classifier_version: CLASSIFIER_VERSION,
+    features_used: featuresUsed,
+  };
+}

--- a/supabase/migrations/0187_paper_trades_setup_taxonomy.sql
+++ b/supabase/migrations/0187_paper_trades_setup_taxonomy.sql
@@ -1,0 +1,41 @@
+-- 0187 — paper_trades setup taxonomy (Step 3 chain post-#577)
+--
+-- Ajoute setup_kind + regime_at_entry + classifier_version pour mesurer
+-- l'espérance × winrate par configuration de trade.
+--
+-- Recherche web 02/06/2026 — sources :
+--   - Zarattini SSRN 4729284 (ORB Stocks-in-Play Sharpe 2.81)
+--   - Marton & Cakir SSRN 4290787 (Hurst + SuperTrend intraday)
+--   - Lopez de Prado SSRN 3517595 (Clustered Feature Importance — features orthogonales)
+--   - Bailey & Lopez de Prado SSRN 2326253 (PBO) + SSRN 2460551 (Deflated Sharpe)
+--   - Harvey, Liu, Zhu NBER w20592 (multiple testing : t-stat > 3.0 hurdle)
+--   - Wyckoff Analytics, Dalton Markets in Profile, Bookmap order flow docs
+--
+-- Granularité respectée Agent 4 :
+--   - Niveau 1 mesurable (gate sizing) : asset_class × regime = 4 × 3 = 12 cellules
+--     → Wilson CI ±8.7% à 125 trades/cellule/mois (1500/mois SmartVest projeté)
+--   - Niveau 2 exploratoire shadow : setup_kind (8 buckets) cross-cutting,
+--     marqué shadow tant que n<100/cellule via classifier_version + reporting.
+--
+-- Forward-compatible : aucune backfill — les rows existants restent NULL,
+-- mesures par cellule démarrent à partir des opens post-déploiement.
+
+ALTER TABLE public.paper_trades
+  ADD COLUMN IF NOT EXISTS setup_kind TEXT,
+  ADD COLUMN IF NOT EXISTS regime_at_entry TEXT,
+  ADD COLUMN IF NOT EXISTS classifier_version TEXT;
+
+-- Index composite pour les requêtes par cellule (sizing decisions niveau-1
+-- via regime × asset_class, mesures exploratoires niveau-2 via setup_kind).
+CREATE INDEX IF NOT EXISTS paper_trades_setup_taxonomy_idx
+  ON public.paper_trades (asset_class, regime_at_entry, setup_kind)
+  WHERE setup_kind IS NOT NULL;
+
+COMMENT ON COLUMN public.paper_trades.setup_kind IS
+  'Classification setup au moment de l''open (v1 = 8 valeurs déterministes : ORB_BREAKOUT / VWAP_RECLAIM / VWAP_FADE / MOMENTUM_BREAKOUT / TREND_PULLBACK / MEAN_REVERSION / GAP_FADE / CHOP_NOISE). Dimension cross-cutting niveau-2 — utiliser shadow tant que n<100/cellule (Wilson CI > ±10%).';
+
+COMMENT ON COLUMN public.paper_trades.regime_at_entry IS
+  'Régime marché au open (3 valeurs : TREND_PORTEUR / RANGE_CALME / VOLATILE_CHOPPY). HOSTILE bloque l''open en amont (cf. MacroVeto Gemini) donc absent ici. Dimension niveau-1 sizing — croisé avec asset_class = 12 cellules (cf. Lopez de Prado / Bailey, Wilson CI ±8.7% à 125 trades/cellule/mois).';
+
+COMMENT ON COLUMN public.paper_trades.classifier_version IS
+  'Version du SetupClassifier qui a produit setup_kind + regime_at_entry. v1 = pseudo-déterministe basé sur features disponibles dans TopGainerCandidate (changePct, volume, momentum, persistence, pathEfficiency, bucket Phase 3). v2 (future) ajoutera VWAP/EMA/ATR/ADX/RSI computés.';


### PR DESCRIPTION
## Summary

**Step 3 du chain** post-#577 — taxonomie 2D des trades intraday pour mesurer espérance × winrate par cellule.

Recherche web 02/06/2026 (5 agents parallèles, 30+ sources canoniques) :
- **Zarattini SSRN 4729284** — ORB Stocks-in-Play Sharpe 2.81
- **Marton & Cakir SSRN 4290787** — Hurst + SuperTrend intraday
- **Lopez de Prado SSRN 3517595** — Clustered Feature Importance (features orthogonales)
- **Bailey & Lopez de Prado SSRN 2326253 (PBO)** + **SSRN 2460551 (Deflated Sharpe)**
- **Harvey, Liu, Zhu NBER w20592** — multiple testing t-stat > 3.0
- **Dalton Markets in Profile**, Wyckoff Analytics, Bookmap order flow

## Granularité statistique respectée

| Niveau | Dimensions | Cellules | Wilson CI/cellule à 1500 trades/mois |
|---|---|---|---|
| **1 — Mesurable (gate sizing)** | `asset_class × regime_at_entry` | 4 × 3 = **12** | ±8.7% (125 trades/cellule/mois) |
| **2 — Exploratoire shadow** | `setup_kind` cross-cutting | 8 buckets | reporting offline avec FDR Benjamini-Hochberg q=0.10 + DSR |

## Changements

### 1. Migration `0187_paper_trades_setup_taxonomy.sql`
`ALTER TABLE paper_trades ADD setup_kind, regime_at_entry, classifier_version` + index composite. Forward-compatible (rows existants restent NULL).

### 2. `packages/ai-analyst/src/strategies/setup-classifier.ts` (272 LoC)
Pure function `classifySetup(input)`. **8 setup_kind**, **3 régimes opérationnels** (HOSTILE bloque l'open en amont via MacroVeto).

Cascade priorités :
1. ORB priority (window <60min + volSpike + closeToHigh ≥ 0.99)
2. VWAP-based (RECLAIM / FADE) si vwap+atr
3. ADX-based (MOMENTUM_BREAKOUT / TREND_PULLBACK / MEAN_REVERSION)
4. GAP_FADE si prevClose
5. **Fallback v1** : momentum Phase 2 + bucket Phase 3 + persistence + path_eff (la majorité des opens SmartVest passent ici tant que VWAP/EMA/ATR pas wirés au open)

Audit `features_used[]` pour traçabilité.

### 3. Tests 33 cas (`setup-classifier.spec.ts`)
- 8 setup_kind couverts
- 3 régimes (v1 fallback + v2 ADX path)
- Edge cases : avgVol=0, high=0, idempotence
- Priorité ordering ORB > VWAP > ADX > GAP > fallback

### 4. Wiring `persistPaperTrade` (`top-gainers-scanner.service.ts:5240`)
`classifySetup()` appelé avant insert, `setup_kind` + `regime_at_entry` + `classifier_version` persistés sur chaque paper trade ouvert via le scanner direct path.

## Caveats v1 (à fix v2)
- CVD/flow exclu (équités EODHD 5m sans tape granulaire — Agent 2 caveat)
- Hurst 15m bruité sur fenêtre courte (Kalman filter v2 — Marton & Cakir)
- VWAP/EMA/ATR/ADX/RSI pas calculés au open path actuel → classifier dégrade gracieusement sur features SmartVest natives (momentum/bucket/persistence)

## Hors scope
- Wiring Live Trader Agent direct paper-broker : sa route open via `openForOpportunityScout` n'écrit pas `paper_trades` (seul le scanner direct path persiste). Si voulu, ajouter classifier dans `paper-broker.openPositionDirect` en follow-up séparé.
- Migration trigger Supabase : à faire via push branche `migrations-trigger-0187-setup-taxonomy` post-merge.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `jest top-gainers-scanner|setup-classifier|scanner-llm-router|postmortem` — 17 suites apps/api (189) + 1 suite ai-analyst (33) = **222 tests verts**
- [ ] Post-deploy + migration : monitor `paper_trades` populated avec `setup_kind`/`regime_at_entry` non-null
- [ ] Mesure offline après 30 jours : `SELECT setup_kind, regime_at_entry, asset_class, COUNT(*), AVG(pnl_pct), STDDEV(pnl_pct) FROM paper_trades WHERE created_at > now()-30d GROUP BY 1,2,3 HAVING COUNT(*) >= 30` — identifier les vraies pépites avec correction multiple testing

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_