### PR TITLE
feat(skeptic): wire SkepticAgent dans scanner top-gainers (shadow mode)

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -102,6 +102,10 @@ import {
   formatFilterLog,
   classifySetup,
   type SetupClassifierInput,
+  evaluateSkeptic,
+  DEFAULT_SKEPTIC_CONFIG,
+  type SkepticInput,
+  type AssetClassKey,
 } from '@smartvest/ai-analyst';
 import { TickerBlacklistService } from './ticker-blacklist.service';
 import { CorrelationGuardService } from './correlation-guard.service';
@@ -4972,6 +4976,91 @@ export class TopGainersScannerService implements OnModuleInit {
           } catch (e) {
             // Fail-open : on ne casse jamais le scanner même si le gate plante.
             this.logger.error(`[debate-gate] ${cand.symbol} eval threw (fail-open): ${String(e).slice(0, 120)}`);
+          }
+        }
+
+        // Step 1 chain (02/06/2026) — SkepticAgent wiring SHADOW mode.
+        // Pure helper @smartvest/ai-analyst/skeptic — 6 règles institutionnelles
+        // (microstructure, regime_macro, correlation, drawdown, liquidity, cooldown).
+        // Mode shadow par défaut — log-only, ne bloque rien. Active blocking règle
+        // par règle après calibration via decision_log (pattern path_eff 25/05).
+        //
+        // Activation par règle :
+        //   SKEPTIC_RULE_<NAME>_MODE=blocking
+        //   (NAME ∈ microstructure | regime_macro | correlation | drawdown | liquidity | cooldown)
+        // Master disable : SKEPTIC_ENABLED=false (default true)
+        const skepticEnabled = (this.config.get<string>('SKEPTIC_ENABLED') ?? 'true').toLowerCase() === 'true';
+        if (skepticEnabled) {
+          try {
+            // Fetch open positions snapshot (best-effort, soft-fail si erreur)
+            const { data: openSnap } = await this.supabase.getClient()
+              .from('lisa_positions')
+              .select('symbol, asset_class, entry_notional_usd')
+              .eq('portfolio_id', portfolioId)
+              .eq('status', 'open');
+            const openPositions = ((openSnap ?? []) as Array<{ symbol: string; asset_class: string; entry_notional_usd: number | string }>)
+              .filter((r) => r.symbol !== cand.symbol)
+              .map((r) => ({
+                symbol: r.symbol,
+                assetClass: r.asset_class as AssetClassKey,
+                notionalUsd: Number(r.entry_notional_usd ?? 0),
+              }));
+
+            // Build config avec mode per-règle override env
+            const cfg = structuredClone(DEFAULT_SKEPTIC_CONFIG);
+            for (const ruleName of ['microstructure', 'regime_macro', 'correlation', 'drawdown', 'liquidity', 'cooldown'] as const) {
+              const envKey = `SKEPTIC_RULE_${ruleName.toUpperCase()}_MODE`;
+              const envVal = (this.config.get<string>(envKey) ?? 'shadow').toLowerCase();
+              if (envVal === 'blocking') cfg[ruleName].mode = 'blocking';
+            }
+
+            const skepticInput: SkepticInput = {
+              candidate: {
+                symbol: cand.symbol,
+                assetClass: cand.assetClass as AssetClassKey,
+                close: cand.close,
+                notionalUsd: directionalNotional,
+                avgVol50d: cand.avgVol50d,
+              },
+              // v1 wiring — macro features défèrent (besoin MarketSnapshot service
+              // injection ; pour l'instant, regime_macro fera 'info' partout)
+              macro: {},
+              openPositions,
+              portfolioCapitalUsd: effectiveCapital,
+              sessionPnlUsd: 0, // v2 : fetch daily_trading_sessions.realized_pnl_today_usd
+              consecutiveLosses: 0, // v2 : fetch via recent paper_trades closed_stop
+            };
+            const verdict = evaluateSkeptic(skepticInput, cfg);
+
+            // Log verdict pour calibration funnel (shadow → blocking règle par règle)
+            await this.decisionLog.append({
+              portfolioId,
+              kind: 'skeptic_verdict',
+              summary: `[SKEPTIC] ${cand.symbol} ${item.direction} veto=${verdict.veto} score=${verdict.score} (${verdict.reasons.filter((r) => r.triggered).map((r) => r.rule).join(',') || 'none triggered'})`,
+              rationale: verdict.reasons.filter((r) => r.triggered).map((r) => `${r.rule}[${r.severity}/${r.mode}]: ${r.detail}`).join(' | ') || 'all rules OK',
+              payload: {
+                symbol: cand.symbol,
+                direction: item.direction,
+                asset_class: cand.assetClass,
+                verdict_veto: verdict.veto,
+                verdict_score: verdict.score,
+                model_version: verdict.modelVersion,
+                reasons: verdict.reasons,
+                features: verdict.features,
+              },
+              triggeredBy: 'autopilot_cron',
+            }).catch(() => { /* non-bloquant */ });
+
+            if (verdict.veto) {
+              // Au moins une règle 'blocking' + 'block' + triggered → veto réel
+              this.logger.log(
+                `[skeptic-agent] ${cand.symbol} ${item.direction.toUpperCase()} BLOCKED — ${verdict.reasons.filter((r) => r.triggered && r.severity === 'block' && r.mode === 'blocking').map((r) => r.rule).join(',')}`,
+              );
+              continue;
+            }
+          } catch (e) {
+            // Fail-open : un bug SkepticAgent ne doit pas bloquer le scanner.
+            this.logger.warn(`[skeptic-agent] ${cand.symbol} eval threw (fail-open): ${String(e).slice(0, 150)}`);
           }
         }
 


### PR DESCRIPTION
## Summary

**Action 1/4 du chain post-#579** — wiring du SkepticAgent helper (livré PR #579) en **mode SHADOW** dans le pipeline scanner top-gainers, juste AVANT le LLM gate Mistral (PR #540).

Le shadow log dans `lisa_decision_log` permet de calibrer chaque règle 24-72h avant de flipper en blocking (pattern path_eff calibration 25/05).

## Changements (89 LoC dans `top-gainers-scanner.service.ts`)

```ts
// Bloc skeptic ajouté ligne ~4978, AVANT le LLM gate Mistral
if (skepticEnabled) {
  // 1. Fetch open positions snapshot (best-effort)
  const openPositions = await fetchOpenPositions(portfolioId, cand.symbol);

  // 2. Build config + override per-règle via env SKEPTIC_RULE_<NAME>_MODE
  const cfg = structuredClone(DEFAULT_SKEPTIC_CONFIG);
  // ...

  // 3. Build SkepticInput minimal
  const verdict = evaluateSkeptic({ candidate, openPositions, portfolioCapital, ... }, cfg);

  // 4. Log dans lisa_decision_log kind='skeptic_verdict' (audit calibration)
  await this.decisionLog.append({ kind: 'skeptic_verdict', payload: verdict });

  // 5. Si verdict.veto=true (au moins 1 règle blocking + block + triggered) → skip
  if (verdict.veto) continue;
  // 6. Fail-open : exception SkepticAgent ne bloque PAS le scanner
}
```

## Env flags

| Var | Default | Effet |
|---|---|---|
| `SKEPTIC_ENABLED` | `true` | Master disable |
| `SKEPTIC_RULE_MICROSTRUCTURE_MODE` | `shadow` | `blocking` pour activer |
| `SKEPTIC_RULE_REGIME_MACRO_MODE` | `shadow` | idem |
| `SKEPTIC_RULE_CORRELATION_MODE` | `shadow` | idem |
| `SKEPTIC_RULE_DRAWDOWN_MODE` | `shadow` | idem |
| `SKEPTIC_RULE_LIQUIDITY_MODE` | `shadow` | idem |
| `SKEPTIC_RULE_COOLDOWN_MODE` | `shadow` | idem |

## Features wirées v1 → v2

**Wirées v1** : candidate.{symbol, assetClass, close, notionalUsd, avgVol50d}, openPositions, portfolioCapitalUsd

**Deferred v2** (sub-checks reportent `info` quand features manquent — pas de faux blocage) :
- `macro` (VIX/HY OAS/DXY) — besoin MarketSnapshotService injection
- `sessionPnlUsd` — fetch daily_trading_sessions.realized_pnl_today_usd
- `consecutiveLosses` — query paper_trades closed_stop récents
- `spreadBps`, `quoteAgeMs` — pas dispo équités EODHD 5m

## Règles immédiatement actives v1 (avec features dispo)

- **CORRELATION** : asset_class cap 40%, sector cap 30% (si sector dispo), pairwise corr si fournie
- **LIQUIDITY** : avgVol50d min par classe, ADV participation cap
- **COOLDOWN** : reportera `info` jusqu'à `lastSlOnSameTickerAt` wiré v2
- **MICROSTRUCTURE** : reportera `info` jusqu'à spread/staleness wiré v2
- **REGIME_MACRO** : reportera `info` jusqu'à macro wiré v2
- **DRAWDOWN** : daily DD check fonctionnel via portfolioCapitalUsd + sessionPnlUsd (=0 v1)

## Test plan
- [x] `npm run typecheck` — clean
- [x] `jest top-gainers-scanner|scanner-llm-router|postmortem` — 17 suites / 189 tests verts (pas de régression)
- [ ] Post-deploy : observer `lisa_decision_log` kind=`skeptic_verdict` accumulation. Histogramme par règle×triggered count.
- [ ] Calibration 24-72h : pour chaque règle, vérifier que % triggered est cohérent (correlation typiquement 5-15%, liquidity rare sur top gainers, etc.). Ajuster seuils si dérive.
- [ ] Quand calibration stable → flip 1 règle à la fois en `blocking` via Fly secrets.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_