### PR TITLE
fix(scanner+trader): 4 gates anti-blow-off OKLO + 12 priors académiques

### DIFF
--- a/apps/api/docs/blow-off-research.md
+++ b/apps/api/docs/blow-off-research.md
@@ -1,0 +1,169 @@
+# Blow-off / Pump-Fade Research — Bibliographie SmartVest
+
+Source : web research 03/06/2026 post-mortem OKLO.US (-1.63% en 35min).
+12 règles les plus actionnables sont injectées dans le TRADER prompt via
+`blow-off-preamble-lessons.ts`. Les 16 autres sont documentées ici pour
+référence future et tuning.
+
+---
+
+## A. Academic P&D detection (crypto + cross-asset)
+
+### 1. Kamps-Kleinberg anomaly windows — HIGH (intégré priors)
+- **Signature** : rolling price/volume z-score sur fenêtre 12h.
+- **Filter** : flag quand price+volume > 2σ vs mean en rolling 12h.
+- **Source** : [Kamps & Kleinberg 2018, Crime Science](https://link.springer.com/article/10.1186/s40163-018-0093-5)
+
+### 2. Xu-Livshits volume-cap signature — HIGH (intégré : `small_cap_telegram_pump`)
+- **Signature** : small/illiquid + 1m volume > 5× MA20 + no scheduled catalyst <24h.
+- **Filter** : skip ou fade ces names sans confirmation indépendante.
+- **Source** : [Xu & Livshits 2019, arXiv:1811.10109](https://arxiv.org/abs/1811.10109)
+
+### 3. La Morgia rush-order detection — HIGH
+- **Signature** : StdRushOrders + AvgRushOrders sur buckets 5s > 3σ vs mean 1h.
+- **Filter** : block entry si rush-order pattern détecté (coordinated insider buys).
+- **Source** : [La Morgia ICCCN 2020 / GitHub dataset](https://github.com/SystemsLab-Sapienza/pump-and-dump-dataset)
+
+### 4. La Morgia 2024 real-time RF/AdaBoost — HIGH
+- **Signature** : 9-feature vector sur tick stream (StdRushOrders, AvgRushOrders, StdVolumes, StdPrice...).
+- **Filter** : RF on labelled dataset, require positive class probability < 0.5.
+- **Source** : [arXiv 2412.18848](https://arxiv.org/html/2412.18848v2)
+
+### 5. Crypto P&D economic estimate — MED
+- ~$7M/mois volume artificiel sur small-cap coins via Telegram pumps.
+- **Source** : [CEPR Vox](https://cepr.org/voxeu/columns/economics-cryptocurrency-pump-and-dump-schemes)
+
+### 6. Order-book imbalance flip — MED
+- **Signature** : depth bid:ask 1.5:1 → 0.6:1 en <30s.
+- **Filter** : skip long si depth ratio drop > 60% sur 30s.
+- **Source** : [Sling Academy](https://www.slingacademy.com/article/monitoring-order-book-imbalances-for-trading-signals-via-cryptofeed/), [Amberdata](https://blog.amberdata.io/monitoring-order-book-snapshots-to-understand-market-depth)
+
+---
+
+## B. Chartist exhaustion / climax patterns
+
+### 7. Exhaustion gap on high volume — HIGH
+- **Signature** : gap > 2 ATR(14) après ≥5 jours consécutifs up + volume > 3× MA20.
+- **Filter** : block long, candidate short fade.
+- **Source** : [Quantified Strategies](https://www.quantifiedstrategies.com/exhaustion-gap/), Zacks
+
+### 8. Climax run (O'Neil) — HIGH (intégré : `climax_run_oneil`)
+- **Signature** : +25-50% en 1-2 semaines après uptrend multi-mois.
+- **Filter** : block new long si 5-day return ≥ 25% AND prior 90-day ≥ 50%.
+- **Source** : O'Neil CAN SLIM / [AAII](https://www.aaii.com/journal/article/william-oneil-can-slim-approach)
+
+### 9. Parabolic blow-off slope test — MED
+- **Signature** : ROC(1m, 5 bars récentes) / ROC(1m, 20 bars antérieurs) > 2.5.
+- **Filter** : chart near-vertical = late FOMO.
+- **Source** : [ChartGuys](https://www.chartguys.com/chart-patterns/parabolic-blow-off-top), [QuantVPS](https://www.quantvps.com/blog/blow-off-top-chart-pattern)
+
+### 10. Shooting star 1m/5m — MED (intégré : `shooting_star_intraday`)
+- **Signature** : upper shadow ≥ 2× body, small body near low, après uptrend.
+- **Source** : [Bulkowski thepatternsite](https://thepatternsite.com/ShootingStar.html)
+
+### 11. Bearish engulfing at resistance — MED
+- **Signature** : current bar body ≥ 100% prior bar range, close < open, après uptrend.
+- **Stats** : 57% base, 65-75% avec volume + resistance.
+- **Source** : TradingSim backtest cheat sheet, [Altrady](https://www.altrady.com/)
+
+### 12. Gravestone / shooting-star doji — MED
+- **Signature** : doji body < 10% range, all wick upper side, après rally.
+- **Stats** : 57% reversal.
+- **Source** : [Liberated Stock Trader 56,680-trade study](https://www.liberatedstocktrader.com/candle-patterns-reliable-profitable/)
+
+### 13. Exhaustion volume spike — HIGH (intégré : `exhaustion_volume_spike`)
+- **Signature** : volume bougie > 4× MA(20×1m volume) sur new 60-min high.
+- **Filter** : never buy that tick, late FOMO bar.
+- **Source** : opofinance, convergent multi-source
+
+---
+
+## C. Momentum trader consensus
+
+### 14. Minervini "don't chase extended" — HIGH (intégré : `minervini_dont_chase_extended`)
+- **Signature** : price > 10% above 20MA (stocks), > 20% (crypto).
+- **Source** : Minervini SEPA / [TraderLion VCP](https://traderlion.com/technical-analysis/volatility-contraction-pattern/)
+
+### 15. O'Neil "7 of 8 days up" — HIGH (intégré : `oneil_7_of_8`)
+- **Signature** : stock up 7 of last 8 OR 8 of last 10 days.
+- **Source** : [O'Neil sell rules Scribd](https://www.scribd.com/document/143549322/William-J-O-Neil-Sell-Rules)
+
+### 16. O'Neil "25% in 1-2 weeks" climax — HIGH
+- **Signature** : ≥ 25% advance 5-10 sessions post prior uptrend.
+- **Source** : [Macro-Ops CAN SLIM](https://macro-ops.com/william-oneils-can-slim-trading-strategy-explained/)
+
+### 17. Raschke "buy first pullback, not first push" — HIGH (intégré : `raschke_first_pullback`)
+- **Signature** : entry sur new HOD sans pullback ≥ 0.38 × impulse.
+- **Source** : [Raschke 12 rules newtraderu](https://www.newtraderu.com/2022/08/25/market-wizard-linda-raschke-trading-strategy/)
+
+### 18. Raschke "no Turtle Soup vs news" — MED
+- **Filter** : news catalyst < 30min → suppress both fade-shorts et chase-longs.
+- **Source** : [atozmarkets Raschke](https://atozmarkets.com/strategies/linda-raschke-strategy/)
+
+### 19. Raschke climax range expansion — HIGH
+- **Signature** : ATR(5×1m) / ATR(20×1m) > 2.0 après uptrend soutenu.
+- **Source** : [forex.in.rs Raschke](https://forex.in.rs/linda-raschke-strategy/)
+
+### 20. Weinstein Stage-3 flattening — MED (long-horizon)
+- **Signature intraday analog** : EMA(200×5m) flat + down-vol > up-vol sur 60min.
+- **Source** : [TraderLion stage-analysis](https://traderlion.com/trading-strategies/stage-analysis/)
+
+### 21. O'Neil 50-day break sell (intraday analog: EMA60×1m) — HIGH
+- **Signature** : close < EMA(60×1m) sur volume > 2× MA20-vol après uptrend horaire.
+- **Source** : [AAII O'Neil tribute](https://www.aaii.com/journal/article/68036)
+
+---
+
+## D. Crypto-specific operational
+
+### 22. Telegram pump time-of-day cluster — MED
+- **Signature** : organized pumps cluster ±5min round UTC hours (00:00, 12:00, 18:00).
+- **Source** : [Doge of Wall Street arXiv](https://arxiv.org/html/2105.00733v2)
+
+### 23. Pre-pump social spike — MED
+- **Signature** : channel-member growth z-score > 3 sur 6h.
+- **Source** : [Hamrick et al, sciencedirect](https://www.sciencedirect.com/science/article/abs/pii/S0957417421007156)
+
+### 24. Adversarial Telegram detection 80% — LOW
+- **Source** : [TNW summary](https://thenextweb.com/news/ai-pump-dump-predictor-telegram)
+
+---
+
+## E. Intraday fade stats (US momentum stocks)
+
+### 25. SmallCapLab gap-fade base rate — MED
+- ~63-67% fade pre-market gappers ; 85% short success après 11:00 ET sur day-1 low-float.
+- **Source** : [smallcaplab.com](https://www.smallcaplab.com/), tradethematrix.net
+
+### 26. Mid-sized opening-move reversion — MED (intégré : `opening_15min_chase`)
+- ~62-67% reversion sur mid-sized 15-min moves.
+- **Source** : [OptionAlpha opening-range](https://optionalpha.com/blog/opening-range-breakout)
+
+### 27. Short-horizon asymmetric reversal — MED-LOW (intégré : `short_horizon_reversal_asymmetric`)
+- Reversal robuste après DOWN > 10%, faible après UP > 10%.
+- **Source** : [Mu et al arXiv cond-mat/0406696](https://arxiv.org/pdf/cond-mat/0406696)
+
+### 28. RSI extreme + deceleration — HIGH (intégré : `rsi_extreme_deceleration`)
+- **Signature** : RSI(7) ≥ 85 ET ROC(1m) < mean(ROC, 5×1m prior). LITERAL OKLO signature.
+- **Source** : [Quantified Strategies RSI](https://www.quantifiedstrategies.com/rsi-trading-strategy/)
+
+---
+
+## Mapping cas OKLO.US 03/06/2026
+
+Les patterns qui auraient bloqué l'entry $66.46 :
+
+| # | Lesson | Statut SmartVest |
+|---|---|---|
+| 28 | RSI extreme + decel | Pas encore (TRADER prompt prior) |
+| 17 | Raschke first pullback | TRADER prompt prior |
+| 9 | Parabolic slope test | Implicit via tf5m/tf30m gate |
+| 13 | Exhaustion volume spike | TRADER prompt prior |
+| 14 | Minervini extended | TRADER prompt prior |
+| 26 | Opening 15-min fade | TRADER prompt prior |
+| 8 | Climax run O'Neil | **Scanner gate (CLIMAX_RUN)** + prompt prior |
+| — | Vertical pump concentration | **Scanner gate (VERTICAL_PUMP)** + prompt prior |
+| — | Path eff structural | **Scanner gate (CHOP_LONG_TF)** + prompt prior |
+| — | Top tick drift | **Scanner gate (TOP_TICK_GUARD)** |
+
+4 gates hardcoded au scanner (déterministe), 12 priors au TRADER (verbalisation + override).

--- a/apps/api/src/modules/lisa/services/__tests__/blow-off-gates.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/blow-off-gates.spec.ts
@@ -1,0 +1,197 @@
+import {
+  evaluatePathEffLongTf,
+  evaluateClimaxRun,
+  evaluateVerticalPump,
+  evaluateTopTickDrift,
+} from '../blow-off-gates.helper';
+
+// Snapshot du candidat OKLO.US au moment de l'ouverture TRADER le 03/06/2026.
+// Tous les gates doivent caler sur ces valeurs (test de non-régression).
+const OKLO_03_06 = {
+  ch1m: 9.84,
+  tf5m: 11.79,
+  tf30m: 12.10,
+  tf1h: 12.08,
+  pathQuality: {
+    tf5m: { pathEfficiency: 1.0 },
+    tf10m: { pathEfficiency: 1.0 },
+    tf15m: { pathEfficiency: 0.4468 },
+    tf30m: { pathEfficiency: 0.5063 },
+    tf1h: { pathEfficiency: 0.2833 },
+  },
+  candClose: 66.35,
+  livePrice: 66.46,
+};
+
+describe('evaluatePathEffLongTf — CHOP_LONG_TF gate', () => {
+  it('null si threshold null', () => {
+    expect(evaluatePathEffLongTf(OKLO_03_06.pathQuality, null)).toBeNull();
+    expect(evaluatePathEffLongTf(OKLO_03_06.pathQuality, undefined)).toBeNull();
+  });
+
+  it('null si pathQuality manquant', () => {
+    expect(evaluatePathEffLongTf(null, 0.3)).toBeNull();
+    expect(evaluatePathEffLongTf(undefined, 0.3)).toBeNull();
+  });
+
+  it('OKLO.US : tf1h=0.28 < 0.30 → CHOP_LONG_TF [non-régression]', () => {
+    const hit = evaluatePathEffLongTf(OKLO_03_06.pathQuality, 0.30);
+    expect(hit).not.toBeNull();
+    expect((hit as any).tf).toBe('tf1h');
+    expect((hit as any).value).toBeCloseTo(0.2833, 3);
+  });
+
+  it('passe si tf1h et tf30m au-dessus du seuil', () => {
+    const pq = {
+      ...OKLO_03_06.pathQuality,
+      tf1h: { pathEfficiency: 0.6 },
+      tf30m: { pathEfficiency: 0.7 },
+    };
+    expect(evaluatePathEffLongTf(pq, 0.30)).toBeNull();
+  });
+
+  it('detecte tf30m en dessous même si tf1h OK', () => {
+    const pq = {
+      ...OKLO_03_06.pathQuality,
+      tf1h: { pathEfficiency: 0.8 },
+      tf30m: { pathEfficiency: 0.20 },
+    };
+    const hit = evaluatePathEffLongTf(pq, 0.30);
+    expect(hit?.tf).toBe('tf30m');
+  });
+
+  it('null si tf1h et tf30m manquent (pas de signal)', () => {
+    const pq = {
+      tf5m: { pathEfficiency: 0.1 },
+      tf10m: null,
+      tf15m: null,
+      tf30m: null,
+      tf1h: null,
+    };
+    expect(evaluatePathEffLongTf(pq, 0.30)).toBeNull();
+  });
+});
+
+describe('evaluateClimaxRun — plateau-then-burst gate', () => {
+  it('OKLO.US : tf5m=11.79, tf30m=12.10 → CLIMAX_RUN [non-régression]', () => {
+    const hit = evaluateClimaxRun(OKLO_03_06.tf5m, OKLO_03_06.tf30m);
+    expect(hit).not.toBeNull();
+    expect((hit as any).gapPct).toBeCloseTo(0.31, 1);
+    expect((hit as any).tf5m).toBe(11.79);
+  });
+
+  it('null si tf5m < minMove (default 5%)', () => {
+    expect(evaluateClimaxRun(3.0, 3.2)).toBeNull();
+    expect(evaluateClimaxRun(4.9, 5.0)).toBeNull();
+  });
+
+  it('null si gap >= maxPlateauGapPct (default 1.5pt)', () => {
+    // tf5m=10%, tf30m=5% → gap 5pt → mouvement progressif, pas plateau
+    expect(evaluateClimaxRun(10, 5)).toBeNull();
+    expect(evaluateClimaxRun(10, 8)).toBeNull(); // gap 2 > 1.5
+  });
+
+  it('détecte plateau standard 6%/6.5% (gap 0.5)', () => {
+    const hit = evaluateClimaxRun(6.5, 6.0);
+    expect(hit).not.toBeNull();
+    expect((hit as any).gapPct).toBeCloseTo(0.5, 2);
+  });
+
+  it('null si tf5m ou tf30m manquent', () => {
+    expect(evaluateClimaxRun(null, 5)).toBeNull();
+    expect(evaluateClimaxRun(5, null)).toBeNull();
+    expect(evaluateClimaxRun(undefined, undefined)).toBeNull();
+  });
+
+  it('seuils tunables', () => {
+    // Avec minMove=3 et maxGap=2, OKLO toujours détecté
+    const hit = evaluateClimaxRun(11.79, 12.10, { minTf5mPct: 3, maxPlateauGapPct: 2 });
+    expect(hit).not.toBeNull();
+    // Avec minMove=15 (très strict), OKLO ne passe plus
+    expect(evaluateClimaxRun(11.79, 12.10, { minTf5mPct: 15 })).toBeNull();
+  });
+});
+
+describe('evaluateVerticalPump — last-minute concentration gate', () => {
+  it('OKLO.US : ch1m=9.84% / tf5m=11.79% = 0.834 → VERTICAL_PUMP [non-régression]', () => {
+    const hit = evaluateVerticalPump(OKLO_03_06.ch1m, OKLO_03_06.tf5m);
+    expect(hit).not.toBeNull();
+    expect((hit as any).ratio).toBeCloseTo(0.834, 2);
+  });
+
+  it('momentum linéaire passe (ratio ~0.2)', () => {
+    // 5min steady : ch1m=2%, tf5m=10% → ratio 0.2
+    expect(evaluateVerticalPump(2, 10)).toBeNull();
+  });
+
+  it('null si tf5m < minMove (default 5%)', () => {
+    // Gentle move : pas de signal vertical pump
+    expect(evaluateVerticalPump(3, 4)).toBeNull();
+  });
+
+  it('null si ch1m <= 0', () => {
+    expect(evaluateVerticalPump(0, 10)).toBeNull();
+    expect(evaluateVerticalPump(-1, 10)).toBeNull();
+  });
+
+  it('null si ch1m ou tf5m manquent', () => {
+    expect(evaluateVerticalPump(null, 10)).toBeNull();
+    expect(evaluateVerticalPump(5, null)).toBeNull();
+  });
+
+  it('boundary ratio = 0.5 ne déclenche pas (strict >)', () => {
+    // ch1m=5, tf5m=10 → ratio exactement 0.5
+    expect(evaluateVerticalPump(5, 10)).toBeNull();
+  });
+
+  it('NaN → null (pas de crash)', () => {
+    expect(evaluateVerticalPump(NaN, 10)).toBeNull();
+    expect(evaluateVerticalPump(5, NaN)).toBeNull();
+  });
+
+  it('seuils tunables : maxRatio=0.3 plus strict', () => {
+    // ch1m=4, tf5m=10 → ratio 0.4 → bloqué avec maxRatio=0.3
+    const hit = evaluateVerticalPump(4, 10, { maxRatio: 0.3 });
+    expect(hit).not.toBeNull();
+  });
+});
+
+describe('evaluateTopTickDrift — anti top-tick au fill', () => {
+  it('OKLO.US : drift +0.166% < seuil 0.25% → passe (limite)', () => {
+    // OKLO réel : drift 0.166% < 0.25% default → passe (les autres gates auront bloqué)
+    expect(evaluateTopTickDrift(66.46, 66.35, 0.25)).toBeNull();
+  });
+
+  it('OKLO.US : seuil resserré à 0.15% → bloque [non-régression possible config]', () => {
+    const hit = evaluateTopTickDrift(66.46, 66.35, 0.15);
+    expect(hit).not.toBeNull();
+    expect((hit as any).driftPct).toBeCloseTo(0.166, 2);
+  });
+
+  it('drift négatif (price baissé) → null', () => {
+    expect(evaluateTopTickDrift(65, 66, 0.25)).toBeNull();
+  });
+
+  it('drift > seuil → bloque', () => {
+    const hit = evaluateTopTickDrift(101, 100, 0.5);
+    expect(hit).not.toBeNull();
+    expect((hit as any).driftPct).toBeCloseTo(1.0, 3);
+  });
+
+  it('null si candClose manquant ou invalide', () => {
+    expect(evaluateTopTickDrift(100, null, 0.25)).toBeNull();
+    expect(evaluateTopTickDrift(100, 0, 0.25)).toBeNull();
+    expect(evaluateTopTickDrift(100, -10, 0.25)).toBeNull();
+  });
+
+  it('null si livePrice invalide', () => {
+    expect(evaluateTopTickDrift(NaN, 100, 0.25)).toBeNull();
+    expect(evaluateTopTickDrift(0, 100, 0.25)).toBeNull();
+  });
+
+  it('null si threshold <= 0 ou invalide (désactive le gate)', () => {
+    expect(evaluateTopTickDrift(101, 100, 0)).toBeNull();
+    expect(evaluateTopTickDrift(101, 100, -1)).toBeNull();
+    expect(evaluateTopTickDrift(101, 100, NaN)).toBeNull();
+  });
+});

--- a/apps/api/src/modules/lisa/services/blow-off-gates.helper.ts
+++ b/apps/api/src/modules/lisa/services/blow-off-gates.helper.ts
@@ -1,0 +1,126 @@
+/**
+ * Blow-off / pump-fade detection gates — pure helpers (no I/O).
+ *
+ * Conçu suite au post-mortem OKLO.US (03/06/2026, -1.63% en 35min, top tick
+ * exact $66.46). Le candidat avait persistence 5/5 et overallEfficiency=0.65
+ * (OK), MAIS :
+ *   - tf1h pathEff=0.28 (choppy) masqué par 5m=1.00 sur 2 ticks
+ *   - tf30m=12.10%, tf5m=11.79% → plateau pré-burst (climax run)
+ *   - ch1m=9.84% / tf5m=11.79% → 83% du move 5min concentré sur la dernière minute
+ *
+ * Les 3 gates ci-dessous capturent ces patterns. Pures fonctions sans I/O ni
+ * dépendances, testables seules. Cf. tests dans __tests__/blow-off-gates.spec.ts
+ *
+ * Références (cf. lessons preamble #7-#28) :
+ *   - O'Neil "climax run" : up 25%+ in 1-2 weeks after prior uptrend
+ *   - Minervini "don't chase extended" : price > 10% above 20MA
+ *   - Raschke "buy first pullback, not first push"
+ *   - Bulkowski shooting star / blow-off top
+ *   - Kamps-Kleinberg / La Morgia : real-time P&D detection
+ */
+
+export interface PathEffByTf {
+  tf5m: { pathEfficiency: number } | null;
+  tf10m: { pathEfficiency: number } | null;
+  tf15m: { pathEfficiency: number } | null;
+  tf30m: { pathEfficiency: number } | null;
+  tf1h: { pathEfficiency: number } | null;
+}
+
+/**
+ * Gate 1 — Path efficiency PAR TF (pas seulement overall).
+ *
+ * Le 1h et le 30m sont les vues structurelles (vrai trend), pas optique. Si
+ * elles sont choppy mais overall est OK (tiré par 5m=1.00 sur 2 ticks), on
+ * masque un setup en réalité chaotique. Cf. OKLO 03/06 : tf1h=0.28, overall=0.65.
+ *
+ * @returns null si pas de violation, sinon { tf, value } du TF fautif.
+ */
+export function evaluatePathEffLongTf(
+  pathQuality: PathEffByTf | undefined | null,
+  threshold: number | null | undefined,
+): { tf: 'tf30m' | 'tf1h'; value: number } | null {
+  if (threshold == null || !pathQuality) return null;
+  const tf1hEff = pathQuality.tf1h?.pathEfficiency;
+  const tf30mEff = pathQuality.tf30m?.pathEfficiency;
+  if (tf1hEff != null && tf1hEff < threshold) return { tf: 'tf1h', value: tf1hEff };
+  if (tf30mEff != null && tf30mEff < threshold) return { tf: 'tf30m', value: tf30mEff };
+  return null;
+}
+
+/**
+ * Gate 2 — Climax run / blow-off : plateau-then-burst.
+ *
+ * Signature : tf30m ≈ tf5m (∆ < 1.5pt) → flat entre H-30min et H-5min ago
+ *             AND tf5m ≥ 5%             → move 5min substantiel
+ * Conclusion : tout le move récent est concentré dans le dernier ~5min après
+ * un long plateau. C'est le top tick par construction (mean reversion immédiate).
+ *
+ * OKLO 03/06 : tf5m=11.79%, tf30m=12.10%, ∆=0.31pt < 1.5 → CLIMAX_RUN.
+ */
+export function evaluateClimaxRun(
+  tf5m: number | null | undefined,
+  tf30m: number | null | undefined,
+  options?: { minTf5mPct?: number; maxPlateauGapPct?: number },
+): { tf5m: number; tf30m: number; gapPct: number } | null {
+  const minMove = options?.minTf5mPct ?? 5;
+  const maxGap = options?.maxPlateauGapPct ?? 1.5;
+  if (tf5m == null || tf30m == null) return null;
+  if (tf5m < minMove) return null;
+  const gap = Math.abs(tf30m - tf5m);
+  if (gap >= maxGap) return null;
+  return { tf5m, tf30m, gapPct: gap };
+}
+
+/**
+ * Gate 3 — Vertical pump : last-minute concentration.
+ *
+ * Signature : ch1m / tf5m > 0.5 AND tf5m ≥ 5%
+ *   → plus de la moitié du move 5min s'est fait dans la dernière minute.
+ *
+ * Healthy momentum linéaire : ch1m ≈ tf5m / 5 (ratio ~0.2). Vertical pump :
+ * ratio > 0.5 → late FOMO bar. Entrée à ce moment = top tick.
+ *
+ * OKLO 03/06 : ch1m=9.84% / tf5m=11.79% = 0.834 → VERTICAL_PUMP.
+ */
+export function evaluateVerticalPump(
+  ch1m: number | null | undefined,
+  tf5m: number | null | undefined,
+  options?: { minTf5mPct?: number; maxRatio?: number },
+): { ch1m: number; tf5m: number; ratio: number } | null {
+  const minMove = options?.minTf5mPct ?? 5;
+  const maxRatio = options?.maxRatio ?? 0.5;
+  if (ch1m == null || tf5m == null) return null;
+  if (!Number.isFinite(ch1m) || !Number.isFinite(tf5m)) return null;
+  if (tf5m < minMove) return null;
+  if (ch1m <= 0) return null;
+  const ratio = ch1m / tf5m;
+  if (ratio <= maxRatio) return null;
+  return { ch1m, tf5m, ratio };
+}
+
+/**
+ * Gate 4 — Top-tick drift à l'open.
+ *
+ * Si le live price au moment du fill a drifté UP de plus de `maxDriftPct` vs
+ * le snapshot scanner (cand.close), le pump continue pendant l'éval gate
+ * (5-15s LLM) et on est en train de buy le peak.
+ *
+ * OKLO 03/06 : cand.close=$66.35, quote.price=$66.46 → +0.166% drift = top tick.
+ * Default seuil 0.25% — tunable via env GAINERS_TOP_TICK_DRIFT_MAX_PCT.
+ *
+ * Raschke "wait first pullback, not first push" — skip ce cycle, le candidat
+ * reviendra peut-être après pullback (sinon mean reversion = bonne décision).
+ */
+export function evaluateTopTickDrift(
+  livePrice: number,
+  candClose: number | null | undefined,
+  maxDriftPct: number,
+): { driftPct: number; threshold: number } | null {
+  if (candClose == null || !Number.isFinite(candClose) || candClose <= 0) return null;
+  if (!Number.isFinite(livePrice) || livePrice <= 0) return null;
+  if (!Number.isFinite(maxDriftPct) || maxDriftPct <= 0) return null;
+  const driftPct = ((livePrice - candClose) / candClose) * 100;
+  if (driftPct <= maxDriftPct) return null;
+  return { driftPct, threshold: maxDriftPct };
+}

--- a/apps/api/src/modules/lisa/services/blow-off-preamble-lessons.ts
+++ b/apps/api/src/modules/lisa/services/blow-off-preamble-lessons.ts
@@ -1,0 +1,184 @@
+/**
+ * Blow-off / pump-fade preamble lessons — priors injected in TRADER prompt.
+ *
+ * Curated from academic and consensus sources (post-mortem OKLO.US 03/06/2026).
+ * The scanner already enforces gates 1-4 (CHOP_LONG_TF, CLIMAX_RUN, VERTICAL_PUMP,
+ * TOP_TICK_GUARD) via blow-off-gates.helper.ts. This file gives the TRADER LLM
+ * the PATTERN VOCABULARY so it can:
+ *   1) recognize blow-off signatures that slip past gates (rare)
+ *   2) justify a HOLD/SKIP with named, sourced pattern in its rationale
+ *   3) override "size+conviction looks OK" reflexes when a fade signature appears
+ *
+ * Sources (full bibliography in `apps/api/docs/blow-off-research.md`) :
+ *   - Xu & Livshits 2019 (arxiv:1811.10109) — Crypto P&D anatomy
+ *   - Kamps & Kleinberg 2018 — "To the moon" anomaly windows
+ *   - La Morgia et al. 2020/2024 — Real-time P&D ML detection
+ *   - Minervini SEPA / TraderLion VCP
+ *   - O'Neil CAN SLIM sell rules / AAII
+ *   - Linda Raschke 12 rules
+ *   - Bulkowski thepatternsite — shooting star / blow-off stats
+ *
+ * Confidence convention (mirrors lessons system): 0.0-1.0.
+ *  - 0.90+ : peer-reviewed + numeric threshold + convergent multi-source
+ *  - 0.75+ : single quantified rule with operational specificity
+ *  - 0.60+ : widely cited heuristic, threshold weakly anchored
+ */
+
+export interface PreambleLesson {
+  /** Stable ID for tracking which lesson influenced a decision. */
+  id: string;
+  /** Pattern family for filtering / grouping. */
+  family: 'blow_off' | 'climax_run' | 'late_fomo' | 'concentration' | 'volume_anomaly' | 'rsi_decel' | 'pullback_discipline' | 'mean_reversion';
+  /** Short human-readable name (cited by TRADER in rationale, e.g. "[OKLO_RULE_climax_run_O'Neil]"). */
+  name: string;
+  /** Numeric signature the TRADER can verify against candidate metrics. */
+  signature: string;
+  /** Action prescribed. */
+  rule: string;
+  /** Source citation. */
+  source: string;
+  /** Confidence prior. */
+  confidence: number;
+}
+
+/**
+ * 12 highest-impact rules (filtered from the 28 surveyed) for momentum entry
+ * decisions. Kept compact to fit prompt budget — full set in research doc.
+ */
+export const BLOW_OFF_PREAMBLE_LESSONS: ReadonlyArray<PreambleLesson> = [
+  {
+    id: 'climax_run_oneil',
+    family: 'climax_run',
+    name: 'climax_run_O\'Neil',
+    signature: 'price +25% en 5-10 sessions APRÈS uptrend multi-mois, OU tf30m ≈ tf5m + tf5m ≥ 5% (intraday)',
+    rule: 'SKIP nouvelle entrée long. C\'est le sommet par construction, mean reversion imminente.',
+    source: 'O\'Neil CAN SLIM sell rules / AAII journal',
+    confidence: 0.90,
+  },
+  {
+    id: 'vertical_pump_last_minute',
+    family: 'concentration',
+    name: 'vertical_pump_concentration',
+    signature: 'ch1m / tf5m > 0.5 ET tf5m ≥ 5% — la dernière minute a fait > 50% du move 5min',
+    rule: 'SKIP long. Late FOMO bar = top tick. Cf. OKLO.US 03/06 : ch1m=9.84/tf5m=11.79=0.83 → -1.6% en 35min.',
+    source: 'Bulkowski blow-off + Raschke "first push" axiom',
+    confidence: 0.92,
+  },
+  {
+    id: 'minervini_dont_chase_extended',
+    family: 'late_fomo',
+    name: 'minervini_extended',
+    signature: '(price - 20MA) / 20MA > 0.10 (stocks) ou > 0.20 (crypto)',
+    rule: 'BLOCK long. Attendre pullback ou prochain setup (VCP base).',
+    source: 'Minervini "Trade Like a Stock Market Wizard" / TraderLion VCP',
+    confidence: 0.85,
+  },
+  {
+    id: 'raschke_first_pullback',
+    family: 'pullback_discipline',
+    name: 'raschke_no_first_push',
+    signature: 'entry sur barre qui imprime un nouveau HOD sans pullback préalable de ≥ 38% de l\'impulsion',
+    rule: 'WAIT au moins 1 candle 1m rouge (ou retrace ≥ 0.38 × impulse) avant entry sur reclaim.',
+    source: 'Linda Raschke 12 rules / newtraderu.com',
+    confidence: 0.88,
+  },
+  {
+    id: 'oneil_7_of_8',
+    family: 'climax_run',
+    name: 'oneil_7_of_8_days',
+    signature: 'stock up 7 of last 8 days OR 8 of last 10 days',
+    rule: 'REFUSE nouvelles entrées long. Précurseur climax run.',
+    source: 'O\'Neil sell rules / Scribd',
+    confidence: 0.82,
+  },
+  {
+    id: 'exhaustion_volume_spike',
+    family: 'volume_anomaly',
+    name: 'exhaustion_volume',
+    signature: 'volume bougie courante > 4× MA(20×1min volume) ET porte le prix à new 60-min high',
+    rule: 'NEVER buy that tick. Late-FOMO bar. Wait pullback ou skip cycle.',
+    source: 'opofinance exhaustion-volume + Kamps-Kleinberg z-score',
+    confidence: 0.87,
+  },
+  {
+    id: 'rsi_extreme_deceleration',
+    family: 'rsi_decel',
+    name: 'rsi85_decel',
+    signature: 'RSI(7) ≥ 85 sur TF entrée ET ROC(dernier 1m) < mean(ROC, 5 dernières 1m)',
+    rule: 'VETO long. Overbought + momentum decelerating = climax. OKLO signature exacte.',
+    source: 'Quantified Strategies RSI study',
+    confidence: 0.91,
+  },
+  {
+    id: 'shooting_star_intraday',
+    family: 'blow_off',
+    name: 'shooting_star_1m',
+    signature: 'sur 1m close: (high - max(open,close)) ≥ 2 × |close - open| après uptrend 5min > 3%',
+    rule: 'VETO new long. Reversal candle ~59% base rate Bulkowski, +20pts avec volume.',
+    source: 'Bulkowski thepatternsite.com/ShootingStar',
+    confidence: 0.78,
+  },
+  {
+    id: 'opening_15min_chase',
+    family: 'mean_reversion',
+    name: 'us_opening_chase',
+    signature: 'US equity, premiers 15 min after 14:30 UTC, ch15m > +5%',
+    rule: 'NE PAS chase. Wait IB break-and-reclaim. Base rate fade 62-67%.',
+    source: 'OptionAlpha opening-range research',
+    confidence: 0.75,
+  },
+  {
+    id: 'small_cap_telegram_pump',
+    family: 'blow_off',
+    name: 'crypto_pump_small_cap',
+    signature: 'small-cap crypto + volume 1m > 5× MA20 + signal à ±5min round UTC hour',
+    rule: 'TREAT adversarial. Require 2× confirmation (news / on-chain) or SKIP.',
+    source: 'Xu-Livshits 2019 / La Morgia P&D dataset',
+    confidence: 0.85,
+  },
+  {
+    id: 'path_eff_long_tf',
+    family: 'blow_off',
+    name: 'chop_structural',
+    signature: 'tf1h pathEff < threshold (default 0.30) OU tf30m pathEff < threshold',
+    rule: 'SKIP. Le 1h/30m est la vue structurelle. Choppy = pas de vrai trend, bruit.',
+    source: 'OKLO post-mortem 03/06 + SmartVest path-quality framework',
+    confidence: 0.88,
+  },
+  {
+    id: 'short_horizon_reversal_asymmetric',
+    family: 'mean_reversion',
+    name: 'extreme_up_no_guaranteed_fade',
+    signature: 'stock up > +10% en 1 session intraday',
+    rule: 'NE PAS shorter mécaniquement. Empirique : reversal robuste après DOWN extreme, faible après UP extreme. Combine avec exhaustion volume + RSI decel avant fade.',
+    source: 'Mu et al. (cond-mat/0406696)',
+    confidence: 0.70,
+  },
+];
+
+/**
+ * Formats the preamble lessons as a prompt block, ready to inject into TRADER
+ * systemPrompt. Compact (~1200 tokens), structured for LLM verification.
+ */
+export function formatBlowOffPreambleBlock(
+  lessons: ReadonlyArray<PreambleLesson> = BLOW_OFF_PREAMBLE_LESSONS,
+): string {
+  if (lessons.length === 0) return '';
+  const sorted = [...lessons].sort((a, b) => b.confidence - a.confidence);
+  const lines = sorted.map((l, i) => {
+    return `${i + 1}. [${l.name} conf=${l.confidence.toFixed(2)}]\n   Signature : ${l.signature}\n   Règle : ${l.rule}\n   Source : ${l.source}`;
+  });
+  return `PRÉAMBULE BLOW-OFF / PUMP-FADE — PRIORS ACADÉMIQUES & CONSENSUS
+
+Tu connais ces ${sorted.length} patterns nommés pour reconnaître / verbaliser les setups
+à risque (top tick, climax run, late FOMO). Le scanner en bloque déjà beaucoup en amont
+(CHOP_LONG_TF, CLIMAX_RUN, VERTICAL_PUMP, TOP_TICK_GUARD). Si UN candidat passe et tu
+détectes l'une de ces signatures dans ses metrics → tu as autorité pour SKIP avec
+citation explicite dans [DIAGNOSTIC] : '[BLOW_OFF_RULE id=<name>]'.
+
+${lines.join('\n\n')}
+
+RÈGLE D'OR : un setup qui matche ≥ 2 de ces 12 patterns = veto presque automatique.
+Cite les IDs dans rationale. Cas réel à éviter : OKLO.US 03/06 matchait 4 patterns
+(climax_run, vertical_pump, chop_structural, no_first_pullback) → -1.6% en 35min.`;
+}

--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -37,6 +37,7 @@ import { PushNotificationsService } from './push-notifications.service';
 import { MistralShadowService } from './mistral-shadow.service';
 import { MistralLargeShadowService } from './mistral-large-shadow.service';
 import { ExitPolicyContextService } from './exit-policy-context.service';
+import { formatBlowOffPreambleBlock } from './blow-off-preamble-lessons';
 import { summarizeMomentumDecisions } from './scanner-momentum-shadow.helper';
 import type { TopGainerCandidate } from '@smartvest/ai-analyst';
 
@@ -2048,6 +2049,17 @@ Recommendation rules :
     selfReflection: string,
   ): string {
     let prompt = SYSTEM_PROMPT_BASE;
+
+    // OKLO-fix 03/06/2026 — Préambule blow-off / pump-fade lessons (priors
+    // académiques + consensus, 12 patterns nommés). Injecté en tête de prompt
+    // pour que ces patterns deviennent une grille de lecture par défaut, pas
+    // un appendice optionnel. Le scanner bloque déjà les 4 plus mécaniques
+    // (cf. blow-off-gates.helper.ts) mais le TRADER doit savoir les nommer
+    // pour verbaliser un skip propre. Configurable via env.
+    const blowOffPreambleOn = (this.config.get<string>('TRADER_BLOW_OFF_PREAMBLE_ENABLED') ?? 'true').toLowerCase() === 'true';
+    if (blowOffPreambleOn) {
+      prompt += `\n\n${formatBlowOffPreambleBlock()}`;
+    }
 
     // Bloc 1 : memory trader-spécifique (post-mortems Trader Agent)
     if (memory.length > 0) {

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -29,6 +29,12 @@ import { TwelveDataService, type MarketMover } from './twelve-data.service';
 import { rankByCompositeScore, parseCompositeWeights } from './composite-ranker.helper';
 import { computeMomentumMetrics, classifyBucket, type Candle as MomentumCandle } from './momentum-analyzer.helper';
 import { evaluateTwelveDataFilters } from './twelve-data-scanner-filters';
+import {
+  evaluatePathEffLongTf,
+  evaluateClimaxRun,
+  evaluateVerticalPump,
+  evaluateTopTickDrift,
+} from './blow-off-gates.helper';
 import { QwDecisionLoggerService } from '../quick-wins/qw-decision-logger.service';
 import { CronJob } from 'cron';
 import { ConfigService } from '@nestjs/config';
@@ -3879,6 +3885,47 @@ export class TopGainersScannerService implements OnModuleInit {
           continue;
         }
 
+        // OKLO-fix 03/06/2026 — 3 gates anti-blow-off (cf. blow-off-gates.helper.ts)
+        // - CHOP_LONG_TF : path eff PAR TF (tf1h/tf30m), pas seulement overall
+        // - CLIMAX_RUN   : plateau pré-burst (tf30m ≈ tf5m + tf5m ≥ 5%)
+        // - VERTICAL_PUMP: last-minute concentration (ch1m/tf5m > 0.5)
+        // Tous configurables via env _GATE_ENABLED (default true).
+        {
+          const chopLongTfHit = evaluatePathEffLongTf(persistence.pathQuality, effectiveMinPathEff);
+          if (chopLongTfHit) {
+            this.logger.log(
+              `[top-gainers] ${cand.symbol} CHOP_LONG_TF: ${chopLongTfHit.tf}=${chopLongTfHit.value.toFixed(2)} < min=${effectiveMinPathEff!.toFixed(2)} → skip [structural chop]`,
+            );
+            recordShadowDecision(cand, 'reject_path_eff', persistence);
+            continue;
+          }
+
+          const climaxGateOn = (this.config.get<string>('GAINERS_CLIMAX_RUN_GATE_ENABLED') ?? 'true').toLowerCase() === 'true';
+          if (climaxGateOn) {
+            const climaxHit = evaluateClimaxRun(persistence.tf5m, persistence.tf30m);
+            if (climaxHit) {
+              this.logger.log(
+                `[top-gainers] ${cand.symbol} CLIMAX_RUN: tf5m=${climaxHit.tf5m.toFixed(2)}% tf30m=${climaxHit.tf30m.toFixed(2)}% (plateau, |∆|=${climaxHit.gapPct.toFixed(2)}pt) → skip [blow-off]`,
+              );
+              recordShadowDecision(cand, 'reject_other', persistence);
+              continue;
+            }
+          }
+
+          const verticalGateOn = (this.config.get<string>('GAINERS_VERTICAL_PUMP_GATE_ENABLED') ?? 'true').toLowerCase() === 'true';
+          if (verticalGateOn) {
+            const ch1m = typeof cand.changePct === 'number' && Number.isFinite(cand.changePct) ? cand.changePct : null;
+            const verticalHit = evaluateVerticalPump(ch1m, persistence.tf5m);
+            if (verticalHit) {
+              this.logger.log(
+                `[top-gainers] ${cand.symbol} VERTICAL_PUMP: ch1m=${verticalHit.ch1m.toFixed(2)}% / tf5m=${verticalHit.tf5m.toFixed(2)}% = ${verticalHit.ratio.toFixed(2)} → skip [last-minute concentration]`,
+              );
+              recordShadowDecision(cand, 'reject_other', persistence);
+              continue;
+            }
+          }
+        }
+
         // CHOP_NOISE GATE (03/06/2026) — exploite le setup_kind classifier.
         // Audit 02-03/06 : 25/34 trades classifiés CHOP_NOISE avec WR 16% et
         // sumPnl -12.19%. Le scanner sélectionne massivement du chop intra-day
@@ -4982,6 +5029,33 @@ export class TopGainersScannerService implements OnModuleInit {
           this.logger.warn(
             `[top-gainers] ${cand.symbol}: live $${livePriceNum} diverges ${(divergePct * 100).toFixed(1)}% from cand.close $${candCloseNum} → skip (sanity bound)`,
           );
+          return null;
+        }
+        // OKLO-fix 03/06/2026 — Anti top-tick guard (cf. blow-off-gates.helper.ts).
+        // Tune via env GAINERS_TOP_TICK_DRIFT_MAX_PCT (default 0.25%).
+        const topTickMax = parseFloat(this.config.get<string>('GAINERS_TOP_TICK_DRIFT_MAX_PCT') ?? '0.25');
+        const topTickHit = evaluateTopTickDrift(livePriceNum, candCloseNum, topTickMax);
+        if (topTickHit) {
+          this.logger.warn(
+            `[top-gainers] ${cand.symbol} TOP_TICK_GUARD: live $${livePriceNum} drift +${topTickHit.driftPct.toFixed(3)}% vs cand.close $${candCloseNum} > ${topTickHit.threshold}% → skip [anti top-tick]`,
+          );
+          await this.decisionLog.append({
+            portfolioId,
+            kind: 'position_open_failed',
+            summary: `[TOP_TICK_GUARD] ${cand.symbol} drift +${topTickHit.driftPct.toFixed(3)}% > ${topTickHit.threshold}% → skip`,
+            rationale: `Live price drift au-dessus du snapshot scanner pendant l'évaluation gate (~5-15s LLM). Buy à ce moment = top tick par construction (Raschke "wait first pullback"). Attendre cycle suivant ou pullback. Tune via GAINERS_TOP_TICK_DRIFT_MAX_PCT.`,
+            payload: {
+              symbol: cand.symbol,
+              asset_class: cand.assetClass,
+              cand_close: candCloseNum,
+              live_price: livePriceNum,
+              drift_pct: topTickHit.driftPct,
+              threshold_pct: topTickHit.threshold,
+              stage: 'scanner_pre_open',
+              error_class: 'TopTickDriftGuard',
+            },
+            triggeredBy: 'autopilot_cron',
+          }).catch(() => { /* non-bloquant */ });
           return null;
         }
       }


### PR DESCRIPTION
## Post-mortem OKLO.US 03/06/2026

Entry $66.46 → SL $65.42 = **-1.63% (-$34.26) en 34.7 min**.

Signature du candidat :
- `overallEfficiency=0.65` OK mais **tf1h=0.28 (choppy)** masqué par tf5m=1.0 (smooth sur 2 ticks)
- `tf30m=12.10% ≈ tf5m=11.79%` → plateau pré-burst (climax run)
- `ch1m=9.84% / tf5m=11.79% = 0.834` → 83% du move 5min concentré dans la dernière minute
- Drift +0.166% entre `cand.close=$66.35` et fill `quote.price=$66.46` → top tick exact

## 4 gates scanner (déterministe, `blow-off-gates.helper.ts`)

| Gate | Signature | Décision |
|---|---|---|
| CHOP_LONG_TF | `tf1h OR tf30m pathEff < threshold` | reject_path_eff |
| CLIMAX_RUN | `tf5m≥5%` + `|tf30m-tf5m|<1.5pt` | reject_other |
| VERTICAL_PUMP | `ch1m/tf5m>0.5` + `tf5m≥5%` | reject_other |
| TOP_TICK_GUARD | `drift_up > GAINERS_TOP_TICK_DRIFT_MAX_PCT` (def 0.25%) | position_open_failed |

Chaque gate désactivable via env. 27/27 tests unitaires + non-régression OKLO chiffrée.

## 12 priors académiques injectés en préambule TRADER (`blow-off-preamble-lessons.ts`)

Patterns nommés que le LLM peut citer dans son rationale :
- O'Neil climax run / "7 of 8 days up"
- Minervini "don't chase extended" (> 10% above 20MA)
- Raschke "buy first pullback, not first push" + climax range expansion ATR
- Bulkowski shooting star 1m / exhaustion volume spike
- Xu-Livshits crypto P&D small-cap signature
- Kamps-Kleinberg anomaly z-score
- RSI extreme + déceleration (signature OKLO exacte)
- Opening 15-min chase US equity

Tunable via `TRADER_BLOW_OFF_PREAMBLE_ENABLED` (default true). Bibliographie complète 28 sources dans `apps/api/docs/blow-off-research.md`.

## Test plan
- [x] `npx jest blow-off-gates` → 27/27 passent (cas OKLO non-régression chiffré)
- [x] `tsc -b apps/api` exit 0
- [ ] Surveiller post-deploy : décompte `reject_other` ↑ (climax+vertical capturés) + `reject_path_eff` ↑ (long-TF)
- [ ] Vérifier que `[BLOW_OFF_RULE id=...]` apparaît dans TRADER rationales

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_