### PR TITLE
chore(scripts): audit complet HIGH oversold + diag oversold-mistral

### DIFF
--- a/scripts/audit-high-oversold.ts
+++ b/scripts/audit-high-oversold.ts
@@ -1,0 +1,211 @@
+/**
+ * Audit complet HIGH oversold — état config, positions, PnL, activité LLM,
+ * boucle d'apprentissage, anomalies récentes.
+ *
+ *   npx tsx scripts/audit-high-oversold.ts
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+const HIGH = 'a0000001-0000-0000-0000-000000000001';
+
+function fmtT(v: unknown, len = 16) {
+  return String(v ?? '').replace('T', ' ').slice(0, len);
+}
+function fmtUsd(n: number | string | null | undefined): string {
+  const v = Number(n ?? 0);
+  return `${v >= 0 ? '+' : ''}${v.toFixed(2)}`;
+}
+function pad(s: unknown, n: number) { return String(s ?? '').padEnd(n).slice(0, n); }
+
+async function main() {
+  const now = new Date();
+  const today00 = `${now.toISOString().slice(0,10)}T00:00:00Z`;
+  const since24h = new Date(Date.now() - 24*3600_000).toISOString();
+  const since7d = new Date(Date.now() - 7*86400_000).toISOString();
+
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  console.log(` AUDIT COMPLET — HIGH oversold  @  ${now.toISOString().slice(0,19)}Z`);
+  console.log('═══════════════════════════════════════════════════════════════════════════════\n');
+
+  // ─── 1. Config session ────────────────────────────────────────────────────
+  const { data: cfg } = await sb
+    .from('lisa_session_configs')
+    .select('*')
+    .eq('portfolio_id', HIGH)
+    .single();
+  console.log('[1] SESSION CONFIG');
+  console.log(`    strategy_mode       : ${cfg?.strategy_mode}`);
+  console.log(`    autopilot_enabled   : ${cfg?.autopilot_enabled}`);
+  console.log(`    kill_switch_active  : ${cfg?.kill_switch_active}`);
+  console.log(`    paused_reason       : ${cfg?.autopilot_paused_reason ?? '(none)'}`);
+  console.log(`    capital_usd         : $${cfg?.capital_usd}`);
+  console.log(`    profile             : ${cfg?.profile}`);
+  console.log(`    daily_cost_budget   : $${cfg?.daily_cost_budget_usd ?? '(none)'}`);
+
+  // ─── 2. Positions ouvertes ────────────────────────────────────────────────
+  const { data: open, count: openCount } = await sb
+    .from('lisa_positions')
+    .select('id, symbol, direction, entry_price, entry_timestamp, take_profit_price, stop_loss_price, size_usd, venue_fee_detail, asset_class', { count: 'exact' })
+    .eq('portfolio_id', HIGH)
+    .eq('status', 'open')
+    .order('entry_timestamp', { ascending: false });
+
+  const oversoldOpen = (open ?? []).filter(p => (p.venue_fee_detail as Record<string, unknown> | null)?.source === 'scanner_oversold');
+  const otherOpen = (open ?? []).filter(p => (p.venue_fee_detail as Record<string, unknown> | null)?.source !== 'scanner_oversold');
+
+  console.log(`\n[2] POSITIONS OUVERTES : ${openCount ?? 0}`);
+  console.log(`    scanner_oversold (cible Mistral 15min) : ${oversoldOpen.length}`);
+  console.log(`    autres sources                          : ${otherOpen.length}`);
+
+  if (oversoldOpen.length) {
+    console.log('\n    Détail scanner_oversold (entry / TP / SL / size) :');
+    console.log(`    ${pad('SYM', 12)} ${pad('ENTRY', 10)} ${pad('TP', 10)} ${pad('SL', 10)} ${pad('SIZE_USD', 10)} ${pad('AGE_MIN', 7)} OPENED`);
+    for (const p of oversoldOpen) {
+      const ageMin = Math.round((Date.now() - new Date(String(p.entry_timestamp)).getTime()) / 60_000);
+      console.log(`    ${pad(p.symbol, 12)} ${pad(Number(p.entry_price).toFixed(2), 10)} ${pad(p.take_profit_price ? Number(p.take_profit_price).toFixed(2) : '-', 10)} ${pad(p.stop_loss_price ? Number(p.stop_loss_price).toFixed(2) : '-', 10)} ${pad(p.size_usd ? Number(p.size_usd).toFixed(0) : '-', 10)} ${pad(ageMin, 7)} ${fmtT(p.entry_timestamp)}`);
+    }
+  }
+
+  // ─── 3. Positions fermées 24h ──────────────────────────────────────────────
+  const { data: closed, count: closedCount } = await sb
+    .from('lisa_positions')
+    .select('symbol, exit_timestamp, entry_timestamp, entry_price, exit_price, realized_pnl_usd, realized_pnl_pct, close_reason, close_rationale, venue_fee_detail, asset_class', { count: 'exact' })
+    .eq('portfolio_id', HIGH)
+    .eq('status', 'closed')
+    .gte('exit_timestamp', since24h)
+    .order('exit_timestamp', { ascending: false });
+
+  const oversoldClosed = (closed ?? []).filter(p => (p.venue_fee_detail as Record<string, unknown> | null)?.source === 'scanner_oversold');
+
+  let sumPnl = 0;
+  let winners = 0;
+  let losers = 0;
+  const byReason = new Map<string, { n: number; pnl: number }>();
+  for (const p of oversoldClosed) {
+    const pnl = Number(p.realized_pnl_usd ?? 0);
+    sumPnl += pnl;
+    if (pnl > 0) winners++; else if (pnl < 0) losers++;
+    const r = String(p.close_reason ?? '?');
+    const acc = byReason.get(r) ?? { n: 0, pnl: 0 };
+    acc.n++; acc.pnl += pnl;
+    byReason.set(r, acc);
+  }
+
+  console.log(`\n[3] POSITIONS FERMÉES scanner_oversold 24h : ${oversoldClosed.length}`);
+  console.log(`    Σ PnL réalisé    : $${fmtUsd(sumPnl)}`);
+  console.log(`    Win rate          : ${winners}W / ${losers}L (${oversoldClosed.length > 0 ? ((winners / (winners + losers || 1)) * 100).toFixed(0) : 0}%)`);
+  console.log(`    Par close_reason :`);
+  for (const [r, { n, pnl }] of [...byReason].sort((a, b) => Math.abs(b[1].pnl) - Math.abs(a[1].pnl))) {
+    console.log(`      ${pad(r, 22)} → n=${pad(n, 3)} Σ=$${fmtUsd(pnl)}`);
+  }
+  if (oversoldClosed.length) {
+    console.log('\n    20 plus récents :');
+    console.log(`    ${pad('CLOSED', 16)} ${pad('SYM', 12)} ${pad('PnL$', 10)} ${pad('PnL%', 8)} ${pad('REASON', 22)} RATIONALE`);
+    for (const p of oversoldClosed.slice(0, 20)) {
+      console.log(`    ${fmtT(p.exit_timestamp)} ${pad(p.symbol, 12)} ${pad(fmtUsd(p.realized_pnl_usd), 10)} ${pad(`${Number(p.realized_pnl_pct ?? 0).toFixed(2)}%`, 8)} ${pad(p.close_reason, 22)} ${String(p.close_rationale ?? '').slice(0, 80)}`);
+    }
+  }
+
+  // ─── 4. Activité decision_log 6h ──────────────────────────────────────────
+  const since6h = new Date(Date.now() - 6*3600_000).toISOString();
+  const { data: events } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, kind, summary')
+    .eq('portfolio_id', HIGH)
+    .gte('timestamp', since6h)
+    .order('timestamp', { ascending: false })
+    .limit(500);
+
+  const kindCounts = new Map<string, number>();
+  for (const e of events ?? []) kindCounts.set(e.kind as string, (kindCounts.get(e.kind as string) ?? 0) + 1);
+  console.log(`\n[4] decision_log HIGH 6h (${events?.length ?? 0} lignes)`);
+  for (const [k, n] of [...kindCounts.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`    ${pad(k, 50)} → ${n}`);
+  }
+
+  // ─── 5. Cron Mistral oversold-mistral-exit (decisions) ─────────────────────
+  const { count: mistralAllTime } = await sb
+    .from('lisa_decision_log')
+    .select('id', { count: 'exact', head: true })
+    .eq('portfolio_id', HIGH)
+    .eq('kind', 'oversold_mistral_gain_pick');
+
+  const { data: mistralDecs } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, summary, payload')
+    .eq('portfolio_id', HIGH)
+    .eq('kind', 'oversold_mistral_gain_pick')
+    .order('timestamp', { ascending: false })
+    .limit(10);
+
+  console.log(`\n[5] CRON Mistral oversold-mistral-exit (15min) — décisions CLOSE écrites`);
+  console.log(`    Total all-time : ${mistralAllTime ?? 0}`);
+  if (mistralDecs?.length) {
+    for (const d of mistralDecs) {
+      const p = (d.payload as Record<string, unknown> | null) ?? {};
+      console.log(`    ${fmtT(d.timestamp)}  ${String(p.symbol).padEnd(10)} conf=${p.mistral_confidence} ${p.mistral_rationale}`);
+    }
+  } else {
+    console.log('    (aucune décision CLOSE — Mistral en HOLD systématique pour le moment)');
+  }
+
+  // ─── 6. Cron scanner 21:15 UTC ─────────────────────────────────────────────
+  const { data: scans } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, kind, summary')
+    .eq('portfolio_id', HIGH)
+    .in('kind', ['oversold_scan_completed', 'oversold_scan_no_candidates'])
+    .gte('timestamp', since7d)
+    .order('timestamp', { ascending: false })
+    .limit(10);
+
+  console.log(`\n[6] CRON Scanner oversold-daily-scan (21:15 UTC) — scans 7j : ${scans?.length ?? 0}`);
+  for (const s of scans ?? []) {
+    console.log(`    ${fmtT(s.timestamp)}  ${pad(s.kind, 35)} ${String(s.summary ?? '').slice(0, 80)}`);
+  }
+
+  // ─── 7. Boucle d'apprentissage ─────────────────────────────────────────────
+  const { count: pcdCount } = await sb
+    .from('position_close_decisions')
+    .select('id', { count: 'exact', head: true })
+    .eq('portfolio_id', HIGH);
+  const { data: pcdLabels } = await sb
+    .from('position_close_decisions')
+    .select('label_outcome_60min')
+    .eq('portfolio_id', HIGH);
+  const labelCounts = new Map<string, number>();
+  for (const r of pcdLabels ?? []) labelCounts.set(String(r.label_outcome_60min ?? 'null'), (labelCounts.get(String(r.label_outcome_60min ?? 'null')) ?? 0) + 1);
+  console.log(`\n[7] BOUCLE D'APPRENTISSAGE`);
+  console.log(`    position_close_decisions all-time : ${pcdCount ?? 0}`);
+  console.log(`    Labels counterfactuels +60min :`);
+  for (const [k, n] of labelCounts) console.log(`      ${pad(k, 12)} → ${n}`);
+  const labeled = (pcdLabels ?? []).filter(r => r.label_outcome_60min !== null).length;
+  console.log(`    Politique apprise injectée à Mistral : ${labeled >= 20 ? '✅ ACTIVE' : `❌ COLD START (${labeled}/20 closes labellisés)`}`);
+
+  // ─── 8. Snapshots indicateurs (input du cron Mistral) ──────────────────────
+  const { count: snapCount } = await sb
+    .from('position_indicators_snapshot')
+    .select('position_id', { count: 'exact', head: true })
+    .gte('captured_at', since24h);
+  console.log(`\n[8] position_indicators_snapshot 24h (input cron Mistral) : ${snapCount ?? 0}`);
+
+  // ─── 9. Anomalies récentes ─────────────────────────────────────────────────
+  const { data: errors } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, kind, summary')
+    .eq('portfolio_id', HIGH)
+    .gte('timestamp', since24h)
+    .or('kind.eq.position_open_failed,kind.eq.risk_manager_thesis_broken,kind.eq.autopilot_paused')
+    .order('timestamp', { ascending: false })
+    .limit(10);
+  console.log(`\n[9] ANOMALIES 24h : ${errors?.length ?? 0}`);
+  for (const e of errors ?? []) {
+    console.log(`    ${fmtT(e.timestamp)}  ${pad(e.kind, 30)} ${String(e.summary ?? '').slice(0, 60)}`);
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════\n');
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/oversold-mistral-diag.ts
+++ b/scripts/oversold-mistral-diag.ts
@@ -1,0 +1,102 @@
+/**
+ * Diagnostic du cron oversold-mistral-exit (toutes les 15min) + scanner 21:15 UTC.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+const NAMES: Record<string, string> = {
+  'b0000001-0000-0000-0000-000000000001': 'TRADER',
+  'a0000001-0000-0000-0000-000000000001': 'HIGH',
+  'a0000002-0000-0000-0000-000000000002': 'MIDDLE',
+  'a0000003-0000-0000-0000-000000000003': 'SMALL',
+};
+const label = (id: string) => NAMES[id] ?? id.slice(0, 8);
+
+async function main() {
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log(' OVERSOLD-MISTRAL-EXIT (15min) + OVERSOLD-DAILY-SCAN (21:15 UTC)');
+  console.log('═══════════════════════════════════════════════════════════════\n');
+
+  // [1] Positions ouvertes scope cron
+  const { data: openPos } = await sb
+    .from('lisa_positions')
+    .select('id, portfolio_id, symbol, entry_price, entry_timestamp, asset_class, venue_fee_detail')
+    .eq('status', 'open')
+    .filter('venue_fee_detail->>source', 'eq', 'scanner_oversold')
+    .order('entry_timestamp', { ascending: false });
+
+  console.log(`[1] POSITIONS OUVERTES scanner_oversold : ${openPos?.length ?? 0}`);
+  if (openPos?.length) {
+    const byPf = new Map<string, number>();
+    for (const p of openPos) byPf.set(p.portfolio_id, (byPf.get(p.portfolio_id) ?? 0) + 1);
+    for (const [pf, n] of byPf) console.log(`    ${label(pf).padEnd(8)} → ${n} pos`);
+  }
+
+  // [2] Décisions cron Mistral (15min)
+  const { data: decisions, count: decCount } = await sb
+    .from('lisa_decision_log')
+    .select('id, created_at, portfolio_id, summary, payload', { count: 'exact' })
+    .eq('kind', 'oversold_mistral_gain_pick')
+    .order('created_at', { ascending: false })
+    .limit(10);
+
+  console.log(`\n[2] DÉCISIONS oversold_mistral_gain_pick (total) : ${decCount ?? 0}`);
+  for (const d of decisions ?? []) {
+    const p = (d.payload as Record<string, unknown> | null) ?? {};
+    const t = new Date(d.created_at as string).toISOString().replace('T', ' ').slice(0, 16);
+    console.log(`    ${t}  ${String(p.symbol).padEnd(10)}  conf=${p.mistral_confidence}  rationale=${p.mistral_rationale}`);
+  }
+
+  // [3] Logs cron 15min "cycle done" — repérables via decision_log si append, ou table dédiée
+  // Le cron n'écrit dans decision_log QUE si CLOSE → si HOLD partout, silence.
+  console.log('\n[3] Note : le cron n\'écrit dans decision_log QUE sur CLOSE.');
+  console.log('    Pour les logs "cycle done — positions=N evaluated=X" : voir fly logs.');
+
+  // [4] Scanner 21:15 UTC — historique des scans daily
+  const since7d = new Date(Date.now() - 7 * 86400_000).toISOString();
+  const { data: scans, count: scanCount } = await sb
+    .from('lisa_decision_log')
+    .select('id, created_at, portfolio_id, summary, payload', { count: 'exact' })
+    .in('kind', ['oversold_scanner_completed', 'oversold_scanner_no_candidates', 'oversold_scanner_run', 'oversold_daily_scan'])
+    .gte('created_at', since7d)
+    .order('created_at', { ascending: false })
+    .limit(15);
+
+  console.log(`\n[4] SCANS DAILY oversold 7j : ${scanCount ?? 0}`);
+  for (const s of scans ?? []) {
+    const t = new Date(s.created_at as string).toISOString().replace('T', ' ').slice(0, 16);
+    console.log(`    ${t}  kind=? pf=${label(s.portfolio_id as string)}  ${s.summary?.slice(0, 80)}`);
+  }
+
+  // [5] Opens des derniers jours (proxy efficace du scanner 21:15)
+  const { data: opens, count: openCount } = await sb
+    .from('lisa_positions')
+    .select('symbol, entry_timestamp, portfolio_id, venue_fee_detail', { count: 'exact' })
+    .filter('venue_fee_detail->>source', 'eq', 'scanner_oversold')
+    .gte('entry_timestamp', since7d)
+    .order('entry_timestamp', { ascending: false });
+
+  console.log(`\n[5] OPENS scanner_oversold 7j : ${openCount ?? 0}`);
+  const byDay = new Map<string, number>();
+  for (const o of opens ?? []) {
+    const day = String(o.entry_timestamp).slice(0, 10);
+    byDay.set(day, (byDay.get(day) ?? 0) + 1);
+  }
+  for (const [day, n] of [...byDay].sort((a, b) => b[0].localeCompare(a[0]))) {
+    console.log(`    ${day}  → ${n} opens`);
+  }
+
+  // [6] Captures position_close_decisions des dernières 24h
+  const since24 = new Date(Date.now() - 24 * 3600_000).toISOString();
+  const { count: caps24 } = await sb
+    .from('position_close_decisions')
+    .select('id', { count: 'exact', head: true })
+    .gte('captured_at', since24);
+  console.log(`\n[6] position_close_decisions captures 24h : ${caps24 ?? 0}`);
+
+  console.log('\n═══════════════════════════════════════════════════════════════\n');
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/oversold-mistral-tables-check.ts
+++ b/scripts/oversold-mistral-tables-check.ts
@@ -1,0 +1,111 @@
+/**
+ * Vérif exhaustive Supabase pour le cron oversold-mistral-exit (15min).
+ * FIX : decision_log utilise `timestamp` pas `created_at`.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const sinceEnableSecret = '2026-06-04T17:55:00Z';
+  const sinceMerge586 = '2026-06-04T19:15:00Z';
+
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log(` Maintenant : ${new Date().toISOString().slice(0,19)}Z`);
+  console.log(` Secret set : ${sinceEnableSecret}`);
+  console.log(` PR #586 squash merge : ${sinceMerge586}`);
+  console.log('═══════════════════════════════════════════════════════════════\n');
+
+  // [A] Mistral cron decisions
+  const { count: mistralAllTime } = await sb
+    .from('lisa_decision_log')
+    .select('id', { count: 'exact', head: true })
+    .eq('kind', 'oversold_mistral_gain_pick');
+  console.log(`[A] lisa_decision_log kind='oversold_mistral_gain_pick' all-time : ${mistralAllTime ?? 0}`);
+
+  // [B] Tous kinds depuis secret set
+  const { data: kindsAfter } = await sb
+    .from('lisa_decision_log')
+    .select('kind')
+    .gte('timestamp', sinceEnableSecret)
+    .limit(5000);
+  const ck = new Map<string, number>();
+  for (const r of kindsAfter ?? []) ck.set(r.kind as string, (ck.get(r.kind as string) ?? 0) + 1);
+  console.log(`\n[B] kinds decision_log depuis secret set (${kindsAfter?.length ?? 0} rows) :`);
+  const oversoldKinds = [...ck.entries()].filter(([k]) => /oversold|mistral/i.test(k));
+  if (oversoldKinds.length === 0) console.log('    Aucun kind oversold/mistral');
+  for (const [k, n] of oversoldKinds) console.log(`    ${k.padEnd(50)} → ${n}`);
+
+  // [C] TOP 15 kinds
+  const sortedKinds = [...ck.entries()].sort((a, b) => b[1] - a[1]);
+  console.log(`\n[C] TOP 15 kinds depuis secret set :`);
+  for (const [k, n] of sortedKinds.slice(0, 15)) console.log(`    ${k.padEnd(50)} → ${n}`);
+
+  // [D] HIGH closes today
+  const HIGH = 'a0000001-0000-0000-0000-000000000001';
+  const { data: highClosesToday, count: highCount } = await sb
+    .from('lisa_positions')
+    .select('symbol, exit_timestamp, close_reason, realized_pnl_usd, close_rationale, venue_fee_detail', { count: 'exact' })
+    .eq('portfolio_id', HIGH)
+    .eq('status', 'closed')
+    .gte('exit_timestamp', '2026-06-04T00:00:00Z')
+    .order('exit_timestamp', { ascending: false })
+    .limit(50);
+  let sumPnl = 0;
+  for (const p of highClosesToday ?? []) sumPnl += Number(p.realized_pnl_usd ?? 0);
+  console.log(`\n[D] HIGH closes 04/06 (TOUTES sources confondues) : ${highCount ?? 0}, Σ PnL = $${sumPnl.toFixed(2)}`);
+  console.log('    8 plus récents :');
+  for (const p of (highClosesToday ?? []).slice(0, 8)) {
+    const t = String(p.exit_timestamp).slice(0, 19).replace('T', ' ');
+    const src = (p.venue_fee_detail as Record<string, unknown> | null)?.source ?? '(null)';
+    const rat = String(p.close_rationale ?? '').slice(0, 50);
+    console.log(`    ${t}  ${String(p.symbol).padEnd(10)}  $${Number(p.realized_pnl_usd ?? 0).toFixed(2).padStart(8)}  src=${src}  ${p.close_reason}  ${rat}`);
+  }
+
+  // [E] HIGH closes 04/06 avec source contenant 'oversold'
+  const oversoldClosedToday = (highClosesToday ?? []).filter(p => {
+    const src = (p.venue_fee_detail as Record<string, unknown> | null)?.source;
+    return typeof src === 'string' && src.includes('oversold');
+  });
+  console.log(`\n[E] HIGH closes 04/06 avec source='scanner_oversold' : ${oversoldClosedToday.length}`);
+
+  // [F] Captures position_close_decisions
+  const { count: pcdAllTime } = await sb
+    .from('position_close_decisions')
+    .select('id', { count: 'exact', head: true });
+  const { count: pcdAfterEnable } = await sb
+    .from('position_close_decisions')
+    .select('id', { count: 'exact', head: true })
+    .gte('captured_at', sinceEnableSecret);
+  const { count: pcdAfterMerge } = await sb
+    .from('position_close_decisions')
+    .select('id', { count: 'exact', head: true })
+    .gte('captured_at', sinceMerge586);
+  console.log(`\n[F] position_close_decisions all-time=${pcdAllTime}, depuis secret=${pcdAfterEnable}, depuis merge=${pcdAfterMerge}`);
+
+  // [G] position_indicators_snapshot (input du cron Mistral)
+  const { count: snapAfterEnable } = await sb
+    .from('position_indicators_snapshot')
+    .select('position_id', { count: 'exact', head: true })
+    .gte('captured_at', sinceEnableSecret);
+  console.log(`\n[G] position_indicators_snapshot écrits depuis secret set : ${snapAfterEnable ?? 0}`);
+
+  console.log('\n═══════════════════════════════════════════════════════════════');
+  console.log(' VERDICT');
+  console.log('═══════════════════════════════════════════════════════════════');
+  if ((mistralAllTime ?? 0) === 0 && (pcdAfterEnable ?? 0) === 0 && (pcdAfterMerge ?? 0) === 0) {
+    console.log(' ❌ ZÉRO trace du cron oversold-mistral-exit dans la base.');
+    if ((snapAfterEnable ?? 0) > 0) {
+      console.log('    BON SIGNE : position_indicators_snapshot tourne (input OK)');
+      console.log('    MAUVAIS : aucune écriture par le cron Mistral lui-même.');
+      console.log('    → soit binary prod pré-ac2d7af → le merge #586 va corriger');
+      console.log('    → soit env appliquée mais HOLD systématique (silence normal)');
+    }
+  } else {
+    console.log(` ✅ ${mistralAllTime} décisions Mistral / ${pcdAfterEnable} captures`);
+  }
+  console.log('═══════════════════════════════════════════════════════════════\n');
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Contexte

Audit one-shot du portfolio HIGH (mode oversold) couvrant 9 dimensions :

1. session config (mode, autopilot, kill_switch, capital, profile)
2. positions ouvertes scanner_oversold (TP/SL/size/âge)
3. positions fermées 24h (PnL, win rate, breakdown par close_reason)
4. activité decision_log 6h
5. décisions Mistral oversold-mistral-exit (cron 15min)
6. scans daily oversold-daily-scan (cron 21:15 UTC, 7j)
7. boucle d'apprentissage (position_close_decisions + labels)
8. position_indicators_snapshot 24h (input cron Mistral)
9. anomalies 24h (thesis_broken, open_failed, paused)

## Usage

```bash
npx tsx scripts/audit-high-oversold.ts
```

Note : inclut aussi les 2 scripts du PR #587 (diag + tables-check) puisqu'ils sont dans la base divergente locale main. Le squash-merge mergera tout proprement.

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_