### PR TITLE
feat(oversold): scanner intraday "rebond confirmé" — 5 ticks 15-19 UTC

### DIFF
--- a/apps/api/src/modules/lisa/services/oversold-intraday.helper.ts
+++ b/apps/api/src/modules/lisa/services/oversold-intraday.helper.ts
@@ -1,0 +1,146 @@
+/**
+ * Helpers PURS du SCANNER INTRADAY oversold ("rebond confirmé").
+ *
+ * Contrairement au scanner EOD 21:15 UTC qui ouvre sur un drop EOD pur,
+ * l'intraday ne déclenche qu'un drop EN TRAIN DE REBONDIR — anti falling-knife
+ * intra-séance.
+ *
+ * 5 critères ALL-MUST-PASS (cf. proposition user 05/06) :
+ *   1. drop dans [-12%, -5%] vs close J-1 (réutilise le filtre existant)
+ *   2. low_60min atteint mais PAS dans les N dernières bars (= bottom passé)
+ *   3. reboundPct ≥ minReboundPct (% du low_60min au prix courant)
+ *   4. trend_15m_pct ≥ min (slope positif sur les 3 dernières bars 5m)
+ *   5. volume_last_30m / volume_first_30m ≥ min (intérêt acheteur sustained)
+ *
+ * Aucune dépendance NestJS / Supabase / réseau ici : 100% déterministe.
+ */
+
+export interface IntradayCandle {
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface IntradayReboundAnalysis {
+  currentPrice: number;
+  lowPrice: number;
+  lowAtBarIdx: number; // 0 = premier bar (le plus ancien), bars.length-1 = courant
+  reboundPct: number; // (current - low) / low * 100
+  trend15mPct: number; // % change sur les 3 derniers bars 5m
+  volumeLast30m: number;
+  volumeFirst30m: number;
+  volumeRatio: number; // volumeLast30m / volumeFirst30m (1.0 = stable)
+  barsCount: number;
+}
+
+export interface IntradayReboundConfig {
+  /** % min de rebond depuis le low_60min jusqu'au prix courant. Ex 1.5 = +1.5%. */
+  minReboundPct: number;
+  /** Slope min sur les 3 derniers bars 5m (= 15min). Ex 0.3 = +0.3%. */
+  minTrend15mPct: number;
+  /** Le low_60min doit être avant les N dernières bars. Ex 2 = pas dans les 10 dernières min. */
+  bottomMustBeBeforeLastNBars: number;
+  /** Ratio min volume_last_30m / volume_first_30m. Ex 0.8 = soutien acheteur. */
+  minVolumeRatio: number;
+  /** Min bars pour analyse fiable (sinon skip). Recommandé 10-12 bars = 50-60min. */
+  minBarsRequired: number;
+}
+
+export const DEFAULT_INTRADAY_REBOUND_CONFIG: IntradayReboundConfig = {
+  minReboundPct: 1.5,
+  minTrend15mPct: 0.3,
+  bottomMustBeBeforeLastNBars: 2,
+  minVolumeRatio: 0.8,
+  minBarsRequired: 10,
+};
+
+/**
+ * Analyse une série de bars 5m pour détecter un "rebond confirmé".
+ * Retourne null si pas assez de bars (< minBarsRequired).
+ */
+export function analyzeIntradayRebound(
+  candles: IntradayCandle[],
+  cfg: IntradayReboundConfig = DEFAULT_INTRADAY_REBOUND_CONFIG,
+): IntradayReboundAnalysis | null {
+  if (!candles || candles.length < cfg.minBarsRequired) return null;
+  const n = candles.length;
+  const currentPrice = candles[n - 1].close;
+  if (!Number.isFinite(currentPrice) || currentPrice <= 0) return null;
+
+  // Low atteint sur la fenêtre (= bas réel intra-séance partiel)
+  let lowPrice = candles[0].low;
+  let lowAtBarIdx = 0;
+  for (let i = 0; i < n; i++) {
+    if (candles[i].low < lowPrice) {
+      lowPrice = candles[i].low;
+      lowAtBarIdx = i;
+    }
+  }
+  if (!Number.isFinite(lowPrice) || lowPrice <= 0) return null;
+
+  const reboundPct = ((currentPrice - lowPrice) / lowPrice) * 100;
+
+  // Trend 15m : close[n-1] vs close[n-4] (3 bars = 15min)
+  let trend15mPct = 0;
+  if (n >= 4) {
+    const refClose = candles[n - 4].close;
+    if (refClose > 0) trend15mPct = ((currentPrice - refClose) / refClose) * 100;
+  }
+
+  // Volumes : partition en 6 premières bars vs 6 dernières (= 30min chacune)
+  const half = Math.min(6, Math.floor(n / 2));
+  let volFirst = 0;
+  let volLast = 0;
+  for (let i = 0; i < half; i++) volFirst += candles[i].volume || 0;
+  for (let i = n - half; i < n; i++) volLast += candles[i].volume || 0;
+  const volumeRatio = volFirst > 0 ? volLast / volFirst : 0;
+
+  return {
+    currentPrice,
+    lowPrice,
+    lowAtBarIdx,
+    reboundPct,
+    trend15mPct,
+    volumeLast30m: volLast,
+    volumeFirst30m: volFirst,
+    volumeRatio,
+    barsCount: n,
+  };
+}
+
+/**
+ * Applique les 4 gates "rebond confirmé" sur une analyse intraday.
+ *
+ * Retourne { pass: bool, reasons: string[] } — reasons liste les gates qui
+ * ont failed (vide si pass=true), pour logging en cas de skip.
+ */
+export function passesIntradayReboundFilter(
+  a: IntradayReboundAnalysis,
+  cfg: IntradayReboundConfig = DEFAULT_INTRADAY_REBOUND_CONFIG,
+): { pass: boolean; reasons: string[] } {
+  const reasons: string[] = [];
+
+  // Gate 1 : rebound minimum
+  if (a.reboundPct < cfg.minReboundPct) {
+    reasons.push(`rebound=${a.reboundPct.toFixed(2)}% < ${cfg.minReboundPct}%`);
+  }
+
+  // Gate 2 : trend récent positif
+  if (a.trend15mPct < cfg.minTrend15mPct) {
+    reasons.push(`trend15m=${a.trend15mPct.toFixed(2)}% < ${cfg.minTrend15mPct}%`);
+  }
+
+  // Gate 3 : low pas dans les N dernières bars (bottom doit être passé)
+  const lastNStart = a.barsCount - cfg.bottomMustBeBeforeLastNBars;
+  if (a.lowAtBarIdx >= lastNStart) {
+    reasons.push(`bottom in last ${cfg.bottomMustBeBeforeLastNBars} bars (idx=${a.lowAtBarIdx}/${a.barsCount}) — falling knife risk`);
+  }
+
+  // Gate 4 : volume ratio (intérêt acheteur sustained)
+  if (a.volumeRatio < cfg.minVolumeRatio) {
+    reasons.push(`volRatio=${a.volumeRatio.toFixed(2)} < ${cfg.minVolumeRatio}`);
+  }
+
+  return { pass: reasons.length === 0, reasons };
+}

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -33,6 +33,13 @@ import {
   type EodBar,
   type OversoldCandidate,
 } from './oversold.helper';
+import {
+  analyzeIntradayRebound,
+  passesIntradayReboundFilter,
+  DEFAULT_INTRADAY_REBOUND_CONFIG,
+  type IntradayReboundConfig,
+} from './oversold-intraday.helper';
+import { IntradayProviderRouter } from './intraday-provider-router.service';
 
 /** Une position oversold enrichie pour l'UI dédiée (book summary). */
 export interface OversoldBookPosition {
@@ -109,6 +116,7 @@ export class OversoldScannerService {
     private readonly lisa: LisaService,
     private readonly decisionLog: DecisionLogService,
     private readonly config: ConfigService,
+    private readonly intraday: IntradayProviderRouter,
   ) {}
 
   /** Gate env — désactivable sans redeploy via secret Fly. */
@@ -265,6 +273,220 @@ export class OversoldScannerService {
       `[oversold] portfolio=${portfolioId.slice(0, 8)} univers=${tickers.length} ` +
         `candidats=${candidates.length} ouverts=${opened}`,
     );
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // INTRADAY SCANNER — 6 ticks horaires pendant la session US (15-20 UTC).
+  //
+  // Différence vs runDailyScan (21:15 UTC) : applique en plus 4 filtres "rebond
+  // confirmé" pour ne pas ouvrir des falling-knives intra-séance.
+  // 1. drop EOD (close J vs close J-1) toujours dans [-12%, -5%]
+  // 2. rebound depuis low_60min ≥ minReboundPct
+  // 3. trend 15m ≥ minTrend15mPct
+  // 4. bottom hors des N dernières bars (≥ 10 min de stabilisation)
+  // 5. volume_last_30m / volume_first_30m ≥ minVolumeRatio
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /** Gate env intraday. Opt-in (default false) — activer via OVERSOLD_INTRADAY_ENABLED=true. */
+  private intradayEnabled(): boolean {
+    return (this.config.get<string>('OVERSOLD_INTRADAY_ENABLED') ?? 'false').toLowerCase() === 'true';
+  }
+
+  private intradayConfig(): IntradayReboundConfig {
+    const num = (key: string, dflt: number) => {
+      const v = Number(this.config.get<string>(key));
+      return Number.isFinite(v) ? v : dflt;
+    };
+    return {
+      minReboundPct: num('OVERSOLD_INTRADAY_MIN_REBOUND_PCT', DEFAULT_INTRADAY_REBOUND_CONFIG.minReboundPct),
+      minTrend15mPct: num('OVERSOLD_INTRADAY_MIN_TREND_15M_PCT', DEFAULT_INTRADAY_REBOUND_CONFIG.minTrend15mPct),
+      bottomMustBeBeforeLastNBars: num('OVERSOLD_INTRADAY_BOTTOM_BEFORE_BARS', DEFAULT_INTRADAY_REBOUND_CONFIG.bottomMustBeBeforeLastNBars),
+      minVolumeRatio: num('OVERSOLD_INTRADAY_MIN_VOLUME_RATIO', DEFAULT_INTRADAY_REBOUND_CONFIG.minVolumeRatio),
+      minBarsRequired: num('OVERSOLD_INTRADAY_MIN_BARS_REQUIRED', DEFAULT_INTRADAY_REBOUND_CONFIG.minBarsRequired),
+    };
+  }
+
+  private intradayMaxOpensPerDay(): number {
+    const v = Number(this.config.get<string>('OVERSOLD_INTRADAY_MAX_OPENS_PER_DAY'));
+    return Number.isFinite(v) && v > 0 ? v : 8;
+  }
+
+  private intradayNotionalRatio(): number {
+    const v = Number(this.config.get<string>('OVERSOLD_INTRADAY_NOTIONAL_RATIO'));
+    return Number.isFinite(v) && v > 0 && v <= 2 ? v : 0.7;
+  }
+
+  /**
+   * Cron horaire pendant session US — 15:00 à 19:00 UTC, weekdays only.
+   * Skip 14:30 (ouverture turbulente) et 20:00 (dernière heure, gamma/EOD prep).
+   */
+  @Cron('0 0 15,16,17,18,19 * * 1-5', { name: 'oversold-intraday-scan', timeZone: 'UTC' })
+  async runIntradayScan(): Promise<void> {
+    try {
+      if (!this.isEnabled() || !this.intradayEnabled()) {
+        this.logger.debug('[oversold-intraday] disabled (OVERSOLD_SCANNER_ENABLED or OVERSOLD_INTRADAY_ENABLED off)');
+        return;
+      }
+      const portfolios = await this.loadOversoldPortfolios();
+      if (portfolios.length === 0) {
+        this.logger.debug('[oversold-intraday] aucun portfolio en mode oversold → skip');
+        return;
+      }
+      for (const row of portfolios) {
+        try {
+          await this.scanPortfolioIntraday(row);
+        } catch (err) {
+          this.logger.error(
+            `[oversold-intraday] portfolio ${row.portfolio_id.slice(0, 8)} échoué: ${String(err).slice(0, 300)}`,
+          );
+        }
+      }
+    } catch (err) {
+      this.logger.error(`[oversold-intraday] runIntradayScan exception: ${String(err).slice(0, 300)}`);
+    }
+  }
+
+  private async scanPortfolioIntraday(row: OversoldPortfolioRow): Promise<void> {
+    const portfolioId = row.portfolio_id;
+    const cfg = this.resolveConfig(row);
+    const reboundCfg = this.intradayConfig();
+    const maxOpensPerDay = this.intradayMaxOpensPerDay();
+    const notionalRatio = this.intradayNotionalRatio();
+
+    const tickers = await this.loadUniverse(cfg.universe);
+    if (tickers.length === 0) return;
+
+    // 1. Drop band filter (EOD reference)
+    const openSymbols = await this.loadOpenSymbols(portfolioId);
+    const barsBySymbol = await this.fetchUniverseBars(tickers);
+    const candidates = buildOversoldCandidates(barsBySymbol, cfg);
+    const toScan = selectOversoldOpens(candidates, openSymbols);
+
+    // 2. Compteur intraday du jour pour respecter le cap
+    const intradayOpenedToday = await this.countIntradayOpenedToday(portfolioId);
+    let remaining = Math.max(0, maxOpensPerDay - intradayOpenedToday);
+    if (remaining === 0) {
+      this.logger.log(
+        `[oversold-intraday] ${portfolioId.slice(0, 8)} cap reached (${intradayOpenedToday}/${maxOpensPerDay}) → skip`,
+      );
+      return;
+    }
+
+    // 3. Pour chaque candidat dans la bande : fetch candles + filtre rebond
+    let evaluated = 0;
+    let opened = 0;
+    let rejectedRebound = 0;
+    const reboundCfgForOpens: OversoldConfig = {
+      ...cfg,
+      positionNotionalUsd: Math.round(cfg.positionNotionalUsd * notionalRatio),
+    };
+
+    for (const cand of toScan) {
+      if (remaining <= 0) break;
+      evaluated++;
+      try {
+        const series = await this.intraday
+          .getCandles(cand.symbol, '5m', 18, { calledBy: 'oversold_intraday' })
+          .catch(() => null);
+        const raw = series?.candles ?? [];
+        if (raw.length < reboundCfg.minBarsRequired) {
+          rejectedRebound++;
+          continue;
+        }
+        const analysis = analyzeIntradayRebound(
+          raw.map((c) => ({ high: c.high, low: c.low, close: c.close, volume: c.volume })),
+          reboundCfg,
+        );
+        if (!analysis) {
+          rejectedRebound++;
+          continue;
+        }
+        const gate = passesIntradayReboundFilter(analysis, reboundCfg);
+        if (!gate.pass) {
+          rejectedRebound++;
+          continue;
+        }
+
+        // Open avec source intraday (distincte de scanner_oversold EOD)
+        await this.openIntradayPosition(portfolioId, cand, reboundCfgForOpens, analysis.currentPrice);
+        opened++;
+        remaining--;
+      } catch (err) {
+        this.logger.warn(
+          `[oversold-intraday] ${cand.symbol} évaluation échouée: ${String(err).slice(0, 160)}`,
+        );
+      }
+    }
+
+    await this.decisionLog
+      .append({
+        portfolioId,
+        kind: 'oversold_intraday_scan_completed',
+        summary: `Intraday scan: ${tickers.length} univers → ${candidates.length} bande → ${evaluated} évalués → ${opened} ouverts`,
+        rationale:
+          `Drop band [${cfg.dropMinPct}%, ${cfg.dropMaxPct}%], rebound ≥${reboundCfg.minReboundPct}%, ` +
+          `trend15m ≥${reboundCfg.minTrend15mPct}%, bottom-before-${reboundCfg.bottomMustBeBeforeLastNBars}bars, ` +
+          `volRatio ≥${reboundCfg.minVolumeRatio}, cap ${maxOpensPerDay}/j (used ${intradayOpenedToday + opened}).`,
+        payload: {
+          universe: cfg.universe,
+          universe_size: tickers.length,
+          drop_band_candidates: candidates.length,
+          evaluated,
+          opened,
+          rejected_rebound: rejectedRebound,
+          intraday_opened_today: intradayOpenedToday + opened,
+          notional_ratio: notionalRatio,
+        },
+        triggeredBy: 'autopilot_cron',
+        watchlistSource: 'mechanical',
+        market: 'us_equity',
+      })
+      .catch((e) => this.logger.warn(`[oversold-intraday] decision_log append failed: ${String(e).slice(0, 160)}`));
+
+    this.logger.log(
+      `[oversold-intraday] portfolio=${portfolioId.slice(0, 8)} bande=${candidates.length} ` +
+        `évalués=${evaluated} ouverts=${opened} (cap ${maxOpensPerDay}, used ${intradayOpenedToday + opened})`,
+    );
+  }
+
+  /** Compte les positions ouvertes par le scanner intraday aujourd'hui UTC. */
+  private async countIntradayOpenedToday(portfolioId: string): Promise<number> {
+    const todayStart = `${new Date().toISOString().slice(0, 10)}T00:00:00Z`;
+    const { count } = await this.supabase
+      .getClient()
+      .from('lisa_positions')
+      .select('id', { count: 'exact', head: true })
+      .eq('portfolio_id', portfolioId)
+      .filter('venue_fee_detail->>source', 'eq', 'scanner_oversold_intraday')
+      .gte('entry_timestamp', todayStart);
+    return count ?? 0;
+  }
+
+  private async openIntradayPosition(
+    portfolioId: string,
+    cand: OversoldCandidate,
+    cfg: OversoldConfig,
+    livePrice: number,
+  ): Promise<void> {
+    // Le SL/TP utilisent le prix LIVE (pas closeJ) puisqu'on entre intraday.
+    const stopLossPrice = String(livePrice * (1 + cfg.stopCatastrophePct / 100));
+    const takeProfitPrice = cfg.tpPct != null ? String(livePrice * (1 + cfg.tpPct / 100)) : null;
+
+    await this.lisa.getPaperBroker().openPositionDirect({
+      portfolioId,
+      symbol: cand.symbol,
+      assetClass: 'us_equity',
+      direction: 'long',
+      venue: 'US',
+      capitalAllocationUsd: String(cfg.positionNotionalUsd),
+      livePrice: String(livePrice),
+      livePriceSource: 'intraday_5m',
+      stopLossPrice,
+      takeProfitPrice,
+      horizonDays: cfg.holdDays,
+      source: 'scanner_oversold_intraday',
+      maxOpenPositions: cfg.maxOpenPositions,
+    });
   }
 
   /** Charge le tableau de tickers d'une watchlist nommée. */


### PR DESCRIPTION
## Contexte

Le cron 21:15 UTC ouvre sur drop EOD pur — pas de PnL réalisé hier (3 opens overnight). Les scans manuels intraday du 04/06 ont fait **$824 (97% WR)** parce qu'ils capturaient des drops **déjà en train de rebondir**.

## Solution

Nouveau cron `oversold-intraday-scan` qui tire **5 ticks 15:00-19:00 UTC weekdays** (= 17:00-21:00 Paris), entre l'ouverture turbulente et la dernière heure agitée. N'ouvre **que** sur drops avec rebond confirmé.

## Pipeline

```
Russell 1000 (447 tickers)
  ↓ EOD bars (close J vs J-1)
  ↓ buildOversoldCandidates : drop dans [-12%, -5%] + liquidité
  ↓ = N candidats bande
  ↓ anti-doublon (positions déjà ouvertes)
  ↓ Pour chaque candidat : intraday.getCandles('5m', 18)
  ↓ analyzeIntradayRebound → IntradayReboundAnalysis
  ↓ passesIntradayReboundFilter : 4 gates ALL-MUST-PASS
  │   ├─ rebound_pct ≥ 1.5% (low_60min → current)
  │   ├─ trend_15m_pct ≥ 0.3% (slope positif)
  │   ├─ bottom hors des 2 dernières bars (≥ 10 min stabilisation)
  │   └─ volume_last_30m / volume_first_30m ≥ 0.8
  ↓ openIntradayPosition (notional × 0.7, source=scanner_oversold_intraday)
```

## Garde-fous

- Cap **8 opens/jour max** (vs 200 en EOD)
- Notional réduit à **70%** du standard
- Source distincte `scanner_oversold_intraday`
- SL/TP calculés sur live price intraday (pas close J-1)
- Audit kind=`oversold_intraday_scan_completed`

## Config — toutes opt-in via env

```
OVERSOLD_INTRADAY_ENABLED=true           # default false
OVERSOLD_INTRADAY_MIN_REBOUND_PCT=1.5
OVERSOLD_INTRADAY_MIN_TREND_15M_PCT=0.3
OVERSOLD_INTRADAY_BOTTOM_BEFORE_BARS=2
OVERSOLD_INTRADAY_MIN_VOLUME_RATIO=0.8
OVERSOLD_INTRADAY_MIN_BARS_REQUIRED=10
OVERSOLD_INTRADAY_MAX_OPENS_PER_DAY=8
OVERSOLD_INTRADAY_NOTIONAL_RATIO=0.7
```

## Test plan

- [x] `npx tsc -b` → 0 erreur
- [ ] Activer en prod via `fly secrets set OVERSOLD_INTRADAY_ENABLED=true`
- [ ] Surveiller `[oversold-intraday]` dans Fly logs + `oversold_intraday_scan_completed` dans decision_log
- [ ] Comparer WR vs scan 21:15 sur 3-5 jours

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_