### PR TITLE
chore(scripts): analyse imitation learning closes oversold pour Mistral

### DIFF
--- a/scripts/analyze-user-closes-for-mistral.ts
+++ b/scripts/analyze-user-closes-for-mistral.ts
@@ -1,0 +1,250 @@
+/**
+ * Analyse "imitation learning" — extrait les signatures techniques de tes
+ * fermetures manuelles oversold du 04/06 pour générer un prompt-block que
+ * Mistral peut digérer (remplace la calibration data hardcoded du SYSTEM_PROMPT).
+ *
+ *   npx tsx scripts/analyze-user-closes-for-mistral.ts
+ *
+ * Pour chaque close `closed_user` source=`scanner_oversold` du 04/06 :
+ *   1. Charge le snapshot indicators le plus proche de exit_timestamp (tolerance ±5min)
+ *   2. Extrait : pnl_pct, mfe_pct, mae_pct, give_back, rsi14, bb_pct_b, hold_min
+ *   3. Calcule minutes_since_nyse_open
+ *   4. Cluster par signature (R1 BB-haut / R2 RSI-surachat / R3 give-back / autres)
+ *   5. Stats agrégées + 5-10 exemples canoniques par cluster
+ *   6. Génère un bloc Markdown ready-to-paste dans SYSTEM_PROMPT
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+const HIGH = 'a0000001-0000-0000-0000-000000000001';
+
+interface CloseRow {
+  id: string;
+  symbol: string;
+  entry_price: string;
+  exit_price: string;
+  entry_timestamp: string;
+  exit_timestamp: string;
+  realized_pnl_pct: number | null;
+  realized_pnl_usd: number | null;
+  status: string;
+}
+
+interface Snapshot {
+  captured_at: string;
+  mfe_pct: number | null;
+  mae_pct: number | null;
+  rsi14: number | null;
+  bb_pct_b: number | null;
+  macd_hist: number | null;
+  atr14_pct: number | null;
+  roc5: number | null;
+  path_efficiency: number | null;
+  persistence_score: number | null;
+}
+
+interface Enriched extends CloseRow {
+  holdMin: number;
+  minutesSinceNyseOpen: number;
+  snap: Snapshot | null;
+  giveBack: number | null;
+  mfeAtClose: number | null;
+}
+
+function fmt(n: number | null | undefined, dec = 2): string {
+  if (n == null || !Number.isFinite(n)) return 'n/a';
+  return Number(n).toFixed(dec);
+}
+
+async function main() {
+  // 1. Load 36 closes user_manual on HIGH yesterday (04/06 UTC)
+  const { data: closes } = await sb
+    .from('lisa_positions')
+    .select('id, symbol, entry_price, exit_price, entry_timestamp, exit_timestamp, realized_pnl_pct, realized_pnl_usd, status')
+    .eq('portfolio_id', HIGH)
+    .eq('status', 'closed_user')
+    .filter('venue_fee_detail->>source', 'eq', 'scanner_oversold')
+    .gte('exit_timestamp', '2026-06-04T00:00:00Z')
+    .lt('exit_timestamp', '2026-06-05T00:00:00Z')
+    .order('exit_timestamp', { ascending: true });
+
+  if (!closes || closes.length === 0) {
+    console.log('Aucun close trouvé');
+    return;
+  }
+  console.log(`Loaded ${closes.length} closes user_manual scanner_oversold 04/06 UTC\n`);
+
+  // 2. Enrich each close with closest snapshot before exit
+  const enriched: Enriched[] = [];
+  for (const c of closes as unknown as CloseRow[]) {
+    const exitMs = new Date(c.exit_timestamp).getTime();
+    const fromMs = exitMs - 10 * 60_000; // window 10min before exit
+
+    const { data: snaps } = await sb
+      .from('position_indicators_snapshot')
+      .select('captured_at, mfe_pct, mae_pct, rsi14, bb_pct_b, macd_hist, atr14_pct, roc5, path_efficiency, persistence_score')
+      .eq('position_id', c.id)
+      .gte('captured_at', new Date(fromMs).toISOString())
+      .lt('captured_at', c.exit_timestamp)
+      .order('captured_at', { ascending: false })
+      .limit(1);
+
+    const snap = (snaps?.[0] as Snapshot | undefined) ?? null;
+    const holdMin = Math.round((exitMs - new Date(c.entry_timestamp).getTime()) / 60_000);
+    const exitDate = new Date(c.exit_timestamp);
+    const nyseOpen = new Date(Date.UTC(exitDate.getUTCFullYear(), exitDate.getUTCMonth(), exitDate.getUTCDate(), 14, 30));
+    const minutesSinceNyseOpen = Math.round((exitDate.getTime() - nyseOpen.getTime()) / 60_000);
+
+    const mfeAtClose = snap?.mfe_pct ?? null;
+    const giveBack = mfeAtClose != null && c.realized_pnl_pct != null ? mfeAtClose - c.realized_pnl_pct : null;
+
+    enriched.push({ ...c, holdMin, minutesSinceNyseOpen, snap, giveBack, mfeAtClose });
+  }
+
+  // 3. Aggregate stats
+  const totalPnl = enriched.reduce((s, e) => s + Number(e.realized_pnl_usd ?? 0), 0);
+  const avgPnlPct = enriched.reduce((s, e) => s + Number(e.realized_pnl_pct ?? 0), 0) / enriched.length;
+  const avgMfe = enriched.filter(e => e.mfeAtClose != null).reduce((s, e) => s + (e.mfeAtClose ?? 0), 0) / Math.max(1, enriched.filter(e => e.mfeAtClose != null).length);
+  const avgGiveBack = enriched.filter(e => e.giveBack != null).reduce((s, e) => s + (e.giveBack ?? 0), 0) / Math.max(1, enriched.filter(e => e.giveBack != null).length);
+  const avgHold = enriched.reduce((s, e) => s + e.holdMin, 0) / enriched.length;
+  const wins = enriched.filter(e => Number(e.realized_pnl_pct ?? 0) > 0).length;
+  const wr = (wins / enriched.length) * 100;
+  const snapCoverage = enriched.filter(e => e.snap != null).length;
+
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' AGGREGATE STATS — 04/06 closes user_manual scanner_oversold (HIGH)');
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  console.log(`  N closes                      : ${enriched.length}`);
+  console.log(`  Σ PnL réalisé                 : $${totalPnl.toFixed(2)}`);
+  console.log(`  Avg PnL %                     : ${fmt(avgPnlPct)}%`);
+  console.log(`  Avg MFE at close              : ${fmt(avgMfe)}%`);
+  console.log(`  Avg give_back (MFE - PnL)     : ${fmt(avgGiveBack)}%`);
+  console.log(`  Avg hold duration             : ${avgHold.toFixed(0)} min`);
+  console.log(`  Win rate                      : ${wr.toFixed(0)}% (${wins}/${enriched.length})`);
+  console.log(`  Snapshot coverage             : ${snapCoverage}/${enriched.length}`);
+
+  // 4. Cluster by signature (basée sur snap si disponible, fallback hold/pnl)
+  const clusters = {
+    'R1 BB-top + low give-back': [] as Enriched[],
+    'R2 RSI surachat + MFE solide': [] as Enriched[],
+    'R3 give-back > 1% défensif': [] as Enriched[],
+    'R4 Hold > 8h (swing patient)': [] as Enriched[],
+    'R5 Hold < 1h scalp opportuniste': [] as Enriched[],
+    'Autres': [] as Enriched[],
+  };
+
+  for (const e of enriched) {
+    const bb = e.snap?.bb_pct_b ?? null;
+    const rsi = e.snap?.rsi14 ?? null;
+    const mfe = e.mfeAtClose;
+    const gb = e.giveBack;
+
+    if (bb != null && bb >= 0.90 && gb != null && gb < 0.5) {
+      clusters['R1 BB-top + low give-back'].push(e);
+    } else if (rsi != null && rsi >= 65 && mfe != null && mfe >= 2.5) {
+      clusters['R2 RSI surachat + MFE solide'].push(e);
+    } else if (gb != null && gb >= 1.0) {
+      clusters['R3 give-back > 1% défensif'].push(e);
+    } else if (e.holdMin >= 480) {
+      clusters['R4 Hold > 8h (swing patient)'].push(e);
+    } else if (e.holdMin <= 60) {
+      clusters['R5 Hold < 1h scalp opportuniste'].push(e);
+    } else {
+      clusters['Autres'].push(e);
+    }
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' CLUSTERS (signatures dominantes)');
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  for (const [name, rows] of Object.entries(clusters)) {
+    if (rows.length === 0) continue;
+    const cPnl = rows.reduce((s, r) => s + Number(r.realized_pnl_usd ?? 0), 0);
+    const cAvgPct = rows.reduce((s, r) => s + Number(r.realized_pnl_pct ?? 0), 0) / rows.length;
+    const cAvgMfe = rows.filter(r => r.mfeAtClose != null).reduce((s, r) => s + (r.mfeAtClose ?? 0), 0) / Math.max(1, rows.filter(r => r.mfeAtClose != null).length);
+    const cAvgGb = rows.filter(r => r.giveBack != null).reduce((s, r) => s + (r.giveBack ?? 0), 0) / Math.max(1, rows.filter(r => r.giveBack != null).length);
+    const cAvgHold = rows.reduce((s, r) => s + r.holdMin, 0) / rows.length;
+    console.log(`\n[${name}]  n=${rows.length}, Σ pnl=$${cPnl.toFixed(2)}`);
+    console.log(`  avg pnl=${fmt(cAvgPct)}%  avg mfe=${fmt(cAvgMfe)}%  avg gb=${fmt(cAvgGb)}%  avg hold=${cAvgHold.toFixed(0)}min`);
+    console.log(`  exemples canoniques :`);
+    for (const r of rows.slice(0, 5)) {
+      const t = String(r.exit_timestamp).slice(11, 16);
+      console.log(`    ${t} ${r.symbol.padEnd(10)} pnl=${fmt(r.realized_pnl_pct)}% mfe=${fmt(r.mfeAtClose)}% gb=${fmt(r.giveBack)}% bb=${fmt(r.snap?.bb_pct_b)} rsi=${fmt(r.snap?.rsi14)} hold=${r.holdMin}min`);
+    }
+  }
+
+  // 5. Output prompt-ready block
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' BLOC SYSTEM_PROMPT REGÉNÉRÉ (à coller en remplacement de la calibration)');
+  console.log('═══════════════════════════════════════════════════════════════════════════════\n');
+
+  const promptBlock = generatePromptBlock(enriched, clusters, totalPnl, wr);
+  console.log(promptBlock);
+
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════\n');
+}
+
+function generatePromptBlock(
+  enriched: Enriched[],
+  clusters: Record<string, Enriched[]>,
+  totalPnl: number,
+  wr: number,
+): string {
+  const lines: string[] = [];
+
+  lines.push(`CALIBRATION DATA-DRIVEN (analyse ${enriched.length} closes HIGH 04/06/2026, $${totalPnl.toFixed(2)} réalisé, ${wr.toFixed(0)}% WR) :`);
+  lines.push('');
+  lines.push("L'humain a fermé manuellement TOUTES ces positions (= ground truth imitation learning).");
+  lines.push("Reproduis cette discipline en t'inspirant des signatures observées :");
+  lines.push('');
+
+  // Pick top 8 canonical examples across clusters
+  lines.push('★ SIGNATURES OBSERVÉES (extraits canoniques, à reproduire) :');
+  let count = 0;
+  for (const [name, rows] of Object.entries(clusters)) {
+    if (rows.length === 0) continue;
+    const sorted = [...rows].sort((a, b) => Number(b.realized_pnl_pct ?? 0) - Number(a.realized_pnl_pct ?? 0));
+    for (const r of sorted.slice(0, 2)) {
+      if (count >= 10) break;
+      count++;
+      const bits: string[] = [];
+      if (r.snap?.bb_pct_b != null) bits.push(`BB%b=${fmt(r.snap.bb_pct_b)}`);
+      if (r.snap?.rsi14 != null) bits.push(`RSI=${fmt(r.snap.rsi14, 0)}`);
+      if (r.giveBack != null) bits.push(`gb=${fmt(r.giveBack)}`);
+      if (r.mfeAtClose != null) bits.push(`mfe=${fmt(r.mfeAtClose)}%`);
+      bits.push(`pnl=${fmt(r.realized_pnl_pct)}%`);
+      bits.push(`hold=${r.holdMin}min`);
+      lines.push(`  - ${r.symbol.padEnd(10)} : ${bits.join(' · ')}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('★★ PATTERNS AGRÉGÉS (statistiques par cluster) :');
+  for (const [name, rows] of Object.entries(clusters)) {
+    if (rows.length === 0) continue;
+    const cAvgPct = rows.reduce((s, r) => s + Number(r.realized_pnl_pct ?? 0), 0) / rows.length;
+    const cAvgMfe = rows.filter(r => r.mfeAtClose != null).reduce((s, r) => s + (r.mfeAtClose ?? 0), 0) / Math.max(1, rows.filter(r => r.mfeAtClose != null).length);
+    const cAvgGb = rows.filter(r => r.giveBack != null).reduce((s, r) => s + (r.giveBack ?? 0), 0) / Math.max(1, rows.filter(r => r.giveBack != null).length);
+    const cAvgHold = rows.reduce((s, r) => s + r.holdMin, 0) / rows.length;
+    lines.push(`  • ${name} : n=${rows.length}, avg pnl=${fmt(cAvgPct)}%, avg mfe=${fmt(cAvgMfe)}%, avg gb=${fmt(cAvgGb)}%, avg hold=${cAvgHold.toFixed(0)}min`);
+  }
+
+  lines.push('');
+  lines.push("★ TIMING WINDOWS observées (heure de close UTC) :");
+  const hourBuckets = new Map<number, { n: number; pnl: number }>();
+  for (const e of enriched) {
+    const h = new Date(e.exit_timestamp).getUTCHours();
+    const b = hourBuckets.get(h) ?? { n: 0, pnl: 0 };
+    b.n++;
+    b.pnl += Number(e.realized_pnl_usd ?? 0);
+    hourBuckets.set(h, b);
+  }
+  for (const [h, b] of [...hourBuckets].sort((a, b) => a[0] - b[0])) {
+    lines.push(`  ${String(h).padStart(2, '0')}:xx UTC : ${b.n} closes, Σ $${b.pnl.toFixed(2)}`);
+  }
+
+  return lines.join('\n');
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-snapshot-schema.ts
+++ b/scripts/check-snapshot-schema.ts
@@ -1,0 +1,9 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+async function main() {
+  const { data } = await sb.from('position_indicators_snapshot').select('*').limit(1);
+  console.log('All columns:');
+  if (data?.[0]) console.log(Object.keys(data[0]).sort().join(', '));
+}
+main();

--- a/scripts/labelize-user-closes-counterfactual.ts
+++ b/scripts/labelize-user-closes-counterfactual.ts
@@ -1,0 +1,165 @@
+/**
+ * COUNTERFACTUAL LABELER — t'as fermé trop tôt ou bien ?
+ *
+ * Pour chaque close manual 04/06, fetch les candles 5m EODHD APRÈS le close
+ * et calcule :
+ *   - max_price_60min      : pic atteint dans les 60 min après close
+ *   - max_extra_pnl_pct    : surplus PnL atteignable si on avait hold
+ *   - price_at_close_session (21:00 UTC) : valeur en fin de séance
+ *   - extra_eod_pnl_pct    : surplus PnL si on avait hold jusqu'au close US
+ *
+ * Verdict :
+ *   - 🟢 GOOD   : extra_pnl ≤ 0.3% (timing parfait, peu/pas d'upside raté)
+ *   - 🟡 OK     : 0.3% < extra_pnl ≤ 1.0% (acceptable)
+ *   - 🔴 EARLY  : extra_pnl > 1.0% (tu as fermé trop tôt, le rebond continuait)
+ *
+ *   npx tsx scripts/labelize-user-closes-counterfactual.ts
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+const HIGH = 'a0000001-0000-0000-0000-000000000001';
+
+const EODHD_API_KEY = process.env.EODHD_API_KEY;
+
+interface IntradayBar {
+  timestamp: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+function pad(s: unknown, n: number) { return String(s ?? '').padEnd(n).slice(0, n); }
+function fmt(n: number | null | undefined, d = 2): string {
+  if (n == null || !Number.isFinite(n)) return 'n/a';
+  return Number(n).toFixed(d);
+}
+
+async function fetchIntradayBars(symbol: string, fromTs: number, toTs: number): Promise<IntradayBar[]> {
+  // EODHD intraday endpoint : /api/intraday/{symbol}?interval=5m&from={unix}&to={unix}
+  const url = `https://eodhd.com/api/intraday/${encodeURIComponent(symbol)}?interval=5m&from=${fromTs}&to=${toTs}&api_token=${EODHD_API_KEY}&fmt=json`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    const json = (await res.json()) as Array<{ timestamp: number; open: number; high: number; low: number; close: number }>;
+    if (!Array.isArray(json)) return [];
+    return json.filter(b =>
+      Number.isFinite(b.timestamp) && Number.isFinite(b.high) && Number.isFinite(b.low) && Number.isFinite(b.close)
+    );
+  } catch {
+    return [];
+  }
+}
+
+async function main() {
+  const { data: closes } = await sb
+    .from('lisa_positions')
+    .select('id, symbol, entry_timestamp, exit_timestamp, entry_price, exit_price, realized_pnl_pct')
+    .eq('portfolio_id', HIGH)
+    .eq('status', 'closed_user')
+    .filter('venue_fee_detail->>source', 'eq', 'scanner_oversold')
+    .gte('exit_timestamp', '2026-06-04T00:00:00Z')
+    .lt('exit_timestamp', '2026-06-05T00:00:00Z')
+    .order('exit_timestamp', { ascending: true });
+
+  if (!closes?.length) { console.log('Aucun close trouvé'); return; }
+
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' COUNTERFACTUAL LABELER — As-tu fermé TROP TÔT le 04/06 ?');
+  console.log('   GOOD ≤ 0.3% extra   |   OK 0.3-1.0%   |   EARLY > 1.0%');
+  console.log('═══════════════════════════════════════════════════════════════════════════════\n');
+  console.log(pad('SYM', 10), pad('EXIT', 6), pad('EXIT$', 8), pad('MAX_60m', 8), pad('PEAK_T+', 8), pad('Δ_60m', 8), pad('Δ_EOD', 8), pad('LABEL', 10));
+
+  const labels = new Map<string, number>();
+  let sumExtra60 = 0;
+  let sumExtraEod = 0;
+  let analyzed = 0;
+  const details: Array<{ sym: string; label: string; extra60: number; extraEod: number }> = [];
+
+  for (const c of closes as unknown as Array<{
+    id: string; symbol: string;
+    entry_timestamp: string; exit_timestamp: string;
+    entry_price: string; exit_price: string;
+    realized_pnl_pct: number | null;
+  }>) {
+    const exitTs = Math.floor(new Date(c.exit_timestamp).getTime() / 1000);
+    const exitPrice = parseFloat(c.exit_price);
+    const entryPrice = parseFloat(c.entry_price);
+    const fromTs = exitTs;
+    const toTs = exitTs + 8 * 3600; // 8h après close (assez pour couvrir jusqu'au close US 21:00 UTC)
+
+    const bars = await fetchIntradayBars(c.symbol, fromTs, toTs);
+    if (bars.length === 0) {
+      console.log(pad(c.symbol, 10), pad(String(c.exit_timestamp).slice(11, 16), 6), pad(fmt(exitPrice), 8), pad('—', 8), pad('—', 8), pad('—', 8), pad('—', 8), pad('NO_DATA', 10));
+      continue;
+    }
+
+    // Bars dans les 60 min après close
+    const bars60 = bars.filter(b => b.timestamp > exitTs && b.timestamp <= exitTs + 3600);
+    const maxIn60 = bars60.length > 0 ? Math.max(...bars60.map(b => b.high)) : exitPrice;
+    const peakBar = bars60.find(b => b.high === maxIn60);
+    const peakDelay = peakBar ? Math.round((peakBar.timestamp - exitTs) / 60) : 0;
+
+    // Bars jusqu'à 21:00 UTC du jour de close (= EOD US 04/06 21:00 UTC)
+    const exitDate = new Date(c.exit_timestamp);
+    const eodTs = Math.floor(Date.UTC(exitDate.getUTCFullYear(), exitDate.getUTCMonth(), exitDate.getUTCDate(), 21, 0) / 1000);
+    const barsEod = bars.filter(b => b.timestamp > exitTs && b.timestamp <= eodTs);
+    const maxToEod = barsEod.length > 0 ? Math.max(...barsEod.map(b => b.high)) : exitPrice;
+
+    // Extra PnL en % du notionnel d'entrée (cohérent avec realized_pnl_pct)
+    const extra60Pct = ((maxIn60 - exitPrice) / entryPrice) * 100;
+    const extraEodPct = ((maxToEod - exitPrice) / entryPrice) * 100;
+
+    sumExtra60 += extra60Pct;
+    sumExtraEod += extraEodPct;
+    analyzed++;
+
+    let label: 'GOOD' | 'OK' | 'EARLY';
+    if (extra60Pct <= 0.3) label = 'GOOD';
+    else if (extra60Pct <= 1.0) label = 'OK';
+    else label = 'EARLY';
+
+    const icon = label === 'GOOD' ? '🟢' : label === 'OK' ? '🟡' : '🔴';
+    labels.set(label, (labels.get(label) ?? 0) + 1);
+    details.push({ sym: c.symbol, label, extra60: extra60Pct, extraEod: extraEodPct });
+
+    console.log(
+      pad(c.symbol, 10),
+      pad(String(c.exit_timestamp).slice(11, 16), 6),
+      pad(fmt(exitPrice), 8),
+      pad(fmt(maxIn60), 8),
+      pad(`+${peakDelay}m`, 8),
+      pad(`${fmt(extra60Pct)}%`, 8),
+      pad(`${fmt(extraEodPct)}%`, 8),
+      pad(`${icon} ${label}`, 10)
+    );
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' SYNTHÈSE');
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  console.log(`  N closes analysés : ${analyzed}/${closes.length}`);
+  for (const [l, n] of [...labels].sort((a, b) => b[1] - a[1])) {
+    const pct = ((n / analyzed) * 100).toFixed(0);
+    console.log(`  ${pad(l, 8)} : ${n} (${pct}%)`);
+  }
+  if (analyzed > 0) {
+    console.log(`\n  Σ extra PnL 60min  : +${sumExtra60.toFixed(2)} pts cumulé (potentiel raté)`);
+    console.log(`  Σ extra PnL EOD    : +${sumExtraEod.toFixed(2)} pts cumulé`);
+    console.log(`  Avg extra 60min    : +${(sumExtra60 / analyzed).toFixed(2)} pts/trade`);
+    console.log(`  Avg extra EOD      : +${(sumExtraEod / analyzed).toFixed(2)} pts/trade`);
+    const earlyDetails = details.filter(d => d.label === 'EARLY').sort((a, b) => b.extra60 - a.extra60);
+    if (earlyDetails.length > 0) {
+      console.log(`\n  TOP 5 closes EARLY (tu as fermé trop tôt) :`);
+      for (const d of earlyDetails.slice(0, 5)) {
+        console.log(`    ${d.sym.padEnd(10)} : tu as raté +${d.extra60.toFixed(2)}pts dans les 60min après ton close`);
+      }
+    }
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════\n');
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/labelize-via-reopens.ts
+++ b/scripts/labelize-via-reopens.ts
@@ -1,0 +1,93 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+const HIGH = 'a0000001-0000-0000-0000-000000000001';
+function pad(s: unknown, n: number) { return String(s ?? '').padEnd(n).slice(0, n); }
+function fmt(n: number | null, d = 2): string { return n == null ? 'n/a' : Number(n).toFixed(d); }
+
+async function main() {
+  // Load ALL positions (open + closed) on HIGH 04/06 with source=scanner_oversold
+  const { data: all } = await sb
+    .from('lisa_positions')
+    .select('symbol, entry_timestamp, exit_timestamp, entry_price, exit_price, status, realized_pnl_pct')
+    .eq('portfolio_id', HIGH)
+    .filter('venue_fee_detail->>source', 'eq', 'scanner_oversold')
+    .gte('entry_timestamp', '2026-06-04T00:00:00Z')
+    .lt('entry_timestamp', '2026-06-05T00:00:00Z')
+    .order('entry_timestamp', { ascending: true });
+
+  if (!all?.length) return;
+
+  // Group by symbol → chronological events
+  type Event = { ts: string; type: 'entry' | 'exit'; price: number; status?: string; pnl?: number | null };
+  const bySymbol = new Map<string, Event[]>();
+  for (const p of all as any[]) {
+    const arr = bySymbol.get(p.symbol) ?? [];
+    arr.push({ ts: p.entry_timestamp, type: 'entry', price: parseFloat(p.entry_price), status: p.status });
+    if (p.exit_timestamp && p.exit_price) {
+      arr.push({ ts: p.exit_timestamp, type: 'exit', price: parseFloat(p.exit_price), status: p.status, pnl: p.realized_pnl_pct });
+    }
+    bySymbol.set(p.symbol, arr);
+  }
+  for (const [, arr] of bySymbol) arr.sort((a, b) => a.ts.localeCompare(b.ts));
+
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' LABELER via re-ouvertures successives (proxy intraday trajectory)');
+  console.log(' Pour chaque user_close, regarde le prochain event sur ce symbole pour mesurer la suite.');
+  console.log('═══════════════════════════════════════════════════════════════════════════════\n');
+  console.log(pad('SYM', 10), pad('EXIT_T', 6), pad('EXIT$', 8), pad('NEXT_T', 6), pad('NEXT$', 8), pad('ΔT', 6), pad('Δ%', 8), pad('LABEL', 10));
+
+  const labels = new Map<string, number>();
+  let sumExtra = 0;
+  let countWithData = 0;
+  const earlyDetails: Array<{ sym: string; t: string; deltaMin: number; extraPct: number }> = [];
+
+  for (const [symbol, events] of bySymbol) {
+    for (let i = 0; i < events.length; i++) {
+      const e = events[i];
+      if (e.type !== 'exit' || e.status !== 'closed_user') continue;
+      const nextEvent = events[i + 1];
+      const t = String(e.ts).slice(11, 16);
+      if (!nextEvent) {
+        console.log(pad(symbol, 10), pad(t, 6), pad(fmt(e.price), 8), pad('—', 6), pad('—', 8), pad('—', 6), pad('—', 8), pad('NO_NEXT', 10));
+        continue;
+      }
+      const exitMs = new Date(e.ts).getTime();
+      const nextMs = new Date(nextEvent.ts).getTime();
+      const deltaMin = Math.round((nextMs - exitMs) / 60_000);
+      const deltaPct = ((nextEvent.price - e.price) / e.price) * 100;
+
+      let label: string;
+      // Positive delta = price kept going UP after your close = you closed early
+      if (deltaPct >= 1.0) { label = '🔴 EARLY'; earlyDetails.push({ sym: symbol, t, deltaMin, extraPct: deltaPct }); }
+      else if (deltaPct >= 0.3) label = '🟡 OK';
+      else if (deltaPct >= -0.3) label = '🟢 GOOD';
+      else label = '🟢 GOOD-'; // price dropped after close = perfect timing
+      const labelKey = label.split(' ')[1];
+      labels.set(labelKey, (labels.get(labelKey) ?? 0) + 1);
+      sumExtra += deltaPct;
+      countWithData++;
+
+      const nextT = String(nextEvent.ts).slice(11, 16);
+      console.log(pad(symbol, 10), pad(t, 6), pad(fmt(e.price), 8), pad(nextT, 6), pad(fmt(nextEvent.price), 8), pad(`${deltaMin}m`, 6), pad(`${deltaPct.toFixed(2)}%`, 8), pad(label, 10));
+    }
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' SYNTHÈSE');
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  for (const [l, n] of [...labels].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${pad(l, 8)} : ${n} (${((n / countWithData) * 100).toFixed(0)}%)`);
+  }
+  if (countWithData > 0) {
+    console.log(`\n  Avg Δ% post-close   : ${(sumExtra / countWithData).toFixed(2)}%`);
+    console.log(`     (positif = tu fermes alors que le rebond continue, négatif = parfait)`);
+  }
+  if (earlyDetails.length > 0) {
+    console.log(`\n  TOP closes EARLY (tu as fermé trop tôt) :`);
+    for (const d of earlyDetails.sort((a, b) => b.extraPct - a.extraPct).slice(0, 8)) {
+      console.log(`    ${d.sym.padEnd(10)} ${d.t} → +${d.extraPct.toFixed(2)}% en ${d.deltaMin}min après ton close`);
+    }
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/simulate-mistral-dual-rule.ts
+++ b/scripts/simulate-mistral-dual-rule.ts
@@ -1,0 +1,168 @@
+/**
+ * Simulation des règles DUAL (R0 quick-lock + R1 RSI fatigue) + HARD CLOSE
+ * vs les closes manuels d'hier.
+ *
+ *   R0 PRIORITÉ ABSOLUE — Quick-lock scalp :
+ *     age_min ≤ 10 ET pnl_pct ≥ 1.5%   → CLOSE
+ *
+ *   R1 — Lock + signal de fatigue :
+ *     pnl_pct ≥ 1.5% ET rsi14 ≥ 60      → CLOSE
+ *
+ *   HARD_CLOSE — Sortie EOD :
+ *     time_utc ≥ 20:30 UTC              → CLOSE
+ *
+ * Verdict appliqué à la PREMIÈRE règle qui fire chronologiquement.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+const HIGH = 'a0000001-0000-0000-0000-000000000001';
+
+const R0_MAX_AGE_MIN = 10;
+const R0_MIN_PNL_PCT = 1.5;
+const R1_MIN_PNL_PCT = 1.5;
+const R1_RSI = 60;
+const HARD_CLOSE_HOUR_UTC = 20.5;
+
+function fmt(n: number | null | undefined, d = 2): string {
+  if (n == null || !Number.isFinite(n)) return 'n/a';
+  return Number(n).toFixed(d);
+}
+function pad(s: unknown, n: number) { return String(s ?? '').padEnd(n).slice(0, n); }
+
+async function main() {
+  const { data: closes } = await sb
+    .from('lisa_positions')
+    .select('id, symbol, entry_timestamp, exit_timestamp, realized_pnl_pct, realized_pnl_usd')
+    .eq('portfolio_id', HIGH)
+    .eq('status', 'closed_user')
+    .filter('venue_fee_detail->>source', 'eq', 'scanner_oversold')
+    .gte('exit_timestamp', '2026-06-04T00:00:00Z')
+    .lt('exit_timestamp', '2026-06-05T00:00:00Z')
+    .order('exit_timestamp', { ascending: true });
+
+  if (!closes?.length) return;
+
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' DUAL RULES SIMULATION — R0 quick-lock + R1 fatigue + HARD CLOSE 20:30 UTC');
+  console.log(`   R0 : age ≤ ${R0_MAX_AGE_MIN}min ET pnl ≥ ${R0_MIN_PNL_PCT}%`);
+  console.log(`   R1 : pnl ≥ ${R1_MIN_PNL_PCT}% ET rsi14 ≥ ${R1_RSI}`);
+  console.log(`   HC : time_utc ≥ ${HARD_CLOSE_HOUR_UTC} UTC`);
+  console.log('═══════════════════════════════════════════════════════════════════════════════\n');
+
+  console.log(pad('SYM', 10), pad('EXIT', 6), pad('Δt', 9), pad('SIM_PNL', 8), pad('ACT_PNL', 8), pad('RULE', 5), pad('VERDICT', 12), 'NOTE');
+
+  type Verdict = 'EARLIER' | 'MATCH' | 'LATER' | 'NEVER';
+  const verdicts = new Map<Verdict, number>();
+  const ruleHits = new Map<string, number>();
+  let sumSimPnl = 0;
+  let sumActPnl = 0;
+  let countedClosed = 0;
+
+  for (const c of closes as unknown as Array<{
+    id: string; symbol: string;
+    entry_timestamp: string; exit_timestamp: string;
+    realized_pnl_pct: number | null; realized_pnl_usd: number | null;
+  }>) {
+    const exitMs = new Date(c.exit_timestamp).getTime();
+    const entryMs = new Date(c.entry_timestamp).getTime();
+
+    const { data: snaps } = await sb
+      .from('position_indicators_snapshot')
+      .select('captured_at, pnl_pct, rsi14, mfe_pct')
+      .eq('position_id', c.id)
+      .gte('captured_at', c.entry_timestamp)
+      .lte('captured_at', c.exit_timestamp)
+      .order('captured_at', { ascending: true });
+
+    let firedAt: { ts: string; pnl: number; rsi: number | null; rule: 'R0' | 'R1' | 'HC' } | null = null;
+
+    // Test rules in chronological order on each snapshot
+    for (const s of (snaps ?? []) as Array<{ captured_at: string; pnl_pct: number | null; rsi14: number | null }>) {
+      const ageMin = (new Date(s.captured_at).getTime() - entryMs) / 60_000;
+      const tUtc = new Date(s.captured_at).getUTCHours() + new Date(s.captured_at).getUTCMinutes() / 60;
+      const pnl = s.pnl_pct;
+      const rsi = s.rsi14;
+      if (pnl == null) continue;
+
+      // HARD CLOSE first (overrides all)
+      if (tUtc >= HARD_CLOSE_HOUR_UTC) {
+        firedAt = { ts: s.captured_at, pnl, rsi, rule: 'HC' };
+        break;
+      }
+      // R0 quick-lock
+      if (ageMin <= R0_MAX_AGE_MIN && pnl >= R0_MIN_PNL_PCT) {
+        firedAt = { ts: s.captured_at, pnl, rsi, rule: 'R0' };
+        break;
+      }
+      // R1 fatigue
+      if (pnl >= R1_MIN_PNL_PCT && rsi != null && rsi >= R1_RSI) {
+        firedAt = { ts: s.captured_at, pnl, rsi, rule: 'R1' };
+        break;
+      }
+    }
+
+    if (!firedAt) {
+      verdicts.set('NEVER', (verdicts.get('NEVER') ?? 0) + 1);
+      console.log(pad(c.symbol, 10), pad(String(c.exit_timestamp).slice(11, 16), 6), pad('—', 9), pad('—', 8), pad(fmt(c.realized_pnl_pct) + '%', 8), pad('—', 5), pad('❌ NEVER', 12), 'aucune règle');
+      continue;
+    }
+
+    const firedMs = new Date(firedAt.ts).getTime();
+    const deltaMin = Math.round((firedMs - exitMs) / 60_000);
+    const actPnl = Number(c.realized_pnl_pct ?? 0);
+    sumSimPnl += firedAt.pnl;
+    sumActPnl += actPnl;
+    countedClosed++;
+
+    let verdict: Verdict;
+    if (deltaMin <= -4) verdict = 'EARLIER';
+    else if (deltaMin >= 4) verdict = 'LATER';
+    else verdict = 'MATCH';
+    verdicts.set(verdict, (verdicts.get(verdict) ?? 0) + 1);
+    ruleHits.set(firedAt.rule, (ruleHits.get(firedAt.rule) ?? 0) + 1);
+
+    const icon = verdict === 'EARLIER' ? '🟢' : verdict === 'MATCH' ? '✅' : '🔴';
+    const dtStr = deltaMin === 0 ? '=' : (deltaMin > 0 ? `+${deltaMin}m` : `${deltaMin}m`);
+
+    console.log(
+      pad(c.symbol, 10),
+      pad(String(c.exit_timestamp).slice(11, 16), 6),
+      pad(dtStr, 9),
+      pad(fmt(firedAt.pnl) + '%', 8),
+      pad(fmt(actPnl) + '%', 8),
+      pad(firedAt.rule, 5),
+      pad(`${icon} ${verdict}`, 12),
+      `rsi=${fmt(firedAt.rsi, 0)} Δpnl=${fmt(firedAt.pnl - actPnl)}pts`
+    );
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' SYNTHÈSE');
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  console.log(`  N closes : ${closes.length}`);
+  for (const [v, n] of [...verdicts].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${pad(v, 10)} : ${n} (${((n / closes.length) * 100).toFixed(0)}%)`);
+  }
+  console.log(`\n  Rules fired :`);
+  for (const [r, n] of [...ruleHits].sort((a, b) => b[1] - a[1])) {
+    console.log(`    ${r} : ${n} closes`);
+  }
+  if (countedClosed > 0) {
+    console.log(`\n  Σ PnL simulé (règle)    : ${sumSimPnl.toFixed(2)}% cumulé sur ${countedClosed} positions`);
+    console.log(`  Σ PnL réel (humain)     : ${sumActPnl.toFixed(2)}% cumulé`);
+    console.log(`  Avg PnL simulé          : ${(sumSimPnl / countedClosed).toFixed(2)}%`);
+    console.log(`  Avg PnL réel            : ${(sumActPnl / countedClosed).toFixed(2)}%`);
+    console.log(`  Δ PnL cumulé            : ${(sumSimPnl - sumActPnl).toFixed(2)} pts`);
+    console.log(`     (négatif = manque à gagner, positif = mieux que toi)`);
+  }
+  const never = verdicts.get('NEVER') ?? 0;
+  if (never > 0) {
+    console.log(`\n  ⚠ ${never} NEVER : positions où Mistral aurait HOLD → fallback J+10 / -15%`);
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════\n');
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/simulate-mistral-rule-vs-actual.ts
+++ b/scripts/simulate-mistral-rule-vs-actual.ts
@@ -1,0 +1,160 @@
+/**
+ * Simulation de la règle R1 proposée vs les closes manuels d'hier.
+ *
+ *   Règle simulée : pnl_pct >= 1.5% ET rsi14 >= 60
+ *                   (ou trend_5m_pct <= 0, mais on n'a pas cette donnée
+ *                   historiquement, donc on utilise rsi14 uniquement comme
+ *                   signal de fatigue testable)
+ *
+ * Pour chaque position : on cherche le PREMIER snapshot où la règle aurait
+ * fired, et on compare au close réel de l'humain. Verdicts :
+ *   - 🟢 EARLIER  : Mistral aurait fermé AVANT l'humain (= pourrait laisser de l'upside)
+ *   - ✅ MATCH    : Mistral aurait fermé au même moment (±2 snapshots = ±4 min)
+ *   - 🔴 LATER    : Mistral aurait fermé APRÈS (= attendrait, give-back possible)
+ *   - ❌ NEVER    : la règle n'aurait jamais déclenché → Mistral aurait HOLD
+ *                   → fallback filet J+10 / -15%
+ *
+ *   npx tsx scripts/simulate-mistral-rule-vs-actual.ts
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+const HIGH = 'a0000001-0000-0000-0000-000000000001';
+
+const RULE_MIN_PNL_PCT = 1.5;
+const RULE_RSI_FATIGUE = 60;
+
+function fmt(n: number | null | undefined, dec = 2): string {
+  if (n == null || !Number.isFinite(n)) return 'n/a';
+  return Number(n).toFixed(dec);
+}
+function pad(s: unknown, n: number) { return String(s ?? '').padEnd(n).slice(0, n); }
+
+async function main() {
+  const { data: closes } = await sb
+    .from('lisa_positions')
+    .select('id, symbol, entry_timestamp, exit_timestamp, entry_price, exit_price, realized_pnl_pct, realized_pnl_usd')
+    .eq('portfolio_id', HIGH)
+    .eq('status', 'closed_user')
+    .filter('venue_fee_detail->>source', 'eq', 'scanner_oversold')
+    .gte('exit_timestamp', '2026-06-04T00:00:00Z')
+    .lt('exit_timestamp', '2026-06-05T00:00:00Z')
+    .order('exit_timestamp', { ascending: true });
+
+  if (!closes?.length) {
+    console.log('Aucun close trouvé');
+    return;
+  }
+
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' SIMULATION RÈGLE R1 vs CLOSES MANUELS 04/06');
+  console.log(`   Règle : pnl_pct ≥ ${RULE_MIN_PNL_PCT}% ET rsi14 ≥ ${RULE_RSI_FATIGUE}`);
+  console.log('═══════════════════════════════════════════════════════════════════════════════\n');
+  console.log(pad('SYM', 10), pad('EXIT', 6), pad('Δt', 9), pad('SIM_PNL', 9), pad('ACT_PNL', 9), pad('VERDICT', 12), 'NOTE');
+
+  type Verdict = 'EARLIER' | 'MATCH' | 'LATER' | 'NEVER';
+  const verdicts = new Map<Verdict, number>();
+  let sumSimPnl = 0;
+  let sumActPnl = 0;
+  let counted = 0;
+  const deltaTimes: number[] = [];
+
+  for (const c of closes as unknown as Array<{
+    id: string; symbol: string;
+    entry_timestamp: string; exit_timestamp: string;
+    entry_price: string; exit_price: string;
+    realized_pnl_pct: number | null; realized_pnl_usd: number | null;
+  }>) {
+    const exitMs = new Date(c.exit_timestamp).getTime();
+    const entryMs = new Date(c.entry_timestamp).getTime();
+
+    // Charge TOUS les snapshots de cette position (durant le hold)
+    const { data: snaps } = await sb
+      .from('position_indicators_snapshot')
+      .select('captured_at, pnl_pct, rsi14, mfe_pct')
+      .eq('position_id', c.id)
+      .gte('captured_at', c.entry_timestamp)
+      .lte('captured_at', c.exit_timestamp)
+      .order('captured_at', { ascending: true });
+
+    if (!snaps?.length) {
+      console.log(pad(c.symbol, 10), pad(String(c.exit_timestamp).slice(11, 16), 6), pad('n/a', 9), pad('n/a', 9), pad(fmt(c.realized_pnl_pct) + '%', 9), pad('NO_SNAP', 12), 'pas de snapshot');
+      continue;
+    }
+
+    // Find FIRST snapshot where rule fires
+    let firedAt: { ts: string; pnl: number; rsi: number } | null = null;
+    for (const s of snaps as Array<{ captured_at: string; pnl_pct: number | null; rsi14: number | null; mfe_pct: number | null }>) {
+      const pnl = s.pnl_pct;
+      const rsi = s.rsi14;
+      if (pnl == null || rsi == null) continue;
+      if (pnl >= RULE_MIN_PNL_PCT && rsi >= RULE_RSI_FATIGUE) {
+        firedAt = { ts: s.captured_at, pnl, rsi };
+        break;
+      }
+    }
+
+    if (!firedAt) {
+      verdicts.set('NEVER', (verdicts.get('NEVER') ?? 0) + 1);
+      console.log(pad(c.symbol, 10), pad(String(c.exit_timestamp).slice(11, 16), 6), pad('—', 9), pad('—', 9), pad(fmt(c.realized_pnl_pct) + '%', 9), pad('❌ NEVER', 12), 'règle jamais matchée');
+      continue;
+    }
+
+    const firedMs = new Date(firedAt.ts).getTime();
+    const deltaMin = Math.round((firedMs - exitMs) / 60_000);
+    deltaTimes.push(deltaMin);
+    const actPnl = Number(c.realized_pnl_pct ?? 0);
+    sumSimPnl += firedAt.pnl;
+    sumActPnl += actPnl;
+    counted++;
+
+    let verdict: Verdict;
+    if (deltaMin <= -4) verdict = 'EARLIER';
+    else if (deltaMin >= 4) verdict = 'LATER';
+    else verdict = 'MATCH';
+    verdicts.set(verdict, (verdicts.get(verdict) ?? 0) + 1);
+
+    const icon = verdict === 'EARLIER' ? '🟢' : verdict === 'MATCH' ? '✅' : '🔴';
+    const dtStr = deltaMin === 0 ? '=' : (deltaMin > 0 ? `+${deltaMin}min` : `${deltaMin}min`);
+
+    console.log(
+      pad(c.symbol, 10),
+      pad(String(c.exit_timestamp).slice(11, 16), 6),
+      pad(dtStr, 9),
+      pad(fmt(firedAt.pnl) + '%', 9),
+      pad(fmt(actPnl) + '%', 9),
+      pad(`${icon} ${verdict}`, 12),
+      `rsi=${fmt(firedAt.rsi, 0)} (Δ pnl=${fmt(firedAt.pnl - actPnl)}pts)`
+    );
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' SYNTHÈSE');
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  console.log(`  Total closes analysés : ${closes.length}`);
+  for (const [v, n] of verdicts) {
+    const pct = ((n / closes.length) * 100).toFixed(0);
+    console.log(`  ${pad(v, 10)} : ${n} (${pct}%)`);
+  }
+  if (counted > 0) {
+    console.log(`\n  Σ PnL simulé (règle)    : ${(sumSimPnl).toFixed(2)}% cumulé sur ${counted} positions`);
+    console.log(`  Σ PnL réel (humain)     : ${(sumActPnl).toFixed(2)}% cumulé`);
+    console.log(`  Avg PnL simulé          : ${(sumSimPnl / counted).toFixed(2)}%`);
+    console.log(`  Avg PnL réel            : ${(sumActPnl / counted).toFixed(2)}%`);
+    const avgDelta = deltaTimes.reduce((s, d) => s + d, 0) / deltaTimes.length;
+    console.log(`  Avg delta time (sim-act): ${avgDelta.toFixed(0)} min`);
+    console.log(`     (négatif = Mistral fermerait AVANT toi, positif = APRÈS)`);
+  }
+
+  const never = verdicts.get('NEVER') ?? 0;
+  if (never > 0) {
+    console.log(`\n  ⚠ ${never} closes où la règle n'aurait JAMAIS matché.`);
+    console.log(`    Ces positions seraient HOLD → fallback J+10 / -15%`);
+    console.log(`    À analyser : faut-il une règle complémentaire ?`);
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════\n');
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Contexte

Analyse des 34 closes user_manual scanner_oversold du 04/06 (HIGH, $825.50, 100% WR) pour générer un bloc CALIBRATION DATA-DRIVEN ready-to-paste dans le SYSTEM_PROMPT de `OversoldMistralExitService` — objectif imitation learning.

## Findings clés

- 2 styles dominants : **R1 patient** (13 closes, 382min hold, $334) et **R5 scalp 2min** (12 closes, $244) → 70% du PnL combiné
- **R2 RSI surachat** = meilleur PnL moyen **3.87%** (n=4, BEST PERFORMER)
- avg give_back = **0.17%** → l'humain ferme quasi au pic
- 19:xx UTC : 17 closes, **$412** (batch entries fraîches après scan-now)

## Usage

```bash
npx tsx scripts/analyze-user-closes-for-mistral.ts
```

Output : stats agrégées + clusters + exemples canoniques + bloc SYSTEM_PROMPT regénéré.

## Follow-up

Décision pending utilisateur : remplacer la calibration hardcoded actuelle (basée sur 14 exemples illustratifs du commit `0f7caf8`) par ce nouveau bloc factuel de 34 trades réels ?

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_