### PR TITLE
feat(trader): env tunables sur 4 gates bloquants (CLIMAX/VERTICAL/Debate/Stale)

### DIFF
--- a/apps/api/src/modules/lisa/services/debate-gate.service.ts
+++ b/apps/api/src/modules/lisa/services/debate-gate.service.ts
@@ -29,6 +29,7 @@ import { ConfigService } from '@nestjs/config';
 import {
   type ConsensusVerdict,
   type DebateInput,
+  type ResolveDebateOptions,
   buildSignal,
   resolveDebate,
   type TradingDecision,
@@ -98,6 +99,36 @@ export class DebateGateService {
   }
 
   /**
+   * Lit les overrides env-tunables pour resolveDebate. Default = constantes
+   * globales (back-compat). Utile pour TRADER mode où on accepte un consensus
+   * plus mou (data-driven 05/06/2026 : DebateGate WAIT bloquait 44% de pumps
+   * réels sur NYSE session, edge raté +67%).
+   *
+   *   GAINERS_DEBATE_MIN_QUORUM           default 2  (set à 1 = solo allowed)
+   *   GAINERS_DEBATE_MIN_CONSENSUS_RATIO  default 0.5
+   *   GAINERS_DEBATE_MIN_WINNER_CONF      default 0.5
+   */
+  private readResolveOptions(): ResolveDebateOptions | undefined {
+    const opts: ResolveDebateOptions = {};
+    const q = this.config.get<string>('GAINERS_DEBATE_MIN_QUORUM');
+    if (q) {
+      const n = parseInt(q, 10);
+      if (Number.isFinite(n) && n >= 1) opts.minQuorum = n;
+    }
+    const cr = this.config.get<string>('GAINERS_DEBATE_MIN_CONSENSUS_RATIO');
+    if (cr) {
+      const n = parseFloat(cr);
+      if (Number.isFinite(n) && n > 0 && n <= 1) opts.minConsensusRatio = n;
+    }
+    const wc = this.config.get<string>('GAINERS_DEBATE_MIN_WINNER_CONF');
+    if (wc) {
+      const n = parseFloat(wc);
+      if (Number.isFinite(n) && n > 0 && n <= 1) opts.minWinnerConfidence = n;
+    }
+    return Object.keys(opts).length > 0 ? opts : undefined;
+  }
+
+  /**
    * Évalue un candidat. Pure fn sauf logger — pas d'I/O DB.
    *
    * Fail-safe : si une exception remonte, retourne `allow=true` (no regression).
@@ -107,7 +138,7 @@ export class DebateGateService {
     const shadowMode = !this.isActive();
     try {
       const inputs = this.buildAgentInputs(scores, now);
-      const verdict = resolveDebate(inputs, now);
+      const verdict = resolveDebate(inputs, now, this.readResolveOptions());
       const debateAllows = verdict.decision === 'BUY';
       const allow = shadowMode ? true : debateAllows;
 

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -3956,7 +3956,22 @@ export class TopGainersScannerService implements OnModuleInit {
 
           const climaxGateOn = (this.config.get<string>('GAINERS_CLIMAX_RUN_GATE_ENABLED') ?? 'true').toLowerCase() === 'true';
           if (climaxGateOn) {
-            const climaxHit = evaluateClimaxRun(persistence.tf5m, persistence.tf30m);
+            // 05/06/2026 — env tunables suite rollback EODHD NYSE 04/06 :
+            // CLIMAX_RUN bloquait 77% de pumps réels (avg +4.24%). POET.US rejeté
+            // 4× malgré pump prolongé +9%. Defaults conservés pour back-compat,
+            // tunable Fly secrets pour relâcher.
+            //   GAINERS_CLIMAX_MIN_TF5M_PCT        default 5  (raise à 8-10 = plus permissif)
+            //   GAINERS_CLIMAX_MAX_PLATEAU_GAP_PCT default 1.5 (lower à 0.5 = plus permissif)
+            const climaxOpts: { minTf5mPct?: number; maxPlateauGapPct?: number } = {};
+            const climaxMinTf5m = parseFloat(this.config.get<string>('GAINERS_CLIMAX_MIN_TF5M_PCT') ?? '');
+            if (Number.isFinite(climaxMinTf5m) && climaxMinTf5m > 0) climaxOpts.minTf5mPct = climaxMinTf5m;
+            const climaxMaxGap = parseFloat(this.config.get<string>('GAINERS_CLIMAX_MAX_PLATEAU_GAP_PCT') ?? '');
+            if (Number.isFinite(climaxMaxGap) && climaxMaxGap > 0) climaxOpts.maxPlateauGapPct = climaxMaxGap;
+            const climaxHit = evaluateClimaxRun(
+              persistence.tf5m,
+              persistence.tf30m,
+              Object.keys(climaxOpts).length > 0 ? climaxOpts : undefined,
+            );
             if (climaxHit) {
               this.logger.log(
                 `[top-gainers] ${cand.symbol} CLIMAX_RUN: tf5m=${climaxHit.tf5m.toFixed(2)}% tf30m=${climaxHit.tf30m.toFixed(2)}% (plateau, |∆|=${climaxHit.gapPct.toFixed(2)}pt) → skip [blow-off]`,
@@ -3977,8 +3992,22 @@ export class TopGainersScannerService implements OnModuleInit {
 
           const verticalGateOn = (this.config.get<string>('GAINERS_VERTICAL_PUMP_GATE_ENABLED') ?? 'true').toLowerCase() === 'true';
           if (verticalGateOn) {
+            // 05/06/2026 — env tunables suite rollback EODHD NYSE 04/06 :
+            // VERTICAL_PUMP bloquait 75% de pumps réels (avg +4.52%). POET/NVTS
+            // rejetés malgré uptrend prolongé. Defaults conservés pour back-compat.
+            //   GAINERS_VERTICAL_PUMP_MAX_RATIO    default 0.5 (raise à 0.8-1.0 = plus permissif)
+            //   GAINERS_VERTICAL_PUMP_MIN_TF5M_PCT default 5   (raise à 8-10 = plus permissif)
+            const verticalOpts: { minTf5mPct?: number; maxRatio?: number } = {};
+            const verticalMaxRatio = parseFloat(this.config.get<string>('GAINERS_VERTICAL_PUMP_MAX_RATIO') ?? '');
+            if (Number.isFinite(verticalMaxRatio) && verticalMaxRatio > 0) verticalOpts.maxRatio = verticalMaxRatio;
+            const verticalMinTf5m = parseFloat(this.config.get<string>('GAINERS_VERTICAL_PUMP_MIN_TF5M_PCT') ?? '');
+            if (Number.isFinite(verticalMinTf5m) && verticalMinTf5m > 0) verticalOpts.minTf5mPct = verticalMinTf5m;
             const ch1m = typeof cand.changePct === 'number' && Number.isFinite(cand.changePct) ? cand.changePct : null;
-            const verticalHit = evaluateVerticalPump(ch1m, persistence.tf5m);
+            const verticalHit = evaluateVerticalPump(
+              ch1m,
+              persistence.tf5m,
+              Object.keys(verticalOpts).length > 0 ? verticalOpts : undefined,
+            );
             if (verticalHit) {
               this.logger.log(
                 `[top-gainers] ${cand.symbol} VERTICAL_PUMP: ch1m=${verticalHit.ch1m.toFixed(2)}% / tf5m=${verticalHit.tf5m.toFixed(2)}% = ${verticalHit.ratio.toFixed(2)} → skip [last-minute concentration]`,
@@ -5122,7 +5151,20 @@ export class TopGainersScannerService implements OnModuleInit {
       // P19-staleness-OPEN (25/05) : étend le check au stale_* (TwelveData
       // LSE/Euronext/SIX figé vendredi → prix de 3j → on ne doit JAMAIS
       // ouvrir sur ce prix, même si le ticker semble être un top gainer).
-      if (typeof quote.source === 'string' && (quote.source.startsWith('fallback') || quote.source.startsWith('stale_'))) {
+      //
+      // 05/06/2026 — env tunable suite rollback EODHD NYSE 04/06 :
+      // StaleOrFallbackSource bloquait 58% de pumps réels (avg +3.17%) sur
+      // small caps US (ALOY/SYRE/ABVX). TwelveData renvoie stale_twelvedata
+      // pendant pump (pas une vraie indisponibilité). Sanity bound 30% + fallback
+      // 'fallback_unknown' restent toujours actifs comme dernier filet.
+      //   GAINERS_STALE_SOURCE_GUARD_ENABLED  default true (set à false = bypass stale_*)
+      // ATTENTION : ne bypass JAMAIS 'fallback_unknown' (prix sentinel $0, garde-fou
+      // immuable du LMT incident 27/04). On filtre uniquement 'stale_*' et 'fallback'
+      // génériques sur small caps US où TwelveData a un comportement connu fragile.
+      const staleGuardEnabled = (this.config.get<string>('GAINERS_STALE_SOURCE_GUARD_ENABLED') ?? 'true').toLowerCase() !== 'false';
+      const isUnknownFallback = quote.source === 'fallback_unknown';
+      const isStaleOrFallback = typeof quote.source === 'string' && (quote.source.startsWith('fallback') || quote.source.startsWith('stale_'));
+      if (isUnknownFallback || (staleGuardEnabled && isStaleOrFallback)) {
         this.logger.warn(`[top-gainers] ${cand.symbol}: unreliable source ${quote.source} → skip open (cycle suivant)`);
         // Fix 26/05 : trace en decision_log pour observabilité (incident nuit 25→26/05,
         // 67 ACCEPT shadow Asia / 0 open / 0 event decision_log — skip invisible).

--- a/packages/ai-analyst/src/decisions/debate-orchestrator.ts
+++ b/packages/ai-analyst/src/decisions/debate-orchestrator.ts
@@ -114,6 +114,20 @@ export interface ConsensusVerdict {
 }
 
 /**
+ * Options de calibration pour resolveDebate. Default = constantes globales
+ * (back-compat). Permet au caller (ex: DebateGateService lisant env vars)
+ * d'ajuster les seuils par contexte (TRADER mode plus permissif).
+ */
+export interface ResolveDebateOptions {
+  /** Override MIN_QUORUM (default 2). Set à 1 pour autoriser solo BUY. */
+  minQuorum?: number;
+  /** Override MIN_CONSENSUS_RATIO (default 0.5 pour BUY/SELL). */
+  minConsensusRatio?: number;
+  /** Override MIN_WINNER_CONFIDENCE (default 0.5). */
+  minWinnerConfidence?: number;
+}
+
+/**
  * Résout un débat multi-agents en consensus déterministe.
  *
  * Algorithme :
@@ -140,7 +154,11 @@ export interface ConsensusVerdict {
 export function resolveDebate(
   inputs: ReadonlyArray<DebateInput>,
   now: number = Date.now(),
+  options?: ResolveDebateOptions,
 ): ConsensusVerdict {
+  const minQuorum = options?.minQuorum ?? MIN_QUORUM;
+  const minConsensusRatio = options?.minConsensusRatio ?? MIN_CONSENSUS_RATIO;
+  const minWinnerConfidence = options?.minWinnerConfidence ?? MIN_WINNER_CONFIDENCE;
   if (inputs.length === 0) {
     return emptyConsensus('no agents');
   }
@@ -219,8 +237,8 @@ export function resolveDebate(
 
   const consensusRatio = winnerBucket ? winnerBucket.weight / totalWeight : 0;
   // Biais défensif : CLOSE peut passer à 40% de consensus (protect first),
-  // BUY/SELL exigent 60%.
-  const requiredRatio = winnerDecision === 'CLOSE' ? DEFENSIVE_CONSENSUS_RATIO : MIN_CONSENSUS_RATIO;
+  // BUY/SELL exigent minConsensusRatio (default 0.5, override possible).
+  const requiredRatio = winnerDecision === 'CLOSE' ? DEFENSIVE_CONSENSUS_RATIO : minConsensusRatio;
 
   const allDissenting = () => fresh.map((f) => ({
     agentId: f.input.agentId,
@@ -242,7 +260,7 @@ export function resolveDebate(
   }
 
   // Quorum minimum : un agent seul ne déclenche jamais une action (sauf veto safety).
-  if (isActionable(winnerDecision) && winnerBucket.agents.length < MIN_QUORUM) {
+  if (isActionable(winnerDecision) && winnerBucket.agents.length < minQuorum) {
     return {
       decision: 'WAIT',
       confidence: 0,
@@ -250,7 +268,7 @@ export function resolveDebate(
       vetoTriggered: false,
       contributingAgents: [],
       dissentingAgents: allDissenting(),
-      rationale: `Quorum insuffisant (${winnerBucket.agents.length} agent(s) < ${MIN_QUORUM} requis pour action ${winnerDecision}). Fallback WAIT.`,
+      rationale: `Quorum insuffisant (${winnerBucket.agents.length} agent(s) < ${minQuorum} requis pour action ${winnerDecision}). Fallback WAIT.`,
       staleAgents: stale,
     };
   }
@@ -258,7 +276,7 @@ export function resolveDebate(
   const avgConfidence = winnerBucket.weight / winnerBucket.agents.length;
 
   // Confidence floor : même unanimité, si conviction faible -> WAIT.
-  if (isActionable(winnerDecision) && avgConfidence < MIN_WINNER_CONFIDENCE) {
+  if (isActionable(winnerDecision) && avgConfidence < minWinnerConfidence) {
     return {
       decision: 'WAIT',
       confidence: avgConfidence,
@@ -266,7 +284,7 @@ export function resolveDebate(
       vetoTriggered: false,
       contributingAgents: [],
       dissentingAgents: allDissenting(),
-      rationale: `Conviction trop faible (avg ${avgConfidence.toFixed(2)} < ${MIN_WINNER_CONFIDENCE}). Consensus mou rejeté. Fallback WAIT.`,
+      rationale: `Conviction trop faible (avg ${avgConfidence.toFixed(2)} < ${minWinnerConfidence}). Consensus mou rejeté. Fallback WAIT.`,
       staleAgents: stale,
     };
   }

--- a/scripts/check-trader-all-kinds.ts
+++ b/scripts/check-trader-all-kinds.ts
@@ -1,0 +1,66 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const TRADER_PORTFOLIO = 'b0000001-0000-0000-0000-000000000001';
+  const nyseFrom = '2026-06-04T14:30:00.000Z';
+  const nyseTo = '2026-06-04T21:00:00.000Z';
+
+  console.log(`\n═══ ALL kinds in lisa_decision_log TRADER pendant NYSE ═══\n`);
+  const { data: rows } = await sb
+    .from('lisa_decision_log')
+    .select('kind')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .gte('timestamp', nyseFrom)
+    .lt('timestamp', nyseTo);
+  const counts = new Map<string, number>();
+  for (const r of rows ?? []) counts.set(r.kind, (counts.get(r.kind) ?? 0) + 1);
+  for (const [k, n] of [...counts].sort((a,b)=>b[1]-a[1])) {
+    console.log(`  ${n.toString().padStart(4)} × ${k}`);
+  }
+
+  // Now break down scanner_candidate_skip by verdict (real reject vs blind_pass)
+  console.log(`\n═══ scanner_candidate_skip drill-down (CHOP_NOISE only) ═══\n`);
+  const { data: skips } = await sb
+    .from('lisa_decision_log')
+    .select('payload')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .eq('kind', 'scanner_candidate_skip')
+    .gte('timestamp', nyseFrom)
+    .lt('timestamp', nyseTo);
+  const verdictSplit = new Map<string, number>();
+  const gateSplit = new Map<string, number>();
+  for (const s of skips ?? []) {
+    const p = s.payload as any;
+    const gate = p?.gate ?? 'unknown';
+    gateSplit.set(gate, (gateSplit.get(gate) ?? 0) + 1);
+    if (gate === 'CHOP_NOISE') {
+      const v = p?.verdict ?? 'unknown';
+      verdictSplit.set(v, (verdictSplit.get(v) ?? 0) + 1);
+    }
+  }
+  console.log('Par gate :');
+  for (const [g, n] of [...gateSplit].sort((a,b)=>b[1]-a[1])) {
+    console.log(`  ${g.padEnd(20)} ${n}`);
+  }
+  console.log('\nCHOP_NOISE verdict split :');
+  for (const [v, n] of [...verdictSplit].sort((a,b)=>b[1]-a[1])) {
+    console.log(`  ${v.padEnd(20)} ${n}  ${v === 'blind_pass' ? '(fail-open, laisse passer)' : '(VRAI skip)'}`);
+  }
+
+  // DebateGate verdict actuels
+  console.log(`\n═══ DebateGate verdicts (gate=debate_gate) ═══\n`);
+  const dgCounts = new Map<string, number>();
+  for (const s of skips ?? []) {
+    const p = s.payload as any;
+    if (p?.gate === 'debate_gate') {
+      const r = p?.reason ?? 'unknown';
+      dgCounts.set(r, (dgCounts.get(r) ?? 0) + 1);
+    }
+  }
+  for (const [r, n] of [...dgCounts].sort((a,b)=>b[1]-a[1])) {
+    console.log(`  ${r.padEnd(20)} ${n}`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-trader-fail-reasons.ts
+++ b/scripts/check-trader-fail-reasons.ts
@@ -1,0 +1,72 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const TRADER_PORTFOLIO = 'b0000001-0000-0000-0000-000000000001';
+  const nyseFrom = '2026-06-04T14:30:00.000Z';
+  const nyseTo = '2026-06-04T21:00:00.000Z';
+
+  console.log(`\n═══ position_open_failed reasons (NYSE session) ═══\n`);
+  const { data: failed } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, payload')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .eq('kind', 'position_open_failed')
+    .gte('timestamp', nyseFrom)
+    .lt('timestamp', nyseTo);
+  const reasonCounts = new Map<string, number>();
+  const samples = new Map<string, any>();
+  for (const f of failed ?? []) {
+    const p = f.payload as any;
+    const reason = p?.reason ?? p?.error_code ?? p?.error ?? JSON.stringify(p).slice(0,80);
+    reasonCounts.set(reason, (reasonCounts.get(reason) ?? 0) + 1);
+    if (!samples.has(reason)) samples.set(reason, { ts: f.timestamp, payload: p });
+  }
+  for (const [r, n] of [...reasonCounts].sort((a,b)=>b[1]-a[1])) {
+    console.log(`  ${n.toString().padStart(3)} × ${r}`);
+    const s = samples.get(r);
+    if (s) console.log(`         sample ${s.ts.slice(11,16)} : ${JSON.stringify(s.payload).slice(0, 200)}`);
+  }
+
+  console.log(`\n═══ scanner_candidate_skip reasons (NYSE session) ═══\n`);
+  const { data: skipped } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, payload')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .eq('kind', 'scanner_candidate_skip')
+    .gte('timestamp', nyseFrom)
+    .lt('timestamp', nyseTo);
+  const skipCounts = new Map<string, number>();
+  const skipSamples = new Map<string, any>();
+  for (const s of skipped ?? []) {
+    const p = s.payload as any;
+    const reason = p?.reason ?? p?.skip_reason ?? p?.error ?? JSON.stringify(p).slice(0,80);
+    skipCounts.set(reason, (skipCounts.get(reason) ?? 0) + 1);
+    if (!skipSamples.has(reason)) skipSamples.set(reason, { ts: s.timestamp, payload: p });
+  }
+  for (const [r, n] of [...skipCounts].sort((a,b)=>b[1]-a[1])) {
+    console.log(`  ${n.toString().padStart(3)} × ${r}`);
+    const s = skipSamples.get(r);
+    if (s) console.log(`         sample ${s.ts.slice(11,16)} : ${JSON.stringify(s.payload).slice(0, 200)}`);
+  }
+
+  console.log(`\n═══ skeptic_verdict outcome distribution (NYSE session) ═══\n`);
+  const { data: verdicts } = await sb
+    .from('lisa_decision_log')
+    .select('payload')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .eq('kind', 'skeptic_verdict')
+    .gte('timestamp', nyseFrom)
+    .lt('timestamp', nyseTo);
+  const verdictCounts = new Map<string, number>();
+  for (const v of verdicts ?? []) {
+    const p = v.payload as any;
+    const verdict = p?.verdict ?? p?.outcome ?? p?.decision ?? 'unknown';
+    verdictCounts.set(verdict, (verdictCounts.get(verdict) ?? 0) + 1);
+  }
+  for (const [k, n] of [...verdictCounts].sort((a,b)=>b[1]-a[1])) {
+    console.log(`  ${n.toString().padStart(3)} × ${k}`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-trader-nyse-session.ts
+++ b/scripts/check-trader-nyse-session.ts
@@ -1,0 +1,89 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const TRADER_PORTFOLIO = 'b0000001-0000-0000-0000-000000000001';
+
+  // Window 1: NYSE session hier (2026-06-04 14:30-21:00 UTC)
+  const nyseFrom = '2026-06-04T14:30:00.000Z';
+  const nyseTo = '2026-06-04T21:00:00.000Z';
+  console.log(`\n═══ Window NYSE 2026-06-04 14:30 → 21:00 UTC ═══\n`);
+
+  // Shadow signals during NYSE session
+  const { data: shadow } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('asset_class, decision')
+    .gte('created_at', nyseFrom)
+    .lt('created_at', nyseTo);
+  const breakdown = new Map<string, Map<string, number>>();
+  for (const s of shadow ?? []) {
+    if (!breakdown.has(s.asset_class)) breakdown.set(s.asset_class, new Map());
+    const m = breakdown.get(s.asset_class)!;
+    m.set(s.decision, (m.get(s.decision) ?? 0) + 1);
+  }
+  console.log(`Shadow signals NYSE session (${shadow?.length ?? 0} total):`);
+  for (const [cls, m] of breakdown) {
+    const total = [...m.values()].reduce((s,n) => s+n, 0);
+    const accept = m.get('accept') ?? 0;
+    const top3 = [...m].filter(([k]) => k !== 'accept').sort((a,b) => b[1]-a[1]).slice(0,3);
+    console.log(`  ${cls.padEnd(22)} total=${total.toString().padStart(4)} accept=${accept.toString().padStart(3)} (${((accept/total)*100).toFixed(0).padStart(3)}%) top: ${top3.map(([k,v]) => `${k}:${v}`).join(', ')}`);
+  }
+
+  // TRADER positions opened during NYSE
+  console.log(`\nTRADER positions ouvertes pendant NYSE :`);
+  const { data: positions } = await sb
+    .from('lisa_positions')
+    .select('symbol, asset_class, entry_price, status, pnl_usd, opened_at')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .gte('opened_at', nyseFrom)
+    .lt('opened_at', nyseTo);
+  console.log(`  Total: ${positions?.length ?? 0}`);
+  for (const p of positions ?? []) {
+    console.log(`    ${p.symbol.padEnd(12)} ${p.asset_class.padEnd(20)} status=${p.status} pnl=$${Number(p.pnl_usd ?? 0).toFixed(2)} opened=${p.opened_at.slice(11,16)}`);
+  }
+
+  // TRADER autopilot_cycle_completed during NYSE
+  console.log(`\nTRADER autopilot_cycle_completed pendant NYSE :`);
+  const { data: cycles } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, payload')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .eq('kind', 'autopilot_cycle_completed')
+    .gte('timestamp', nyseFrom)
+    .lt('timestamp', nyseTo)
+    .order('timestamp', { ascending: false });
+  console.log(`  Total: ${cycles?.length ?? 0}`);
+  let totalOpens = 0, totalCloses = 0;
+  for (const c of cycles ?? []) {
+    const p = c.payload as any;
+    totalOpens += p?.opens ?? 0;
+    totalCloses += p?.closes ?? 0;
+  }
+  console.log(`  Sum opens: ${totalOpens}, Sum closes: ${totalCloses}`);
+
+  // Sample payloads
+  if (cycles?.length) {
+    console.log(`\nSample payloads (premier + dernier) :`);
+    console.log('  First:', JSON.stringify(cycles[cycles.length-1].payload).slice(0, 200));
+    console.log('  Last :', JSON.stringify(cycles[0].payload).slice(0, 200));
+  }
+
+  // Other relevant kinds during NYSE
+  console.log(`\nTop 10 decision_log kinds pendant NYSE (TRADER) :`);
+  const { data: allKinds } = await sb
+    .from('lisa_decision_log')
+    .select('kind')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .gte('timestamp', nyseFrom)
+    .lt('timestamp', nyseTo);
+  const kindCounts = new Map<string, number>();
+  for (const k of allKinds ?? []) {
+    kindCounts.set(k.kind, (kindCounts.get(k.kind) ?? 0) + 1);
+  }
+  const sortedKinds = [...kindCounts].sort((a,b) => b[1]-a[1]).slice(0, 15);
+  for (const [k, v] of sortedKinds) {
+    console.log(`  ${k.padEnd(40)} ${v}`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-trader-positions.ts
+++ b/scripts/check-trader-positions.ts
@@ -1,0 +1,66 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const TRADER_PORTFOLIO = 'b0000001-0000-0000-0000-000000000001';
+  const since = new Date(Date.now() - 24 * 3600_000).toISOString();
+
+  const { data: positions } = await sb
+    .from('lisa_positions')
+    .select('symbol, asset_class, direction, entry_price, exit_price, size_usd, pnl_usd, status, opened_at, closed_at')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .gte('opened_at', since)
+    .order('opened_at', { ascending: false });
+
+  console.log(`\n═══ TRADER positions ouvertes ${since.slice(0,16)} → now ═══`);
+  console.log(`Total : ${positions?.length ?? 0}\n`);
+  if (positions?.length) {
+    let pnl = 0;
+    let wins = 0, losses = 0, open = 0;
+    for (const p of positions) {
+      const pnlVal = Number(p.pnl_usd ?? 0);
+      pnl += pnlVal;
+      if (p.status === 'open' || p.status === 'active') open++;
+      else if (pnlVal > 0) wins++;
+      else losses++;
+      console.log(`  ${p.symbol.padEnd(12)} ${p.asset_class.padEnd(20)} ${p.direction.padEnd(5)} entry=$${Number(p.entry_price ?? 0).toFixed(2).padStart(8)} status=${p.status.padEnd(20)} pnl=$${pnlVal.toFixed(2).padStart(8)} opened=${p.opened_at.slice(11,16)} closed=${p.closed_at?.slice(11,16) ?? '—'}`);
+    }
+    console.log(`\nTotal PnL: $${pnl.toFixed(2)}, Wins: ${wins}, Losses: ${losses}, Open: ${open}`);
+  } else {
+    console.log('  ⚠ Aucune position ouverte par TRADER ces 24h.');
+  }
+
+  console.log(`\n═══ Last 5 TRADER autopilot_cycle_completed events ═══`);
+  const { data: cycles } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, payload')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .eq('kind', 'autopilot_cycle_completed')
+    .order('timestamp', { ascending: false })
+    .limit(5);
+  for (const c of cycles ?? []) {
+    const p = c.payload as any;
+    console.log(`  ${c.timestamp.slice(11,19)} opens=${p?.opens ?? 0} closes=${p?.closes ?? 0} candidates=${p?.candidates_count ?? '?'}`);
+  }
+
+  console.log(`\n═══ Shadow signals last 6h (post-secret-set) ═══`);
+  const since6h = new Date(Date.now() - 6 * 3600_000).toISOString();
+  const { data: shadow } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('asset_class, decision')
+    .gte('created_at', since6h);
+  const breakdown = new Map<string, Map<string, number>>();
+  for (const s of shadow ?? []) {
+    if (!breakdown.has(s.asset_class)) breakdown.set(s.asset_class, new Map());
+    const m = breakdown.get(s.asset_class)!;
+    m.set(s.decision, (m.get(s.decision) ?? 0) + 1);
+  }
+  for (const [cls, m] of breakdown) {
+    const total = [...m.values()].reduce((s,n) => s+n, 0);
+    const accept = m.get('accept') ?? 0;
+    const top3 = [...m].filter(([k]) => k !== 'accept').sort((a,b) => b[1]-a[1]).slice(0,3);
+    console.log(`  ${cls.padEnd(22)} total=${total.toString().padStart(4)} accept=${accept.toString().padStart(3)} (${((accept/total)*100).toFixed(0).padStart(3)}%) top: ${top3.map(([k,v]) => `${k}:${v}`).join(', ')}`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/rollback-trader-nyse-blockers.ts
+++ b/scripts/rollback-trader-nyse-blockers.ts
@@ -1,0 +1,185 @@
+/**
+ * ROLLBACK EODHD ciblé sur les VRAIS blockages TRADER NYSE 2026-06-04 14:30-21:00 UTC.
+ *
+ * Source = lisa_decision_log (pas gainers_user_shadow_signals) car les vrais
+ * blockages sont POST-shadow (DebateGate, CLIMAX_RUN, VERTICAL_PUMP, StaleSource,
+ * TopTickDrift).
+ *
+ * Pour chaque event blockage :
+ *   1. Fetch EODHD intraday 5m sur [event_time - 5min, event_time + 60min]
+ *   2. Prix entry = première barre après event_time
+ *   3. Prix max = max(high) dans la fenêtre
+ *   4. Delta = (max - entry) / entry × 100
+ *
+ * Classification :
+ *   🟢 GOOD-REJECT < +0.5%
+ *   🟡 MARGINAL  0.5%-1.5%
+ *   🔴 BAD-REJECT ≥ +1.5%
+ *
+ *   npx tsx scripts/rollback-trader-nyse-blockers.ts
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+const EODHD_KEY = process.env.EODHD_API_KEY ?? '69e6325aa2c162.98850425';
+const TRADER_PORTFOLIO = 'b0000001-0000-0000-0000-000000000001';
+const NYSE_FROM = '2026-06-04T14:30:00.000Z';
+const NYSE_TO = '2026-06-04T21:00:00.000Z';
+
+function pad(s: unknown, n: number) { return String(s ?? '').padEnd(n).slice(0, n); }
+function fmt(n: number, d = 2): string { return Number(n).toFixed(d); }
+
+interface Blockage {
+  symbol: string;
+  gateLabel: string;
+  ts: string;
+  assetClass: string;
+  hintPrice?: number;
+}
+
+async function fetchIntradayBars(symbol: string, fromUnix: number, toUnix: number): Promise<Array<{ ts: number; high: number; close: number }>> {
+  const url = `https://eodhd.com/api/intraday/${encodeURIComponent(symbol)}?interval=5m&from=${fromUnix}&to=${toUnix}&api_token=${EODHD_KEY}&fmt=json`;
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+    if (!res.ok) return [];
+    const json = await res.json() as Array<{ timestamp: number; high: number; close: number; open: number }>;
+    if (!Array.isArray(json)) return [];
+    return json
+      .map(b => ({ ts: Number(b.timestamp), high: Number(b.high ?? b.close), close: Number(b.close) }))
+      .filter(b => Number.isFinite(b.ts) && Number.isFinite(b.high) && b.high > 0);
+  } catch { return []; }
+}
+
+async function main() {
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' ROLLBACK EODHD — TRADER NYSE 2026-06-04 14:30-21:00 UTC');
+  console.log(' Mesure du vrai edge des candidats VRAIMENT bloqués (post-shadow gates)');
+  console.log('═══════════════════════════════════════════════════════════════════════════════\n');
+
+  // 1. Récupérer les vrais blockages dans decision_log
+  const blockages: Blockage[] = [];
+
+  // scanner_candidate_skip : DebateGate (WAIT/HOLD/CHASE), CLIMAX_RUN, VERTICAL_PUMP
+  const { data: skips } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, payload')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .eq('kind', 'scanner_candidate_skip')
+    .gte('timestamp', NYSE_FROM)
+    .lt('timestamp', NYSE_TO);
+
+  for (const s of skips ?? []) {
+    const p = s.payload as any;
+    const gate = p?.gate;
+    const symbol = p?.symbol;
+    const assetClass = p?.asset_class ?? 'unknown';
+    if (!symbol) continue;
+    // Skip CHOP_NOISE blind_pass (fail-open, pas un vrai skip)
+    if (gate === 'CHOP_NOISE' && p?.verdict === 'blind_pass') continue;
+    let gateLabel = gate ?? 'unknown';
+    if (gate === 'debate_gate') gateLabel = `debate_gate_${p?.reason ?? 'unknown'}`;
+    blockages.push({ symbol, gateLabel, ts: s.timestamp, assetClass });
+  }
+
+  // position_open_failed : StaleOrFallbackSource, TopTickDriftGuard
+  const { data: fails } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, payload')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .eq('kind', 'position_open_failed')
+    .gte('timestamp', NYSE_FROM)
+    .lt('timestamp', NYSE_TO);
+
+  for (const f of fails ?? []) {
+    const p = f.payload as any;
+    const symbol = p?.symbol;
+    const assetClass = p?.asset_class ?? 'unknown';
+    const errorClass = p?.error_class ?? 'unknown';
+    if (!symbol) continue;
+    const hintPrice = p?.live_price ? Number(p.live_price) : (p?.price ? Number(p.price) : undefined);
+    blockages.push({ symbol, gateLabel: `open_fail_${errorClass}`, ts: f.timestamp, assetClass, hintPrice });
+  }
+
+  console.log(`Loaded ${blockages.length} vrais blockages TRADER (post-shadow)\n`);
+
+  // 2. Fetch EODHD pour chaque blockage (parallèle batch 5)
+  type Outcome = { gate: string; cls: string; symbol: string; ts: string; entryPrice: number; maxAfter: number; deltaPct: number };
+  const outcomes: Outcome[] = [];
+  const BATCH = 5;
+  for (let i = 0; i < blockages.length; i += BATCH) {
+    const batch = blockages.slice(i, i + BATCH);
+    const results = await Promise.all(batch.map(async (b) => {
+      const t0 = Math.floor(new Date(b.ts).getTime() / 1000);
+      const tStart = t0 - 5 * 60;
+      const tEnd = t0 + 60 * 60;
+      const bars = await fetchIntradayBars(b.symbol, tStart, tEnd);
+      if (bars.length === 0) return null;
+      // Entry price = première barre à partir de t0 (ou hintPrice si présent)
+      const entryBar = bars.find(bb => bb.ts >= t0) ?? bars[0];
+      const entryPrice = b.hintPrice ?? entryBar.close ?? entryBar.high;
+      if (!entryPrice || entryPrice <= 0) return null;
+      // Max high dans les 60 min après
+      const futureBars = bars.filter(bb => bb.ts >= t0 && bb.ts <= t0 + 60 * 60);
+      if (futureBars.length === 0) return null;
+      const maxHigh = Math.max(...futureBars.map(bb => bb.high));
+      const deltaPct = ((maxHigh - entryPrice) / entryPrice) * 100;
+      return { gate: b.gateLabel, cls: b.assetClass, symbol: b.symbol, ts: b.ts, entryPrice, maxAfter: maxHigh, deltaPct };
+    }));
+    for (const r of results) if (r) outcomes.push(r);
+    process.stdout.write(`\r  Progress : ${Math.min(i + BATCH, blockages.length)}/${blockages.length}`);
+  }
+  console.log(`\n\nAnalysed ${outcomes.length}/${blockages.length} blockages avec data EODHD\n`);
+
+  // 3. Aggregate par gate
+  type Stats = { n: number; good: number; neutral: number; bad: number; sumBadDelta: number; topMissed: Array<{ sym: string; delta: number }> };
+  const byGate = new Map<string, Stats>();
+  for (const o of outcomes) {
+    const acc = byGate.get(o.gate) ?? { n: 0, good: 0, neutral: 0, bad: 0, sumBadDelta: 0, topMissed: [] };
+    acc.n++;
+    if (o.deltaPct >= 1.5) { acc.bad++; acc.sumBadDelta += o.deltaPct; acc.topMissed.push({ sym: o.symbol, delta: o.deltaPct }); }
+    else if (o.deltaPct >= 0.5) acc.neutral++;
+    else acc.good++;
+    byGate.set(o.gate, acc);
+  }
+
+  console.log('═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' EDGE par GATE de rejet TRADER (NYSE 2026-06-04)');
+  console.log('═══════════════════════════════════════════════════════════════════════════════\n');
+  console.log(`${pad('GATE', 38)} ${pad('Sample', 7)} ${pad('🟢 GOOD', 9)} ${pad('🟡 NEUT', 9)} ${pad('🔴 BAD', 8)} ${pad('Avg BAD edge', 14)} ${pad('% BAD', 7)}`);
+  console.log('─'.repeat(95));
+  const sorted = [...byGate].sort((a, b) => b[1].n - a[1].n);
+  for (const [gate, s] of sorted) {
+    const avgBad = s.bad > 0 ? `+${fmt(s.sumBadDelta / s.bad)}%` : 'n/a';
+    const pctBad = s.n > 0 ? `${fmt((s.bad / s.n) * 100, 0)}%` : '–';
+    const flag = s.bad / s.n >= 0.3 ? '⚠' : s.bad / s.n >= 0.15 ? '·' : ' ';
+    console.log(`${pad(flag + ' ' + gate, 38)} ${pad(s.n, 7)} ${pad(s.good, 9)} ${pad(s.neutral, 9)} ${pad(s.bad, 8)} ${pad(avgBad, 14)} ${pad(pctBad, 7)}`);
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' TOP 15 candidats rejetés qui ont VRAIMENT pumpé (gates les plus coupables)');
+  console.log('═══════════════════════════════════════════════════════════════════════════════\n');
+  const allBad: Array<{ gate: string; sym: string; delta: number }> = [];
+  for (const [gate, s] of byGate) for (const m of s.topMissed) allBad.push({ gate, sym: m.sym, delta: m.delta });
+  allBad.sort((a, b) => b.delta - a.delta);
+  console.log(`${pad('SYMBOL', 14)} ${pad('REJECTED BY', 38)} EDGE RATÉ +60min`);
+  for (const m of allBad.slice(0, 15)) {
+    console.log(`${pad(m.sym, 14)} ${pad(m.gate, 38)} +${fmt(m.delta)}%`);
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════════════════════');
+  console.log(' VERDICT GLOBAL');
+  console.log('═══════════════════════════════════════════════════════════════════════════════\n');
+  const totalN = outcomes.length;
+  const totalBad = outcomes.filter(o => o.deltaPct >= 1.5).length;
+  const totalGood = outcomes.filter(o => o.deltaPct < 0.5).length;
+  const sumBadAll = outcomes.filter(o => o.deltaPct >= 1.5).reduce((s, o) => s + o.deltaPct, 0);
+  console.log(`Total mesurés : ${totalN}`);
+  console.log(`🟢 GOOD-REJECT (justifiés)  : ${totalGood} (${fmt((totalGood/totalN)*100, 0)}%)`);
+  console.log(`🔴 BAD-REJECT (pumps ratés) : ${totalBad} (${fmt((totalBad/totalN)*100, 0)}%)`);
+  if (totalBad > 0) {
+    console.log(`   Edge moyen raté : +${fmt(sumBadAll/totalBad)}%`);
+    console.log(`   Sum edge raté : +${fmt(sumBadAll)}% sur la session`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Contexte

Audit TRADER NYSE session 2026-06-04 14:30-21:00 UTC : **0 position ouverte** malgré bump shadow gates US_LARGE 100% accept + US_SMALL_MID 72% accept (PR #596 mergée).

Rollback EODHD intraday 5m sur **114 vrais blockages** (`scripts/rollback-trader-nyse-blockers.ts`) a quantifié l'edge perdu :

| Gate | Sample | % BAD-REJECT | Avg BAD edge | Edge raté total |
|---|---|---|---|---|
| ⚠ CLIMAX_RUN | 13 | **77%** | +4.24% | ~+42% |
| ⚠ VERTICAL_PUMP | 8 | **75%** | +4.52% | ~+27% |
| ⚠ open_fail_StaleSource | 26 | **58%** | +3.17% | ~+47% |
| ⚠ debate_gate_WAIT | 50 | **44%** | +3.06% | ~+67% |
| · open_fail_TopTickDrift | 8 | 25% | +1.81% | ~+4% |
| debate_gate_HOLD | 7 | 14% | +4.00% | ~+4% |
| debate_gate_CHASE_THE_TOP | 2 | 0% | n/a | 0% |

**Sum edge raté = +191.95% sur la session** (~$3-4k PnL bruts à sizing $200/trade). 49% de tous les rejets ont pumpé ≥+1.5% dans les 60min suivantes.

Top candidats les plus coupables :
- **POET.US** : rejeté 6× CLIMAX/VERTICAL, a pumpé +9.12% +8.78% +8.69% +8.34% +4.39%
- **ALOY.US** : rejeté 3× StaleOrFallback, a pumpé +5.63% +4.69% +4.02%
- **AMPG.US** : rejeté 2× DebateGate WAIT, a pumpé +7.79% +4.57%
- **NVTS.US** : DebateGate WAIT, a pumpé +4.94%
- **DEBS.LSE** : 2× DebateGate WAIT, a pumpé +4.50% +4.27%

## Action

Ce PR ajoute **6 env tunables** sans changer les defaults (back-compat preserved). Tuning se fait via Fly secrets après merge, pas dans le code → permet rollback granulaire et A/B test per-gate.

### Secrets Fly suggérés (à set post-merge, progressivement)

```bash
# CLIMAX_RUN — relâcher pour small caps US sustained uptrend (POET pattern)
fly secrets set GAINERS_CLIMAX_MIN_TF5M_PCT=8 -a smartvest
# OU plus permissif :
fly secrets set GAINERS_CLIMAX_MAX_PLATEAU_GAP_PCT=0.5 -a smartvest

# VERTICAL_PUMP — relâcher pour pumps modérés (ratio actuel 0.5 trop strict)
fly secrets set GAINERS_VERTICAL_PUMP_MAX_RATIO=1.0 -a smartvest

# DebateGate — solo BUY allowed (test) ou consensus 0.5→0.4
fly secrets set GAINERS_DEBATE_MIN_QUORUM=1 -a smartvest
# OU :
fly secrets set GAINERS_DEBATE_MIN_CONSENSUS_RATIO=0.4 -a smartvest

# StaleOrFallback — bypass TwelveData stale_* (small caps US)
fly secrets set GAINERS_STALE_SOURCE_GUARD_ENABLED=false -a smartvest
```

**Garde-fous immuables conservés** (jamais bypassed) :
- `fallback_unknown` price ($0 sentinel) → toujours skip (LMT incident 27/04)
- Sanity bound 30% drift live vs cand.close → toujours actif
- `TopTickDriftGuard` 10% → conservé (25% BAD seulement, gate raisonnable)
- DebateGate `MIN_FRESHNESS_THRESHOLD` → conservé (stale signal filter)
- Veto safety (KILL_SWITCH / STALE_PRICE / MARKET_UNSAFE) → toujours prioritaire

## Changements

### `packages/ai-analyst/src/decisions/debate-orchestrator.ts`
- Ajout interface `ResolveDebateOptions { minQuorum?, minConsensusRatio?, minWinnerConfidence? }`
- Signature `resolveDebate(inputs, now, options?)` — back-compat (option facultative)
- Defaults inchangés : `MIN_QUORUM=2`, `MIN_CONSENSUS_RATIO=0.5`, `MIN_WINNER_CONFIDENCE=0.5`

### `apps/api/src/modules/lisa/services/debate-gate.service.ts`
- Méthode `readResolveOptions()` qui parse env vars GAINERS_DEBATE_*
- Passe options à `resolveDebate(inputs, now, options)`

### `apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts`
- CLIMAX_RUN (~3957) : parse `GAINERS_CLIMAX_MIN_TF5M_PCT` + `GAINERS_CLIMAX_MAX_PLATEAU_GAP_PCT`, passe à `evaluateClimaxRun(opts)`
- VERTICAL_PUMP (~3978) : parse `GAINERS_VERTICAL_PUMP_MAX_RATIO` + `GAINERS_VERTICAL_PUMP_MIN_TF5M_PCT`, passe à `evaluateVerticalPump(opts)`
- StaleOrFallback (~5154) : `GAINERS_STALE_SOURCE_GUARD_ENABLED` (default true), si false bypass `stale_*` mais conserve `fallback_unknown` immuable

### Scripts diagnostic ajoutés
- `scripts/check-trader-positions.ts` — positions ouvertes TRADER 24h
- `scripts/check-trader-nyse-session.ts` — activité TRADER pendant NYSE session
- `scripts/check-trader-fail-reasons.ts` — drill-down `position_open_failed` reasons
- `scripts/check-trader-all-kinds.ts` — distribution `decision_log` kinds
- `scripts/rollback-trader-nyse-blockers.ts` — rollback EODHD intraday sur blockages

## Tests

- 29 debate-orchestrator ✅
- 27 blow-off-gates ✅
- 19 debate-gate.service ✅
- 13 debate-gate-metrics.store ✅

Total : 88 tests verts. Aucun changement de comportement sans set explicite des secrets.

## Plan post-merge

1. Merger (auto-merge sur CI green selon CLAUDE.md)
2. Workflow Fly auto-deploy
3. Set secrets Fly progressivement (1 à 1, mesurer impact 4-8h entre chaque)
4. Re-run `scripts/rollback-trader-nyse-blockers.ts` après chaque set pour mesurer delta edge récupéré
5. Si winRate paper s'effondre < 30% OU drawdown jour > 5% → flip secret OFF immédiat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_