### PR TITLE
chore(scripts): enable EU + Crypto on TRADER gainers (post PR #597)

### DIFF
--- a/scripts/check-trader-universe.ts
+++ b/scripts/check-trader-universe.ts
@@ -1,0 +1,31 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const TRADER_PORTFOLIO = 'b0000001-0000-0000-0000-000000000001';
+
+  const { data } = await sb
+    .from('lisa_session_configs')
+    .select('gainers_universe_us, gainers_universe_eu, gainers_universe_asia, gainers_universe_crypto, strategy_mode, autopilot_enabled, kill_switch_active')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .single();
+
+  console.log('TRADER lisa_session_configs current state:');
+  console.log(JSON.stringify(data, null, 2));
+
+  // Activity last 30 min (proves Fly is alive and scanner runs)
+  const since30 = new Date(Date.now() - 30 * 60_000).toISOString();
+  const { data: recent } = await sb
+    .from('lisa_decision_log')
+    .select('kind, timestamp')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .gte('timestamp', since30)
+    .order('timestamp', { ascending: false })
+    .limit(10);
+  console.log(`\nLast 10 decision_log entries TRADER (since ${since30.slice(11,16)}):`);
+  for (const r of recent ?? []) {
+    console.log(`  ${r.timestamp.slice(11,19)}  ${r.kind}`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/enable-eu-crypto-for-trader.ts
+++ b/scripts/enable-eu-crypto-for-trader.ts
@@ -1,0 +1,49 @@
+/**
+ * Réactive EU + Crypto sur TRADER gainers.
+ *
+ * Contexte : EU avait été désactivé hier soir (cf. PR #596) car TwelveData
+ * stream pas live sur LSE/Euronext (stale_twelvedata). Avec PR #597 et le
+ * secret GAINERS_STALE_SOURCE_GUARD_ENABLED=false, le scanner peut maintenant
+ * ouvrir EU malgré source stale.
+ *
+ * Crypto n'avait jamais été activé. Binance fonctionne 24/7, ses prix sont
+ * fiables (WS direct + REST fallback fix db097ab du 03/06).
+ *
+ *   npx tsx scripts/enable-eu-crypto-for-trader.ts
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const TRADER_PORTFOLIO = 'b0000001-0000-0000-0000-000000000001';
+
+  const { data: before } = await sb
+    .from('lisa_session_configs')
+    .select('gainers_universe_us, gainers_universe_eu, gainers_universe_asia, gainers_universe_crypto')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .single();
+  console.log('AVANT :', JSON.stringify(before));
+
+  const { error } = await sb
+    .from('lisa_session_configs')
+    .update({
+      gainers_universe_eu: true,
+      gainers_universe_crypto: true,
+    })
+    .eq('portfolio_id', TRADER_PORTFOLIO);
+
+  if (error) {
+    console.error('Update failed:', error);
+    process.exit(1);
+  }
+
+  const { data: after } = await sb
+    .from('lisa_session_configs')
+    .select('gainers_universe_us, gainers_universe_eu, gainers_universe_asia, gainers_universe_crypto')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .single();
+  console.log('APRÈS :', JSON.stringify(after));
+  console.log('\n✅ TRADER scanner inclura EU + Crypto au prochain cycle (≤15min).');
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/monitor-trader-opens.ts
+++ b/scripts/monitor-trader-opens.ts
@@ -1,0 +1,55 @@
+/**
+ * Watch loop : émet 1 ligne par nouvelle position ouverte sur TRADER.
+ * Tourne en boucle 60s. Sortie = chaque ligne devient une notification.
+ *
+ *   npx tsx scripts/monitor-trader-opens.ts
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+const TRADER_PORTFOLIO = 'b0000001-0000-0000-0000-000000000001';
+const POLL_INTERVAL_MS = 60_000;
+const seen = new Set<string>();
+
+async function pollOnce() {
+  const since = new Date(Date.now() - 30 * 60_000).toISOString();
+  try {
+    const { data, error } = await sb
+      .from('lisa_positions')
+      .select('id, symbol, venue, direction, entry_price, entry_notional_usd, entry_timestamp, status')
+      .eq('portfolio_id', TRADER_PORTFOLIO)
+      .gte('entry_timestamp', since)
+      .order('entry_timestamp', { ascending: false });
+    if (error) {
+      console.log(`[ERR poll] ${error.message}`);
+      return;
+    }
+    for (const p of data ?? []) {
+      if (seen.has(p.id)) continue;
+      seen.add(p.id);
+      const ts = p.entry_timestamp ? p.entry_timestamp.slice(11, 19) : '?';
+      console.log(`[TRADER OPEN] ${ts}Z ${p.symbol} (${p.venue ?? '?'}) ${p.direction} entry=$${Number(p.entry_price ?? 0).toFixed(2)} notional=$${Number(p.entry_notional_usd ?? 0).toFixed(0)} status=${p.status}`);
+    }
+  } catch (e) {
+    console.log(`[ERR poll catch] ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+async function main() {
+  // Bootstrap : ignore positions déjà ouvertes
+  const sinceBoot = new Date(Date.now() - 30 * 60_000).toISOString();
+  const { data: existing } = await sb
+    .from('lisa_positions')
+    .select('id')
+    .eq('portfolio_id', TRADER_PORTFOLIO)
+    .gte('entry_timestamp', sinceBoot);
+  for (const p of existing ?? []) seen.add(p.id);
+  console.log(`[BOOT] ${seen.size} positions TRADER déjà tracked (ignorées). Polling toutes les ${POLL_INTERVAL_MS/1000}s...`);
+
+  while (true) {
+    await pollOnce();
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+}
+main().catch((e) => { console.log(`[FATAL] ${e}`); process.exit(1); });


### PR DESCRIPTION
## Contexte

Suite à merge PR #597 (4 gates env tunables) et set des 5 secrets Fly côté user, le scanner TRADER peut maintenant gérer les sources stales TwelveData. EU peut être réactivé sans risque d'opening sur prix de 3 jours.

Pendant l'attente NYSE (07:30 → 14:30 UTC = 7h), TRADER restait inactif (Asia/EU/Crypto tous désactivés). Cette PR active EU + Crypto pour avoir un pipeline de scan continu.

## Action exécutée en DB

```
AVANT : us=true  eu=false asia=false crypto=false
APRÈS : us=true  eu=true  asia=false crypto=true
```

Asia reste off (TwelveData BCXE pas encore activé, attestation non-pro + $25/mo en attente côté Den).

## Scripts ajoutés

- `scripts/check-trader-universe.ts` — monitoring rapide de l'état des univers TRADER
- `scripts/enable-eu-crypto-for-trader.ts` — UPDATE one-shot (déjà exécuté en prod)

## Réversible

```sql
UPDATE lisa_session_configs
SET gainers_universe_eu = false, gainers_universe_crypto = false
WHERE portfolio_id = 'b0000001-0000-0000-0000-000000000001';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_