### PR TITLE
chore(scripts): diagnostic tools for TRADER EU silent skips

### DIFF
--- a/scripts/check-cmcx-full.ts
+++ b/scripts/check-cmcx-full.ts
@@ -1,0 +1,44 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const TRADER = 'b0000001-0000-0000-0000-000000000001';
+  const since = new Date(Date.now() - 30 * 60_000).toISOString();
+
+  // FULL payload des skeptic_verdict CMCX
+  const { data: skeptics } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, payload')
+    .eq('portfolio_id', TRADER)
+    .eq('kind', 'skeptic_verdict')
+    .gte('timestamp', since)
+    .order('timestamp', { ascending: false })
+    .limit(3);
+  console.log('═══ Skeptic verdicts CMCX (FULL payload) ═══\n');
+  for (const s of skeptics ?? []) {
+    const p = s.payload as any;
+    console.log(`${s.timestamp.slice(11,19)} verdict_veto=${p?.verdict_veto} verdict_score=${p?.verdict_score}`);
+    console.log('  features:', JSON.stringify(p?.features));
+    console.log('  reasons:');
+    for (const r of p?.reasons ?? []) {
+      console.log(`    - ${r.rule.padEnd(15)} mode=${r.mode.padEnd(10)} severity=${r.severity.padEnd(7)} triggered=${r.triggered} | ${r.detail}`);
+    }
+    console.log('');
+  }
+
+  // Search for ALL kinds touching CMCX in last hour
+  const sinceHour = new Date(Date.now() - 60 * 60_000).toISOString();
+  const { data: allCmcx } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, kind, summary, payload')
+    .gte('timestamp', sinceHour)
+    .or('summary.like.%CMCX%,payload->>symbol.eq.CMCX.LSE')
+    .order('timestamp', { ascending: false })
+    .limit(20);
+  console.log(`\n═══ ALL events CMCX last hour : ${allCmcx?.length ?? 0} ═══\n`);
+  for (const e of allCmcx ?? []) {
+    console.log(`${e.timestamp.slice(11,19)} ${e.kind.padEnd(28)} ${(e.summary ?? '').slice(0, 80)}`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-recent-skips.ts
+++ b/scripts/check-recent-skips.ts
@@ -1,0 +1,39 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const TRADER = 'b0000001-0000-0000-0000-000000000001';
+  const since = new Date(Date.now() - 30 * 60_000).toISOString();
+
+  // All recent scanner_candidate_skip + position_open_failed with full payload
+  const { data } = await sb
+    .from('lisa_decision_log')
+    .select('timestamp, kind, payload')
+    .eq('portfolio_id', TRADER)
+    .in('kind', ['scanner_candidate_skip', 'position_open_failed', 'skeptic_verdict'])
+    .gte('timestamp', since)
+    .order('timestamp', { ascending: false })
+    .limit(20);
+  console.log(`Recent TRADER skip/fail events (30min) : ${data?.length ?? 0}\n`);
+  for (const e of data ?? []) {
+    const p = e.payload as any;
+    console.log(`${e.timestamp.slice(11,19)} ${e.kind}`);
+    console.log(`  payload: ${JSON.stringify(p).slice(0, 300)}`);
+    console.log('');
+  }
+
+  // Aussi : récents shadow signals SEULEMENT EU et US (les actifs pour TRADER)
+  console.log('═══ Shadow signals EU + US 30min ═══\n');
+  const { data: shadow } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('created_at, symbol, asset_class, decision, entry_price')
+    .in('asset_class', ['eu_equity', 'us_equity_large', 'us_equity_small_mid', 'crypto_major', 'crypto_alt'])
+    .gte('created_at', since)
+    .order('created_at', { ascending: false })
+    .limit(20);
+  for (const s of shadow ?? []) {
+    console.log(`${s.created_at.slice(11,19)} ${s.symbol.padEnd(14)} ${s.asset_class.padEnd(22)} ${s.decision.padEnd(28)} entry=$${Number(s.entry_price ?? 0).toFixed(2)}`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-trader-cycle.ts
+++ b/scripts/check-trader-cycle.ts
@@ -1,0 +1,40 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const TRADER = 'b0000001-0000-0000-0000-000000000001';
+  const { data } = await sb
+    .from('lisa_session_configs')
+    .select('gainers_cycle_minutes, autopilot_cycle_minutes, profile, capital_discipline_mode, strategy_mode, capital_usd, max_open_positions, max_exposure_per_asset_class_pct, max_exposure_per_instrument_pct, daily_cost_budget_usd, autopilot_paused_reason')
+    .eq('portfolio_id', TRADER)
+    .single();
+  console.log('TRADER session config:');
+  console.log(JSON.stringify(data, null, 2));
+
+  // Check ALL portfolios in mode gainers to see who else gets scanned
+  const { data: allGainers } = await sb
+    .from('lisa_session_configs')
+    .select('portfolio_id, strategy_mode, autopilot_enabled, gainers_universe_us, gainers_universe_eu, gainers_cycle_minutes')
+    .eq('strategy_mode', 'gainers');
+  console.log(`\nALL gainers portfolios (${allGainers?.length ?? 0}) :`);
+  for (const p of allGainers ?? []) {
+    const isTrader = p.portfolio_id === TRADER ? '🎯' : '  ';
+    console.log(`  ${isTrader} ${p.portfolio_id.slice(0,12)}... autopilot=${p.autopilot_enabled} cycle=${p.gainers_cycle_minutes}min us=${p.gainers_universe_us} eu=${p.gainers_universe_eu}`);
+  }
+
+  // Last 10 events across ALL portfolios (any kind)
+  const since30 = new Date(Date.now() - 30 * 60_000).toISOString();
+  const { data: anyEvents } = await sb
+    .from('lisa_decision_log')
+    .select('portfolio_id, kind, timestamp')
+    .gte('timestamp', since30)
+    .order('timestamp', { ascending: false })
+    .limit(20);
+  console.log(`\nLast 20 decision_log ALL portfolios 30min:`);
+  for (const e of anyEvents ?? []) {
+    const isTrader = e.portfolio_id === TRADER ? '🎯' : '  ';
+    console.log(`  ${isTrader} ${e.timestamp.slice(11,19)} ${e.portfolio_id.slice(0,12)}... ${e.kind}`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/diag-trader-eu-now.ts
+++ b/scripts/diag-trader-eu-now.ts
@@ -1,0 +1,79 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const TRADER = 'b0000001-0000-0000-0000-000000000001';
+  const since30 = new Date(Date.now() - 30 * 60_000).toISOString();
+  const since60 = new Date(Date.now() - 60 * 60_000).toISOString();
+
+  console.log(`\n═══ Now: ${new Date().toISOString().slice(11,19)} UTC ═══\n`);
+
+  // 1. Univers config
+  const { data: cfg } = await sb
+    .from('lisa_session_configs')
+    .select('gainers_universe_us, gainers_universe_eu, gainers_universe_asia, gainers_universe_crypto, strategy_mode, autopilot_enabled, kill_switch_active')
+    .eq('portfolio_id', TRADER)
+    .single();
+  console.log('TRADER cfg :', JSON.stringify(cfg));
+
+  // 2. Shadow signals 30min toutes classes
+  const { data: shadow } = await sb
+    .from('gainers_user_shadow_signals')
+    .select('asset_class, decision, created_at, symbol')
+    .gte('created_at', since30)
+    .order('created_at', { ascending: false });
+  console.log(`\nShadow signals 30min: ${shadow?.length ?? 0}`);
+  const byClass = new Map<string, Map<string, number>>();
+  for (const s of shadow ?? []) {
+    if (!byClass.has(s.asset_class)) byClass.set(s.asset_class, new Map());
+    const m = byClass.get(s.asset_class)!;
+    m.set(s.decision, (m.get(s.decision) ?? 0) + 1);
+  }
+  for (const [cls, m] of byClass) {
+    const total = [...m.values()].reduce((a,b)=>a+b, 0);
+    const accept = m.get('accept') ?? 0;
+    const top = [...m].filter(([k]) => k !== 'accept').sort((a,b)=>b[1]-a[1]).slice(0,3);
+    console.log(`  ${cls.padEnd(22)} total=${total.toString().padStart(3)} accept=${accept.toString().padStart(3)} top: ${top.map(([k,v]) => `${k}:${v}`).join(', ')}`);
+  }
+  console.log(`Latest 3 shadow signals:`);
+  for (const s of (shadow ?? []).slice(0, 3)) {
+    console.log(`  ${s.created_at.slice(11,19)} ${s.symbol.padEnd(14)} ${s.asset_class.padEnd(22)} ${s.decision}`);
+  }
+
+  // 3. Tous les kinds TRADER 30min
+  const { data: kinds } = await sb
+    .from('lisa_decision_log')
+    .select('kind, timestamp')
+    .eq('portfolio_id', TRADER)
+    .gte('timestamp', since30)
+    .order('timestamp', { ascending: false });
+  console.log(`\nDecision_log TRADER 30min: ${kinds?.length ?? 0}`);
+  const kindCounts = new Map<string, number>();
+  for (const k of kinds ?? []) kindCounts.set(k.kind, (kindCounts.get(k.kind) ?? 0) + 1);
+  for (const [k, n] of [...kindCounts].sort((a,b)=>b[1]-a[1])) {
+    console.log(`  ${n.toString().padStart(3)} × ${k}`);
+  }
+  if (kinds?.length) {
+    console.log(`  Latest: ${kinds[0].timestamp.slice(11,19)} ${kinds[0].kind}`);
+  }
+
+  // 4. Positions ouvertes ALL portfolios 60min (au cas où le monitor manque qqch)
+  const { data: pos } = await sb
+    .from('lisa_positions')
+    .select('portfolio_id, symbol, venue, status, entry_timestamp, entry_price, entry_notional_usd')
+    .gte('entry_timestamp', since60)
+    .order('entry_timestamp', { ascending: false });
+  console.log(`\nPositions ALL portfolios 60min: ${pos?.length ?? 0}`);
+  for (const p of pos ?? []) {
+    const isTrader = p.portfolio_id === TRADER ? '🎯TRADER' : 'other';
+    console.log(`  ${isTrader} ${p.entry_timestamp.slice(11,19)} ${p.symbol.padEnd(14)} venue=${p.venue ?? '?'} status=${p.status} entry=$${Number(p.entry_price ?? 0).toFixed(2)} notional=$${Number(p.entry_notional_usd ?? 0).toFixed(0)}`);
+  }
+
+  // 5. Recent Fly deploy version (via version endpoint si possible — sinon git_sha dans decision_log)
+  console.log(`\nLatest 5 decision_log kinds TRADER (full timestamps):`);
+  for (const k of (kinds ?? []).slice(0, 5)) {
+    console.log(`  ${k.timestamp}  ${k.kind}`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Contexte

4 scripts read-only utilisés pour investiguer pourquoi TRADER scanne EU candidats (CMCX.LSE +16.85% × 4 cycles) mais 0 ouverture ce matin.

## Découverte

CMCX.LSE passe :
- ✅ Shadow accept
- ✅ CHOP_NOISE blind_pass (fail-open)
- ✅ SkepticAgent verdict_veto=false (shadow mode)

Puis disparaît silencieusement. Pas de DebateGate event, pas de position_open, pas de position_open_failed.

**Hypothèse principale** : Fly deploy PR #597 pas encore actif (40min après merge, secrets pas lus, comportement legacy avec skip silencieux).

## Scripts

- `scripts/diag-trader-eu-now.ts` — état univers + shadow signals + decision_log 30min
- `scripts/check-trader-cycle.ts` — config cycle_minutes + tous gainers portfolios
- `scripts/check-recent-skips.ts` — payloads complets skip/fail events 30min
- `scripts/check-cmcx-full.ts` — drill skeptic_verdict + ALL events sur 1 ticker

Aucun impact runtime. Tous read-only Supabase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_