### PR TITLE
chore(scripts): diagnostic tools for TRADER LLM arbitration bottleneck

### DIFF
--- a/scripts/check-trader-arbitration.ts
+++ b/scripts/check-trader-arbitration.ts
@@ -1,0 +1,50 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const TRADER = 'b0000001-0000-0000-0000-000000000001';
+  const since = new Date(Date.now() - 60 * 60_000).toISOString();
+  console.log(`\n═══ Now: ${new Date().toISOString().slice(11,19)} UTC ═══\n`);
+
+  // 1. scanner_proposals 60min
+  const { data: proposals, error: err1 } = await sb
+    .from('scanner_proposals')
+    .select('symbol, asset_class, direction, score, change_pct, notional_usd_suggested, created_at, expires_at')
+    .eq('portfolio_id', TRADER)
+    .gte('created_at', since)
+    .order('created_at', { ascending: false })
+    .limit(20);
+  if (err1) console.log('scanner_proposals err:', err1.message);
+  console.log(`scanner_proposals 60min: ${proposals?.length ?? 0}`);
+  for (const p of proposals?.slice(0, 10) ?? []) {
+    console.log(`  ${p.created_at.slice(11,19)} ${p.symbol.padEnd(14)} ${p.asset_class.padEnd(20)} ${p.direction} score=${p.score} change=${Number(p.change_pct ?? 0).toFixed(2)}% notional=$${Number(p.notional_usd_suggested ?? 0).toFixed(0)}`);
+  }
+
+  // 2. trader_agent_decisions 60min
+  const { data: decisions, error: err2 } = await sb
+    .from('trader_agent_decisions')
+    .select('*')
+    .eq('portfolio_id', TRADER)
+    .gte('created_at', since)
+    .order('created_at', { ascending: false })
+    .limit(10);
+  if (err2) console.log('\ntrader_agent_decisions err:', err2.message);
+  else {
+    console.log(`\ntrader_agent_decisions 60min: ${decisions?.length ?? 0}`);
+    for (const d of decisions?.slice(0, 5) ?? []) {
+      console.log(`  ${d.created_at?.slice(11,19)} cols: ${Object.keys(d).slice(0,8).join(', ')}`);
+      console.log(`    sample: ${JSON.stringify(d).slice(0, 300)}`);
+    }
+  }
+
+  // 3. Check TRADER_ARBITRATION_ENABLED — via /admin/config-dump si possible (besoin ADMIN_TOKEN)
+  console.log('\n═══ Indices supplémentaires ═══');
+  // Check si scanner_proposals existe et est utilisée
+  const { count } = await sb
+    .from('scanner_proposals')
+    .select('*', { count: 'exact', head: true })
+    .eq('portfolio_id', TRADER);
+  console.log(`Total scanner_proposals TRADER all time: ${count ?? 0}`);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-trader-llm-decisions.ts
+++ b/scripts/check-trader-llm-decisions.ts
@@ -1,0 +1,16 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  // First, inspect cols of trader_agent_decisions
+  const { data: sample } = await sb.from('trader_agent_decisions').select('*').limit(1);
+  if (sample?.[0]) {
+    console.log('trader_agent_decisions columns:');
+    console.log(Object.keys(sample[0]).sort().join(', '));
+    console.log('\nSample row:', JSON.stringify(sample[0], null, 2).slice(0, 600));
+  } else {
+    console.log('trader_agent_decisions is EMPTY (table exists, no rows).');
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/check-trader-llm-recent.ts
+++ b/scripts/check-trader-llm-recent.ts
@@ -1,0 +1,46 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+async function main() {
+  const TRADER = 'b0000001-0000-0000-0000-000000000001';
+  const since = new Date(Date.now() - 60 * 60_000).toISOString();
+
+  const { data } = await sb
+    .from('trader_agent_decisions')
+    .select('decided_at, action_kind, action_applied, target_symbol, confidence, direction, notional_usd, applied_position_id, apply_error, mistral_latency_ms, mistral_cost_usd, mistral_large_latency_ms, thesis')
+    .eq('portfolio_id', TRADER)
+    .gte('decided_at', since)
+    .order('decided_at', { ascending: false })
+    .limit(20);
+  console.log(`\ntrader_agent_decisions TRADER 60min: ${data?.length ?? 0}\n`);
+  for (const d of data ?? []) {
+    const applied = d.action_applied ? '✅' : '❌';
+    const sym = d.target_symbol ?? '—';
+    const thesisShort = (d.thesis ?? '').slice(0, 100);
+    console.log(`${d.decided_at?.slice(11,19)} ${applied} action=${d.action_kind?.padEnd(10)} sym=${sym.padEnd(14)} conf=${d.confidence ?? '—'} dir=${d.direction ?? '—'} notional=$${Number(d.notional_usd ?? 0).toFixed(0)}`);
+    if (d.apply_error) console.log(`    ⚠ apply_error: ${d.apply_error.slice(0, 200)}`);
+    if (thesisShort) console.log(`    thesis: ${thesisShort}`);
+  }
+
+  // Aussi count action_kind on 24h
+  const since24h = new Date(Date.now() - 24 * 3600_000).toISOString();
+  const { data: all24 } = await sb
+    .from('trader_agent_decisions')
+    .select('action_kind, action_applied')
+    .eq('portfolio_id', TRADER)
+    .gte('decided_at', since24h);
+  const counts = new Map<string, number>();
+  let applied = 0;
+  for (const r of all24 ?? []) {
+    const key = `${r.action_kind}_${r.action_applied ? 'applied' : 'rejected'}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    if (r.action_applied) applied++;
+  }
+  console.log(`\n═══ 24h trader_agent_decisions ═══`);
+  console.log(`Total: ${all24?.length ?? 0}, Applied: ${applied}`);
+  for (const [k, n] of [...counts].sort((a,b)=>b[1]-a[1])) {
+    console.log(`  ${k}: ${n}`);
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Contexte

3 scripts read-only utilisés pour identifier le vrai blocker derrière 0 ouverture TRADER ce matin.

## Découverte

Le scanner pousse 12 candidats EU dans `scanner_proposals` à 08:07 UTC :
- CMCX.LSE score=1.0 +16.85%
- FTC.LSE score=0.72 +13.59%
- NEM.XETRA score=0.48 +8.79%
- SAVE.LSE score=0.48 +7.58%
- BME.LSE score=0.45 +6.55%
- HGT.LSE score=0.41 +5.44%
- GNFT.PA score=0.39 +6.43%
- QIA.XETRA score=0.35 +5.34%

Mais le TRADER LLM (Mistral) les ignore avec :
- `[SKIP_LLM_EMPTY_CONTEXT] 0 candidat in band + 0 position ouverte → skip Gemini call`
- `[OBJ_CAUTIOUS_NO_VALID] Aucun candidat valide dans le contexte actuel`

## Stats 24h `trader_agent_decisions`

| Action | Count |
|---|---|
| `hold` rejected | **988 (98.8%)** |
| `open_directional` applied | 5 |
| `open_directional` rejected | 2 |
| `trail_stop` applied | 3 |
| `trail_stop` rejected | 2 |

## Solution (déjà dispo dans CLAUDE.md)

Activer le bypass LLM pour high conviction candidates via Fly secrets :

```
TRADER_BYPASS_HIGH_CONVICTION=active
TRADER_BYPASS_MIN_SCORE=0.7
```

## Scripts

- `check-trader-arbitration.ts` — scanner_proposals + total count
- `check-trader-llm-decisions.ts` — schema trader_agent_decisions
- `check-trader-llm-recent.ts` — actions + apply_error + thesis 60min/24h

Aucun impact runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_