### PR TITLE
fix(mechanical): tolérance stale_eodhd pour TP/SL EU equity

### DIFF
--- a/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
+++ b/apps/api/src/modules/lisa/services/mechanical-trading.service.ts
@@ -1925,7 +1925,34 @@ export class MechanicalTradingService {
     // position légitime à $513 (LMT) est instantanément liquidée à $100 = -80%.
     // On skip ce cycle pour cette position ; au prochain tick (60s), si EODHD
     // est revenu, on reprend normalement.
-    if (this.isFallbackSource(quote.source)) {
+    //
+    // 05/06/2026 — EU STALE TOLERANCE :
+    // Bug observé : SAVE.LSE TP=$6.84 touché par live EODHD $6.869 mais
+    // tagged stale_eodhd (age 16min > 180s default) → TP/SL skip → user
+    // dû fermer manuellement à +$50. Pour LSE/XETRA/PA, EODHD intraday a
+    // une latence naturelle 10-20min, le threshold 180s est inadapté.
+    // Fix : pour EU equity stale_eodhd ou stale_twelvedata, accepter si age
+    // < MECHANICAL_STALE_AGE_MAX_MIN_EU (default 30min). Sanity bound 30%
+    // (ligne ci-dessous) reste filet anti-LMT-incident. fallback_unknown
+    // ($0 sentinel) et fallback_* restent toujours bloqués.
+    const symU = pos.symbol.toUpperCase();
+    const isEu = (pos.assetClass === 'eu_equity') || /\.(LSE|XETRA|PA|AS|SW|F|DE|MI|BR|ST|HE|VI|LS)$/.test(symU);
+    const isStaleQuote = typeof quote.source === 'string' && quote.source.startsWith('stale_');
+    let euStaleAccepted = false;
+    if (isStaleQuote && isEu && quote.asOf) {
+      const ageMin = (Date.now() - Date.parse(quote.asOf)) / 60_000;
+      const maxAgeMin = (() => {
+        const v = parseFloat(process.env.MECHANICAL_STALE_AGE_MAX_MIN_EU ?? '30');
+        return Number.isFinite(v) && v > 0 ? v : 30;
+      })();
+      if (Number.isFinite(ageMin) && ageMin < maxAgeMin) {
+        this.logger.log(
+          `[EU_STALE_TOLERANCE] ${pos.symbol}: source=${quote.source} age=${ageMin.toFixed(0)}min < ${maxAgeMin}min — accept TP/SL check (sanity bound 30% reste actif)`,
+        );
+        euStaleAccepted = true;
+      }
+    }
+    if (this.isFallbackSource(quote.source) && !euStaleAccepted) {
       this.logger.warn(
         `[FALLBACK_GUARD] ${pos.symbol}: source=${quote.source} price=${quote.price} — skip stop/target check (prix non fiable, cycle suivant)`,
       );


### PR DESCRIPTION
## Bug critique

User a observé 05/06/2026 : **SAVE.LSE TP=$6.84 touché par EODHD live $6.869** (+2.9% gain) mais auto-close JAMAIS déclenché. User dû fermer manuellement à **+$50**.

## Root cause

[`mechanical-trading.service.ts:1928`](apps/api/src/modules/lisa/services/mechanical-trading.service.ts#L1928) :
```ts
if (this.isFallbackSource(quote.source)) return; // BLOQUE TP/SL
```

[`isFallbackSource`](apps/api/src/modules/lisa/services/mechanical-trading.service.ts#L2511) rejette tout source `stale_*`.

[`tagStaleness`](apps/api/src/modules/lisa/services/lisa.service.ts#L3654) tag `stale_eodhd` dès **180s (3min)** d'age.

EODHD intraday LSE/XETRA/PA/etc. a une **latence naturelle 10-20min** → toutes les positions EU tagged stale → TP/SL skip systématiquement → user dû fermer manuellement.

**Impact** : depuis qu'on a activé EU sur TRADER (PR #598), AUCUNE position LSE/XETRA/PA ne déclenche son TP/SL automatique.

## Fix

Dans `checkStopTarget`, avant le `isFallbackSource` check, détecter :
1. `quote.source` startsWith `stale_` (stale_eodhd / stale_twelvedata)
2. Position EU (`assetClass === 'eu_equity'` OU symbol suffix `.LSE/.XETRA/.PA/.AS/.SW/.F/.DE/.MI/.BR/.ST/.HE/.VI/.LS`)
3. Age = `(now - quote.asOf) < MECHANICAL_STALE_AGE_MAX_MIN_EU` (default 30min)

Si toutes 3 conditions : `euStaleAccepted=true` → log `[EU_STALE_TOLERANCE]` → laisser passer.

**Garde-fous immuables conservés** :
- ✅ Sanity bound 30% (ligne 1948) reste actif comme filet anti-LMT-incident
- ✅ `fallback_unknown` ($0 sentinel) toujours bloqué
- ✅ `fallback_*` génériques toujours bloqués
- ✅ Zero-price guard toujours actif

## Env tunable

```
MECHANICAL_STALE_AGE_MAX_MIN_EU  default 30
```

- `10` → strict, plus de positions ne fermeront pas auto
- `60` → laxiste, accepte EODHD très en retard

## Effets attendus

- TP/SL auto déclenchent enfin sur EU positions
- Plus besoin de fermer manuellement les LSE/XETRA gagnantes
- Risque résiduel : si EODHD live carrément faux (parse glitch), sanity bound 30% le bloque OU divergence > maxAgeMin le bloque

## Tests

- Typecheck OK
- Pas de test unitaire ajouté car logique trivial guard ; test E2E = prochaine position LSE/XETRA qui touche TP devrait fermer auto

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_