### PR TITLE
fix(ui): renomme 'Invalidée' → 'Fermée par IA' pour closed_invalidated

### DIFF
--- a/apps/web/src/components/lisa/mechanical-agent-card.tsx
+++ b/apps/web/src/components/lisa/mechanical-agent-card.tsx
@@ -24,7 +24,7 @@ const KIND_LABELS: Record<string, { label: string; color: string; bg: string }> 
   mechanical_open: { label: 'OPEN', color: 'text-blue-700 dark:text-blue-300', bg: 'bg-blue-50 dark:bg-blue-950/40' },
   mechanical_close_stop: { label: 'STOP', color: 'text-red-700 dark:text-red-300', bg: 'bg-red-50 dark:bg-red-950/40' },
   mechanical_close_target: { label: 'TARGET', color: 'text-emerald-700 dark:text-emerald-300', bg: 'bg-emerald-50 dark:bg-emerald-950/40' },
-  mechanical_close_invalidated: { label: 'INVALIDE', color: 'text-orange-700 dark:text-orange-300', bg: 'bg-orange-50 dark:bg-orange-950/40' },
+  mechanical_close_invalidated: { label: 'FERMÉE PAR IA', color: 'text-orange-700 dark:text-orange-300', bg: 'bg-orange-50 dark:bg-orange-950/40' },
   mechanical_skip: { label: 'SKIP', color: 'text-slate-600 dark:text-slate-400', bg: 'bg-slate-50 dark:bg-slate-900/40' },
   autopilot_cycle_started: { label: 'CYCLE', color: 'text-slate-600 dark:text-slate-400', bg: 'bg-slate-50 dark:bg-slate-900/40' },
   autopilot_cycle_completed: { label: 'CYCLE', color: 'text-slate-600 dark:text-slate-400', bg: 'bg-slate-50 dark:bg-slate-900/40' },

--- a/apps/web/src/components/lisa/positions-table.tsx
+++ b/apps/web/src/components/lisa/positions-table.tsx
@@ -17,7 +17,7 @@ const STATUS_LABELS: Record<LisaPosition['status'], { label: string; color: stri
   open: { label: 'Ouverte', color: 'bg-blue-50 text-blue-700 border-blue-200' },
   closed_target: { label: 'TP hit', color: 'bg-emerald-50 text-emerald-700 border-emerald-200' },
   closed_stop: { label: 'SL hit', color: 'bg-red-50 text-red-700 border-red-200' },
-  closed_invalidated: { label: 'Invalidée', color: 'bg-amber-50 text-amber-700 border-amber-200' },
+  closed_invalidated: { label: 'Fermée par IA', color: 'bg-amber-50 text-amber-700 border-amber-200' },
   closed_user: { label: 'Fermée user', color: 'bg-slate-50 text-slate-700 border-slate-200' },
   closed_kill: { label: 'Kill switch', color: 'bg-red-100 text-red-800 border-red-300' },
   closed_expired: { label: 'Expirée', color: 'bg-slate-50 text-slate-500 border-slate-200' },


### PR DESCRIPTION
## Bug UX

User a observé : NVTS.US fermée par trader-agent (perte -0.46%) affichait le statut **"Invalidée"** qui suggère à tort que la thèse était fausse. En réalité, `closed_invalidated` = fermeture par décision LLM (trader-agent Mistral ou Gemini RiskManager), pas un échec de thèse.

## Fix

Renommage simple, neutre, plus juste :
- `positions-table.tsx` : `'Invalidée'` → `'Fermée par IA'`
- `mechanical-agent-card.tsx` : `'INVALIDE'` → `'FERMÉE PAR IA'`

Pas de changement de sémantique côté code (status reste `closed_invalidated`). Seul le libellé d'affichage change.

## Tests

Typecheck OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_