### PR TITLE
fix(persistence): stale guard manquant sur cache_stale + eodhd_ticks

### DIFF
--- a/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
+++ b/apps/api/src/modules/lisa/services/multi-tf-persistence.service.ts
@@ -493,7 +493,7 @@ export class MultiTimeframePersistenceService {
     // OHLCV bars côté client. Ref :
     //   `vendor/eodhd-claude-skills/.../endpoints/us-tick-data.md`
     const tickSeries = await this.eodhd.getCandlesViaTicks(eodhdTicker, '5m', 13).catch(() => null);
-    if (tickSeries && tickSeries.candles.length > 0) {
+    if (tickSeries && tickSeries.candles.length > 0 && !isLastCandleStale(tickSeries.candles)) {
       const tickFiveMin = tickSeries.candles.map((c) => ({
         datetime: new Date(c.timestamp * 1000).toISOString(),
         open: c.open,
@@ -521,7 +521,7 @@ export class MultiTimeframePersistenceService {
 
     // 3. Cache Supabase (last_known < 15 min)
     const cached = await this.intradayCache.read(cacheKey).catch(() => null);
-    if (cached && cached.candles.length > 0) {
+    if (cached && cached.candles.length > 0 && !isLastCandleStale(cached.candles)) {
       // Convert CachedCandle[] back to the shape expected by extractors
       const cachedAsFiveMin = cached.candles.map((c) => ({
         datetime: new Date(c.timestamp * 1000).toISOString(),


### PR DESCRIPTION
## Suite de PR #607

PR #607 a ajouté `isLastCandleStale()` aux 3 sources primaires (Yahoo / EODHD 1m / EODHD 5m) mais **2 sources fallback étaient oubliées** :
1. `eodhd_ticks` (line 495)
2. `cache_stale` (line 523) — IntradayCacheService Supabase

## Root cause découverte 10:55 UTC

User signale que 0P4G.LSE, 0ROY.LSE etc. affichent toujours +106%/+87% dans UI Top Gainers malgré PR #607 mergé.

Test EODHD live :
```
GET /api/intraday/0P4G.LSE?interval=5m → []  (vide)
GET /api/real-time/0P4G.LSE → close=11.99 change_p=+2.06%
```

Trace du flow pour 0P4G.LSE :
1. Yahoo → null (LSE DR pas couvert)
2. EODHD 1m → null
3. EODHD 5m → `[]` (vide)
4. EODHD ticks → null
5. **IntradayCache → HIT** avec candles ANCIENNES (cache TTL 5min mais peut contenir candles de plusieurs jours/semaines au moment de la dernière write)

Le `evaluatePersistence(currentPrice, prices)` calcule alors avec :
- `currentPrice` = $12 (live EODHD real-time)
- `candle.open` = $5.82 (cached d'une vieille période, peut-être quand le ticker avait des prices différents)
- → tfXm = (12-5.82) / 5.82 × 100 = **+106%** affiché faussement

## Fix

Ajouter `isLastCandleStale()` check aux 2 branches manquantes :
- Line 496 : `eodhd_ticks` fallback
- Line 524 : `cache_stale` fallback

`GAINERS_PERSISTENCE_MAX_CANDLE_AGE_MIN` reste tunable (default 30min).

## Effet attendu

0P4G/0ROY/0A0F/0QG9/0AAL/0RGY/0RQP/0LBY/0A3B/etc. tous **disparaissent** du tableau UI Top Gainers une fois deploy effectif (~5min après merge + cache UI expire).

## Tests

- Typecheck OK
- p18e + p19i : 26/26 passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_