### PR TITLE
fix(scanner): pre-filter EODHD screener pour fantômes refund_1d_p > 50%

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -2060,8 +2060,20 @@ export class TopGainersScannerService implements OnModuleInit {
           break; // stop pagination sur erreur, retour ce qu'on a déjà
         }
         const json = (await res.json()) as { data?: EodhdScreenerRow[] } | EodhdScreenerRow[];
-        const rows: EodhdScreenerRow[] = Array.isArray(json) ? json : (json.data ?? []);
-        totalRowsReturned += rows.length;
+        const rawRows: EodhdScreenerRow[] = Array.isArray(json) ? json : (json.data ?? []);
+        totalRowsReturned += rawRows.length;
+        // 05/06/2026 — PRE-FILTER FANTOMES EODHD :
+        // Le screener EODHD LSE/XETRA retourne des depository receipts (0XXX.LSE)
+        // avec refund_1d_p aberrant (110-466%), valeurs périmées last_day_data_date.
+        // Ex confirmé live : 0QN3 +466%, 0A0F +176%, 0QG9 +110%, 0P4G +109%.
+        // Filtre client-side amont : refund_1d_p > 50% → aberrant.
+        // (Un vrai pump blue chip ne dépasse pratiquement jamais 30%/jour sans
+        // halted/restructuration majeure.) Économie ~5 fetches/cycle + UI nettoyée.
+        const rows = rawRows.filter((r) => {
+          const change = Number(r.refund_1d_p ?? r.change_p ?? 0);
+          if (Number.isFinite(change) && change > 50) return false;
+          return true;
+        });
         let pageMapped = rows
           .map((r) => this.mapEodhdRow(r, exUpper))
           .filter((c): c is TopGainerCandidate => c !== null);


### PR DESCRIPTION
## Bug

Audit EU 24h a révélé diversification limitée à 9 unique tickers. Cause : le screener EODHD LSE retourne en tête des **depository receipts** (0XXX.LSE) avec `refund_1d_p` aberrant (110-466%) qui saturent le top gainers.

## Confirmation EODHD live

```
GET /api/screener?filters=[["exchange","=","LSE"],["refund_1d_p",">",3]]
→ data[0] : 0QN3 (GAM Holding)        refund_1d_p=466.12% ❌ aberrant
→ data[1] : 0A0F (Citycon)            refund_1d_p=176.61% ❌
→ data[2] : 0QG9 (Prosiebensat 1)     refund_1d_p=110.48% ❌
→ data[3] : 0P4G (SIG Combibloc)      refund_1d_p=109.39% ❌
... (avgvol_1d=0, last_day_data_date=2026-06-04 périmé)
```

Réalité via `/api/real-time/0P4G.LSE` : **change_p=+2.06%** (pas +109%).

## Fix

Pre-filter `rawRows` BEFORE map dans `fetchEodhdScreener` :
```ts
if (refund_1d_p > 50%) skip; // aberrant
```

(Un vrai pump blue chip ne dépasse pratiquement jamais 30%/jour sans halted/restructuration majeure.)

## Effets attendus

- 0P4G/0ROY/0A0F/0QG9/0AAL/0RGY/0RQP/0LBY/0A3B/etc. tous **filtrés AVANT mapping**
- UI Top Gainers affiche enfin de **VRAIS tickers EU pump** (3-30% range)
- Économie ~5 fetches intraday/cycle (5 fantômes éliminés du flow)
- Scanner ne perd RIEN car ces fantômes étaient déjà rejected par G4 Overextended (cap +15% EU), juste plus tôt dans le pipeline

## Tests

**165/165 top-gainers tests passent.** Aucune régression sur fixtures existantes (mocks utilisent refund_1d_p=5.2 typique, sous le seuil 50%).

## Tunable

Pas de env tunable ajouté volontairement car 50% est un seuil dur (rien de légitime au-dessus). Si besoin futur, facile à ajouter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_