### PR TITLE
hotfix(scanner): pagination break prématuré dans PR #611

### DIFF
--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -2092,7 +2092,12 @@ export class TopGainersScannerService implements OnModuleInit {
             }),
           },
         });
-        if (rows.length < pageSize) break; // fin de la liste exchange
+        // 05/06/2026 — Check pagination sur rawRows (avant filter), pas rows
+        // filtrées. Sinon une page entièrement de fantômes (5 rows > 50%)
+        // → rows.length=0 → break prématuré → scanner arrête tout.
+        // Cas vu en prod 13:25 UTC : screener LSE page 1 = 0QN3/0A0F/0QG9/0P4G/0A3B
+        // tous > 50% → filtered → 0 → break → AUCUN candidat EU récupéré.
+        if (rawRows.length < pageSize) break; // fin de la liste exchange
       }
       if (allMapped.length > perExchangeCap) {
         allMapped.length = perExchangeCap; // trim


### PR DESCRIPTION
## Bug critique

PR #611 a introduit un break prématuré de la pagination du screener EODHD.

**Cas observé en prod 13:25 UTC :**
- Screener LSE page 1 = `0QN3, 0A0F, 0QG9, 0P4G, 0A3B` — tous `refund_1d_p > 50%`
- Mon filter PR #611 les supprime tous → `rows.length=0`
- Check `if (rows.length < pageSize) break` → **break prématuré**
- → AUCUN candidat EU récupéré pour TOUTE la liste
- → 0 shadow signals 30min → 0 ouvertures

**Symptômes** :
- TRADER positions ouvertes = 0 (depuis ~10:30)
- shadow signals 30min toutes classes = 0
- scanner_proposals 60min = 1 seul

## Fix

Check pagination sur `rawRows.length` (taille EODHD brute, avant filter), pas `rows.length` (post-filter). Le but du check est de détecter "fin de la liste EODHD", pas "fin des candidats qui m'intéressent".

```diff
- if (rows.length < pageSize) break;
+ if (rawRows.length < pageSize) break;
```

## Tests

165/165 top-gainers tests passent. À merger ASAP pour rétablir pipeline TRADER avant NYSE 14:30 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_