### PR TITLE
feat(ui): TraderMindPanel — esprit décision TRADER live (poll 60s)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -1781,6 +1781,17 @@ export class LisaController {
     return this.lisa.getDecisionLog(extractUserId(headers), portfolioId, limit ? parseInt(limit, 10) : 50);
   }
 
+  // 05/06/2026 — TRADER mind feed pour panel UI live (poll 60s côté front).
+  @Get('trader-mind/:portfolioId')
+  getTraderMind(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+    @Query('limit') limit?: string,
+  ) {
+    const n = Math.min(Math.max(parseInt(limit ?? '30', 10) || 30, 1), 100);
+    return this.lisa.getTraderMind(extractUserId(headers), portfolioId, n);
+  }
+
   // LISA refonte B.2 — Lessons Impact Tracker.
   // Agrège les citations sur une fenêtre glissante (default 30j, max 365).
   @Get('lessons-impact/:portfolioId')

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -2598,6 +2598,42 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
   }
 
   /**
+   * 05/06/2026 — TRADER mind feed pour panel UI live.
+   * Retourne les N dernières décisions du TRADER agent (LLM + bypass) filtrées
+   * des CYCLE_TICK pings (sentinel cron). Permet à l'utilisateur de suivre
+   * l'esprit décisionnel de TRADER minute par minute.
+   */
+  async getTraderMind(userId: string, portfolioId: string, limit = 30) {
+    await this.assertPortfolioOwner(userId, portfolioId);
+    const { data, error } = await this.supabase.getClient()
+      .from('trader_agent_decisions')
+      .select('id, decided_at, action_kind, action_applied, target_symbol, confidence, direction, notional_usd, thesis, gemini_provider, gemini_cost_usd, mistral_cost_usd, mistral_large_cost_usd, applied_position_id, apply_error, input_state')
+      .eq('portfolio_id', portfolioId)
+      .order('decided_at', { ascending: false })
+      .limit(limit * 3);
+    if (error) throw new BadRequestException(error.message);
+    const filtered = (data ?? []).filter((d) => {
+      const state = d.input_state as { cycle_tick_sentinel?: boolean } | null;
+      return !state?.cycle_tick_sentinel;
+    }).slice(0, limit);
+    return filtered.map((d) => ({
+      id: d.id,
+      decided_at: d.decided_at,
+      action_kind: d.action_kind,
+      action_applied: d.action_applied,
+      target_symbol: d.target_symbol,
+      confidence: d.confidence,
+      direction: d.direction,
+      notional_usd: d.notional_usd,
+      thesis: d.thesis,
+      llm_provider: d.gemini_provider,
+      total_cost_usd: Number(d.gemini_cost_usd ?? 0) + Number(d.mistral_cost_usd ?? 0) + Number(d.mistral_large_cost_usd ?? 0),
+      applied_position_id: d.applied_position_id,
+      apply_error: d.apply_error,
+    }));
+  }
+
+  /**
    * LISA refonte B.2 — Lessons Impact Tracker.
    *
    * Agrège les citations de lessons par TRADER sur une fenêtre glissante.

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -31,6 +31,7 @@ import { DailyHarvestTracker } from '@/components/lisa/daily-harvest-tracker';
 import { DailyHarvestPanel } from '@/components/lisa/daily-harvest-panel';
 import { MacroModeSelector } from '@/components/lisa/macro-mode-selector';
 import { GainersStatusTile } from '@/components/lisa/gainers-status-tile';
+import { TraderMindPanel } from '@/components/lisa/trader-mind-panel';
 import { GainersConfigPanel } from '@/components/lisa/gainers-config-panel';
 import { LisaStickyHeader } from '@/components/lisa/lisa-sticky-header';
 import { GainsTracker } from '@/components/lisa/gains-tracker';
@@ -731,6 +732,9 @@ export default function LisaPage() {
       {/* Shadow Sizing — RETIRÉ 04/06. Les shadows MIDDLE/SMALL sont figés et
           HIGH est passé en oversold : le comparatif A/B momentum n'a plus de sens.
           Carte supprimée de l'UI dans tous les modes (historique conservé en DB). */}
+
+      {/* 05/06/2026 — TRADER mind feed live (poll 60s) */}
+      {selectedPortfolioId && <TraderMindPanel portfolioId={selectedPortfolioId} />}
 
       {/* LISA refonte C.2 — Strategy Coach proposals (Gemini hourly + review modal) */}
       {selectedPortfolioId && <CoachProposalsPanel portfolioId={selectedPortfolioId} />}

--- a/apps/web/src/components/lisa/trader-mind-panel.tsx
+++ b/apps/web/src/components/lisa/trader-mind-panel.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { Brain, CheckCircle2, XCircle, AlertCircle } from 'lucide-react';
+import { useTraderMind } from '@/hooks/use-lisa';
+import { SkeletonCard } from '@/components/ui/skeleton';
+
+interface Props {
+  portfolioId: string;
+}
+
+function fmtTime(iso: string): string {
+  return iso.slice(11, 19);
+}
+
+function relativeAge(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return 'à l\'instant';
+  const min = Math.round(ms / 60_000);
+  if (min < 60) return `il y a ${min} min`;
+  const h = Math.round(min / 60);
+  return `il y a ${h}h`;
+}
+
+const ACTION_LABELS: Record<string, { label: string; color: string }> = {
+  open_directional: { label: 'OPEN', color: 'bg-emerald-50 text-emerald-700 border-emerald-200' },
+  scale_in: { label: 'SCALE IN', color: 'bg-blue-50 text-blue-700 border-blue-200' },
+  close: { label: 'CLOSE', color: 'bg-red-50 text-red-700 border-red-200' },
+  trail_stop: { label: 'TRAIL SL', color: 'bg-amber-50 text-amber-700 border-amber-200' },
+  hold: { label: 'HOLD', color: 'bg-slate-50 text-slate-600 border-slate-200' },
+};
+
+export function TraderMindPanel({ portfolioId }: Props) {
+  const { data, isLoading, error } = useTraderMind(portfolioId, 30);
+
+  return (
+    <div className="rounded-lg border p-5 space-y-3">
+      <div className="flex items-center gap-2">
+        <Brain className="h-4 w-4 text-muted-foreground" />
+        <h2 className="text-sm font-medium">Esprit décision TRADER</h2>
+        <span className="text-xs text-muted-foreground">(30 derniers cycles · refresh 60s)</span>
+      </div>
+
+      {isLoading && <SkeletonCard />}
+
+      {error && (
+        <div className="text-xs text-red-600 flex items-center gap-1.5">
+          <AlertCircle className="h-3 w-3" />
+          Erreur chargement : {error instanceof Error ? error.message : String(error)}
+        </div>
+      )}
+
+      {!isLoading && !error && (data?.length ?? 0) === 0 && (
+        <div className="rounded border border-dashed p-4 text-center text-xs text-muted-foreground">
+          Aucune décision pour l'instant.
+        </div>
+      )}
+
+      {!isLoading && data && data.length > 0 && (
+        <div className="space-y-2 max-h-[60vh] overflow-y-auto">
+          {data.map((d) => {
+            const spec = ACTION_LABELS[d.action_kind ?? ''] ?? { label: (d.action_kind ?? '?').toUpperCase(), color: 'bg-slate-50 text-slate-600 border-slate-200' };
+            const applied = d.action_applied === true;
+            const isBypass = (d.thesis ?? '').includes('TRADER_BYPASS_HIGH_CONVICTION');
+            return (
+              <div
+                key={d.id}
+                className="rounded-md border p-2.5 bg-card hover:bg-accent/30 transition-colors"
+              >
+                <div className="flex items-center gap-2 flex-wrap text-xs">
+                  <span className="font-mono text-muted-foreground">{fmtTime(d.decided_at)}Z</span>
+                  {applied ? (
+                    <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
+                  ) : (
+                    <XCircle className="h-3.5 w-3.5 text-slate-400" />
+                  )}
+                  <span className={`inline-flex items-center rounded border px-1.5 py-0.5 font-medium ${spec.color}`}>
+                    {spec.label}
+                  </span>
+                  {d.target_symbol && (
+                    <span className="font-mono font-medium">{d.target_symbol}</span>
+                  )}
+                  {d.direction && (
+                    <span className="text-muted-foreground uppercase">{d.direction}</span>
+                  )}
+                  {d.confidence != null && (
+                    <span className="text-muted-foreground">conf={Number(d.confidence).toFixed(2)}</span>
+                  )}
+                  {d.notional_usd && (
+                    <span className="text-muted-foreground">${Number(d.notional_usd).toFixed(0)}</span>
+                  )}
+                  <span className="ml-auto text-[10px] text-muted-foreground">
+                    {isBypass ? '⚡ bypass' : d.llm_provider ?? '—'} · ${d.total_cost_usd.toFixed(4)}
+                  </span>
+                </div>
+                {d.thesis && (
+                  <div className="mt-1.5 text-xs text-muted-foreground line-clamp-2">
+                    💭 {d.thesis}
+                  </div>
+                )}
+                {d.apply_error && (
+                  <div className="mt-1 text-[10px] text-red-600 line-clamp-1">
+                    ⚠ {d.apply_error}
+                  </div>
+                )}
+                <div className="mt-1 text-[10px] text-muted-foreground/70">{relativeAge(d.decided_at)}</div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-lisa.ts
+++ b/apps/web/src/hooks/use-lisa.ts
@@ -238,6 +238,32 @@ export function useLisaConfig(portfolioId: string | null) {
   });
 }
 
+// 05/06/2026 — TRADER mind live feed (poll 60s).
+export interface TraderMindDecision {
+  id: string;
+  decided_at: string;
+  action_kind: string | null;
+  action_applied: boolean | null;
+  target_symbol: string | null;
+  confidence: number | null;
+  direction: string | null;
+  notional_usd: number | null;
+  thesis: string | null;
+  llm_provider: string | null;
+  total_cost_usd: number;
+  applied_position_id: string | null;
+  apply_error: string | null;
+}
+
+export function useTraderMind(portfolioId: string | null, limit = 30) {
+  return useQuery({
+    queryKey: ['lisa', 'trader-mind', portfolioId, limit],
+    queryFn: () => apiFetch<TraderMindDecision[]>(`/lisa/trader-mind/${portfolioId}?limit=${limit}`),
+    enabled: !!portfolioId,
+    refetchInterval: 60_000,
+  });
+}
+
 export function useUpsertLisaConfig(portfolioId: string) {
   const qc = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Feature UI

User veut **suivre l'esprit décisionnel du TRADER minute par minute** dans son UI sans avoir à demander à Claude de relayer les events. Sont affichées les décisions du LLM Mistral + bypass HIGH_CONVICTION.

## Modifications

### Backend
- **`lisa.service.ts`** : `getTraderMind(portfolioId, limit)` — filtre les CYCLE_TICK pings et retourne les N dernières décisions actionables avec `total_cost_usd` consolidé (Gemini + Mistral medium + Mistral large)
- **`lisa.controller.ts`** : `GET /lisa/trader-mind/:portfolioId?limit=N` (default 30, max 100)

### Frontend
- **`use-lisa.ts`** : hook `useTraderMind` avec `refetchInterval=60s`
- **`trader-mind-panel.tsx`** : composant qui affiche pour chaque décision :
  - Timestamp UTC + age relatif
  - Icône applied/rejected
  - Badge action (OPEN / HOLD / CLOSE / SCALE IN / TRAIL SL)
  - Symbol, direction, confidence, notional
  - LLM provider (ou ⚡ bypass) + cost
  - Thesis tronqué + apply_error si présent
- **`lisa/page.tsx`** : intégration entre Gainers et CoachProposals

## UX

- Panel scrollable `max-h-60vh`
- Refresh auto 60s
- Max 30 cycles affichés
- Code couleur par action

## Tests

Typecheck OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_