### PR TITLE
feat(oversold): overnight protection (option A + nuance) + recovery monitor J+10

### DIFF
--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -781,4 +781,185 @@ export class OversoldScannerService {
       maxOpenPositions: cfg.maxOpenPositions,
     });
   }
+
+  /**
+   * 05/06/2026 — OVERNIGHT PROTECTION (option A + nuance user-validated).
+   * Cron 20:45 UTC weekdays (15min avant NYSE close 21:00).
+   * Pour chaque position oversold US open :
+   *   - PnL >= -OVERSOLD_TOLERABLE_LOSS_PCT (default 3%) → force close
+   *   - PnL < seuil → enter EXTENDED mode (deadline J+OVERSOLD_EXTENDED_DEADLINE_DAYS)
+   * Évite les "claques overnight" comme celle observée 04/06 → 05/06 (-$418).
+   * Opt-in via OVERSOLD_FORCE_CLOSE_ENABLED=true.
+   */
+  @Cron('0 45 20 * * 1-5', { name: 'oversold-overnight-protection', timeZone: 'UTC' })
+  async runOvernightProtection(): Promise<void> {
+    try {
+      if (!this.isEnabled()) return;
+      const enabled = (this.config.get<string>('OVERSOLD_FORCE_CLOSE_ENABLED') ?? 'false').toLowerCase() === 'true';
+      if (!enabled) {
+        this.logger.debug('[oversold-overnight] OVERSOLD_FORCE_CLOSE_ENABLED=false → skip');
+        return;
+      }
+      const tolerableLossPct = parseFloat(this.config.get<string>('OVERSOLD_TOLERABLE_LOSS_PCT') ?? '3.0');
+      const deadlineDays = parseInt(this.config.get<string>('OVERSOLD_EXTENDED_DEADLINE_DAYS') ?? '10', 10);
+
+      const { data: positions } = await this.supabase.getClient()
+        .from('lisa_positions')
+        .select('id, portfolio_id, symbol, asset_class, entry_price, entry_notional_usd, source')
+        .eq('status', 'open')
+        .in('source', ['scanner_oversold', 'scanner_oversold_intraday'])
+        .like('asset_class', 'us_%')
+        .is('extended_deadline_at', null);
+
+      if (!positions || positions.length === 0) {
+        this.logger.log('[oversold-overnight] no eligible positions to protect');
+        return;
+      }
+
+      let closedCount = 0;
+      let extendedCount = 0;
+      for (const pos of positions) {
+        try {
+          const quote = await this.lisa.getLivePrice(pos.symbol).catch(() => null);
+          if (!quote || !quote.price) continue;
+          const livePrice = Number(quote.price);
+          const entryPrice = Number(pos.entry_price);
+          if (!Number.isFinite(livePrice) || livePrice <= 0 || !Number.isFinite(entryPrice) || entryPrice <= 0) continue;
+          const pnlPct = ((livePrice - entryPrice) / entryPrice) * 100;
+
+          if (pnlPct >= -tolerableLossPct) {
+            try {
+              await this.lisa.closeForOpportunityScout({
+                positionId: pos.id,
+                symbol: pos.symbol,
+                livePrice,
+                livePriceSource: quote.source,
+                reason: 'closed_invalidated',
+                rationale: `[OVERSOLD_OVERNIGHT] Force close 20:45 UTC (PnL ${pnlPct.toFixed(2)}% >= -${tolerableLossPct}% seuil)`,
+              });
+              closedCount++;
+            } catch (e) {
+              this.logger.warn(`[oversold-overnight] ${pos.symbol} close failed: ${String(e).slice(0, 100)}`);
+            }
+          } else {
+            const deadlineAt = new Date(Date.now() + deadlineDays * 24 * 3600 * 1000).toISOString();
+            try {
+              await this.supabase.getClient()
+                .from('lisa_positions')
+                .update({
+                  extended_deadline_at: deadlineAt,
+                  extended_entered_at: new Date().toISOString(),
+                  manual_control: true,
+                })
+                .eq('id', pos.id);
+              await this.decisionLog.append({
+                portfolioId: pos.portfolio_id,
+                kind: 'oversold_extended_entered',
+                summary: `[OVERSOLD_EXTENDED] ${pos.symbol} entered J+${deadlineDays} mode (PnL ${pnlPct.toFixed(2)}% < -${tolerableLossPct}%)`,
+                rationale: `Position trop perdante pour force close à 20:45 UTC. Recovery monitor cherche window de close (breakeven < seuil, PnL positif, ou deadline ${deadlineAt}). manual_control activé pour bloquer SL/TP auto pendant extended.`,
+                payload: { symbol: pos.symbol, pnl_pct: pnlPct, deadline_at: deadlineAt },
+                triggeredBy: 'autopilot_cron',
+              }).catch(() => null);
+              extendedCount++;
+            } catch (e) {
+              this.logger.warn(`[oversold-overnight] ${pos.symbol} extended-set failed: ${String(e).slice(0, 100)}`);
+            }
+          }
+        } catch (e) {
+          this.logger.warn(`[oversold-overnight] ${pos.symbol} eval failed: ${String(e).slice(0, 150)}`);
+        }
+      }
+
+      this.logger.log(`[oversold-overnight] processed ${positions.length} positions: ${closedCount} closed, ${extendedCount} extended`);
+    } catch (err) {
+      this.logger.error(`[oversold-overnight] cron crashed: ${String(err).slice(0, 300)}`);
+    }
+  }
+
+  /**
+   * 05/06/2026 — RECOVERY MONITOR pour positions OVERSOLD_EXTENDED.
+   * Cron 1min : check chaque position en mode extended et close si :
+   *   - PnL_usd >= -OVERSOLD_BREAKEVEN_THRESHOLD_USD (default $10) → breakeven approx
+   *   - PnL_usd > 0 → rebond, lock dès que positif
+   *   - now > extended_deadline_at → force close (deadline J+10)
+   */
+  @Cron('0 */1 * * * *', { name: 'oversold-recovery-monitor', timeZone: 'UTC' })
+  async runRecoveryMonitor(): Promise<void> {
+    try {
+      if (!this.isEnabled()) return;
+      const enabled = (this.config.get<string>('OVERSOLD_FORCE_CLOSE_ENABLED') ?? 'false').toLowerCase() === 'true';
+      if (!enabled) return;
+
+      const breakevenUsd = parseFloat(this.config.get<string>('OVERSOLD_BREAKEVEN_THRESHOLD_USD') ?? '10');
+
+      const { data: positions } = await this.supabase.getClient()
+        .from('lisa_positions')
+        .select('id, portfolio_id, symbol, entry_price, entry_notional_usd, extended_deadline_at')
+        .eq('status', 'open')
+        .not('extended_deadline_at', 'is', null);
+
+      if (!positions || positions.length === 0) return;
+
+      const now = Date.now();
+      for (const pos of positions) {
+        try {
+          const deadline = pos.extended_deadline_at ? new Date(pos.extended_deadline_at).getTime() : null;
+          const quote = await this.lisa.getLivePrice(pos.symbol).catch(() => null);
+          if (!quote || !quote.price) continue;
+          const livePrice = Number(quote.price);
+          const entryPrice = Number(pos.entry_price);
+          if (!Number.isFinite(livePrice) || livePrice <= 0 || !Number.isFinite(entryPrice) || entryPrice <= 0) continue;
+          const pnlPct = ((livePrice - entryPrice) / entryPrice) * 100;
+          const notional = Number(pos.entry_notional_usd ?? 0);
+          const pnlUsd = (notional * pnlPct) / 100;
+
+          let shouldClose = false;
+          let reason = '';
+
+          if (deadline && now > deadline) {
+            shouldClose = true;
+            reason = `[OVERSOLD_EXTENDED] deadline atteinte (PnL final ${pnlPct.toFixed(2)}% / $${pnlUsd.toFixed(2)})`;
+          } else if (pnlUsd > 0) {
+            shouldClose = true;
+            reason = `[OVERSOLD_EXTENDED] PnL passé positif (+$${pnlUsd.toFixed(2)}) — lock`;
+          } else if (pnlUsd >= -breakevenUsd) {
+            shouldClose = true;
+            reason = `[OVERSOLD_EXTENDED] breakeven approx (PnL $${pnlUsd.toFixed(2)} >= -$${breakevenUsd})`;
+          }
+
+          if (shouldClose) {
+            try {
+              await this.lisa.closeForOpportunityScout({
+                positionId: pos.id,
+                symbol: pos.symbol,
+                livePrice,
+                livePriceSource: quote.source,
+                reason: 'closed_invalidated',
+                rationale: reason,
+              });
+              await this.decisionLog.append({
+                portfolioId: pos.portfolio_id,
+                kind: 'oversold_extended_closed',
+                summary: `[OVERSOLD_EXTENDED] ${pos.symbol} closed (PnL ${pnlPct.toFixed(2)}% / $${pnlUsd.toFixed(2)})`,
+                rationale: reason,
+                payload: {
+                  symbol: pos.symbol,
+                  pnl_pct: pnlPct,
+                  pnl_usd: pnlUsd,
+                  deadline_reached: !!(deadline && now > deadline),
+                },
+                triggeredBy: 'autopilot_cron',
+              }).catch(() => null);
+            } catch (e) {
+              this.logger.warn(`[oversold-recovery] ${pos.symbol} close failed: ${String(e).slice(0, 100)}`);
+            }
+          }
+        } catch (e) {
+          this.logger.warn(`[oversold-recovery] ${pos.symbol} eval failed: ${String(e).slice(0, 150)}`);
+        }
+      }
+    } catch (err) {
+      this.logger.error(`[oversold-recovery] cron crashed: ${String(err).slice(0, 300)}`);
+    }
+  }
 }

--- a/supabase/migrations/0193_oversold_extended_deadline.sql
+++ b/supabase/migrations/0193_oversold_extended_deadline.sql
@@ -1,0 +1,22 @@
+-- 0193_oversold_extended_deadline.sql
+-- Mode "OVERSOLD EXTENDED" : positions oversold US qui dépassent un seuil de
+-- perte à la fenêtre de force-close 20:45 UTC sont mises en mode "extended"
+-- avec une deadline J+10 pour tenter de récupérer breakeven.
+--
+-- Si `extended_deadline_at` IS NOT NULL → position en mode extended :
+--   - Mechanical cron skip standard SL/TP
+--   - Recovery monitor cherche fenêtre de close (breakeven, vélocité positive, deadline)
+--
+-- Cohabite avec `manual_control` (PR #614 DANGER_ZONE_LLM peut aussi avoir
+-- activé manual_control auparavant).
+
+ALTER TABLE lisa_positions
+  ADD COLUMN IF NOT EXISTS extended_deadline_at TIMESTAMPTZ NULL,
+  ADD COLUMN IF NOT EXISTS extended_entered_at TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN lisa_positions.extended_deadline_at IS 'Si non-null, position en mode OVERSOLD_EXTENDED jusqu''à cette date (J+10). Recovery monitor cherche window de close.';
+COMMENT ON COLUMN lisa_positions.extended_entered_at IS 'Timestamp d''entrée en mode extended (= 20:45 UTC du jour où la position a dépassé le seuil de perte).';
+
+CREATE INDEX IF NOT EXISTS idx_lisa_positions_extended_open
+  ON lisa_positions (extended_deadline_at)
+  WHERE extended_deadline_at IS NOT NULL AND status = 'open';


### PR DESCRIPTION
## Contexte

User a subi une **"méchante claque overnight"** 04/06 → 05/06 (~**-$418** sur 12 positions oversold US tenues across NYSE close 21:00 UTC) :
- CLS.US -5.94%, MU.US -5.03%, CRWV.US -7.40%, IBM.US -5.26%, DDOG.US -5.06%, etc.

User a dû passer en manuel pour stopper l'hémorragie.

## Stratégie validée (option A + nuance)

```
20:45 UTC chaque weekday (15min avant NYSE close)
└── Pour chaque position oversold US OPEN :
    │
    ├── PnL >= -3% (tolérable) ?
    │   └── ✅ FORCE CLOSE (limite overnight risk)
    │
    └── PnL < -3% (perte trop importante) ?
        └── ENTER OVERSOLD_EXTENDED mode :
            ├── extended_deadline_at = now + 10 jours
            ├── manual_control = true (bloque SL/TP auto)
            └── Recovery monitor (cron 1min) cherche window de close :
                ├── PnL_usd > 0 → CLOSE (lock dès positif)
                ├── PnL_usd >= -$10 → CLOSE (breakeven approx)
                └── now > deadline J+10 → CLOSE forcé
```

## Compatibilité DANGER_ZONE_LLM (PR #614)

| Mécanisme | Quand | Cible |
|---|---|---|
| DANGER_ZONE_LLM | Cron 60s pendant marché | Position à 80% SL → LLM décide |
| Overnight protection | 20:45 UTC weekdays | Toutes positions oversold US |
| Recovery monitor | Cron 1min | Positions en mode EXTENDED only |

**Pas de conflit, complémentaires.**

## Env tunables

```
OVERSOLD_FORCE_CLOSE_ENABLED            default false (opt-in)
OVERSOLD_TOLERABLE_LOSS_PCT             default 3.0
OVERSOLD_EXTENDED_DEADLINE_DAYS         default 10
OVERSOLD_BREAKEVEN_THRESHOLD_USD        default 10
```

## Migration 0193

```sql
ALTER TABLE lisa_positions ADD:
  - extended_deadline_at TIMESTAMPTZ NULL
  - extended_entered_at TIMESTAMPTZ NULL
+ index partiel sur (extended_deadline_at) WHERE NOT NULL AND status=open
```

## Pour activer en prod (après merge + Fly deploy + migration applied)

```bash
fly secrets set OVERSOLD_FORCE_CLOSE_ENABLED=true
```

## Note MVP

Vélocité non encore implémentée (déféré). Pour l'instant `PnL > 0 = close` (proxy simple cohérent avec ta demande "gain >0 on liquide").

## Tests

Typecheck OK. Pas de unit tests ajoutés (logique trivial fetch+compute+close). E2E sera demain 20:45 UTC si secret set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_