### PR TITLE
hotfix(oversold): query venue_fee_detail->>source au lieu de colonne source

### DIFF
--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -803,11 +803,14 @@ export class OversoldScannerService {
       const tolerableLossPct = parseFloat(this.config.get<string>('OVERSOLD_TOLERABLE_LOSS_PCT') ?? '3.0');
       const deadlineDays = parseInt(this.config.get<string>('OVERSOLD_EXTENDED_DEADLINE_DAYS') ?? '10', 10);
 
+      // 05/06/2026 HOTFIX : la colonne `source` est 'lisa' (writer LisaService),
+      // la vraie source oversold est dans venue_fee_detail->>source. Cf audit
+      // open positions HIGH 12/12 ont source='lisa' + venue_fee_detail.source=scanner_oversold.
       const { data: positions } = await this.supabase.getClient()
         .from('lisa_positions')
-        .select('id, portfolio_id, symbol, asset_class, entry_price, entry_notional_usd, source')
+        .select('id, portfolio_id, symbol, asset_class, entry_price, entry_notional_usd, source, venue_fee_detail')
         .eq('status', 'open')
-        .in('source', ['scanner_oversold', 'scanner_oversold_intraday'])
+        .in('venue_fee_detail->>source', ['scanner_oversold', 'scanner_oversold_intraday'])
         .like('asset_class', 'us_%')
         .is('extended_deadline_at', null);
 


### PR DESCRIPTION
## Bug critique PR #615

Mon PR #615 introduit overnight protection sur les positions oversold US. Mais la query filtre sur la colonne `source` :
```ts
.in('source', ['scanner_oversold', 'scanner_oversold_intraday'])
```

**Audit live découvert** : les 12 positions oversold HIGH actuellement ouvertes ont :
- `source = 'lisa'` (writer LisaService)
- `venue_fee_detail.source = 'scanner_oversold'` (la VRAIE source dans JSONB nested)

→ Ma query match **0 positions** → le cron overnight protection 20:45 **ne fait rien**.

## Fix

```diff
- .in('source', ['scanner_oversold', 'scanner_oversold_intraday'])
+ .in('venue_fee_detail->>source', ['scanner_oversold', 'scanner_oversold_intraday'])
```

Le recovery monitor n'a pas le bug (il filtre par `extended_deadline_at` qui sera correctement setté par le fix overnight protection).

## Tests

Typecheck OK. Critique pour que PR #615 fonctionne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_