### PR TITLE
fix(opportunity-scout): recalcule SL/TP sur verifiedPrice après drift

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -5546,6 +5546,38 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     const verifiedPrice = parseFloat(fresh.price);
     if (!Number.isFinite(verifiedPrice) || verifiedPrice <= 0) return null;
 
+    // Bug fix 05/06 (ABVX.US -0.40% SL hit 26 min après open) :
+    // Le scout pré-calcule SL/TP sur SON livePrice cached. Si le prix dérive
+    // entre le calcul scout et le verifiedPrice ici, le SL/TP devient
+    // déphasé (cas ABVX : scout px=102.32 → SL=100.78 ; verifiedPx=101 →
+    // SL effectif à 0.21% du entry au lieu de 1.5% → SL touché par le bruit).
+    // Solution : recalculer SL/TP à partir de verifiedPrice en préservant
+    // les ratios cibles annoncés par le scout (cmd.stopLossPrice /
+    // cmd.takeProfitPrice / cmd.livePrice).
+    let recomputedSl = cmd.stopLossPrice;
+    let recomputedTp = cmd.takeProfitPrice;
+    const scoutPx = Number(cmd.livePrice);
+    const scoutSlPx = parseFloat(cmd.stopLossPrice);
+    const scoutTpPx = parseFloat(cmd.takeProfitPrice);
+    if (
+      Number.isFinite(scoutPx) && scoutPx > 0 &&
+      Number.isFinite(scoutSlPx) && scoutSlPx > 0 &&
+      Number.isFinite(scoutTpPx) && scoutTpPx > 0
+    ) {
+      const slPct = 1 - scoutSlPx / scoutPx; // ex 0.015 (1.5%)
+      const tpPct = scoutTpPx / scoutPx - 1; // ex 0.025 (2.5%)
+      recomputedSl = (verifiedPrice * (1 - slPct)).toFixed(6);
+      recomputedTp = (verifiedPrice * (1 + tpPct)).toFixed(6);
+      const driftPct = ((verifiedPrice - scoutPx) / scoutPx) * 100;
+      if (Math.abs(driftPct) > 0.5) {
+        this.logger.log(
+          `[opportunity-scout] ${cmd.symbol} prix drift ${driftPct.toFixed(2)}% (scout=$${scoutPx} → verified=$${verifiedPrice}). ` +
+            `SL recalculé ${cmd.stopLossPrice} → ${recomputedSl} (ratio ${(slPct * 100).toFixed(2)}% préservé). ` +
+            `TP recalculé ${cmd.takeProfitPrice} → ${recomputedTp}.`,
+        );
+      }
+    }
+
     try {
       const pos = await this.paperBroker.openPositionDirect({
         portfolioId: cmd.portfolioId,
@@ -5555,8 +5587,8 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
         venue: cmd.venue,
         capitalAllocationUsd: cmd.notionalUsd.toFixed(2),
         livePrice: verifiedPrice.toFixed(6),
-        stopLossPrice: cmd.stopLossPrice,
-        takeProfitPrice: cmd.takeProfitPrice,
+        stopLossPrice: recomputedSl,
+        takeProfitPrice: recomputedTp,
         horizonDays: cmd.horizonDays ?? 1,
         source: 'opportunity_scout',
         maxOpenPositions: cmd.maxOpenPositions,

--- a/scripts/abvx-trader-decisions.ts
+++ b/scripts/abvx-trader-decisions.ts
@@ -1,0 +1,26 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+async function main() {
+  // trader_agent_decisions autour de 15:48-15:51 sur TRADER
+  const { data } = await sb.from('trader_agent_decisions')
+    .select('decided_at, action_kind, gemini_parsed, gemini_provider, gemini_raw_response, input_candidates')
+    .eq('portfolio_id','b0000001-0000-0000-0000-000000000001')
+    .gte('decided_at','2026-06-05T15:45:00Z')
+    .lte('decided_at','2026-06-05T15:55:00Z')
+    .order('decided_at', { ascending: true });
+  console.log(`trader_agent_decisions 15:45-15:55 : ${data?.length ?? 0}`);
+  for (const d of data ?? []) {
+    console.log(`\n  ${d.decided_at.slice(11,19)} action=${d.action_kind} provider=${d.gemini_provider}`);
+    const cand = (d as any).input_candidates;
+    if (Array.isArray(cand)) {
+      const abvx = cand.find((c:any) => c?.symbol === 'ABVX.US');
+      if (abvx) console.log(`    ABVX in candidates: ${JSON.stringify(abvx).slice(0,200)}`);
+    }
+    const parsed = (d as any).gemini_parsed;
+    if (parsed && JSON.stringify(parsed).includes('ABVX')) {
+      console.log(`    parsed contains ABVX: ${JSON.stringify(parsed).slice(0,300)}`);
+    }
+  }
+}
+main().catch(console.error);

--- a/scripts/audit-abvx-path.ts
+++ b/scripts/audit-abvx-path.ts
@@ -1,0 +1,38 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+async function main() {
+  // ABVX entry was 15:50:12. Cherche TOUT le contexte autour.
+  const { data: logs } = await sb.from('lisa_decision_log')
+    .select('timestamp, kind, summary, payload')
+    .eq('portfolio_id','b0000001-0000-0000-0000-000000000001')
+    .gte('timestamp','2026-06-05T15:48:00Z')
+    .lte('timestamp','2026-06-05T15:51:00Z')
+    .order('timestamp', { ascending: true });
+  console.log(`Logs autour ouverture ABVX (15:48-15:51): ${logs?.length ?? 0}`);
+  for (const l of logs ?? []) {
+    const isAbvx = (l.summary ?? '').includes('ABVX') || JSON.stringify(l.payload ?? {}).includes('ABVX');
+    if (isAbvx) {
+      console.log(`  ${l.timestamp.slice(11,19)} [${l.kind}]`);
+      console.log(`    summary: ${(l.summary ?? '').slice(0,200)}`);
+      const p = l.payload as any;
+      if (p) {
+        const keys = Object.keys(p).slice(0, 15);
+        for (const k of keys) console.log(`    ${k}: ${JSON.stringify(p[k]).slice(0,100)}`);
+      }
+      console.log();
+    }
+  }
+  
+  // Y a-t-il une scanner_proposal pour ABVX ?
+  const { data: props } = await sb.from('scanner_proposals')
+    .select('*')
+    .eq('symbol','ABVX.US')
+    .gte('proposed_at','2026-06-05T15:00:00Z')
+    .order('proposed_at', { ascending: false });
+  console.log(`\nscanner_proposals ABVX.US aujourd'hui: ${props?.length ?? 0}`);
+  for (const p of props ?? []) {
+    console.log(`  ${p.proposed_at} pf=${p.portfolio_id?.slice(0,12)} score=${p.score} status=${p.status ?? '?'} reasoning=${(p.scanner_reasoning ?? '').slice(0,100)}`);
+  }
+}
+main().catch(console.error);

--- a/scripts/audit-abvx-trader.ts
+++ b/scripts/audit-abvx-trader.ts
@@ -1,0 +1,38 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+async function main() {
+  // trader_agent_decisions ?
+  const tables = ['trader_agent_decisions','live_trader_decisions','scanner_proposals','lisa_proposals'];
+  for (const t of tables) {
+    try {
+      const { data } = await sb.from(t).select('*').limit(2);
+      console.log(`${t} cols:`, Object.keys(data?.[0] ?? {}).slice(0,15));
+    } catch {}
+  }
+  console.log();
+  // ABVX in any of these
+  for (const t of ['trader_agent_decisions','scanner_proposals']) {
+    try {
+      const cols = await sb.from(t).select('*').limit(1);
+      const c = Object.keys(cols.data?.[0] ?? {});
+      const symCol = c.includes('symbol') ? 'symbol' : null;
+      if (!symCol) continue;
+      const { data } = await sb.from(t).select('*').eq('symbol','ABVX.US').gte(c.includes('decided_at') ? 'decided_at' : (c.includes('proposed_at') ? 'proposed_at' : 'created_at'),'2026-06-05T00:00:00Z');
+      console.log(`${t} ABVX: ${data?.length ?? 0}`);
+      for (const r of data ?? []) console.log(' ', JSON.stringify(r).slice(0,250));
+    } catch (e) { console.log(`err ${t}:`, String(e).slice(0,80)); }
+  }
+  
+  // Tout decision_log autour ABVX (élargi 15:40-15:55)
+  console.log('\n--- decision_log élargi 15:40-15:55 ABVX ---');
+  const { data: all } = await sb.from('lisa_decision_log')
+    .select('timestamp, kind, summary')
+    .eq('portfolio_id','b0000001-0000-0000-0000-000000000001')
+    .gte('timestamp','2026-06-05T15:40:00Z').lte('timestamp','2026-06-05T15:55:00Z');
+  for (const l of all ?? []) {
+    const txt = (l.summary ?? '');
+    if (txt.includes('ABVX')) console.log(`  ${l.timestamp.slice(11,19)} [${l.kind}] ${txt.slice(0,120)}`);
+  }
+}
+main().catch(console.error);

--- a/scripts/backtest-eu-oversold-full.ts
+++ b/scripts/backtest-eu-oversold-full.ts
@@ -1,0 +1,156 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+const EODHD = '69e6325aa2c162.98850425';
+
+interface Bar { date: string; close: number; volume: number }
+
+async function fetchBars(sym: string): Promise<Bar[]> {
+  try {
+    const r = await fetch(`https://eodhd.com/api/eod/${sym}?from=2026-03-25&to=2026-06-04&api_token=${EODHD}&fmt=json`, { signal: AbortSignal.timeout(8000) });
+    if (!r.ok) return [];
+    const j = await r.json() as any[];
+    if (!Array.isArray(j)) return [];
+    return j
+      .map(b => ({ date: String(b.date ?? ''), close: Number(b.close ?? NaN), volume: Number(b.volume ?? 0) }))
+      .filter(b => b.date && Number.isFinite(b.close) && b.close > 0)
+      .sort((a,b) => a.date.localeCompare(b.date));
+  } catch { return []; }
+}
+
+async function fetchMany(syms: string[], concurrency=10): Promise<Map<string, Bar[]>> {
+  const res = new Map<string, Bar[]>();
+  const queue = [...syms];
+  const workers = Array.from({ length: concurrency }, async () => {
+    while (queue.length) {
+      const s = queue.shift();
+      if (!s) return;
+      const b = await fetchBars(s);
+      if (b.length > 10) res.set(s, b);
+    }
+  });
+  await Promise.all(workers);
+  return res;
+}
+
+async function main() {
+  // 1. Univers stoxx600
+  const { data: uni } = await sb.from('watchlist_universe').select('tickers').eq('name','stoxx600').maybeSingle();
+  const tickers = (uni?.tickers as string[]) ?? [];
+  console.log(`Tickers stoxx600: ${tickers.length}`);
+  
+  // 2. V2TX + SX5E pour computer le contexte régime à chaque date
+  console.log('\nFetching V2TX + SX5E...');
+  const v2tx = await fetchBars('V2TX.INDX');
+  const sx5e = await fetchBars('SX5E.INDX');
+  console.log(`V2TX ${v2tx.length} bars, SX5E ${sx5e.length} bars`);
+  
+  // Map date → V2TX level + V2TX chg 1d + SX5E 5d return
+  const regimeByDate = new Map<string, {v2tx:number; v2txChg:number|null; sx5e5d:number|null}>();
+  for (let i = 0; i < v2tx.length; i++) {
+    const prev = i > 0 ? v2tx[i-1].close : null;
+    const chg = prev ? (v2tx[i].close / prev - 1) * 100 : null;
+    // Find SX5E 5d at this date
+    const sx5eIdx = sx5e.findIndex(s => s.date === v2tx[i].date);
+    const sx5e5d = sx5eIdx >= 5 ? (sx5e[sx5eIdx].close / sx5e[sx5eIdx-5].close - 1) * 100 : null;
+    regimeByDate.set(v2tx[i].date, { v2tx: v2tx[i].close, v2txChg: chg, sx5e5d });
+  }
+  
+  // 3. Fetch univers (518 tickers en parallèle)
+  console.log(`\nFetching ${tickers.length} stoxx600 EOD bars (concurrency 10)...`);
+  const t0 = Date.now();
+  const bars = await fetchMany(tickers, 10);
+  console.log(`Fetched ${bars.size}/${tickers.length} in ${((Date.now()-t0)/1000).toFixed(1)}s`);
+  
+  // 4. Simulation : pour chaque ticker, pour chaque jour J, si drop[-12,-5%] → enter, exit J+10
+  type Trade = { ticker:string; entryDate:string; dropPct:number; pnlPct:number; v2tx:number|null; v2txChg:number|null; sx5e5d:number|null };
+  const trades: Trade[] = [];
+  for (const [sym, b] of bars.entries()) {
+    for (let i = 1; i < b.length - 10; i++) {
+      const dropPct = (b[i].close / b[i-1].close - 1) * 100;
+      if (dropPct < -12 || dropPct > -5) continue;
+      // liquidité
+      if (b[i].close < 5 || b[i].close * b[i].volume < 1_000_000) continue;
+      const exitIdx = Math.min(i + 10, b.length - 1);
+      const pnlPct = (b[exitIdx].close / b[i].close - 1) * 100;
+      const r = regimeByDate.get(b[i].date) ?? { v2tx: null, v2txChg: null, sx5e5d: null };
+      trades.push({ ticker: sym, entryDate: b[i].date, dropPct, pnlPct, v2tx: r.v2tx as any, v2txChg: r.v2txChg, sx5e5d: r.sx5e5d });
+    }
+  }
+  console.log(`\nTotal trades simulés: ${trades.length}`);
+  
+  const wins = trades.filter(t => t.pnlPct > 0).length;
+  const totalPnl = trades.reduce((s,t) => s+t.pnlPct, 0);
+  console.log(`Global : winRate=${(wins/trades.length*100).toFixed(1)}%  avgPnL=${(totalPnl/trades.length).toFixed(2)}%  sumPnL=${totalPnl.toFixed(1)}%`);
+  
+  // ─── Buckets V2TX ───
+  console.log('\n=== Buckets V2TX level ===');
+  const v2txBuckets = [
+    { label:'< 20', filter: (t:Trade) => t.v2tx !== null && t.v2tx < 20 },
+    { label:'20-22', filter: (t:Trade) => t.v2tx !== null && t.v2tx >= 20 && t.v2tx < 22 },
+    { label:'22-24', filter: (t:Trade) => t.v2tx !== null && t.v2tx >= 22 && t.v2tx < 24 },
+    { label:'24-26', filter: (t:Trade) => t.v2tx !== null && t.v2tx >= 24 && t.v2tx < 26 },
+    { label:'>= 26', filter: (t:Trade) => t.v2tx !== null && t.v2tx >= 26 },
+  ];
+  for (const b of v2txBuckets) {
+    const ts = trades.filter(b.filter);
+    if (!ts.length) continue;
+    const w = ts.filter(t => t.pnlPct > 0).length;
+    const sum = ts.reduce((s,t)=>s+t.pnlPct,0);
+    console.log(`  V2TX ${b.label.padEnd(8)}  n=${String(ts.length).padStart(4)}  winRate=${(w/ts.length*100).toFixed(1)}%  avgPnL=${(sum/ts.length).toFixed(2)}%  sumPnL=${sum.toFixed(1)}%`);
+  }
+  
+  // ─── Buckets SX5E 5d ───
+  console.log('\n=== Buckets SX5E 5d return ===');
+  const sx5eBuckets = [
+    { label:'< -2%', filter: (t:Trade) => t.sx5e5d !== null && t.sx5e5d < -2 },
+    { label:'-2 to -1%', filter: (t:Trade) => t.sx5e5d !== null && t.sx5e5d >= -2 && t.sx5e5d < -1 },
+    { label:'-1 to 0%', filter: (t:Trade) => t.sx5e5d !== null && t.sx5e5d >= -1 && t.sx5e5d < 0 },
+    { label:'0 to 1%', filter: (t:Trade) => t.sx5e5d !== null && t.sx5e5d >= 0 && t.sx5e5d < 1 },
+    { label:'>= 1%', filter: (t:Trade) => t.sx5e5d !== null && t.sx5e5d >= 1 },
+  ];
+  for (const b of sx5eBuckets) {
+    const ts = trades.filter(b.filter);
+    if (!ts.length) continue;
+    const w = ts.filter(t => t.pnlPct > 0).length;
+    const sum = ts.reduce((s,t)=>s+t.pnlPct,0);
+    console.log(`  SX5E_5d ${b.label.padEnd(10)}  n=${String(ts.length).padStart(4)}  winRate=${(w/ts.length*100).toFixed(1)}%  avgPnL=${(sum/ts.length).toFixed(2)}%  sumPnL=${sum.toFixed(1)}%`);
+  }
+  
+  // ─── Buckets ΔV2TX 1d ───
+  console.log('\n=== Buckets ΔV2TX 1d ===');
+  const dvBuckets = [
+    { label:'< -5%', filter: (t:Trade) => t.v2txChg !== null && t.v2txChg < -5 },
+    { label:'-5 to 0%', filter: (t:Trade) => t.v2txChg !== null && t.v2txChg >= -5 && t.v2txChg < 0 },
+    { label:'0 to 5%', filter: (t:Trade) => t.v2txChg !== null && t.v2txChg >= 0 && t.v2txChg < 5 },
+    { label:'5 to 10%', filter: (t:Trade) => t.v2txChg !== null && t.v2txChg >= 5 && t.v2txChg < 10 },
+    { label:'>= 10%', filter: (t:Trade) => t.v2txChg !== null && t.v2txChg >= 10 },
+  ];
+  for (const b of dvBuckets) {
+    const ts = trades.filter(b.filter);
+    if (!ts.length) continue;
+    const w = ts.filter(t => t.pnlPct > 0).length;
+    const sum = ts.reduce((s,t)=>s+t.pnlPct,0);
+    console.log(`  ΔV2TX ${b.label.padEnd(10)}  n=${String(ts.length).padStart(4)}  winRate=${(w/ts.length*100).toFixed(1)}%  avgPnL=${(sum/ts.length).toFixed(2)}%  sumPnL=${sum.toFixed(1)}%`);
+  }
+  
+  // ─── Test "what-if" gates avec différents seuils ───
+  console.log('\n=== Simulation gates (V2TX_MAX × SX5E_5D_MIN) ===');
+  console.log('Format : gates → trades restants / total | winRate | avgPnL | sumPnL');
+  const combos = [
+    { vmax: 99, smin: -99, label: 'PAS_DE_GATE' },
+    { vmax: 22, smin: -1.5, label: 'PR#620 défaut' },
+    { vmax: 23, smin: -1.5, label: 'V2TX 23 SX5E -1.5' },
+    { vmax: 24, smin: -1.5, label: 'V2TX 24 SX5E -1.5 (data-driven)' },
+    { vmax: 24, smin: -2.0, label: 'V2TX 24 SX5E -2.0 (permissif)' },
+    { vmax: 25, smin: -2.0, label: 'V2TX 25 SX5E -2.0 (très permissif)' },
+  ];
+  for (const c of combos) {
+    const passed = trades.filter(t => (t.v2tx ?? 0) <= c.vmax && (t.sx5e5d ?? 0) >= c.smin);
+    if (!passed.length) { console.log(`  ${c.label.padEnd(40)} 0/${trades.length} aucun trade`); continue; }
+    const w = passed.filter(t => t.pnlPct > 0).length;
+    const sum = passed.reduce((s,t)=>s+t.pnlPct,0);
+    console.log(`  ${c.label.padEnd(40)} ${String(passed.length).padStart(4)}/${trades.length} | wr=${(w/passed.length*100).toFixed(1)}% | avg=${(sum/passed.length).toFixed(2)}% | sum=${sum.toFixed(1)}%`);
+  }
+}
+main().catch(console.error);

--- a/scripts/backtest-eu-regime.ts
+++ b/scripts/backtest-eu-regime.ts
@@ -1,0 +1,71 @@
+import 'dotenv/config';
+const EODHD = '69e6325aa2c162.98850425';
+
+async function eod(sym: string, from: string, to: string) {
+  const r = await fetch(`https://eodhd.com/api/eod/${sym}?from=${from}&to=${to}&api_token=${EODHD}&fmt=json`);
+  if (!r.ok) { console.log(`  ${sym} HTTP ${r.status}`); return null; }
+  return await r.json() as any[];
+}
+
+async function main() {
+  console.log('=== Backtest EU regime — V2TX + SX5E historique 60j ===\n');
+  
+  const v2tx = await eod('V2TX.INDX','2026-04-01','2026-06-04');
+  const sx5e = await eod('SX5E.INDX','2026-04-01','2026-06-04');
+  if (!v2tx || !sx5e) { console.log('failed to fetch'); return; }
+  
+  console.log(`V2TX bars: ${v2tx.length}, range ${v2tx[0]?.date} → ${v2tx[v2tx.length-1]?.date}`);
+  console.log(`SX5E bars: ${sx5e.length}, range ${sx5e[0]?.date} → ${sx5e[sx5e.length-1]?.date}`);
+  
+  // distribution V2TX
+  const vix = v2tx.map(d => d.close).sort((a,b) => a-b);
+  const pct = (arr: number[], p: number) => arr[Math.floor(arr.length*p)];
+  console.log(`\nV2TX distribution 60j:`);
+  console.log(`  min=${vix[0].toFixed(2)}  p25=${pct(vix,0.25).toFixed(2)}  median=${pct(vix,0.5).toFixed(2)}  p75=${pct(vix,0.75).toFixed(2)}  p90=${pct(vix,0.9).toFixed(2)}  max=${vix[vix.length-1].toFixed(2)}`);
+  
+  // SX5E 5d returns
+  const sx5eSorted = sx5e.sort((a,b)=>a.date.localeCompare(b.date));
+  const r5d: {date:string; r5:number}[] = [];
+  for (let i = 5; i < sx5eSorted.length; i++) {
+    const r = (sx5eSorted[i].close / sx5eSorted[i-5].close - 1) * 100;
+    r5d.push({ date: sx5eSorted[i].date, r5: r });
+  }
+  const rs = r5d.map(x=>x.r5).sort((a,b)=>a-b);
+  console.log(`\nSX5E 5d return distribution 55j:`);
+  console.log(`  min=${rs[0].toFixed(2)}%  p10=${pct(rs,0.1).toFixed(2)}%  p25=${pct(rs,0.25).toFixed(2)}%  median=${pct(rs,0.5).toFixed(2)}%  p75=${pct(rs,0.75).toFixed(2)}%  p90=${pct(rs,0.9).toFixed(2)}%  max=${rs[rs.length-1].toFixed(2)}%`);
+  
+  // V2TX 1d delta
+  const v2txSorted = v2tx.sort((a,b)=>a.date.localeCompare(b.date));
+  const v2txChg: {date:string; chg:number; close:number}[] = [];
+  for (let i = 1; i < v2txSorted.length; i++) {
+    const chg = (v2txSorted[i].close / v2txSorted[i-1].close - 1) * 100;
+    v2txChg.push({ date: v2txSorted[i].date, chg, close: v2txSorted[i].close });
+  }
+  const chgs = v2txChg.map(x=>x.chg).sort((a,b)=>a-b);
+  console.log(`\nΔV2TX 1d distribution:`);
+  console.log(`  min=${chgs[0].toFixed(1)}%  p10=${pct(chgs,0.1).toFixed(1)}%  median=${pct(chgs,0.5).toFixed(1)}%  p90=${pct(chgs,0.9).toFixed(1)}%  max=${chgs[chgs.length-1].toFixed(1)}%`);
+  
+  // identifier journées de stress
+  console.log(`\n=== Top 10 jours de stress EU (V2TX > seuils) ===`);
+  const stressDays = v2txChg
+    .map(x => ({...x, r5: r5d.find(y => y.date === x.date)?.r5 ?? null}))
+    .filter(x => x.close > 20 || x.chg > 15 || (x.r5 !== null && x.r5 < -2))
+    .sort((a,b) => b.close - a.close);
+  for (const d of stressDays.slice(0,15)) {
+    console.log(`  ${d.date}  V2TX=${d.close.toFixed(2)}  Δ1d=${d.chg.toFixed(1)}%  SX5E_5d=${d.r5?.toFixed(2) ?? '?'}%`);
+  }
+  
+  // Suggestion seuils data-driven : p75/p90 V2TX, p10 SX5E 5d
+  console.log(`\n=== Recommandation calibration EU data-driven (60j) ===`);
+  const v2txP75 = pct(vix, 0.75);
+  const v2txP85 = pct(vix, 0.85);
+  const v2txP90 = pct(vix, 0.9);
+  const r5p10 = pct(rs, 0.1);
+  const r5p15 = pct(rs, 0.15);
+  console.log(`Si on cible "bloquer 10-15% des pires régimes" :`);
+  console.log(`  V2TX_MAX = ${v2txP85.toFixed(1)} (p85) ou ${v2txP90.toFixed(1)} (p90)  [actuel défaut 22]`);
+  console.log(`  SX5E_5D_MIN = ${r5p10.toFixed(2)}% (p10) ou ${r5p15.toFixed(2)}% (p15)  [actuel défaut -1.5%]`);
+  const chgP90 = pct(chgs, 0.9);
+  console.log(`  V2TX_DELTA_MAX = ${chgP90.toFixed(1)}% (p90)  [actuel défaut 10%]`);
+}
+main().catch(console.error);

--- a/scripts/check-scanner-proposals.ts
+++ b/scripts/check-scanner-proposals.ts
@@ -1,0 +1,12 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+async function main() {
+  const { data } = await sb.from('scanner_proposals').select('*').order('proposed_at', { ascending: false }).limit(2);
+  console.log('cols:', Object.keys(data?.[0] ?? {}).sort());
+  if (data && data[0]) {
+    console.log('\n=== latest scanner_proposal ===');
+    for (const k of Object.keys(data[0]).sort()) console.log(`  ${k} = ${JSON.stringify((data[0] as any)[k]).slice(0,150)}`);
+  }
+}
+main().catch(console.error);


### PR DESCRIPTION
## Bug constaté

ABVX.US ouverte 05/06 à 17:50 (15:50 UTC) → SL touché à -0.40% en 26 min.

```
Scout livePrice  = $102.32 → SL calculé = $100.78 (1.5% en-dessous) ✅
                            ↓ re-fetch verifiedPrice
verifiedPrice    = $101.00 → SL reste $100.78 → distance effective 0.21% ❌
```

Cause : `LisaService.openForOpportunityScout` re-fetch un `verifiedPrice` frais avant l'open mais utilise les SL/TP pré-calculés par le caller (scout / LiveTraderAgent) sur l'ancien livePrice. Si le prix dérive entre les deux fetches, SL/TP deviennent déphasés.

## Fix

Préserver les ratios `slPct` / `tpPct` du caller et recalculer SL/TP à partir de `verifiedPrice` au moment de l'open :

```typescript
const slPct = 1 - scoutSlPx / scoutPx;       // ex 0.015 (1.5%)
const tpPct = scoutTpPx / scoutPx - 1;       // ex 0.025 (2.5%)
recomputedSl = (verifiedPrice * (1 - slPct)).toFixed(6);
recomputedTp = (verifiedPrice * (1 + tpPct)).toFixed(6);
```

Log warning si drift > 0.5% pour visibilité.

## Pourquoi ça reste utile

L'OpportunityScout standalone est killed depuis 04/06, **mais** `LisaService.openForOpportunityScout` est toujours utilisé par `LiveTraderAgent` (PR #614 TRADER_BYPASS + path Mistral). Le bug SL drift peut toucher les synthetic decisions du bypass.

## Test plan
- [x] TypeScript build OK
- [ ] Jest CI
- [ ] Au prochain ouverture via ce helper, vérifier log `[opportunity-scout] X prix drift Y% ... SL recalculé`
- [ ] La distance SL effective doit toujours respecter le ratio annoncé (typiquement 1.5%)

## Note hors scope (à traiter séparément)

Le user a set `TRADER_BYPASS_MIN_SCORE=0.85` (avant 0.35). Cela réduit la fréquence du bypass aux scores ≥ 0.85. Indépendant de ce fix mais résout la cause amont (Mistral redevient le filtre principal).

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_