### PR TITLE
fix(shadow-sizing): use capital_usd réel pour drawdown denom (kill-switch HIGH faux positif)

### DIFF
--- a/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
+++ b/apps/api/src/modules/lisa/services/shadow-sizing-orchestrator.service.ts
@@ -307,8 +307,20 @@ export class ShadowSizingOrchestratorService {
     const totalPnl = realized + unrealizedPnl;
     const netPnl = totalPnl - feesPaid;
 
-    // Drawdown = perte cumulée depuis matin si négatif
-    const drawdownPct = realized < 0 ? Math.abs((realized / 10500) * 100) : 0;
+    // Read kill switch state + capital_usd (denom drawdown).
+    const { data: cfgRow } = await client
+      .from('lisa_session_configs')
+      .select('kill_switch_active, capital_usd')
+      .eq('portfolio_id', portfolioId)
+      .maybeSingle();
+
+    // Bug fix 05/06 : drawdownPct calculait `realized / 10500` (denom hardcoded
+    // valeur shadow nominale d'origine). HIGH portfolio a depuis été upgradé à
+    // $150k (oversold mode) → toute perte > -$525 sur HIGH déclenchait faussement
+    // un kill drawdown > 5%. Désormais on utilise capital_usd réel.
+    const capitalForDenom = Number(cfgRow?.capital_usd ?? 10500);
+    const denom = Number.isFinite(capitalForDenom) && capitalForDenom > 0 ? capitalForDenom : 10500;
+    const drawdownPct = realized < 0 ? Math.abs((realized / denom) * 100) : 0;
 
     // Extrapolation daily PnL (linéaire depuis maintenant)
     const nowUtc = new Date();
@@ -319,13 +331,6 @@ export class ShadowSizingOrchestratorService {
 
     const capacityUsedPct = (openCount / maxPosCount) * 100;
     const targetProgressPct = (netPnl / DAILY_TARGET_USD) * 100;
-
-    // Read kill switch state
-    const { data: cfgRow } = await client
-      .from('lisa_session_configs')
-      .select('kill_switch_active')
-      .eq('portfolio_id', portfolioId)
-      .maybeSingle();
 
     return {
       portfolioId,


### PR DESCRIPTION
## Bug constaté

Le 05/06 le kill-switch HIGH (a0000001, oversold, capital $150k) s'armait répétitivement, forçant le user à désarmer plusieurs fois.

Cause : `shadow-sizing-orchestrator.service.ts:311`

```typescript
const drawdownPct = realized < 0 ? Math.abs((realized / 10500) * 100) : 0;
//                                                  ↑↑↑↑↑
//                                       HARDCODÉ — valeur shadow nominale d'origine
```

HIGH a été upgradé à $150k (oversold mode). Le denom restait à $10,500. Donc toute perte cumulée > -$525 sur la journée déclenchait :
```
drawdownPct = 525 / 10500 × 100 = 5.0% > 5.0% seuil → KILL
```

Réalité : -$525 / $150,000 = **-0.35% drawdown** (totalement normal).

## Fix

Charger `capital_usd` depuis `lisa_session_configs` (déjà lu pour `kill_switch_active`) et l'utiliser comme denom.

```typescript
const capitalForDenom = Number(cfgRow?.capital_usd ?? 10500);
const denom = Number.isFinite(capitalForDenom) && capitalForDenom > 0 ? capitalForDenom : 10500;
const drawdownPct = realized < 0 ? Math.abs((realized / denom) * 100) : 0;
```

Fallback à 10500 préservé pour back-compat (si capital_usd NULL pour anciens shadows).

## Impact

| PF | Capital | Perte journalière qui kill avant | Perte journalière qui kill après |
|---|---|---|---|
| HIGH (a0000001) | $150,000 | -$525 ❌ trop sensible | -$7,500 ✅ |
| MIDDLE (a0000002) | (à vérifier) | -$525 | -5% du capital réel |
| SMALL (a0000003) | (à vérifier) | -$525 | -5% du capital réel |

## Test plan
- [x] TypeScript build OK (après `npm run build --workspace=@smartvest/ai-analyst`)
- [ ] Jest CI
- [ ] Au prochain cron shadow-sizing, vérifier que kill n'est pas armé sur HIGH si pertes < -$7500
- [ ] Si kill armé légitime → payload doit citer drawdownPct calculé avec capital réel

https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXUmhLnCiqUup4MwFihXsk)_