### PR TITLE
fix(ui): cache-bust useLisaConfig — tue l'alerte fantôme kill-switch

### DIFF
--- a/apps/web/src/hooks/use-lisa.ts
+++ b/apps/web/src/hooks/use-lisa.ts
@@ -234,7 +234,18 @@ export function useLisaConfig(portfolioId: string | null) {
     queryKey: ['lisa', 'config', portfolioId],
     queryFn: () => apiFetch<LisaSessionConfigRow | null>(`/lisa/config/${portfolioId}`),
     enabled: !!portfolioId,
-    ...LISA_QUERY_OPTIONS,
+    // 06/06 — anti alerte fantôme kill-switch. Le bandeau kill-switch lit
+    // kill_switch_active depuis ce query. useLisaConfigRealtime n'invalide que
+    // pendant que la page est ouverte ; un changement DB survenu page fermée
+    // (ex : reset kill-switch côté serveur) n'est jamais livré → un cache
+    // persisté (Vercel CDN / React Query) ressort un `true` périmé au prochain
+    // chargement et déclenche une fausse alarme. On NE spread donc PAS
+    // LISA_QUERY_OPTIONS ici : on force refetch au mount + focus + staleTime 0
+    // pour toujours recharger la vérité DB. Calqué sur le fix chart #619.
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: true,
+    staleTime: 0,
+    retry: false,
   });
 }
 


### PR DESCRIPTION
## Problème

Le bandeau « kill-switch armé » lit `kill_switch_active` depuis `useLisaConfig`. La seule invalidation vivante de ce query est `useLisaConfigRealtime` (Supabase Realtime) — qui ne livre les events **que pendant que la page est ouverte/connectée**. Un reset du kill-switch **côté serveur survenu page fermée** n'est jamais propagé au client, et le cache persisté (Vercel CDN / React Query) ressort un `true` périmé au prochain chargement → **fausse alarme**.

Conséquence réelle le 04/06 : l'alerte fantôme a poussé à fermer des positions HIGH profitables (+$220 de latent transformé en réalisé prématurément) alors que la DB disait `false` partout.

## Fix

On ne spread plus `LISA_QUERY_OPTIONS` dans `useLisaConfig` ; on force :
- `refetchOnMount: 'always'`
- `refetchOnWindowFocus: true`
- `staleTime: 0`

→ au montage de `/lisa` et à chaque retour d'onglet, on revalide toujours contre la DB. Même traitement que le fix chart #619.

## Pourquoi c'est sans friction (vérifié)

| Risque | Vérification | Résultat |
|---|---|---|
| Variable morte `LISA_QUERY_OPTIONS` | reste utilisée par 7 autres hooks | ✅ |
| Clobbering du formulaire config | `lisa-config-panel` utilise un pattern draft-override (`value={draft!=='' ? draft : DB}`) immune au refetch | ✅ |
| Conflit avec invalidations existantes | disarm/upsert/realtime invalident déjà ce query → ce changement est purement additif | ✅ |
| Autres consommateurs (targets/chart/page) | lecture seule, bénéficient de données fraîches | ✅ |

## Périmètre

1 fichier, 1 fonction (`apps/web/src/hooks/use-lisa.ts`). Aucune logique métier touchée, aucun secret requis.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_