### PR TITLE
feat(oversold): gate régime intraday US lit le VIX live (real-time EODHD)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/oversold-scanner.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/oversold-scanner.spec.ts
@@ -9,8 +9,10 @@ import {
   passesLiquidity,
   buildOversoldCandidates,
   selectOversoldOpens,
+  decideRegimeBlock,
   type EodBar,
   type OversoldConfig,
+  type RegimeThresholds,
 } from '../oversold.helper';
 
 const CFG: OversoldConfig = {
@@ -144,5 +146,62 @@ describe('selectOversoldOpens (anti-doublon)', () => {
     const cands = buildOversoldCandidates(map, CFG);
     const toOpen = selectOversoldOpens(cands, new Set());
     expect(toOpen.map((c) => c.symbol)).toEqual(['BBB.US', 'AAA.US', 'CCC.US']);
+  });
+});
+
+// US : vixMax 17, ΔVIX 10%, SPY 5d -1%. EU : V2TX 22, ΔV2TX 10%, SX5E 5d -1.5%.
+const US_THRESH: RegimeThresholds = { vixMax: 17, vixDeltaMax: 10, idx5dMin: -1 };
+const US_LABELS = { vix: 'VIX', idx: 'SPY' };
+
+describe('decideRegimeBlock', () => {
+  it('bloque si VIX > vixMax (cas 05/06 : VIX 21.51)', () => {
+    const r = decideRegimeBlock({ vix: 21.51, vixChg: 39.7, idx5d: -2.5 }, US_THRESH, US_LABELS);
+    expect(r.block).toBe(true);
+    expect(r.reason).toBe('VIX 21.51 > 17');
+  });
+
+  it('bloque sur un spike ΔVIX > max même si le niveau VIX est OK', () => {
+    const r = decideRegimeBlock({ vix: 16, vixChg: 12.5, idx5d: 0.5 }, US_THRESH, US_LABELS);
+    expect(r.block).toBe(true);
+    expect(r.reason).toBe('ΔVIX 1d 12.5% > +10%');
+  });
+
+  it('bloque si index 5j < idx5dMin', () => {
+    const r = decideRegimeBlock({ vix: 15, vixChg: 2, idx5d: -1.4 }, US_THRESH, US_LABELS);
+    expect(r.block).toBe(true);
+    expect(r.reason).toBe('SPY 5d -1.40% < -1%');
+  });
+
+  it('passe en régime calme (cas 04/06)', () => {
+    const r = decideRegimeBlock({ vix: 15.4, vixChg: 0.5, idx5d: 0.33 }, US_THRESH, US_LABELS);
+    expect(r.block).toBe(false);
+    expect(r.reason).toBe('pass');
+  });
+
+  it('un indicateur null n’enclenche jamais un block (fail-open par indicateur)', () => {
+    expect(decideRegimeBlock({ vix: null, vixChg: null, idx5d: null }, US_THRESH, US_LABELS).block).toBe(false);
+    // VIX null mais ΔVIX hostile → bloque quand même sur ΔVIX présent
+    expect(decideRegimeBlock({ vix: null, vixChg: 20, idx5d: null }, US_THRESH, US_LABELS).block).toBe(true);
+    // VIX null + reste sain → pass
+    expect(decideRegimeBlock({ vix: null, vixChg: 1, idx5d: 0 }, US_THRESH, US_LABELS).block).toBe(false);
+  });
+
+  it('priorité : niveau VIX testé avant ΔVIX avant index', () => {
+    // VIX>max ET idx5d<min → la raison citée est le VIX (premier check)
+    const r = decideRegimeBlock({ vix: 18, vixChg: 0, idx5d: -5 }, US_THRESH, US_LABELS);
+    expect(r.reason).toBe('VIX 18.00 > 17');
+  });
+
+  it('formate les labels EU (V2TX / SX5E)', () => {
+    const euThresh: RegimeThresholds = { vixMax: 22, vixDeltaMax: 10, idx5dMin: -1.5 };
+    const r = decideRegimeBlock({ vix: 24, vixChg: 1, idx5d: 0 }, euThresh, { vix: 'V2TX', idx: 'SX5E' });
+    expect(r.reason).toBe('V2TX 24.00 > 22');
+  });
+
+  it('bornes strictes : égalité au seuil ne bloque pas', () => {
+    // VIX == max : 17 > 17 est faux → pas de block
+    expect(decideRegimeBlock({ vix: 17, vixChg: 0, idx5d: 0 }, US_THRESH, US_LABELS).block).toBe(false);
+    // idx5d == min : -1 < -1 est faux → pas de block
+    expect(decideRegimeBlock({ vix: 15, vixChg: 0, idx5d: -1 }, US_THRESH, US_LABELS).block).toBe(false);
   });
 });

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -29,6 +29,7 @@ import {
   buildOversoldCandidates,
   selectOversoldOpens,
   businessDaysSince,
+  decideRegimeBlock,
   type OversoldConfig,
   type EodBar,
   type OversoldCandidate,
@@ -230,6 +231,7 @@ export class OversoldScannerService {
             vix: regime.vix,
             vix_chg_pct: regime.vixChg,
             idx_5d_pct: regime.idx5d,
+            vix_source: regime.vixSource,
             reason: regime.reason,
             thresholds: regime.thresholds,
           },
@@ -420,8 +422,9 @@ export class OversoldScannerService {
     const notionalRatio = this.intradayNotionalRatio();
 
     // Regime gate aussi appliqué à l'intraday (sinon le filet du daily 21:15
-    // est contourné par les opens 15-19 UTC en plein régime hostile).
-    const regime = await this.checkRegimeGate(cfg.universe);
+    // est contourné par les opens 15-19 UTC en plein régime hostile). En US,
+    // le gate lit le VIX LIVE ici (intraday) au lieu du close EOD J-1.
+    const regime = await this.checkRegimeGate(cfg.universe, { intraday: true });
     if (regime.block) {
       this.logger.log(
         `[oversold-intraday] portfolio=${portfolioId.slice(0, 8)} universe=${cfg.universe} region=${regime.region} BLOCKED: ${regime.reason}`,
@@ -431,7 +434,7 @@ export class OversoldScannerService {
           portfolioId,
           kind: 'oversold_scan_blocked_regime',
           summary: `Oversold intraday bloqué (régime ${regime.region}): ${regime.reason}`,
-          rationale: `intraday cron ${new Date().toISOString().slice(11, 16)} UTC, gate macro tire`,
+          rationale: `intraday cron ${new Date().toISOString().slice(11, 16)} UTC — ${regime.reason} (VIX ${regime.vixSource})`,
           payload: {
             phase: 'intraday',
             region: regime.region,
@@ -439,6 +442,7 @@ export class OversoldScannerService {
             vix: regime.vix,
             vix_chg_pct: regime.vixChg,
             idx_5d_pct: regime.idx5d,
+            vix_source: regime.vixSource,
             reason: regime.reason,
           },
           triggeredBy: 'autopilot_cron',
@@ -608,13 +612,17 @@ export class OversoldScannerService {
    * Désactivable via OVERSOLD_REGIME_GATE_ENABLED=false. Tous les seuils
    * sont individuellement tunables via secret env (cf. ci-dessous).
    */
-  private async checkRegimeGate(universe: string): Promise<{
+  private async checkRegimeGate(
+    universe: string,
+    opts?: { intraday?: boolean },
+  ): Promise<{
     block: boolean;
     reason: string;
     region: 'US' | 'EU';
     vix: number | null;
     vixChg: number | null;
     idx5d: number | null;
+    vixSource: 'live' | 'eod';
     thresholds: { vixMax: number; vixDeltaMax: number; idx5dMin: number };
   }> {
     const enabled =
@@ -643,17 +651,45 @@ export class OversoldScannerService {
     const thresholds = { vixMax, vixDeltaMax, idx5dMin };
 
     if (!enabled) {
-      return { block: false, reason: 'gate disabled', region, vix: null, vixChg: null, idx5d: null, thresholds };
+      return { block: false, reason: 'gate disabled', region, vix: null, vixChg: null, idx5d: null, vixSource: 'eod', thresholds };
     }
 
-    const [vixBars, idxBars] = await Promise.all([
-      this.fetchEodBars(vixSym).catch(() => [] as EodBar[]),
-      this.fetchEodBars(idxSym).catch(() => [] as EodBar[]),
-    ]);
+    const labels = { vix: region === 'EU' ? 'V2TX' : 'VIX', idx: region === 'EU' ? 'SX5E' : 'SPY' };
+
+    // Intraday US : on lit le VIX LIVE (real-time EODHD) au lieu du close EOD
+    // J-1. Sinon un spike intraday (ex 05/06 : VIX 15.40 → 21.51) n'est vu qu'au
+    // scan EOD de 21:15, après que l'intraday ait pu ouvrir en plein régime
+    // hostile. EODHD ne sert PAS le live des indices EU (V2TX/SX5E = "NA") →
+    // l'EU reste sur EOD. Tout échec live → fallback EOD (jamais de bypass).
+    const liveIntraday =
+      opts?.intraday === true &&
+      region === 'US' &&
+      (this.config.get<string>('OVERSOLD_REGIME_GATE_INTRADAY_LIVE') ?? 'true').toLowerCase() === 'true';
 
     let vix: number | null = null;
     let vixChg: number | null = null;
-    if (vixBars.length >= 2) {
+    let vixSource: 'live' | 'eod' = 'eod';
+
+    if (liveIntraday) {
+      const q = await this.fetchLiveIndexQuote(vixSym).catch(() => null);
+      if (q) {
+        vix = q.live;
+        vixChg = Number.isFinite(q.changePct) ? q.changePct : null;
+        vixSource = 'live';
+      }
+    }
+
+    // VIX EOD : seulement si le live n'a pas fourni (gate EOD, EU, ou échec live).
+    // SPY/SX5E 5j : TOUJOURS EOD (signal lent, drift intraday négligeable).
+    const needVixEod = vixSource === 'eod';
+    const [vixBars, idxBars] = await Promise.all([
+      needVixEod
+        ? this.fetchEodBars(vixSym).catch(() => [] as EodBar[])
+        : Promise.resolve([] as EodBar[]),
+      this.fetchEodBars(idxSym).catch(() => [] as EodBar[]),
+    ]);
+
+    if (needVixEod && vixBars.length >= 2) {
       vix = vixBars[vixBars.length - 1].close;
       const prev = vixBars[vixBars.length - 2].close;
       vixChg = prev > 0 ? (vix / prev - 1) * 100 : null;
@@ -666,27 +702,44 @@ export class OversoldScannerService {
       idx5d = fiveBack > 0 ? (last / fiveBack - 1) * 100 : null;
     }
 
-    const vixLabel = region === 'EU' ? 'V2TX' : 'VIX';
-    const idxLabel = region === 'EU' ? 'SX5E' : 'SPY';
+    const decision = decideRegimeBlock({ vix, vixChg, idx5d }, thresholds, labels);
+    return { ...decision, region, vix, vixChg, idx5d, vixSource, thresholds };
+  }
 
-    if (vix !== null && vix > vixMax) {
-      return { block: true, reason: `${vixLabel} ${vix.toFixed(2)} > ${vixMax}`, region, vix, vixChg, idx5d, thresholds };
-    }
-    if (vixChg !== null && vixChg > vixDeltaMax) {
+  /**
+   * Quote temps réel EODHD pour un indice/ETF (endpoint real-time).
+   * Retourne { live, prevClose, changePct } ou null si indispo ("NA") / échec.
+   *
+   * Utilisé par le gate régime INTRADAY US (VIX live). EODHD ne sert PAS le live
+   * des indices EU (V2TX/SX5E renvoient "NA" → Number("NA")=NaN → null), d'où le
+   * fallback EOD côté caller.
+   */
+  private async fetchLiveIndexQuote(
+    symbol: string,
+  ): Promise<{ live: number; prevClose: number; changePct: number } | null> {
+    const apiKey = this.config.get<string>('EODHD_API_KEY');
+    if (!apiKey) return null;
+    const url =
+      `https://eodhd.com/api/real-time/${encodeURIComponent(symbol)}` +
+      `?api_token=${apiKey}&fmt=json`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) return null;
+      const j = (await res.json()) as Record<string, unknown>;
+      const live = Number(j.close);
+      if (!Number.isFinite(live) || live <= 0) return null;
+      const prevClose = Number(j.previousClose);
+      const changePct = Number(j.change_p);
       return {
-        block: true,
-        reason: `Δ${vixLabel} 1d ${vixChg.toFixed(1)}% > +${vixDeltaMax}%`,
-        region,
-        vix,
-        vixChg,
-        idx5d,
-        thresholds,
+        live,
+        prevClose: Number.isFinite(prevClose) ? prevClose : NaN,
+        changePct: Number.isFinite(changePct) ? changePct : NaN,
       };
+    } finally {
+      clearTimeout(timer);
     }
-    if (idx5d !== null && idx5d < idx5dMin) {
-      return { block: true, reason: `${idxLabel} 5d ${idx5d.toFixed(2)}% < ${idx5dMin}%`, region, vix, vixChg, idx5d, thresholds };
-    }
-    return { block: false, reason: 'pass', region, vix, vixChg, idx5d, thresholds };
   }
 
   /**

--- a/apps/api/src/modules/lisa/services/oversold.helper.ts
+++ b/apps/api/src/modules/lisa/services/oversold.helper.ts
@@ -151,3 +151,55 @@ export function businessDaysSince(from: Date | string, to: Date | string): numbe
   }
   return count;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gate régime macro — décision PURE (extraite pour testabilité).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Seuils du gate régime (région-aware : VIX/SPY US ou V2TX/SX5E EU). */
+export interface RegimeThresholds {
+  vixMax: number; // ex 17 (US) / 22 (EU)
+  vixDeltaMax: number; // ex +10% — spike de volatilité 1 jour
+  idx5dMin: number; // ex -1% (US) / -1.5% (EU) — momentum index 5 jours
+}
+
+/** Indicateurs observés (null = indisponible → la condition est ignorée). */
+export interface RegimeInputs {
+  vix: number | null;
+  vixChg: number | null; // Δ 1 jour en %
+  idx5d: number | null; // perf index 5 jours en %
+}
+
+/**
+ * Décide si le régime macro BLOQUE le scan oversold.
+ *
+ * Block si AU MOINS UNE des 3 conditions est violée :
+ *   1. vix    > vixMax       (volatilité absolue trop haute)
+ *   2. vixChg > vixDeltaMax  (spike de vol 1 jour)
+ *   3. idx5d  < idx5dMin      (index en chute sur 5 jours)
+ *
+ * Un indicateur `null` (indispo) n'enclenche jamais un block — le gate ne mord
+ * que sur une donnée présente ET hostile (fail-open par indicateur). `labels`
+ * ne sert qu'à formater `reason` (VIX/SPY ou V2TX/SX5E).
+ *
+ * Logique identique à l'ancienne version inline du service (behavior-preserving),
+ * extraite ici pour être testable sans mock réseau.
+ */
+export function decideRegimeBlock(
+  inputs: RegimeInputs,
+  thresholds: RegimeThresholds,
+  labels: { vix: string; idx: string },
+): { block: boolean; reason: string } {
+  const { vix, vixChg, idx5d } = inputs;
+  const { vixMax, vixDeltaMax, idx5dMin } = thresholds;
+  if (vix !== null && vix > vixMax) {
+    return { block: true, reason: `${labels.vix} ${vix.toFixed(2)} > ${vixMax}` };
+  }
+  if (vixChg !== null && vixChg > vixDeltaMax) {
+    return { block: true, reason: `Δ${labels.vix} 1d ${vixChg.toFixed(1)}% > +${vixDeltaMax}%` };
+  }
+  if (idx5d !== null && idx5d < idx5dMin) {
+    return { block: true, reason: `${labels.idx} 5d ${idx5d.toFixed(2)}% < ${idx5dMin}%` };
+  }
+  return { block: false, reason: 'pass' };
+}

--- a/scripts/diag-us-oversold-entry-audit.ts
+++ b/scripts/diag-us-oversold-entry-audit.ts
@@ -1,0 +1,145 @@
+/**
+ * DIAGNOSTIC (non committé) — Audit entry_price vs close EODHD du jour d'entrée
+ * sur TOUTES les positions oversold US (a0000001).
+ *
+ * But : prouver qu'aucune position n'ouvre à un prix ABERRANT (hors range réel
+ * du marché ce jour-là, comme le craignait l'utilisateur).
+ *
+ * Méthode : pour chaque position, on compare entry_price à la fenêtre [low, high]
+ * des bars EOD EODHD autour du jour d'entrée (J-4..J+1, tolérance ±10%). Un prix
+ * dans cette fenêtre = sain (entrée au close EOD OU au prix intraday du jour).
+ * Un prix hors fenêtre (ex 10x) = aberrant → flag.
+ *
+ * Run : set -a; . .env; set +a; npx tsx scripts/diag-us-oversold-entry-audit.ts
+ */
+
+const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SRK = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const EODHD = process.env.EODHD_API_KEY!;
+const PF = 'a0000001-0000-0000-0000-000000000001';
+
+interface Pos {
+  symbol: string;
+  entry_price: number;
+  entry_timestamp: string;
+  status: string;
+  venue_fee_detail: { source?: string } | null;
+}
+interface Bar { date: string; open: number; high: number; low: number; close: number }
+
+async function sb(path: string): Promise<any> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    headers: { apikey: SRK, Authorization: `Bearer ${SRK}` },
+  });
+  if (!res.ok) throw new Error(`SB ${res.status} ${await res.text()}`);
+  return res.json();
+}
+
+function shiftDate(d: string, days: number): string {
+  const dt = new Date(d + 'T00:00:00Z');
+  dt.setUTCDate(dt.getUTCDate() + days);
+  return dt.toISOString().slice(0, 10);
+}
+
+async function main() {
+  const rows: Pos[] = await sb(
+    `lisa_positions?portfolio_id=eq.${PF}&select=symbol,entry_price,entry_timestamp,status,venue_fee_detail&order=entry_timestamp.asc`,
+  );
+  console.log(`Positions US oversold (a0000001) : ${rows.length}`);
+
+  const bySym = new Map<string, Pos[]>();
+  for (const r of rows) {
+    if (!bySym.has(r.symbol)) bySym.set(r.symbol, []);
+    bySym.get(r.symbol)!.push(r);
+  }
+  console.log(`Symboles distincts : ${bySym.size}`);
+
+  // Fetch EOD bars par symbole couvrant la plage des entrées (+ buffer).
+  const barsBySym = new Map<string, Map<string, Bar>>();
+  let eodErrors = 0;
+  for (const [sym, ps] of bySym) {
+    const dates = ps.map((p) => p.entry_timestamp.slice(0, 10)).sort();
+    const from = shiftDate(dates[0], -7);
+    const to = shiftDate(dates[dates.length - 1], 2);
+    const url = `https://eodhd.com/api/eod/${encodeURIComponent(sym)}?api_token=${EODHD}&fmt=json&from=${from}&to=${to}&order=d`;
+    try {
+      const res = await fetch(url);
+      const m = new Map<string, Bar>();
+      if (res.ok) {
+        const bars = await res.json();
+        if (Array.isArray(bars)) for (const b of bars) m.set(b.date, b);
+      } else {
+        eodErrors++;
+      }
+      barsBySym.set(sym, m);
+    } catch {
+      eodErrors++;
+      barsBySym.set(sym, new Map());
+    }
+  }
+
+  let matched = 0;
+  let noBar = 0;
+  const flagged: Array<Record<string, unknown>> = [];
+  const worst: Array<{ symbol: string; pct: number; entry: number; close: number; day: string }> = [];
+
+  for (const r of rows) {
+    const day = r.entry_timestamp.slice(0, 10);
+    const m = barsBySym.get(r.symbol)!;
+    let minLow = Infinity;
+    let maxHigh = -Infinity;
+    let refClose: number | null = null;
+    let used = 0;
+    for (let off = -4; off <= 1; off++) {
+      const b = m.get(shiftDate(day, off));
+      if (b) {
+        minLow = Math.min(minLow, b.low);
+        maxHigh = Math.max(maxHigh, b.high);
+        if (off === 0 || refClose === null) refClose = b.close;
+        used++;
+      }
+    }
+    if (used === 0) {
+      noBar++;
+      continue;
+    }
+    const e = r.entry_price;
+    const inRange = e >= minLow * 0.9 && e <= maxHigh * 1.1;
+    const pctVsClose = refClose && refClose > 0 ? (e / refClose - 1) * 100 : NaN;
+    if (Number.isFinite(pctVsClose)) {
+      worst.push({ symbol: r.symbol, pct: pctVsClose, entry: e, close: refClose!, day });
+    }
+    if (!inRange) {
+      flagged.push({
+        symbol: r.symbol,
+        status: r.status,
+        source: r.venue_fee_detail?.source ?? '?',
+        entry: e,
+        day,
+        winLow: Number(minLow.toFixed(2)),
+        winHigh: Number(maxHigh.toFixed(2)),
+        close: refClose,
+        pctVsClose: Number(pctVsClose.toFixed(1)),
+      });
+    } else {
+      matched++;
+    }
+  }
+
+  console.log(`\nErreurs fetch EODHD : ${eodErrors} symbole(s)`);
+  console.log(`✅ entry_price DANS le range réel du jour : ${matched}/${rows.length}`);
+  console.log(`⚪ sans bar EOD (skip, ex weekend/délisté) : ${noBar}`);
+  console.log(`🔴 ABERRANTS (hors range ±10%) : ${flagged.length}`);
+  for (const f of flagged) console.log('   ', JSON.stringify(f));
+
+  worst.sort((a, b) => Math.abs(b.pct) - Math.abs(a.pct));
+  console.log(`\nTop 8 écarts |entry vs close du jour| (sanity, pas forcément un bug) :`);
+  for (const w of worst.slice(0, 8)) {
+    console.log(`   ${w.symbol.padEnd(10)} ${w.day}  entry=${w.entry}  close=${w.close}  ${w.pct >= 0 ? '+' : ''}${w.pct.toFixed(2)}%`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## En langage simple

La stratégie **oversold US** achète des actions US qui viennent de beaucoup chuter, en pariant sur un rebond à ~10 jours. Un **garde-fou ("regime gate")** empêche d'acheter quand le marché est trop stressé — mesuré par le **VIX (indice de la peur)** et la tendance du **S&P 500**.

**Problème :** le système achète à 2 moments — des petits scans **pendant** la séance (intraday) + un gros scan **après clôture** (21:15 UTC). Or le garde-fou intraday lisait le VIX de **la veille**. Donc un jour où la peur explose en cours de séance (05/06 : VIX 15.40 → 21.51), les achats intraday ne « voyaient » pas le pic — ils utilisaient le chiffre calme de la veille — et pouvaient continuer à acheter en pleine tempête. Seul le scan de 21:15 attrapait le pic.

**Correctif :** le garde-fou intraday lit maintenant le **VIX en temps réel**. Si la peur monte en séance, le système **arrête d'acheter immédiatement** au lieu d'attendre 21:15.

**Résultat :** moins de positions ouvertes dans une tempête soudaine = moins d'entrées « nées dans le rouge » les jours volatils. Protection en temps réel.

## Détail technique

`checkRegimeGate(universe, { intraday })` : en **US + intraday + flag ON**, lit le VIX **live** via real-time EODHD (niveau + ΔVIX 1j en 1 call). 

- **EU inchangé** : EODHD ne sert pas le live des indices EU (`V2TX/SX5E` → `"NA"`) → EU reste sur EOD.
- **Scan EOD 21:15 inchangé** (le close est correct post-cloche). **SPY/SX5E 5j toujours EOD** (signal lent).
- **Fallback EOD** sur tout échec live → jamais de crash, jamais de gate bypassé.
- Décision extraite en helper pur `decideRegimeBlock(...)` (+ 8 tests unitaires).
- Traçabilité `vix_source: 'live' | 'eod'` dans le `decision_log`.

## Flag

`OVERSOLD_REGIME_GATE_INTRADAY_LIVE` — **défaut `true`** (s'active au déploiement). Revert sans redeploy : secret Fly `=false`.

## Vérification

- `tsc -b` ✅
- `jest oversold-scanner` ✅ **22/22** (dont 8 nouveaux : VIX 21.51, spike ΔVIX, null-safety, labels EU, bornes strictes).

## Inclus aussi

`scripts/diag-us-oversold-entry-audit.ts` — audit read-only (entry_price vs close EODHD) qui a prouvé 88/90 entrées dans le range, 0 prix aberrant.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_