### PR TITLE
fix(llm): pause définitive shadow A/B (−72% coût LLM) + rename portfolios

### DIFF
--- a/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
+++ b/apps/api/src/modules/lisa/services/live-trader-agent.service.ts
@@ -901,7 +901,12 @@ export class LiveTraderAgentService {
       // décisions dans gemini_ab_decisions pour analyse comparative ultérieure.
       // Best-effort : n'augmente pas la latence du cycle (fire-and-forget),
       // catch toutes les erreurs (n'altère jamais le comportement TRADER).
-      const abEnabled = (this.config.get<string>('GEMINI_AB_PRO_VS_FLASH_ENABLED') ?? 'true').toLowerCase() === 'true';
+      // 06/06 — PAUSE DÉFINITIVE du shadow A/B (default basculé 'true' → 'false').
+      // Le shadow lançait Gemini Flash + Mistral Medium + Mistral Large 3 à CHAQUE
+      // cycle (Mistral Large = 72% du coût LLM, ~$9.50/j) pour une comparaison
+      // jamais appliquée à un trade. Prod (Mistral Medium primary) inchangée.
+      // Réactivable explicitement via le secret GEMINI_AB_PRO_VS_FLASH_ENABLED=true.
+      const abEnabled = (this.config.get<string>('GEMINI_AB_PRO_VS_FLASH_ENABLED') ?? 'false').toLowerCase() === 'true';
       if (abEnabled) {
         void this.recordAbShadow({
           cycleStartedAt,

--- a/apps/api/src/modules/lisa/services/llm-ab-shadow.service.ts
+++ b/apps/api/src/modules/lisa/services/llm-ab-shadow.service.ts
@@ -98,7 +98,11 @@ export class LlmABShadowService {
     @Optional() private readonly mistralShadow?: MistralShadowService,
     @Optional() private readonly mistralLargeShadow?: MistralLargeShadowService,
   ) {
-    this.enabled = (this.config.get<string>('LLM_AB_SHADOW_ENABLED') ?? 'true').toLowerCase() === 'true';
+    // 06/06 — PAUSE DÉFINITIVE (default basculé 'true' → 'false'). Ce shadow
+    // faisait tourner Gemini Flash + Mistral Medium + Mistral Large sur les call
+    // sites cron (risk_monitor, scanner_postmortem, strategy_coach, daily_brief)
+    // pour comparaison jamais appliquée. Réactivable via LLM_AB_SHADOW_ENABLED=true.
+    this.enabled = (this.config.get<string>('LLM_AB_SHADOW_ENABLED') ?? 'false').toLowerCase() === 'true';
     if (!this.enabled) {
       this.logger.warn('[llm-ab-shadow] DISABLED (LLM_AB_SHADOW_ENABLED=false) — no shadow calls will fire');
     }

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -104,10 +104,6 @@ const RETIRED_SHADOW_IDS = new Set<string>([
   'a0000003-0000-0000-0000-000000000003', // SMALL
 ]);
 
-// HIGH recyclé en mode oversold (mean-reversion swing, $150k paper) — gardé
-// visible avec un libellé dédié dans le sélecteur.
-const HIGH_OVERSOLD_PORTFOLIO_ID = 'a0000001-0000-0000-0000-000000000001';
-
 export default function LisaPage() {
   const portfoliosQuery = usePortfolios();
   const qc = useQueryClient();
@@ -643,13 +639,13 @@ export default function LisaPage() {
               className="h-9 flex-1 min-w-[200px] rounded-md border bg-background px-3 text-sm"
             >
               {simulationPortfolios.map((p) => {
+                // Noms DB nettoyés (06/06) : "Trader Agent", "US Oversold
+                // (Russell 1000 mean-rev)", "EU Oversold (stoxx600 mean-rev)".
+                // Plus de suffixe modèle ("(Gemini Pro)") ni de redite oversold.
                 const isTrader = p.id === TRADER_PORTFOLIO_ID;
-                const isOversold = p.id === HIGH_OVERSOLD_PORTFOLIO_ID;
                 const label = isTrader
                   ? `🤖 ${p.name} (agent autonome LISA)`
-                  : isOversold
-                  ? `📉 ${p.name} (mean-reversion oversold)`
-                  : `🎯 ${p.name}`;
+                  : `📉 ${p.name}`;
                 return (
                   <option key={p.id} value={p.id}>{label}</option>
                 );
@@ -667,7 +663,7 @@ export default function LisaPage() {
               )}
           </div>
           <p className="text-[11px] text-muted-foreground">
-            TRADER = agent LLM autonome (Mistral primary, Gemini fallback) + scanner Gainers d&apos;observation. HIGH = mode Oversold (mean-reversion swing, $150k paper). Shadows MIDDLE/SMALL retirés (momentum sans edge, prouvé 3-fold).
+            TRADER = agent LLM autonome (Mistral primary, Gemini fallback) + scanner Gainers d&apos;observation. US / EU Oversold = mean-reversion swing (achat -5 à -12%, hold J+10). Shadows MIDDLE/SMALL retirés (momentum sans edge, prouvé 3-fold).
           </p>
         </div>
       )}


### PR DESCRIPTION
## Contexte

Le panneau "Coût LLM temps réel" affichait 171 calls pour **les 4 modèles** (Gemini Pro/Flash, Mistral Medium, Mistral Large 3) → confusion. **Audit DB** : ce n'est PAS le routing prod, c'est un **shadow A/B** qui faisait tourner les 4 modèles à chaque cycle pour comparaison.

- **Prod (appliqué) = Mistral Medium** (176/177 cycles). Gemini = fallback (1/177). ✅
- **Mistral Large 3 = 72% du coût LLM (~$9.50/j)** — un **shadow jamais appliqué** à un trade.

## Décision utilisateur : pause définitive du shadow A/B

On arrête de consommer des calls de comparaison (Gemini + Mistral Large). **Aucun impact sur les décisions de trading** (la prod Mistral Medium est hors de ces switches).

- `GEMINI_AB_PRO_VS_FLASH_ENABLED` default `'true'` → `'false'` (shadow TRADER `recordAbShadow` off)
- `LLM_AB_SHADOW_ENABLED` default `'true'` → `'false'` (shadow des call-sites cron : risk_monitor, scanner_postmortem, strategy_coach, daily_brief)

⚡ **Arrêt instantané = secrets Fly** `GEMINI_AB_PRO_VS_FLASH_ENABLED=false` + `LLM_AB_SHADOW_ENABLED=false` (un secret prime sur le default code). Ce PR fige le default OFF de façon permanente.

## Rename sélecteur portfolios (UI)

Le `(Gemini Pro)` venait du **nom DB** du portfolio. Renommages DB appliqués (hors-code, immédiat) :
- `b0000001` : "Trader Agent (Gemini Pro)" → **"Trader Agent"**
- `a0000001` : "Shadow High Sizing" → **"US Oversold (Russell 1000 mean-rev)"** (cohérent avec "EU Oversold (stoxx600 mean-rev)")

UI `page.tsx` : labels propres et cohérents → `🤖 Trader Agent (agent autonome LISA)` / `📉 US Oversold …` / `📉 EU Oversold …` (retrait du suffixe modèle + redite oversold).

## Vérif
- `tsc -b` ✅

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_