### PR TITLE
feat(llm): tier rapide cheap — Mistral Small pour les tâches simples

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -55,6 +55,7 @@ import { ShadowSizingOrchestratorService } from './services/shadow-sizing-orches
 import { LiveTraderAgentService } from './services/live-trader-agent.service';
 import { MistralShadowService } from './services/mistral-shadow.service';
 import { MistralLargeShadowService } from './services/mistral-large-shadow.service';
+import { MistralSmallService } from './services/mistral-small.service';
 import { LlmABShadowService } from './services/llm-ab-shadow.service';
 import { LlmAccuracyService } from './services/llm-accuracy.service';
 import { MainScannerPostMortemService } from './services/main-scanner-postmortem.service';
@@ -229,8 +230,11 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     // concordance avant migration éventuelle TRADER vers Mistral Large 3 (74%
     // moins cher que Gemini Pro). Activation MISTRAL_API_KEY + MISTRAL_SHADOW_ENABLED.
     MistralShadowService,
-    // PR #521 — 2e instance dédiée Mistral Large 3 (cheap tier) pour 4-way A/B
+    // PR #521 — 2e instance dédiée Mistral Large 3 (FLAGSHIP $2/$6, PAS cheap) pour 4-way A/B
     MistralLargeShadowService,
+    // 06/06 — Mistral Small (tier rapide cheap ~$0.10/$0.30, 20.83 RPS) pour le
+    // tier simple/fréquent quand LLM_FAST_PROVIDER=mistral-small.
+    MistralSmallService,
     // PR #523 — LlmABShadowService générique pour 4 call sites peripheriques
     // (scanner_postmortem, strategy_coach, daily_brief, risk_monitor)
     LlmABShadowService,

--- a/apps/api/src/modules/lisa/services/mistral-small.service.ts
+++ b/apps/api/src/modules/lisa/services/mistral-small.service.ts
@@ -1,39 +1,30 @@
 /**
- * MistralLargeShadowService — 2e adapter Mistral dédié au tier "Large 3"
- * (FLAGSHIP — le modèle Mistral le PLUS cher et le plus capable, PAS un cheap
- * tier malgré l'ancien libellé erroné corrigé le 06/06).
+ * MistralSmallService — adapter Mistral "Small" dédié au TIER RAPIDE (tâches
+ * simples & fréquentes : scanner signal gate, risk_monitor scoring, daily brief,
+ * retrospective…).
  *
- * Complémente MistralShadowService (Medium = mid-tier) en ajoutant un shadow sur
- * le flagship Mistral pour comparer simultanément :
- *   - Pro (decision réelle appliquée)
- *   - Flash (shadow Gemini cheap tier)
- *   - Medium (shadow Mistral mid-tier)
- *   - Large 3 (shadow Mistral FLAGSHIP, ce service)
+ * Rationale (06/06/2026) : ne PLUS payer du Mistral Medium ($0.40/$2.00 par MTok,
+ * throttlé 0.42 RPS) sur des tâches simples à fort volume. Mistral Small 2506 =
+ * ~$0.10/$0.30 par MTok ET 20.83 RPS / 5M TPM → cheap ET sans goulot. Le tier
+ * RAISONNEMENT (callWithPro : décisions trader, post-mortem, lessons, coach) reste
+ * sur Mistral Medium — seul le tier rapide bascule ici.
  *
- * Pourquoi un service séparé plutôt qu'instance multiple de MistralShadowService :
- * NestJS DI inject la même instance partout par défaut. Pour avoir 2 instances
- * Mistral avec configs différentes (Medium vs Large), le plus clean est 2 classes
- * dédiées qui partagent le même fetch logic mais hardcodent leur model.
- *
- * Pricing officiel (recalibré 03/06/2026, mistral.ai/pricing) :
- *   - Mistral Large : $2.00 / MTok input, $6.00 / MTok output (≈ 7× Mistral Medium)
- *
- * Activation :
- *   - MISTRAL_API_KEY (partagé avec MistralShadowService)
- *   - MISTRAL_LARGE_SHADOW_ENABLED=true (flag dédié, default false)
+ * Activé par ScannerLlmRouterService.call() quand LLM_FAST_PROVIDER=mistral-small.
+ * Modèle override via MISTRAL_SMALL_MODEL. Partage MISTRAL_API_KEY + MISTRAL_FREE_TIER
+ * avec les autres adapters Mistral (Medium/Large).
  */
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 const MISTRAL_API_URL = 'https://api.mistral.ai/v1/chat/completions';
-const MODEL_LARGE_LATEST = 'mistral-large-latest';
-// Recalibré 03/06/2026 (mistral.ai/pricing) — mistral-large-2.x facturé
-// $2.00/$6.00 par MTok (anciennes valeurs 0.50/1.50 sous-estimaient × 4).
-const PRICE_INPUT_PER_M = 2.00;
-const PRICE_OUTPUT_PER_M = 6.00;
-const PRICE_CACHED_PER_M = 0.50; // ~25% du fresh input
+const MODEL_SMALL_DEFAULT = 'mistral-small-2506';
+// Pricing officiel Mistral Small (mistral.ai/pricing, ~2026). Sert au TRACKING
+// du coût, pas à la facturation — ajuster si le tarif dérive durablement.
+const PRICE_INPUT_PER_M = 0.1;
+const PRICE_OUTPUT_PER_M = 0.3;
+const PRICE_CACHED_PER_M = 0.025; // ~25% du fresh input
 
-export interface MistralLargeShadowResult {
+export interface MistralSmallResult {
   content: string | null;
   inputTokens: number;
   outputTokens: number;
@@ -45,25 +36,22 @@ export interface MistralLargeShadowResult {
 }
 
 @Injectable()
-export class MistralLargeShadowService {
-  private readonly logger = new Logger(MistralLargeShadowService.name);
+export class MistralSmallService {
+  private readonly logger = new Logger(MistralSmallService.name);
   private readonly apiKey: string | undefined;
-  private readonly enabled: boolean;
+  private readonly model: string;
   private readonly freeTier: boolean;
 
   constructor(private readonly config: ConfigService) {
     this.apiKey = this.config.get<string>('MISTRAL_API_KEY');
-    this.enabled = (this.config.get<string>('MISTRAL_LARGE_SHADOW_ENABLED') ?? 'false').toLowerCase() === 'true';
+    this.model = this.config.get<string>('MISTRAL_SMALL_MODEL') ?? MODEL_SMALL_DEFAULT;
     this.freeTier = (this.config.get<string>('MISTRAL_FREE_TIER') ?? 'true').toLowerCase() === 'true';
-    if (this.enabled && !this.apiKey) {
-      this.logger.warn('[mistral-large-shadow] ENABLED=true mais MISTRAL_API_KEY absent → service inerte');
-    } else if (this.enabled) {
-      this.logger.log(`[mistral-large-shadow] ENABLED — model=${MODEL_LARGE_LATEST} freeTier=${this.freeTier}`);
-    }
   }
 
+  /** Configuré dès que la clé Mistral partagée est présente. L'activation runtime
+   *  est gouvernée par LLM_FAST_PROVIDER=mistral-small côté router. */
   isConfigured(): boolean {
-    return this.enabled && !!this.apiKey;
+    return !!this.apiKey;
   }
 
   async call(params: {
@@ -72,16 +60,16 @@ export class MistralLargeShadowService {
     temperature?: number;
     maxTokens?: number;
     timeoutMs?: number;
-  }): Promise<MistralLargeShadowResult> {
+  }): Promise<MistralSmallResult> {
     const t0 = Date.now();
-    const result: MistralLargeShadowResult = {
+    const result: MistralSmallResult = {
       content: null,
       inputTokens: 0,
       outputTokens: 0,
       costUsd: 0,
       latencyMs: 0,
-      providerId: 'mistral-large',
-      model: MODEL_LARGE_LATEST,
+      providerId: 'mistral-small',
+      model: this.model,
       error: null,
     };
 
@@ -99,7 +87,7 @@ export class MistralLargeShadowService {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          model: MODEL_LARGE_LATEST,
+          model: this.model,
           messages: [
             { role: 'system', content: params.system },
             { role: 'user', content: params.user },
@@ -132,8 +120,6 @@ export class MistralLargeShadowService {
       result.outputTokens = data.usage?.completion_tokens ?? 0;
       const cachedTokens = data.usage?.prompt_tokens_details?.cached_tokens ?? 0;
       const freshInputTokens = Math.max(0, result.inputTokens - cachedTokens);
-      // En free tier (default), coût réel = 0 (Experiment plan Mistral 1B tok/mois).
-      // Cf. mistral-shadow.service.ts pour la rationale et MISTRAL_FREE_TIER env.
       if (this.freeTier) {
         result.costUsd = 0;
       } else {

--- a/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
+++ b/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
@@ -26,6 +26,7 @@ import {
 } from '@smartvest/ai-analyst';
 import { GeminiBudgetGuardService } from './gemini-budget-guard.service';
 import { MistralShadowService } from './mistral-shadow.service';
+import { MistralSmallService } from './mistral-small.service';
 
 @Injectable()
 export class ScannerLlmRouterService {
@@ -43,6 +44,13 @@ export class ScannerLlmRouterService {
    * Si Mistral fail (rate limit, API down), fallback automatique vers Gemini Pro.
    */
   private readonly primaryProvider: string;
+  /**
+   * 06/06 — Tier RAPIDE switchable. LLM_FAST_PROVIDER='mistral-small' route les
+   * tâches simples (call()) vers Mistral Small 2506 (cheap + 20.83 RPS) au lieu
+   * de Mistral Medium. Le tier RAISONNEMENT (callWithPro) reste sur Medium.
+   * Vide/unset → comportement historique (call() suit primaryProvider).
+   */
+  private readonly fastProvider: string;
 
   constructor(
     private readonly config: ConfigService,
@@ -51,11 +59,16 @@ export class ScannerLlmRouterService {
     // injecté.
     @Optional() @Inject(GeminiBudgetGuardService) private readonly budgetGuard?: GeminiBudgetGuardService,
     @Optional() private readonly mistralShadow?: MistralShadowService,
+    @Optional() private readonly mistralSmall?: MistralSmallService,
   ) {
     this.enabled = (this.config.get<string>('SCANNER_LLM_ROUTER_ENABLED') ?? 'false').toLowerCase() === 'true';
     this.primaryProvider = (this.config.get<string>('LLM_PRIMARY_PROVIDER') ?? 'gemini-pro').toLowerCase();
     if (this.primaryProvider === 'mistral-medium') {
       this.logger.log('[scanner-llm] LLM_PRIMARY_PROVIDER=mistral-medium → Mistral Medium 3.5 décideur principal, Gemini Pro en fallback automatique');
+    }
+    this.fastProvider = (this.config.get<string>('LLM_FAST_PROVIDER') ?? '').toLowerCase();
+    if (this.fastProvider === 'mistral-small') {
+      this.logger.log('[scanner-llm] LLM_FAST_PROVIDER=mistral-small → tier rapide (call) sur Mistral Small, fallback Medium/Gemini');
     }
 
     if (!this.enabled) {
@@ -133,6 +146,37 @@ export class ScannerLlmRouterService {
    * post-mortem, Strategy Coach) passe par Mistral en primary quand activé.
    */
   async call(params: LlmCallParams): Promise<{ content: string; providerId: string; costUsd: number; latencyMs: number; fallbackUsed: boolean }> {
+    // Tier RAPIDE cheap : Mistral Small 2506 en tête (06/06). Tâches simples &
+    // fréquentes (scanner gate, risk_monitor, daily brief). Si fail (empty,
+    // timeout, 429), on retombe sur le chemin existant (Mistral Medium si primary,
+    // sinon Gemini Flash-Lite) → jamais de tâche skipée.
+    if (this.fastProvider === 'mistral-small' && this.mistralSmall?.isConfigured()) {
+      try {
+        const res = await this.mistralSmall.call({
+          system: params.system,
+          user: params.user,
+          temperature: params.temperature ?? 0.3,
+          maxTokens: params.maxTokens ?? 1500,
+          timeoutMs: params.timeoutMs ?? 30_000,
+        });
+        if (!res.content) {
+          throw new Error(`Mistral Small returned empty content (error=${res.error ?? 'unknown'})`);
+        }
+        return {
+          content: res.content,
+          providerId: res.providerId,
+          costUsd: res.costUsd,
+          latencyMs: res.latencyMs,
+          fallbackUsed: false,
+        };
+      } catch (e) {
+        this.logger.debug(
+          `[scanner-llm] Mistral Small (fast) failed → fallback. err=${String(e).slice(0, 150)}`,
+        );
+        // tombe sur le chemin existant ci-dessous
+      }
+    }
+
     // Mistral primary path (gated par env)
     if (this.primaryProvider === 'mistral-medium' && this.mistralShadow) {
       try {


### PR DESCRIPTION
## Objectif

Tu voulais **garder Mistral Medium pour le complexe** et un **modèle cheap pour le simple/fréquent**. L'audit a montré que l'archi sépare déjà les 2 tiers (`call()` rapide vs `callWithPro()` raisonnement), **mais** comme `LLM_PRIMARY_PROVIDER=mistral-medium`, les **deux** routaient vers Mistral Medium ($0.40/$2.00, throttlé **0.42 RPS**). Donc les tâches simples surpayaient.

## Ce que fait ce PR

Découple le **tier rapide** du **tier raisonnement** :

| Tier | Tâches | Modèle après ce PR |
|---|---|---|
| 🧠 Raisonnement (`callWithPro`) | TRADER décisions, post-mortem, lessons, coach | **Mistral Medium** (inchangé) |
| ⚡ Simple (`call`) | scanner gate, risk_monitor /5min, daily brief, retrospective | **Mistral Small 2506** (si activé) |

- **Nouvel adapter `MistralSmallService`** : `mistral-small-2506`, **~$0.10/$0.30 par MTok** (≈4× moins cher que Medium) et **20.83 RPS / 5M TPM** (vs Medium 0.42 RPS) → cheap **ET** sans goulot pour le volume.
- `ScannerLlmRouterService.call()` : Mistral Small en tête, **fallback robuste** → Mistral Medium (si primary) → Gemini Flash-Lite. **Jamais de tâche skipée.**
- `callWithPro()` **inchangé** (Mistral Medium reste le décideur des raisonnements).
- **Fix d'un commentaire trompeur** : Mistral Large 3 = **FLAGSHIP $2/$6** (~7× Medium), PAS « cheap tier » — c'est ce libellé erroné qui avait semé la confusion.

## Activation (flag-gated, default OFF)

Default `LLM_FAST_PROVIDER` unset → **comportement historique préservé** (rien ne change tant que tu n'actives pas). Pour passer le tier simple sur Mistral Small :

```
LLM_FAST_PROVIDER = mistral-small        (Fly secret)
```
Override modèle possible via `MISTRAL_SMALL_MODEL`.

⚠️ **Note** : le tier simple inclut le **scanner signal gate** (qui influence les entrées). Reco : activer puis surveiller 24h les décisions du gate avant de considérer ça acquis. Revert = retirer le secret.

## Vérif
- `tsc -b` ✅

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_