### PR TITLE
fix(eodhd): skip live-price EODHD quand le marché equity est fermé (−6k/h weekend)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/market-session.helper.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/market-session.helper.spec.ts
@@ -1,0 +1,48 @@
+import { isMarketOpen, sessionClassForSymbol } from '../market-session.helper';
+
+describe('isMarketOpen', () => {
+  it('fermé le weekend (sam/dim) quelle que soit l’heure', () => {
+    expect(isMarketOpen('us', new Date('2026-06-06T15:00:00Z'))).toBe(false); // samedi
+    expect(isMarketOpen('eu', new Date('2026-06-07T10:00:00Z'))).toBe(false); // dimanche
+    expect(isMarketOpen('asia', new Date('2026-06-06T03:00:00Z'))).toBe(false);
+  });
+
+  it('ouvert en séance un jour de semaine', () => {
+    expect(isMarketOpen('us', new Date('2026-06-05T15:00:00Z'))).toBe(true); // vendredi 15:00 UTC
+    expect(isMarketOpen('eu', new Date('2026-06-05T10:00:00Z'))).toBe(true);
+    expect(isMarketOpen('asia', new Date('2026-06-05T03:00:00Z'))).toBe(true);
+  });
+
+  it('fermé hors séance en semaine', () => {
+    expect(isMarketOpen('us', new Date('2026-06-05T22:00:00Z'))).toBe(false); // après cloche US
+    expect(isMarketOpen('eu', new Date('2026-06-05T18:00:00Z'))).toBe(false);
+    expect(isMarketOpen('asia', new Date('2026-06-05T09:00:00Z'))).toBe(false);
+  });
+
+  it('bornes : ouverture incluse, clôture exclue', () => {
+    expect(isMarketOpen('eu', new Date('2026-06-05T07:00:00Z'))).toBe(true); // open inclus
+    expect(isMarketOpen('eu', new Date('2026-06-05T16:30:00Z'))).toBe(false); // close exclu
+  });
+});
+
+describe('sessionClassForSymbol', () => {
+  it('mappe les suffixes equity vers leur session', () => {
+    expect(sessionClassForSymbol('AAL.LSE')).toBe('eu');
+    expect(sessionClassForSymbol('ADYEN.AS')).toBe('eu');
+    expect(sessionClassForSymbol('IFX.XETRA')).toBe('eu');
+    expect(sessionClassForSymbol('GNFT.PA')).toBe('eu');
+    expect(sessionClassForSymbol('AAPL.US')).toBe('us');
+    expect(sessionClassForSymbol('358570.KQ')).toBe('asia');
+    expect(sessionClassForSymbol('0700.HK')).toBe('asia');
+    expect(sessionClassForSymbol('005930.KO')).toBe('asia');
+  });
+
+  it('null (fail-open) pour crypto / forex / indices / inconnu', () => {
+    expect(sessionClassForSymbol('BTCUSDT')).toBeNull(); // paire Binance sans suffixe
+    expect(sessionClassForSymbol('BTC-USD.CC')).toBeNull();
+    expect(sessionClassForSymbol('EURUSD.FOREX')).toBeNull();
+    expect(sessionClassForSymbol('VIX.INDX')).toBeNull();
+    expect(sessionClassForSymbol('BRENT.COMM')).toBeNull();
+    expect(sessionClassForSymbol('FOO.ZZZ')).toBeNull(); // suffixe inconnu
+  });
+});

--- a/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa-autopilot.service.ts
@@ -7,6 +7,7 @@ import { PerformanceService } from '../../performance/performance.service';
 import { LisaService } from './lisa.service';
 import { DecisionLogService } from './decision-log.service';
 import { RealtimePriceService } from './realtime-price.service';
+import { isMarketOpen, sessionClassForSymbol } from './market-session.helper';
 import { MaterialChangeDetectorService } from './material-change-detector.service';
 import { DailyProfitGovernor } from './daily-profit-governor.service';
 import { LisaReplayConnectorService } from '../../bot-lab/services/lisa-replay-connector.service';
@@ -889,7 +890,16 @@ export class LisaAutopilotService implements OnApplicationBootstrap {
     //    refetch pas si un ticker a déjà un prix de <30s).
     // Serrer à 15s (avec cron à 30s → refresh chaque tick = max age 30s)
     const STALE_MS = 15_000;
+    // 06/06 — skip les equities dont le marché est FERMÉ : leur quote EOD est
+    // gelée → re-fetch EODHD inutile (cf. fix LIVE_PRICE_SKIP_CLOSED_MARKET côté
+    // fetchLivePriceInner). Crypto déjà géré via WS plus haut. Suffixe inconnu
+    // (forex, indices…) → sessionClassForSymbol=null → non gaté (fail-open).
+    const skipClosed = (this.config.get<string>('LIVE_PRICE_SKIP_CLOSED_MARKET') ?? 'true').toLowerCase() === 'true';
     const toRefresh = Array.from(otherSymbols).filter((s) => {
+      if (skipClosed) {
+        const sess = sessionClassForSymbol(s);
+        if (sess && !isMarketOpen(sess)) return false;
+      }
       const cached = this.realtimePrice.getCached(s);
       if (!cached) return true;
       return (Date.now() - new Date(cached.asOf).getTime()) > STALE_MS;

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -27,6 +27,7 @@ import { BinanceAdapter } from '@smartvest/brokers';
 import { SupabaseService } from '../../supabase/supabase.service';
 import { DecisionLogService } from './decision-log.service';
 import { RealtimePriceService } from './realtime-price.service';
+import { isMarketOpen, sessionClassForSymbol } from './market-session.helper';
 import { EodhdEnrichmentService } from './eodhd-enrichment.service';
 import { EodhdCalendarService } from './eodhd-calendar.service';
 import { NewsRankerService } from './news-ranker.service';
@@ -3766,6 +3767,36 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       // Si symbole inconnu de la table fallback : marqué 'fallback_unknown'
       // → garde-fou consumer DOIT skipper toute action destructive.
       return { symbol, price: fb ?? '0', asOf: now, source: fb ? 'fallback_quota_cap' : 'fallback_unknown' };
+    }
+
+    // 06/06 — Skip EODHD real-time si le marché EQUITY est FERMÉ. La quote serait
+    // l'EOD close gelé (~15h stale) ; la re-tirer en boucle = gaspillage pur
+    // (constaté : ~6k calls EODHD/h le weekend sur des positions equity figées).
+    // On renvoie le dernier prix connu (cache même périmé via snapshot(), sinon
+    // fallback statique) marqué '*_market_closed' → stale → les garde-fous stop/TP
+    // ne déclenchent pas sur un prix figé (correct : marché fermé = 0 mouvement).
+    // Crypto (24/7), forex, indices et marchés OUVERTS : sessionClassForSymbol=null
+    // ou isMarketOpen=true → inchangés. Réversible via LIVE_PRICE_SKIP_CLOSED_MARKET.
+    if ((this.config.get<string>('LIVE_PRICE_SKIP_CLOSED_MARKET') ?? 'true').toLowerCase() === 'true') {
+      const sess = sessionClassForSymbol(symbol);
+      if (sess && !isMarketOpen(sess, new Date())) {
+        const anyCached = this.realtimePrice
+          .snapshot()
+          .find((s) => s.symbol.toUpperCase() === symbol.toUpperCase());
+        if (anyCached) {
+          return {
+            symbol,
+            price: anyCached.price,
+            asOf: new Date(Date.now() - anyCached.ageMs).toISOString(),
+            source: `${anyCached.source}_market_closed`,
+          };
+        }
+        const fbClosed = this.getFallbackPrice(symbol);
+        if (fbClosed) {
+          return { symbol, price: fbClosed, asOf: now, source: 'fallback_market_closed' };
+        }
+        // Ni cache ni fallback → on laisse la cascade EODHD seeder 1× (rare).
+      }
     }
 
     // 1. Try EODHD real-time endpoint

--- a/apps/api/src/modules/lisa/services/market-session.helper.ts
+++ b/apps/api/src/modules/lisa/services/market-session.helper.ts
@@ -1,0 +1,54 @@
+/**
+ * Helpers de session de marché (horaires UTC US/EU/Asia) — PURS, testables.
+ *
+ * Extraits pour le live-price / price-warmer : on skip l'appel EODHD real-time
+ * quand le marché EQUITY est fermé (la quote serait l'EOD close gelé ; la
+ * re-tirer en boucle = gaspillage de quota — constaté weekend 06/06 ~6k calls/h
+ * sur 9 positions equity figées). Le scanner gainers garde sa propre copie
+ * locale (non touché ici pour limiter le blast radius ; même logique).
+ */
+export type MarketSessionClass = 'us' | 'eu' | 'asia';
+
+// Fenêtres LARGES (couvrent été ET hiver) pour ne JAMAIS skip un marché ouvert.
+export const MARKET_SESSION_HOURS: Record<MarketSessionClass, { openUtcMin: number; closeUtcMin: number }> = {
+  us: { openUtcMin: 13 * 60 + 30, closeUtcMin: 21 * 60 }, // 13:30-21:00 UTC (EDT+EST)
+  eu: { openUtcMin: 7 * 60, closeUtcMin: 16 * 60 + 30 }, // 07:00-16:30 UTC
+  asia: { openUtcMin: 0, closeUtcMin: 8 * 60 }, // 00:00-08:00 UTC
+};
+
+/** Marché ouvert maintenant (UTC), Lun-Ven uniquement. Crypto 24/7 → géré ailleurs. */
+export function isMarketOpen(cls: MarketSessionClass, now: Date = new Date()): boolean {
+  const day = now.getUTCDay(); // 0=dim, 6=sam
+  if (day === 0 || day === 6) return false;
+  const min = now.getUTCHours() * 60 + now.getUTCMinutes();
+  const { openUtcMin, closeUtcMin } = MARKET_SESSION_HOURS[cls];
+  return min >= openUtcMin && min < closeUtcMin;
+}
+
+const US_SUFFIXES = new Set(['US']);
+const EU_SUFFIXES = new Set([
+  'LSE', 'L', 'PA', 'AS', 'XETRA', 'DE', 'F', 'BR', 'MI', 'MC', 'SW', 'ST',
+  'HE', 'OL', 'CO', 'LS', 'VI', 'IR', 'MA', 'AT', 'WA',
+]);
+const ASIA_SUFFIXES = new Set([
+  'T', 'HK', 'KO', 'KQ', 'SHG', 'SHE', 'AU', 'TW', 'SI', 'KS', 'NS', 'BO', 'JK', 'BK',
+]);
+
+/**
+ * Mappe un SYMBOLE (par son suffixe) vers sa session de marché.
+ * null pour : crypto (BTCUSDT sans suffixe, *.CC), forex (*.FOREX), indices
+ * (*.INDX), commodities (*.COMM) ET tout suffixe inconnu.
+ *
+ * FAIL-OPEN volontaire : on ne "ferme" (skip EODHD) que ce qu'on classe avec
+ * certitude comme equity US/EU/Asia. Suffixe non listé → null → JAMAIS gaté
+ * (on préfère un appel EODHD de trop qu'un prix manquant sur une position).
+ */
+export function sessionClassForSymbol(symbol: string): MarketSessionClass | null {
+  const dot = symbol.lastIndexOf('.');
+  if (dot < 0) return null; // ex BTCUSDT (paire Binance) → null
+  const suf = symbol.slice(dot + 1).toUpperCase();
+  if (US_SUFFIXES.has(suf)) return 'us';
+  if (EU_SUFFIXES.has(suf)) return 'eu';
+  if (ASIA_SUFFIXES.has(suf)) return 'asia';
+  return null;
+}


### PR DESCRIPTION
## Root cause (diagnostiqué sur logs Fly + code)

`fetchLivePriceInner` (`lisa.service.ts`) appelle EODHD real-time pour un equity dès que le cache est jugé périmé. **Marché fermé** → la quote EOD renvoyée a un `asOf` de ~15h → jugée périmée **en boucle** → chaque appelant (**price warmer toutes les 30s** + risk monitor + mécanique) re-fetch un prix **gelé** qui ne peut pas bouger.

**Constaté samedi 06/06** : ~**6 000 calls EODHD/h** sur 9 positions equity figées (`44k/100k` un jour où **aucune action n'est tradeable**). Les logs montraient en boucle :
```
[live-price] AAL.LSE STALE quote tagged (source=eodhd → stale_eodhd, age=56881s, threshold=3600s)
[LisaAutopilotService] Price warmer: refreshed 9 non-crypto symbols
```

## Fix (flag `LIVE_PRICE_SKIP_CLOSED_MARKET`, default `true`)

1. **`market-session.helper.ts`** (extrait, testé) : `isMarketOpen` + `sessionClassForSymbol` (par suffixe). **Fail-open** : suffixe inconnu / crypto / forex / indices → `null` → **jamais gaté**.
2. **`fetchLivePriceInner`** : si le marché equity est fermé → renvoie le **dernier prix connu** (`snapshot()` même périmé, sinon fallback statique) marqué `*_market_closed`, **sans appeler EODHD**. Même mécanique que le garde-fou quota déjà présent.
3. **Price warmer** : skip les equities dont le marché est fermé (crypto déjà via WS Binance).

## Sécurité (point clé — touche le chemin live-price des stops)

- **Stops / TP tournent H24** sur le prix gelé → **0 déclenchement parasite** (marché fermé = 0 mouvement réel ; quand le marché rouvre, prix frais → stops réactifs).
- **Crypto 24/7 inchangé** (`sessionClassForSymbol`=null → Binance WS continue).
- **Marchés ouverts inchangés** (`isMarketOpen`=true → cascade EODHD normale).
- Réversible : `LIVE_PRICE_SKIP_CLOSED_MARKET=false`.

**Effet attendu : conso EODHD weekend/hors-séance → ~0** (au lieu de 6k/h), sans toucher au crypto ni à la protection des positions.

## Vérif
- `tsc -b` ✅
- `jest market-session` ✅ **6/6** (weekend fermé, séance ouverte, bornes, mapping suffixes, fail-open crypto/forex).

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_