### PR TITLE
fix(eodhd): skip la jambe EODHD du dual-call intraday quand le marché est fermé

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
@@ -25,7 +25,11 @@ jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
 jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
 
 function makeConfig(env: Record<string, string>): ConfigService {
-  return { get: jest.fn((k: string) => env[k]) } as unknown as ConfigService;
+  // 06/06 — skip EODHD-when-closed OFF par défaut dans les tests : les cas
+  // dual-call assument EODHD appelé, on ne veut pas dépendre de l'heure réelle
+  // (weekend → marchés fermés). Un test peut l'override en passant la clé.
+  const merged: Record<string, string> = { INTRADAY_SKIP_EODHD_WHEN_CLOSED: 'false', ...env };
+  return { get: jest.fn((k: string) => merged[k]) } as unknown as ConfigService;
 }
 
 function makeEodhdMock(opts?: {

--- a/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
+++ b/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { TwelveDataService } from './twelve-data.service';
 import { EodhdIntradayService, type CandleSeries } from './eodhd-intraday.service';
+import { isMarketOpen, sessionClassForSymbol } from './market-session.helper';
 import { TickerBlacklistService } from './ticker-blacklist.service';
 import { eodhdToTdSymbol, eodhdToCboeEuropeSymbol, isIntradayEodOnly } from './td-symbol-mapper';
 import { SupabaseService } from '../../supabase/supabase.service';
@@ -223,13 +224,33 @@ export class IntradayProviderRouter implements OnModuleInit {
    * Quote temps réel. Caller passe un ticker EODHD-style (ex `AAPL.US`,
    * `005930.KO`). Dual-call EODHD+TD si éligible.
    */
+  /**
+   * 06/06 — Skip la jambe EODHD du dual-call quand le marché equity est FERMÉ.
+   * EODHD intraday échoue systématiquement marché fermé (constaté 229/229 dans
+   * eodhd_request_log) mais compte dans le quota (~6k calls EODHD/h gaspillés le
+   * weekend). On ne skip QUE si TD peut servir (tdEligible) → jamais de perte de
+   * source. Marché ouvert / crypto / forex / TD inéligible → dual-call inchangé
+   * (contrainte "ZERO offload" préservée en séance). Réversible via
+   * INTRADAY_SKIP_EODHD_WHEN_CLOSED=false.
+   */
+  private shouldSkipEodhdClosed(eodhdTicker: string, tdEligible: boolean): boolean {
+    if ((this.config.get<string>('INTRADAY_SKIP_EODHD_WHEN_CLOSED') ?? 'true').toLowerCase() !== 'true') {
+      return false;
+    }
+    if (!tdEligible) return false;
+    const sess = sessionClassForSymbol(eodhdTicker);
+    return sess !== null && !isMarketOpen(sess);
+  }
+
   async getQuote(eodhdTicker: string, calledBy = 'intraday_router'): Promise<IntradayQuote | null> {
     this.logFirstCallOnce('quote', eodhdTicker, calledBy);
     const tdSkipReason = this.computeTdSkipReason(eodhdTicker, false);
     const tdSymbol = tdSkipReason === null ? this.convertToTdSymbol(eodhdTicker) : null;
     const tdEligible = tdSymbol !== null && this.td !== null;
 
-    const eodhdPromise = this.eodhd.getQuote(eodhdTicker);
+    const eodhdPromise = this.shouldSkipEodhdClosed(eodhdTicker, tdEligible)
+      ? Promise.resolve(null)
+      : this.eodhd.getQuote(eodhdTicker);
     const tdPromise = tdEligible
       ? this.td!.getQuote(tdSymbol!, calledBy)
       : Promise.resolve(null);
@@ -284,17 +305,19 @@ export class IntradayProviderRouter implements OnModuleInit {
     const tdSymbol = tdSkipReason === null ? this.convertToTdSymbol(eodhdTicker) : null;
     const tdEligible = tdSymbol !== null && this.td !== null;
 
-    const eodhdPromise = this.eodhd.getCandles(
-      eodhdTicker,
-      interval,
-      count,
-      hasTimeWindow
-        ? {
-            ...(options.fromTs != null ? { fromTs: options.fromTs } : {}),
-            ...(options.toTs != null ? { toTs: options.toTs } : {}),
-          }
-        : undefined,
-    );
+    const eodhdPromise = this.shouldSkipEodhdClosed(eodhdTicker, tdEligible)
+      ? Promise.resolve(null)
+      : this.eodhd.getCandles(
+          eodhdTicker,
+          interval,
+          count,
+          hasTimeWindow
+            ? {
+                ...(options.fromTs != null ? { fromTs: options.fromTs } : {}),
+                ...(options.toTs != null ? { toTs: options.toTs } : {}),
+              }
+            : undefined,
+        );
     const tdPromise = tdEligible
       ? this.td!.getCandles(
           tdSymbol!,


### PR DESCRIPTION
## Cause racine — DÉFINITIVE (table `eodhd_request_log`)

La traque a fini par donner la ventilation exacte des appels EODHD (`called_by`) sur 15 min :

| `called_by` | calls/15min | succès |
|---|---|---|
| **`intraday`** | **229** | **0% (229 échecs)** |
| `market_snapshot` | 50 | VIX/SPY/crypto |
| `live_price` | **0** | ✅ éliminé par #627 |

L'`IntradayProviderRouter` appelle **EODHD inconditionnellement** en parallèle de TwelveData (`getQuote`, `getCandles`). Sur marché **fermé** / Chine-Corée non couverts, la jambe EODHD **échoue systématiquement** (229/229) **mais compte dans le quota** → ~**6000 calls EODHD/h gaspillés** le weekend (constaté samedi 06/06 : 44k→50k un jour SANS action tradeable).

> Note honnête : les 2 fixes précédents (`SCANNER_SESSION_AWARE`, live-price #627) visaient de **petits** consommateurs. #627 a bien marché (`live_price`=0) mais le gros était ici.

## Fix

- `shouldSkipEodhdClosed(ticker, tdEligible)` : skip la jambe EODHD **UNIQUEMENT si** TwelveData peut servir (`tdEligible` → jamais de perte de source) **ET** le marché equity est fermé (`market-session.helper`).
- **Marché ouvert / crypto / forex / TD inéligible / requête time-window → dual-call inchangé** (contrainte "ZERO offload" préservée en séance).
- Flag `INTRADAY_SKIP_EODHD_WHEN_CLOSED` (default `true`, réversible).

## Sécurité
- En séance, rien ne change (EODHD toujours appelé). Hors séance, on tire **uniquement TwelveData** (illimité, renvoie déjà l'EOD close) → le risk-monitor garde une source de prix valide.
- Skip **conditionné à `tdEligible`** → jamais de symbole privé de données.

## Vérif
- `tsc -b` ✅
- `jest intraday-provider-router + market-session` ✅ **73/73** (les cas dual-call passent, helper de session testé).

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_