### PR TITLE
docs(ui): corrige les libellés de modes (Gainers LLM, Oversold cadence scan)

### DIFF
--- a/apps/web/src/components/lisa/macro-mode-selector.tsx
+++ b/apps/web/src/components/lisa/macro-mode-selector.tsx
@@ -110,7 +110,7 @@ export function MacroModeSelector({ portfolioId }: { portfolioId: string }) {
         <ModeCard
           icon={Rocket}
           title="🚀 Gainers"
-          subtitle="Scanner momentum 24/7 · 100% autonome · zero LLM"
+          subtitle="Scanner momentum cross-asset · agent LLM Mistral · autonome"
           description={gainersDescription}
           isActive={currentMode === 'gainers'}
           onClick={() => handleSelect('gainers')}
@@ -119,7 +119,7 @@ export function MacroModeSelector({ portfolioId }: { portfolioId: string }) {
         <ModeCard
           icon={TrendingDown}
           title="📉 Oversold"
-          subtitle="Mean-reversion swing · achète les chutes · scan 1×/jour"
+          subtitle="Mean-reversion swing · achète les chutes · scan EOD + intraday"
           description="Inverse du momentum : achète les titres ayant chuté de -5 à -12% sur 1J (sur-réaction), exclut les falling-knife (<-12%). Hold J+10 ouvrés, stop catastrophe -15% par position, book diversifié (~150 lignes). Edge mean-reversion validé 3-fold (alpha +1.4% vs SPY, N=1416)."
           isActive={currentMode === 'oversold'}
           onClick={() => handleSelect('oversold')}
@@ -145,7 +145,7 @@ export function MacroModeSelector({ portfolioId }: { portfolioId: string }) {
                 {confirmMode === 'gainers'
                   ? 'Active le scanner Gainers (24/7 cross-asset). Autopilot activé, kill-switch désarmé. Profile et capital_discipline_mode actuels préservés.'
                   : confirmMode === 'oversold'
-                  ? 'Active le scanner Oversold (mean-reversion swing, 1 scan/jour post-close US). Achète les titres ayant chuté de -5 à -12%, hold J+10, stop catastrophe -15%/position. Autopilot activé, kill-switch désarmé. Exige capital ≥ $5000. Profile et capital_discipline_mode préservés.'
+                  ? 'Active le scanner Oversold (mean-reversion swing, scan EOD post-close + intraday horaire EU + US). Achète les titres ayant chuté de -5 à -12%, hold J+10, stop catastrophe -15%/position. Autopilot activé, kill-switch désarmé. Exige capital ≥ $5000. Profile et capital_discipline_mode préservés.'
                   : 'Cette action écrase les paramètres suivants : profile, capital_discipline_mode, risk_constraints (caps, stops, leverage), autopilot_aggressive, cycle_minutes. Capital, objectifs, kill-switch préservés.'}
               </p>
               {applyError && (


### PR DESCRIPTION
## Audit du texte du sélecteur de modes → 3 libellés périmés corrigés

| Élément | Avant | Après | Pourquoi |
|---|---|---|---|
| **Gainers** subtitle | `Scanner momentum 24/7 · 100% autonome · zero LLM` | `Scanner momentum cross-asset · agent LLM Mistral · autonome` | **« zero LLM » faux** : le TRADER tourne sur un agent LLM **Mistral Medium** (176/177 cycles). « 24/7 » trompeur depuis `SCANNER_SESSION_AWARE` (equities session-gated, seul le crypto est 24/7). |
| **Oversold** subtitle | `…scan 1×/jour` | `…scan EOD + intraday` | Il y a aussi des **crons intraday horaires EU + US** en plus du 21:15. |
| **Oversold** texte de confirmation | `…1 scan/jour post-close US…` | `…scan EOD post-close + intraday horaire EU + US…` | Idem + corrige le biais US-only (l'EU Oversold tourne aussi). |

Investment / Harvest et le cœur d'Oversold (drop band, hold J+10, stop -15%, alpha 3-fold) étaient **corrects** → inchangés.

**Texte UI uniquement, aucune logique touchée.**

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_