### PR TITLE
chore(eodhd): trace temporaire des appels EODHD (pinpoint consommateur invisible)

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,6 +5,49 @@ import { AppModule } from './app.module';
 import { AllExceptionsFilter } from './common/all-exceptions.filter';
 import { BufferLogger } from './modules/admin/log-buffer.service';
 
+// ─── 06/06 TRACE EODHD (TEMPORAIRE — à retirer une fois le coupable trouvé) ───
+// Wrappe fetch global pour attribuer TOUT appel eodhd.com/api/* (endpoint +
+// caller via la stack) → dump du top toutes les 60s via le Nest Logger (capté
+// par BufferLogger → grep via /admin/logs?pattern=eodhd-trace). Sert à
+// pinpointer le consommateur EODHD invisible (résiduel ~4-5k/h hors instrument).
+// Gated EODHD_TRACE_ENABLED (default 'true').
+if ((process.env.EODHD_TRACE_ENABLED ?? 'true').toLowerCase() === 'true') {
+  const _origFetch = globalThis.fetch;
+  const eodhdCounts = new Map<string, number>();
+  globalThis.fetch = function (
+    input: Parameters<typeof _origFetch>[0],
+    init?: Parameters<typeof _origFetch>[1],
+  ): ReturnType<typeof _origFetch> {
+    try {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('eodhd.com/api/')) {
+        const m = url.match(/eodhd\.com\/api\/([a-z0-9-]+)/i);
+        const ep = m ? m[1] : 'unknown';
+        const frames = (new Error().stack ?? '')
+          .split('\n')
+          .slice(2, 7)
+          .map((s) => s.trim().replace(/^at /, ''));
+        const caller =
+          frames.find((s) => /\.service\.|scanner|oversold|ohlcv|atr|macro|lisa/.test(s)) ?? frames[0] ?? '?';
+        const key = `${ep} | ${caller.replace(/\s*\(.*$/, '').slice(0, 60)}`;
+        eodhdCounts.set(key, (eodhdCounts.get(key) ?? 0) + 1);
+      }
+    } catch {
+      /* never break fetch */
+    }
+    return _origFetch(input, init);
+  };
+  const eodhdTraceLogger = new Logger('eodhd-trace');
+  setInterval(() => {
+    if (eodhdCounts.size === 0) return;
+    const entries = [...eodhdCounts.entries()].sort((a, b) => b[1] - a[1]);
+    const total = entries.reduce((s, [, v]) => s + v, 0);
+    const top = entries.slice(0, 12).map(([k, v]) => `${v}× ${k}`).join('  ||  ');
+    eodhdTraceLogger.log(`[eodhd-trace] 60s total=${total} || ${top}`);
+    eodhdCounts.clear();
+  }, 60_000).unref();
+}
+
 async function bootstrap() {
   // P19x.6 (29/04/2026) — BufferLogger capture les Nest logs dans un ring
   // buffer in-memory (5000 lignes, rolls over). Exposé via /admin/logs/recent


### PR DESCRIPTION
## But : pinpointer le consommateur EODHD **invisible**

Après #627 (live-price) + #628 (intraday) → −24%, il reste **~4-5k/h** qui n'apparaît **nulle part** : ni dans `eodhd_request_log` (~950/h loggés), ni dans le buffer de logs Fly (que des lectures de cache + skips), ni dans `/admin/eodhd-status` (`perEndpoint` vide — le `recordCall` n'a jamais été câblé).

→ Le consommateur fait des `fetch('https://eodhd.com/api/…')` **bruts, sans aucun log**. Impossible à voir sans instrumenter.

## Ce que fait ce PR (temporaire)

Wrappe **`globalThis.fetch`** au boot (`main.ts`) : pour tout `eodhd.com/api/<endpoint>`, incrémente un compteur `endpoint | caller` (caller extrait de la stack), et **dump le top 12 toutes les 60s** via le Nest Logger → capté par `BufferLogger` → grep-able via `/admin/logs?pattern=eodhd-trace`.

- **Ne modifie pas le comportement** (try/catch, renvoie toujours `_origFetch`).
- Gated `EODHD_TRACE_ENABLED` (default `true`).
- **TEMPORAIRE** : à retirer une fois le coupable identifié.

Une fois déployé → je grep les logs → on voit **exactement** quel endpoint + quel service brûle le quota → PR de fix ciblée.

## Vérif
- `tsc -b` ✅

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_