### PR TITLE
fix(oversold): cron daily-scan 21:15 → Lun-Ven (stop weekend stale + EODHD waste)

### DIFF
--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -126,10 +126,14 @@ export class OversoldScannerService {
   }
 
   /**
-   * Cron quotidien 21:15 UTC.
+   * Cron 21:15 UTC, LUN-VEN uniquement (06/06). Le scan EOD agit sur la dernière
+   * barre de clôture, qui ne se met à jour qu'après une vraie séance. Sam+dim =
+   * marchés fermés → barre = vendredi (stale) → 0 nouvelle opportunité + burst
+   * EODHD inutile sur tout l'univers. Vendredi (jour 5) reste inclus : les chutes
+   * du vendredi sont achetées et tenues le weekend (hold J+10, weekends exclus).
    * Format crontab nestjs (6 champs) : sec min hour day month weekday.
    */
-  @Cron('0 15 21 * * *', { name: 'oversold-daily-scan', timeZone: 'UTC' })
+  @Cron('0 15 21 * * 1-5', { name: 'oversold-daily-scan', timeZone: 'UTC' })
   async runDailyScan(): Promise<void> {
     // Fail-safe global : jamais throw qui crashe le cron NestJS.
     try {


### PR DESCRIPTION
## Problème
Le cron `oversold-daily-scan` (21:15 UTC) tournait **7j/7** (`0 15 21 * * *`). Or le scan EOD agit sur la **dernière barre de clôture**, qui ne se met à jour **qu'après une vraie séance**.

→ **Samedi 21:15 + Dimanche 21:15** : marchés fermés, dernière barre = vendredi (**stale**) → **0 nouvelle opportunité** + **burst EODHD inutile** (fetch `/api/eod` sur tout l'univers russell1000 + stoxx600, 2× pour rien) + risque d'ouverture sur données périmées.

## Fix
`'0 15 21 * * *'` → `'0 15 21 * * 1-5'` (Lun-Ven).

- **Vendredi (jour 5) reste inclus** : les chutes du vendredi sont achetées et tenues le weekend — c'est le design oversold (hold J+10, weekends exclus du compteur).
- **Pas de "restart dimanche"** nécessaire : le prochain scan utile après le weekend = **lundi 21:15** (déclenché automatiquement).
- Les crons intraday (`1-5`) et overnight (`1-5`) étaient déjà correctement weekday-only — inchangés.

## Vérif
- Change isolé sur le schedule (string décorateur), aucune logique touchée. `tsc -b` + Jest via CI.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_