### PR TITLE
fix(eodhd): garde session-closed sur getQuote (résiduel /api/real-time ~3000/h)

### DIFF
--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -414,6 +414,28 @@ export class EodhdIntradayService {
   ): Promise<{ price: number; changePct: number; timestamp: number } | null> {
     const key = this.apiKey();
     if (!key) return null;
+
+    // PR #632 — Même garde session-closed que getCandles (lignes 259-271).
+    // getQuote est le fallback de getCandles : quand getCandles skip un marché
+    // fermé (return null), le caller retombe ici et martelait /api/real-time
+    // sans aucun filtre. Trace 06/06 : EodhdIntradayService.getQuote = ~50/min
+    // = ~3000/h, LE résiduel EODHD invisible (weekend + sessions fermées).
+    // Crypto exempté (24/7). Marché inconnu (forex/commodities/indices) = passe.
+    // Partage le kill-switch EODHD_WEEKEND_FILTER_ENABLED avec getCandles.
+    if (this.weekendFilterEnabled) {
+      const cls = marketForSymbol(eodhdTicker);
+      if (cls && cls !== 'crypto' && !isMarketOpenForClass(cls, new Date())) {
+        this.logger.debug(`[eodhd:real-time] ${eodhdTicker} skipped (session closed for ${cls})`);
+        this.logCall({
+          ticker: eodhdTicker,
+          success: false,
+          statusCode: 0,
+          errorMessage: 'SKIP_SESSION_CLOSED',
+        });
+        return null;
+      }
+    }
+
     const normalized = this.normalizeForEodhdIntraday(eodhdTicker);
     const tStart = Date.now();
     try {


### PR DESCRIPTION
## Le coupable est nommé

La trace globale `fetch` (#630) a définitivement identifié le consommateur EODHD invisible (résiduel ~3000-4500/h qui survivait à tous les fix précédents) :

```
[eodhd-trace] 60s total=48 || 47× real-time | EodhdIntradayService.getQuote
[eodhd-trace] 60s total=57 || 56× real-time | EodhdIntradayService.getQuote
[eodhd-trace] 60s total=59 || 57× real-time | EodhdIntradayService.getQuote
```

`EodhdIntradayService.getQuote` martèle `/api/real-time` ~50/min (~3000/h), **y compris week-ends et sessions fermées**.

## Cause racine

`getQuote` est le **fallback de `getCandles`**. Quand `getCandles` skip un marché fermé (return `null` via le filtre PR #339, lignes 259-271), le caller retombe sur `getQuote` — qui n'avait **aucun filtre session**. Résultat : sur marché fermé, `getCandles` renvoie null *correctement*, puis le caller appelle `getQuote` qui tape EODHD pour rien (réponse garantie vide/stale).

C'est pour ça que les fix précédents (live-price #627, intraday-router #628) n'ont réduit le rate que partiellement : ils couvraient d'autres chemins, jamais `getQuote` lui-même à la couche basse.

## Fix

Miroir exact de la garde de `getCandles` dans `getQuote` :
- **crypto exempté** (24/7) ;
- **marché inconnu** (forex / commodities / indices) laissé passer (conservateur, on ne casse rien) ;
- partage le **même kill-switch** `EODHD_WEEKEND_FILTER_ENABLED` que `getCandles` → une seule manette de réversibilité ;
- log `[eodhd:real-time] … skipped (session closed for …)` + `eodhd_request_log` (`SKIP_SESSION_CLOSED`) pour traçabilité.

## En clair

Avant : sur un week-end (comme aujourd'hui) ou hors séance, le système continuait d'appeler EODHD ~3000 fois/heure pour des cotations de marchés fermés → quota brûlé pour rien (28k+ calls observés un samedi).

Après : ces appels sont court-circuités à la source. Le quota EODHD ne sera plus consommé pour coter un marché qui n'ouvre pas. Crypto (seul actif 24/7) continue de coter normalement.

## Tests

90 tests verts (`eodhd-intraday.p19o` + `p19o3` + `intraday-provider-router`). Les specs `getQuote` tournent avec `EODHD_WEEKEND_FILTER_ENABLED=false` par défaut → garde désactivée → aucune dépendance à l'horloge réelle (pas de flakiness week-end).

## Suite

La trace temporaire (#630) reste **active** le temps de vérifier la chute du rate en prod. Un follow-up la retirera une fois la baisse confirmée.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_