### PR TITLE
chore(eodhd): retire la trace temporaire global-fetch (#630)

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,49 +5,6 @@ import { AppModule } from './app.module';
 import { AllExceptionsFilter } from './common/all-exceptions.filter';
 import { BufferLogger } from './modules/admin/log-buffer.service';
 
-// ─── 06/06 TRACE EODHD (TEMPORAIRE — à retirer une fois le coupable trouvé) ───
-// Wrappe fetch global pour attribuer TOUT appel eodhd.com/api/* (endpoint +
-// caller via la stack) → dump du top toutes les 60s via le Nest Logger (capté
-// par BufferLogger → grep via /admin/logs?pattern=eodhd-trace). Sert à
-// pinpointer le consommateur EODHD invisible (résiduel ~4-5k/h hors instrument).
-// Gated EODHD_TRACE_ENABLED (default 'true').
-if ((process.env.EODHD_TRACE_ENABLED ?? 'true').toLowerCase() === 'true') {
-  const _origFetch = globalThis.fetch;
-  const eodhdCounts = new Map<string, number>();
-  globalThis.fetch = function (
-    input: Parameters<typeof _origFetch>[0],
-    init?: Parameters<typeof _origFetch>[1],
-  ): ReturnType<typeof _origFetch> {
-    try {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-      if (url.includes('eodhd.com/api/')) {
-        const m = url.match(/eodhd\.com\/api\/([a-z0-9-]+)/i);
-        const ep = m ? m[1] : 'unknown';
-        const frames = (new Error().stack ?? '')
-          .split('\n')
-          .slice(2, 7)
-          .map((s) => s.trim().replace(/^at /, ''));
-        const caller =
-          frames.find((s) => /\.service\.|scanner|oversold|ohlcv|atr|macro|lisa/.test(s)) ?? frames[0] ?? '?';
-        const key = `${ep} | ${caller.replace(/\s*\(.*$/, '').slice(0, 60)}`;
-        eodhdCounts.set(key, (eodhdCounts.get(key) ?? 0) + 1);
-      }
-    } catch {
-      /* never break fetch */
-    }
-    return _origFetch(input, init);
-  };
-  const eodhdTraceLogger = new Logger('eodhd-trace');
-  setInterval(() => {
-    if (eodhdCounts.size === 0) return;
-    const entries = [...eodhdCounts.entries()].sort((a, b) => b[1] - a[1]);
-    const total = entries.reduce((s, [, v]) => s + v, 0);
-    const top = entries.slice(0, 12).map(([k, v]) => `${v}× ${k}`).join('  ||  ');
-    eodhdTraceLogger.log(`[eodhd-trace] 60s total=${total} || ${top}`);
-    eodhdCounts.clear();
-  }, 60_000).unref();
-}
-
 async function bootstrap() {
   // P19x.6 (29/04/2026) — BufferLogger capture les Nest logs dans un ring
   // buffer in-memory (5000 lignes, rolls over). Exposé via /admin/logs/recent


### PR DESCRIPTION
## Cleanup — la trace a fait son travail

La trace globale `fetch` (#630) était instrumentation **temporaire** (annotée comme telle) pour pinpointer le consommateur EODHD invisible. Mission accomplie :

1. **#630** a nommé le coupable : `EodhdIntradayService.getQuote` → `/api/real-time` ~50/min (~3000/h), y compris week-ends et sessions fermées.
2. **#632** l'a corrigé (garde session-closed miroir de `getCandles`).
3. **Vérification post-deploy** (trace + quota EODHD `/api/user`) :

| | Avant | Après #632 |
|---|---|---|
| `getQuote /api/real-time` | ~50/min | **0 (éliminé)** ✅ |
| Plancher EODHD (fenêtre calme) | ~3000/h (drip permanent) | **~170/h (vrai idle)** |
| Moyenne incluant bursts news | ~4560/h | ~1130/h |

Mesure quota finale : **Δ = 17 appels en 6 min ≈ 170/h** (fenêtre sans burst news) — le drip continu sur marchés fermés est mort.

## Ce que retire ce PR

Le wrapper `globalThis.fetch` dans `main.ts` (43 lignes). Il s'exécutait sur **chaque** appel HTTP sortant de l'app (tous providers : EODHD, TwelveData, Binance, Gemini, Mistral, Anthropic, Supabase…), pas seulement EODHD — donc à retirer une fois le diagnostic terminé.

## Réversibilité

- Le diagnostic reste reproductible via `git` (commit #630) si un futur résiduel apparaît.
- `eodhd_request_log` conserve les entrées `SKIP_SESSION_CLOSED` pour un audit continu de la garde sans la trace.
- `Logger` reste importé (utilisé dans `bootstrap()`). Typecheck OK.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_