### PR TITLE
feat(eodhd): garde marché-fermé (week-end + horaires + fériés) sur les exits oversold [LOT 1]

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/exchange-sessions.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/exchange-sessions.spec.ts
@@ -13,6 +13,7 @@
 
 import {
   isInExchangeSession,
+  isKnownMarketClosed,
   extractSuffix,
   minutesToExchangeClose,
   minutesSinceExchangeOpen,
@@ -633,6 +634,77 @@ describe('minutesSinceExchangeOpen — opening buffer (DST-safe)', () => {
     expect(minutesSinceExchangeOpen('MC.PA', '2026-05-23T09:00:00Z')).toBeNull(); // samedi
     expect(minutesSinceExchangeOpen('BTCUSDT', '2026-05-22T09:00:00Z')).toBeNull();
     expect(minutesSinceExchangeOpen('X.ZZZ', '2026-05-22T09:00:00Z')).toBeNull();
+  });
+});
+
+describe('isKnownMarketClosed — garde anti-gaspillage EODHD (PR #634)', () => {
+  // Skip un appel UNIQUEMENT si le marché est connu ET fermé. Fail-open partout
+  // ailleurs (invariant "100% fonctionnel" : jamais couper sur un actif non classé).
+
+  // --- Equity connu OUVERT → false (ne pas skip) ---
+  it('US en séance (17:00 UTC = 13:00 EDT) → false (ouvert, ne pas skip)', () => {
+    expect(isKnownMarketClosed('AAPL.US', '2026-05-15T17:00:00Z')).toBe(false);
+  });
+
+  it('EU Paris en séance (08:00 UTC été = 10:00 CEST) → false', () => {
+    expect(isKnownMarketClosed('MC.PA', '2026-07-15T08:00:00Z')).toBe(false);
+  });
+
+  // --- Equity connu FERMÉ → true (skip OK) ---
+  it('US week-end (samedi 17:00 UTC) → true (skip)', () => {
+    expect(isKnownMarketClosed('AAPL.US', '2026-05-09T17:00:00Z')).toBe(true);
+  });
+
+  it('US after-hours (22:00 UTC = 18:00 EDT) → true (skip)', () => {
+    expect(isKnownMarketClosed('AAPL.US', '2026-05-15T22:00:00Z')).toBe(true);
+  });
+
+  it('US férié Memorial Day 25/05/2026 en heures RTH → true (skip)', () => {
+    expect(isKnownMarketClosed('AAPL.US', '2026-05-25T15:00:00Z')).toBe(true);
+  });
+
+  it('US férié Christmas 25/12/2026 en heures RTH → true (skip)', () => {
+    expect(isKnownMarketClosed('AAPL.US', '2026-12-25T17:00:00Z')).toBe(true);
+  });
+
+  it('EU férié Whit Monday 25/05/2026 (Paris) → true (skip)', () => {
+    expect(isKnownMarketClosed('NANO.PA', '2026-05-25T10:00:00Z')).toBe(true);
+  });
+
+  it('EU férié Good Friday 03/04/2026 (XETRA) → true (skip)', () => {
+    expect(isKnownMarketClosed('SAP.XETRA', '2026-04-03T10:00:00Z')).toBe(true);
+  });
+
+  it('Asia Tokyo hors séance (10:00 UTC = 19:00 JST) → true (week-end+horaires gardés)', () => {
+    expect(isKnownMarketClosed('7203.T', '2026-05-15T10:00:00Z')).toBe(true);
+  });
+
+  // --- FAIL-OPEN : jamais skip (invariant "100% fonctionnel") ---
+  it('crypto .CC → false (24/7, fail-open) même un samedi', () => {
+    expect(isKnownMarketClosed('BTC-USD.CC', '2026-05-09T03:00:00Z')).toBe(false);
+  });
+
+  it('Binance pair sans suffixe (BTCUSDT) → false (fail-open)', () => {
+    expect(isKnownMarketClosed('BTCUSDT', '2026-05-09T03:00:00Z')).toBe(false);
+  });
+
+  it('forex .FOREX → false (fail-open)', () => {
+    expect(isKnownMarketClosed('EURUSD.FOREX', '2026-05-09T03:00:00Z')).toBe(false);
+  });
+
+  it('CRITIQUE — suffixe equity INCONNU → false (fail-open, ≠ isInExchangeSession)', () => {
+    // isInExchangeSession('FOO.ZZZ') = false (fermé/inconnu) MAIS isKnownMarketClosed
+    // = false aussi (ne PAS skip) → on préfère un appel de trop qu'un prix manquant.
+    expect(isInExchangeSession('FOO.ZZZ', '2026-05-15T17:00:00Z')).toBe(false);
+    expect(isKnownMarketClosed('FOO.ZZZ', '2026-05-15T17:00:00Z')).toBe(false);
+  });
+
+  it('symbole vide → false (fail-open)', () => {
+    expect(isKnownMarketClosed('', '2026-05-15T17:00:00Z')).toBe(false);
+  });
+
+  it('symbole sans point (AAPL legacy) → false (fail-open)', () => {
+    expect(isKnownMarketClosed('AAPL', '2026-05-15T17:00:00Z')).toBe(false);
   });
 });
 

--- a/apps/api/src/modules/lisa/services/exchange-sessions.helper.ts
+++ b/apps/api/src/modules/lisa/services/exchange-sessions.helper.ts
@@ -159,6 +159,39 @@ export function isInExchangeSession(symbol: string, at: Date | string | number):
 }
 
 /**
+ * PR #634 — Garde "skip appel EODHD" SÛRE pour gater les consommateurs de prix.
+ *
+ * Retourne `true` UNIQUEMENT quand le marché du ticker est **connu ET fermé**
+ * (week-end, hors horaires de session DST-aware, OU jour férié de SA bourse).
+ *
+ * FAIL-OPEN volontaire (≠ isInExchangeSession qui est fail-closed) : tout ce
+ * qu'on ne classe pas avec certitude comme equity-fermé renvoie `false` (= NE
+ * PAS skip). Cela préserve l'invariant "100% fonctionnel" : on ne coupe jamais
+ * un appel sur un actif always-on, un suffixe inconnu, ou un symbole sans
+ * suffixe — on préfère un appel EODHD de trop qu'un prix manquant sur position.
+ *
+ *   - sans suffixe (BTCUSDT, AAPL legacy)      → false (fail-open)
+ *   - always-on (.CC/.FOREX/.COMM/.INDX)       → false (24/7)
+ *   - suffixe equity inconnu (pas dans EXCHANGE_SESSIONS) → false (fail-open)
+ *   - equity connu en session                  → false (ouvert, ne pas skip)
+ *   - equity connu hors session / WE / férié   → true  (fermé, skip OK)
+ *
+ * Fériés couverts : US (NYSE) + EU (LSE, Euronext, SIX, XETRA) via
+ * HOLIDAYS_BY_SUFFIX. Asia/.TO/.NSE : week-end + horaires gardés, fériés non
+ * couverts (fail-open sur leurs fériés → appel de trop ces jours-là, sans
+ * risque de blocage). Cf. HOLIDAYS_BY_SUFFIX (follow-up calendriers Asia).
+ */
+export function isKnownMarketClosed(symbol: string, at: Date | string | number): boolean {
+  if (!symbol) return false;
+  const suffix = extractSuffix(symbol);
+  if (suffix === null) return false;             // crypto Binance / legacy no-suffix → fail-open
+  if (ALWAYS_ON_SUFFIXES.has(suffix)) return false; // crypto/fx/commodity/index → 24/7
+  if (!EXCHANGE_SESSIONS[suffix]) return false;  // equity à suffixe inconnu → fail-open
+  // Equity à suffixe CONNU : fermé = hors session (week-end + horaires + férié bourse).
+  return !isInExchangeSession(symbol, at);
+}
+
+/**
  * P19-EXT (25/05/2026) — Détecte si TOUTES les bourses majeures (US + UK + EU
  * + CH + DE) sont fermées pour férié à l'instant donné.
  *

--- a/apps/api/src/modules/lisa/services/oversold-exit.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-exit.service.ts
@@ -31,6 +31,7 @@ import { SupabaseService } from '../../supabase/supabase.service';
 import { LisaService } from './lisa.service';
 import { DecisionLogService } from './decision-log.service';
 import { businessDaysSince } from './oversold.helper';
+import { isKnownMarketClosed } from './exchange-sessions.helper';
 
 interface OpenOversoldPosition {
   id: string;
@@ -62,6 +63,12 @@ export class OversoldExitService {
 
   private isEnabled(): boolean {
     return (this.config.get<string>('OVERSOLD_EXIT_ENABLED') ?? 'true').toLowerCase() === 'true';
+  }
+
+  /** PR #634 — garde anti-gaspillage : skip le fetch EODHD quand le marché du
+   * ticker est connu+fermé. Réversible via OVERSOLD_EXIT_SKIP_MARKET_CLOSED. */
+  private skipWhenClosed(): boolean {
+    return (this.config.get<string>('OVERSOLD_EXIT_SKIP_MARKET_CLOSED') ?? 'true').toLowerCase() === 'true';
   }
 
   /**
@@ -111,6 +118,15 @@ export class OversoldExitService {
     cfg: OversoldExitCfg,
     now: Date,
   ): Promise<void> {
+    // PR #634 — skip si le marché du ticker est connu ET fermé (week-end, hors
+    // session DST-aware, férié bourse). Le close EOD serait figé → ni stop
+    // catastrophe (0 mouvement marché fermé) ni nouvelle info ; le hold J+10 se
+    // ferme à la prochaine séance (swing, retard de quelques h négligeable).
+    if (this.skipWhenClosed() && isKnownMarketClosed(pos.symbol, now)) {
+      this.logger.debug(`[oversold-exit] ${pos.symbol} marché fermé → skip ce cycle (économie EODHD)`);
+      return;
+    }
+
     const heldDays = businessDaysSince(pos.entry_timestamp, now);
     const holdExpired = heldDays >= cfg.holdDays;
 

--- a/apps/api/src/modules/lisa/services/oversold-mistral-exit.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-mistral-exit.service.ts
@@ -35,6 +35,7 @@ import { OversoldExitPolicyService } from './research/oversold-exit-policy.servi
 import { IntradayProviderRouter } from './intraday-provider-router.service';
 import { computeIndicatorSnapshot, type IndicatorCandle } from './position-indicators.helper';
 import { businessDaysSince } from './oversold.helper';
+import { isKnownMarketClosed } from './exchange-sessions.helper';
 
 interface OpenOversoldRow {
   id: string;
@@ -163,6 +164,12 @@ export class OversoldMistralExitService {
     return Number(this.config.get<string>('OVERSOLD_MISTRAL_HARD_CLOSE_UTC_HOUR') ?? '20.5');
   }
 
+  /** PR #634 — skip le fetch EODHD quand le marché du ticker est connu+fermé.
+   * Réversible via OVERSOLD_MISTRAL_EXIT_SKIP_MARKET_CLOSED (default true). */
+  private skipWhenClosed(): boolean {
+    return (this.config.get<string>('OVERSOLD_MISTRAL_EXIT_SKIP_MARKET_CLOSED') ?? 'true').toLowerCase() === 'true';
+  }
+
   /**
    * Cron toutes les 15 minutes. Plus réactif que l'OversoldExitService déterministe
    * (30min) pour capter les rebonds intelligents en cours de journée. Coût LLM
@@ -182,6 +189,7 @@ export class OversoldMistralExitService {
       let evaluated = 0;
       let closed = 0;
       let skippedMfe = 0;
+      let skippedClosed = 0;
 
       for (const pos of positions) {
         try {
@@ -189,6 +197,7 @@ export class OversoldMistralExitService {
           if (result === 'closed') closed++;
           else if (result === 'evaluated') evaluated++;
           else if (result === 'skipped_mfe') skippedMfe++;
+          else if (result === 'skipped_market_closed') skippedClosed++;
         } catch (err) {
           this.logger.warn(
             `[oversold-mistral-exit] ${pos.symbol} (${pos.id.slice(0, 8)}) échoué: ${String(err).slice(0, 200)}`,
@@ -197,7 +206,7 @@ export class OversoldMistralExitService {
       }
 
       this.logger.log(
-        `[oversold-mistral-exit] cycle done — positions=${positions.length} evaluated=${evaluated} closed=${closed} skipped_mfe=${skippedMfe}`,
+        `[oversold-mistral-exit] cycle done — positions=${positions.length} evaluated=${evaluated} closed=${closed} skipped_mfe=${skippedMfe} skipped_closed=${skippedClosed}`,
       );
     } catch (err) {
       this.logger.error(`[oversold-mistral-exit] runExitCycle exception: ${String(err).slice(0, 300)}`);
@@ -207,7 +216,13 @@ export class OversoldMistralExitService {
   private async evaluatePosition(
     pos: OpenOversoldRow,
     policyCache: Map<string, string>,
-  ): Promise<'closed' | 'evaluated' | 'skipped_mfe' | 'skipped_no_price'> {
+  ): Promise<'closed' | 'evaluated' | 'skipped_mfe' | 'skipped_no_price' | 'skipped_market_closed'> {
+    // PR #634 — service intraday-only (hard-close 20:30 UTC, jamais overnight) :
+    // hors séance US le marché est fermé → rien à faire. Skip avant tout fetch
+    // EODHD/LLM (économie quota + appels Mistral inutiles le week-end/férié).
+    if (this.skipWhenClosed() && isKnownMarketClosed(pos.symbol, new Date())) {
+      return 'skipped_market_closed';
+    }
     const price = await this.fetchLastClose(pos.symbol);
     if (price == null) return 'skipped_no_price';
 


### PR DESCRIPTION
## Mandat : zéro appel EODHD inutile hors séance, 100% fonctionnel lun-ven hors fériés par place

**LOT 1** d'une série. Un audit exhaustif des consommateurs EODHD a montré que plusieurs services tournent 24/7 sans garde marché-fermé. Ce PR s'attaque aux **2 plus gros gaspilleurs week-end** + introduit la brique réutilisable pour la suite.

### Nouveau helper : `isKnownMarketClosed(symbol, at)`

Dans `exchange-sessions.helper.ts`, à côté de `isInExchangeSession` (PR #296, déjà holiday-aware US+EU par bourse, DST-aware). Il renvoie `true` **uniquement** si le marché du ticker est **connu ET fermé** (week-end, hors horaires, OU jour férié de SA bourse).

**FAIL-OPEN volontaire** (≠ `isInExchangeSession` qui est fail-closed) — c'est le point clé pour respecter ton invariant *"100% fonctionnel"* :

| Cas | `isKnownMarketClosed` |
|---|---|
| Equity connu en séance | `false` (ouvert, ne pas skip) |
| Equity connu hors séance / week-end / férié | `true` (skip OK) |
| Crypto `.CC`, forex `.FOREX`, indices `.INDX` | `false` (24/7, fail-open) |
| Pair Binance sans suffixe (`BTCUSDT`) | `false` (fail-open) |
| **Suffixe equity inconnu** (`FOO.ZZZ`) | **`false` (fail-open)** |

→ On ne coupe **jamais** un appel sur un actif qu'on ne classe pas avec certitude comme equity-fermé. Un appel EODHD de trop vaut mieux qu'un prix manquant sur une position.

Fériés couverts : **US (NYSE) + toute l'EU (LSE, Euronext, SIX, XETRA)**. Asia/`.TO`/`.NSE` : week-end + horaires gardés, fériés non encore couverts (fail-open sur leurs fériés → un appel de trop ces jours-là, sans risque de blocage). Follow-up.

### Branchements

- **`OversoldExitService`** (cron 30 min, ~26 positions US × 48/jour le week-end d'après l'audit) → skip avant `fetchLastClose`. Marché fermé = close EOD figé : ni stop catastrophe (0 mouvement) ni nouvelle info ; le hold J+10 se ferme à la prochaine séance (swing, retard de quelques heures négligeable).
- **`OversoldMistralExitService`** (cron 15 min, **intraday-only**, hard-close 20:30 UTC, jamais overnight) → skip avant le fetch EODHD **et l'appel LLM Mistral**. Hors séance US, il n'a rien à faire.

### En clair

Avant : tout le week-end, ces deux crons fetchaient EODHD (et brûlaient du Mistral) pour des positions US sur un marché fermé — prix figés, aucune décision possible. Après : ils s'abstiennent hors séance et **les jours fériés** (US et EU). Lundi à l'ouverture, tout reprend normalement. Crypto (seul 24/7) n'est jamais affecté.

### Réversibilité

Par service : `OVERSOLD_EXIT_SKIP_MARKET_CLOSED` / `OVERSOLD_MISTRAL_EXIT_SKIP_MARKET_CLOSED` (default `true`).

### Tests

+16 cas `isKnownMarketClosed` (146 verts au total sur `exchange-sessions.spec`), dont le cas critique **"suffixe inconnu → false (fail-open)"**. `oversold-exit.spec` inchangé (12 verts). Typecheck OK.

### Suite (prochains lots)

- **LOT 2** : fériés sur `getQuote`/`getCandles` (session-filter ai-analyst) + `fetchLivePriceInner`.
- **LOT 3** : calendriers fériés Asia (Tokyo/Séoul/HK/Shanghai).

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_