### PR TITLE
feat(eodhd): coupe les fetchs les jours fériés (couche basse + live price) [LOT 2]

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/exchange-sessions.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/exchange-sessions.spec.ts
@@ -14,6 +14,7 @@
 import {
   isInExchangeSession,
   isKnownMarketClosed,
+  isKnownMarketHoliday,
   extractSuffix,
   minutesToExchangeClose,
   minutesSinceExchangeOpen,
@@ -705,6 +706,55 @@ describe('isKnownMarketClosed — garde anti-gaspillage EODHD (PR #634)', () => 
 
   it('symbole sans point (AAPL legacy) → false (fail-open)', () => {
     expect(isKnownMarketClosed('AAPL', '2026-05-15T17:00:00Z')).toBe(false);
+  });
+});
+
+describe('isKnownMarketHoliday — fériés additifs pour getCandles/getQuote/livePrice (PR #635)', () => {
+  // Détecte UNIQUEMENT les jours fériés de la bourse (≠ week-end, ≠ horaires,
+  // gérés ailleurs). Couvre US + EU. Fail-open partout ailleurs.
+
+  it('US Christmas 25/12/2026 → true', () => {
+    expect(isKnownMarketHoliday('AAPL.US', '2026-12-25T17:00:00Z')).toBe(true);
+  });
+
+  it('US Memorial Day 25/05/2026 → true', () => {
+    expect(isKnownMarketHoliday('NVDA.US', '2026-05-25T15:00:00Z')).toBe(true);
+  });
+
+  it('US jour ouvré normal (15/05/2026) → false', () => {
+    expect(isKnownMarketHoliday('AAPL.US', '2026-05-15T17:00:00Z')).toBe(false);
+  });
+
+  it('US week-end (samedi, PAS un férié) → false (le week-end est géré ailleurs)', () => {
+    expect(isKnownMarketHoliday('AAPL.US', '2026-05-09T17:00:00Z')).toBe(false);
+  });
+
+  it('EU Whit Monday 25/05/2026 (Paris) → true', () => {
+    expect(isKnownMarketHoliday('NANO.PA', '2026-05-25T10:00:00Z')).toBe(true);
+  });
+
+  it('EU Good Friday 03/04/2026 (XETRA + LSE) → true', () => {
+    expect(isKnownMarketHoliday('SAP.XETRA', '2026-04-03T10:00:00Z')).toBe(true);
+    expect(isKnownMarketHoliday('VOD.L', '2026-04-03T10:00:00Z')).toBe(true);
+  });
+
+  // --- FAIL-OPEN : pas de calendrier → false (ne pas couper) ---
+  it('crypto .CC → false (fail-open)', () => {
+    expect(isKnownMarketHoliday('BTC-USD.CC', '2026-12-25T12:00:00Z')).toBe(false);
+  });
+
+  it('Asia Tokyo (pas de calendrier férié) → false (fail-open) même un 1er janvier', () => {
+    expect(isKnownMarketHoliday('7203.T', '2026-01-01T02:00:00Z')).toBe(false);
+  });
+
+  it('suffixe inconnu → false (fail-open)', () => {
+    expect(isKnownMarketHoliday('FOO.ZZZ', '2026-12-25T17:00:00Z')).toBe(false);
+  });
+
+  it('sans suffixe / vide / date invalide → false', () => {
+    expect(isKnownMarketHoliday('BTCUSDT', '2026-12-25T12:00:00Z')).toBe(false);
+    expect(isKnownMarketHoliday('', '2026-12-25T12:00:00Z')).toBe(false);
+    expect(isKnownMarketHoliday('AAPL.US', 'not-a-date')).toBe(false);
   });
 });
 

--- a/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
+++ b/apps/api/src/modules/lisa/services/eodhd-intraday.service.ts
@@ -4,6 +4,8 @@ import { SupabaseService } from '../../supabase/supabase.service';
 import { TickerBlacklistService } from './ticker-blacklist.service';
 // PR #339 — Weekend / session-closed filter sur getCandles (couche basse).
 import { isMarketOpenForClass, marketForSymbol } from '@smartvest/ai-analyst';
+// PR #635 — Fériés par bourse (US/EU), additif aux gardes week-end/horaires.
+import { isKnownMarketHoliday } from './exchange-sessions.helper';
 
 /**
  * EodhdIntradayService — récupère les bougies intraday OHLCV depuis EODHD
@@ -257,14 +259,17 @@ export class EodhdIntradayService {
     // Crypto exempté (24/7). Unknown market = passe (conservateur, on ne casse
     // rien pour forex/commodities/indices futurs).
     if (this.weekendFilterEnabled) {
+      const now = new Date();
       const cls = marketForSymbol(eodhdTicker);
-      if (cls && cls !== 'crypto' && !isMarketOpenForClass(cls, new Date())) {
-        this.logger.debug(`[eodhd] ${eodhdTicker} skipped (session closed for ${cls})`);
+      const sessionClosed = cls != null && cls !== 'crypto' && !isMarketOpenForClass(cls, now);
+      const holiday = isKnownMarketHoliday(eodhdTicker, now); // PR #635 — férié bourse US/EU
+      if (sessionClosed || holiday) {
+        this.logger.debug(`[eodhd] ${eodhdTicker} skipped (${holiday ? 'market holiday' : `session closed for ${cls}`})`);
         this.logCall({
           ticker: eodhdTicker,
           success: false,
           statusCode: 0,
-          errorMessage: 'SKIP_SESSION_CLOSED',
+          errorMessage: holiday ? 'SKIP_MARKET_HOLIDAY' : 'SKIP_SESSION_CLOSED',
         });
         return null;
       }
@@ -423,14 +428,17 @@ export class EodhdIntradayService {
     // Crypto exempté (24/7). Marché inconnu (forex/commodities/indices) = passe.
     // Partage le kill-switch EODHD_WEEKEND_FILTER_ENABLED avec getCandles.
     if (this.weekendFilterEnabled) {
+      const now = new Date();
       const cls = marketForSymbol(eodhdTicker);
-      if (cls && cls !== 'crypto' && !isMarketOpenForClass(cls, new Date())) {
-        this.logger.debug(`[eodhd:real-time] ${eodhdTicker} skipped (session closed for ${cls})`);
+      const sessionClosed = cls != null && cls !== 'crypto' && !isMarketOpenForClass(cls, now);
+      const holiday = isKnownMarketHoliday(eodhdTicker, now); // PR #635 — férié bourse US/EU
+      if (sessionClosed || holiday) {
+        this.logger.debug(`[eodhd:real-time] ${eodhdTicker} skipped (${holiday ? 'market holiday' : `session closed for ${cls}`})`);
         this.logCall({
           ticker: eodhdTicker,
           success: false,
           statusCode: 0,
-          errorMessage: 'SKIP_SESSION_CLOSED',
+          errorMessage: holiday ? 'SKIP_MARKET_HOLIDAY' : 'SKIP_SESSION_CLOSED',
         });
         return null;
       }

--- a/apps/api/src/modules/lisa/services/exchange-sessions.helper.ts
+++ b/apps/api/src/modules/lisa/services/exchange-sessions.helper.ts
@@ -192,6 +192,34 @@ export function isKnownMarketClosed(symbol: string, at: Date | string | number):
 }
 
 /**
+ * PR #635 — Détecte UNIQUEMENT le cas "jour férié de la bourse du ticker"
+ * (≠ week-end, ≠ hors-horaires). Complément ADDITIF aux gardes week-end/horaires
+ * existantes (isMarketOpenForClass dans getCandles/getQuote, isMarketOpen dans
+ * fetchLivePriceInner) : ces gardes ignorent les fériés → un jour férié EN
+ * SÉANCE, l'appel EODHD passait (close EOD figé = gaspillage). Ce helper le
+ * coupe SANS toucher au comportement horaire existant.
+ *
+ * Fail-open : suffixe sans calendrier (Asia/.TO/.NSE, inconnu), crypto/fx/
+ * commodity, sans suffixe → false (ne PAS skip). Couvre US (NYSE) + EU
+ * (LSE/Euronext/SIX/XETRA) via HOLIDAYS_BY_SUFFIX.
+ */
+export function isKnownMarketHoliday(symbol: string, at: Date | string | number): boolean {
+  if (!symbol) return false;
+  const suffix = extractSuffix(symbol);
+  if (suffix === null) return false;
+  const holidaySet = HOLIDAYS_BY_SUFFIX.get(suffix);
+  if (!holidaySet) return false;            // pas de calendrier pour cette bourse → fail-open
+  const session = EXCHANGE_SESSIONS[suffix];
+  if (!session) return false;
+  let date: Date;
+  if (at instanceof Date) date = at;
+  else if (typeof at === 'number') date = new Date(at < 1e10 ? at * 1000 : at);
+  else date = new Date(at);
+  if (Number.isNaN(date.getTime())) return false;
+  return holidaySet.has(getLocalDateString(date, session.tz));
+}
+
+/**
  * P19-EXT (25/05/2026) — Détecte si TOUTES les bourses majeures (US + UK + EU
  * + CH + DE) sont fermées pour férié à l'instant donné.
  *

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -73,7 +73,7 @@ import {
   fetchWithRetry,
 } from '../helpers/macro-fallback.helper';
 import { assertRegimeInputsHealthy } from '../helpers/regime-healthcheck.helper';
-import { isInExchangeSession } from './exchange-sessions.helper';
+import { isInExchangeSession, isKnownMarketHoliday } from './exchange-sessions.helper';
 
 /**
  * LisaService — orchestrateur principal du module AI analyst.
@@ -3779,7 +3779,12 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     // ou isMarketOpen=true → inchangés. Réversible via LIVE_PRICE_SKIP_CLOSED_MARKET.
     if ((this.config.get<string>('LIVE_PRICE_SKIP_CLOSED_MARKET') ?? 'true').toLowerCase() === 'true') {
       const sess = sessionClassForSymbol(symbol);
-      if (sess && !isMarketOpen(sess, new Date())) {
+      // PR #635 — ajoute les fériés (par bourse, US/EU) à la garde week-end/horaires.
+      // Un jour férié EN séance, isMarketOpen=true → l'appel EODHD passait sur un
+      // close EOD figé (gaspillage). Même traitement que marché fermé : cache/fallback stale.
+      const closedOrHoliday =
+        (sess != null && !isMarketOpen(sess, new Date())) || isKnownMarketHoliday(symbol, new Date());
+      if (closedOrHoliday) {
         const anyCached = this.realtimePrice
           .snapshot()
           .find((s) => s.symbol.toUpperCase() === symbol.toUpperCase());


### PR DESCRIPTION
## Mandat (suite) : 100% fonctionnel lun-ven **hors fériés** par place

**LOT 2.** L'axe week-end/horaires est déjà bien couvert (getQuote #632, oversold exits #634, live-price #627). Ce qui manquait : **les jours fériés**. Un jour férié *en pleine séance*, les gardes existantes laissaient passer l'appel EODHD (`isMarketOpen=true` car elles ignorent les fériés) → fetch sur un close EOD figé = gaspillage.

### Helper additif : `isKnownMarketHoliday(symbol, at)`

Renvoie `true` **uniquement** si le ticker est un jour férié de **sa** bourse (US/NYSE + EU/LSE/Euronext/SIX/XETRA via `HOLIDAYS_BY_SUFFIX`, DST-aware). Fail-open partout ailleurs :

| Cas | Résultat |
|---|---|
| US Christmas, Memorial Day | `true` |
| EU Whit Monday (Paris), Good Friday (XETRA/LSE) | `true` |
| US jour ouvré / **week-end** (≠ férié) | `false` (géré ailleurs) |
| crypto `.CC`, Asia sans calendrier (`.T`), suffixe inconnu, sans suffixe | `false` (fail-open) |

### Branchements (en complément `OR`, pas en remplacement)

- **`getCandles` + `getQuote`** (couche basse `eodhd-intraday`) → protège **tous** les callers d'un coup (scanner via fetch, persistence multi-TF, shadow-sim, live quote). Audit distinct `SKIP_MARKET_HOLIDAY`. Sous le kill-switch existant `EODHD_WEEKEND_FILTER_ENABLED`.
- **`fetchLivePriceInner`** (lisa.service) → retourne le cache/fallback stale `*_market_closed` (même traitement que marché fermé : prix figé, stops/TP ne se déclenchent pas — correct un jour férié). Sous `LIVE_PRICE_SKIP_CLOSED_MARKET`.

### Pourquoi c'est sans risque

**100% additif** : zéro changement au comportement horaire/week-end existant. On ne fait qu'**ajouter** la coupe les jours fériés. Aucune régression possible pendant les heures de séance. Et fail-open garanti : on ne coupe jamais un actif sans calendrier de fériés connu.

### En clair

Le prochain Memorial Day / Good Friday / Whit Monday, le système ne brûlera plus de quota EODHD à coter des bourses US/EU fermées. Lundi ouvré normal : rien ne change, tout fonctionne.

### Limite connue → LOT 3

Asia (Tokyo/Séoul/HK/Shanghai) : fériés pas encore couverts (calendriers lunaires complexes) → **fail-open**, donc un appel de trop ces jours-là mais **zéro risque de blocage**. Calendriers Asia = LOT 3.

### Tests

+12 cas `isKnownMarketHoliday` (179 verts au total `exchange-sessions` + `eodhd-intraday`), dont *"Asia sans calendrier → false (fail-open)"* et *"week-end ≠ férié → false"*. Typecheck OK.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_