### PR TITLE
feat(eodhd): gate marché-fermé sur fixed-basket scanner + fériés macro [LOT 3]

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.fixed-basket.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.fixed-basket.spec.ts
@@ -9,6 +9,7 @@
 
 import { Logger } from '@nestjs/common';
 import { TopGainersScannerService, GAINERS_FIXED_BASKET, GAINERS_LEVERAGED_PROXIES } from '../services/top-gainers-scanner.service';
+import { isKnownMarketClosed } from '../services/exchange-sessions.helper';
 
 const mockSupabase = { getClient: jest.fn() } as any;
 const mockLisa = {} as any;
@@ -28,7 +29,16 @@ jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
 jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
 
 function makeService(configImpl?: (key: string) => unknown): TopGainersScannerService {
-  mockConfig.get.mockImplementation(configImpl ?? ((key: string) => (key === 'SCAN_INTERVAL_MINUTES' ? '15' : undefined)));
+  const baseImpl = configImpl ?? ((key: string) => (key === 'SCAN_INTERVAL_MINUTES' ? '15' : undefined));
+  // PR #636 — défaut 'false' pour GAINERS_FIXED_BASKET_SKIP_CLOSED UNIQUEMENT si
+  // le configImpl ne le fournit pas : rend les tests de fetch déterministes
+  // (sinon un run le week-end skip le fetch et casse les assertions), tout en
+  // laissant les tests de gating activer explicitement le gate via 'true'.
+  mockConfig.get.mockImplementation((key: string) => {
+    const v = baseImpl(key);
+    if (key === 'GAINERS_FIXED_BASKET_SKIP_CLOSED' && v === undefined) return 'false';
+    return v;
+  });
   return new TopGainersScannerService(
     mockSupabase, mockLisa, mockDecisionLog, mockConfig, mockBinance, mockScheduler, mockMtf, mockLlmRouter, { isShadowEnabled: () => false } as any, { evaluate: () => ({ raw: {} as any, compositeScore: null, decision: 'REJECT', rejectReason: null, spreadProxy: null, spreadProxySource: null, trendFilter: null, rvolIntraday: null }) } as any,
     { estimateProbability: async () => ({ pWin: 0.5, confidence: 0, sampleSize: 0, modelVersion: 'none', fallback: true }) } as any,
@@ -149,5 +159,50 @@ describe('fetchFixedBasket — gold/energy proxies', () => {
     expect(decoded).toContain('NUGT.US');
     expect(decoded).toContain('GUSH.US');
     expect(candidates.find((c: any) => c.symbol === 'NUGT.US')).toBeDefined();
+  });
+
+  // PR #636 — skip le batch quand TOUT le panier est sur marché connu+fermé.
+  it('skips the batch entirely when GAINERS_FIXED_BASKET_SKIP_CLOSED actif et panier fermé', async () => {
+    // Samedi 2026-05-09 17:00 UTC → tout le panier .US fermé (week-end).
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-09T17:00:00Z'));
+    try {
+      // configImpl vide → GAINERS_FIXED_BASKET_SKIP_CLOSED défaut 'true' (gating actif)
+      const svc = makeService((key: string) => (key === 'GAINERS_FIXED_BASKET_SKIP_CLOSED' ? 'true' : undefined));
+      const candidates = await (svc as any).fetchFixedBasket('test-key');
+      expect(candidates).toEqual([]);
+      expect((global.fetch as jest.Mock)).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('fetche normalement en séance US même avec le gating actif', async () => {
+    // Vendredi 2026-05-15 17:00 UTC = 13:00 EDT → US en séance.
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-15T17:00:00Z'));
+    try {
+      const svc = makeService((key: string) => (key === 'GAINERS_FIXED_BASKET_SKIP_CLOSED' ? 'true' : undefined));
+      const candidates = await (svc as any).fetchFixedBasket('test-key');
+      expect(candidates).toHaveLength(GAINERS_FIXED_BASKET.length);
+      expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('GAINERS_FIXED_BASKET — couverture du gate marché-fermé (PR #636)', () => {
+  it('tout le panier est "connu+fermé" un samedi (le skip se déclenchera)', () => {
+    const sat = new Date('2026-05-09T17:00:00Z'); // samedi
+    expect(GAINERS_FIXED_BASKET.every((e) => isKnownMarketClosed(e.symbol, sat))).toBe(true);
+  });
+
+  it('aucun symbole "fermé" en séance US (vendredi 13:00 EDT) → le fetch passe', () => {
+    const fri = new Date('2026-05-15T17:00:00Z'); // vendredi 13:00 EDT
+    expect(GAINERS_FIXED_BASKET.some((e) => isKnownMarketClosed(e.symbol, fri))).toBe(false);
+  });
+
+  it('tout le panier fermé un jour férié US (Memorial Day 25/05/2026)', () => {
+    const memorial = new Date('2026-05-25T15:00:00Z');
+    expect(GAINERS_FIXED_BASKET.every((e) => isKnownMarketClosed(e.symbol, memorial))).toBe(true);
   });
 });

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -4117,6 +4117,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     // US equities (.US) : lun-ven 13h-21h UTC (tolère pre/post market étendu)
     if (ticker.endsWith('.US')) {
       if (day === 0 || day === 6) return false; // weekend
+      if (isKnownMarketHoliday(ticker, now)) return false; // PR #636 — férié NYSE (proxies macro figés)
       if (minuteOfDay < 13 * 60 || minuteOfDay >= 21 * 60) return false;
       return true;
     }

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -82,7 +82,7 @@ import { SymbolAtrCacheService } from './symbol-atr-cache.service';
 import { MacroVetoService } from './macro-veto.service';
 import { GainersUserShadowService, type ShadowDecision } from './gainers-user-shadow.service';
 import { dollarVolumeUsd, passesLiquidityFloor } from './gainers-liquidity.helper';
-import { isInExchangeSession, minutesToExchangeClose, minutesSinceExchangeOpen } from './exchange-sessions.helper';
+import { isInExchangeSession, isKnownMarketClosed, minutesToExchangeClose, minutesSinceExchangeOpen } from './exchange-sessions.helper';
 import { ScannerLlmRouterService } from './scanner-llm-router.service';
 import { parseLlmJson } from './llm-json-parser.helper';
 // PR6.3 — Shadow wiring (LisaModule import GainersModule pour résolution DI)
@@ -2350,6 +2350,20 @@ export class TopGainersScannerService implements OnModuleInit {
     const leveragedOn = (this.config.get<string>('GAINERS_LEVERAGED_PROXIES_ENABLED') ?? 'false').toLowerCase() === 'true';
     const basket = leveragedOn ? [...GAINERS_FIXED_BASKET, ...GAINERS_LEVERAGED_PROXIES] : GAINERS_FIXED_BASKET;
     if (!enabled || basket.length === 0) return [];
+
+    // PR #636 — skip le batch real-time si TOUT le panier est sur marché connu+
+    // fermé (week-end, hors session, férié US/EU). Panier 100% .US (ETF GLD/XLE/
+    // GDX… + majors XOM/CVX) → close EOD figé hors séance = gaspillage pur. Un
+    // seul appel HTTP batch → gating tout-ou-rien (si ≥1 symbole tradable on
+    // garde l'appel). Réversible via GAINERS_FIXED_BASKET_SKIP_CLOSED (default true).
+    const skipClosed = (this.config.get<string>('GAINERS_FIXED_BASKET_SKIP_CLOSED') ?? 'true').toLowerCase() !== 'false';
+    if (skipClosed) {
+      const now = new Date();
+      if (basket.every((e) => isKnownMarketClosed(e.symbol, now))) {
+        this.logger.debug('[top-gainers] fixed-basket skip — panier entièrement sur marché fermé (économie EODHD)');
+        return [];
+      }
+    }
 
     const capBySymbol = new Map(basket.map((e) => [e.symbol.toUpperCase(), e]));
     const symbols = basket.map((e) => e.symbol);


### PR DESCRIPTION
## LOT 3 (marginaux) — tu as choisi "marginaux d'abord"

### 1. Scanner fixed-basket (la vraie cible concrète)

`TopGainersScannerService.fetchFixedBasket` envoie un batch real-time de 8-11 ETF/majors or & énergie (**100% `.US`** : GLD/USO/XLE/GDX/NEM/GOLD/XOM/CVX) à **chaque cycle scanner**, sans aucun check session → close EOD figé tout le week-end et les fériés US.

**Gating tout-ou-rien** : si **tout** le panier est sur marché connu+fermé (`isKnownMarketClosed`), on skip l'appel HTTP. Si ≥1 symbole reste tradable, on garde l'appel (c'est un seul batch). Réversible via `GAINERS_FIXED_BASKET_SKIP_CLOSED` (default `true`).

### 2. Macro snapshot — fériés

En vérifiant, j'ai trouvé que le filtre week-end/horaires **existait déjà** (`isMacroTickerMarketOpen`, pour `.US`/`.FOREX`/`.COMM`). **Le macro n'était donc PAS un gaspilleur week-end** — contrairement au soupçon initial de l'audit. Le seul trou était les **fériés** : un Memorial Day en séance, les proxies macro `.US` (VXX/UUP/GLD/SLV/HYG/LQD/USO) étaient re-fetchés alors que figés. → ajout d'un check `isKnownMarketHoliday` pour `.US`.

### Ce que je n'ai PAS touché (vérifié — ce ne sont pas des gaspillages)

- **`EodhdMacroService`** : cache 24h sur données mensuelles (CPI, GDP, chômage) → ~4 calls/jour. Déjà optimal.
- **Quota self-poll** (`/api/user`, 30 s + 5 min) : **gratuit** (0 crédit EODHD). Le couper n'économiserait rien.

→ J'ai préféré te le dire plutôt que d'ajouter un gating cosmétique sur des appels gratuits ou déjà cachés.

### Tests

+5 cas fixed-basket (skip un samedi / Memorial Day, fetch en séance US, couverture du panier), **170 verts** au total scanner + **166 verts** macro. Typecheck OK.

### Reste pour plus tard (ton choix précédent)

- **Fériés Asia** (Tokyo/Séoul/HK/Shanghai) — calendriers lunaires, fail-open en attendant.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_