### PR TITLE
fix(oversold): cron intraday EU/US borné [ouverture +1h, clôture -1h] DST-aware

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/exchange-sessions.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/exchange-sessions.spec.ts
@@ -758,6 +758,66 @@ describe('isKnownMarketHoliday — fériés additifs pour getCandles/getQuote/li
   });
 });
 
+describe('Fenêtre oversold intraday [ouverture +1h, clôture -1h] DST-aware (PR #637)', () => {
+  // Reproduit le gate scanPortfolioIntraday : on ne scanne qu'entre +1h après
+  // l'ouverture et -1h avant la clôture de la bourse. Même logique US et EU ;
+  // le DST décale la séance EU d'1h (été 07:00-15:30 vs hiver 08:00-16:30 UTC).
+  const inWindow = (sym: string, at: string): boolean => {
+    const so = minutesSinceExchangeOpen(sym, at);
+    const tc = minutesToExchangeClose(sym, at);
+    return so != null && so >= 60 && tc != null && tc >= 60;
+  };
+
+  // --- EU Euronext (.PA) ÉTÉ : séance 07:00-15:30 UTC → fenêtre [08:00, 14:30] ---
+  it('EU été : 07:30 UTC (30min après open) → hors fenêtre', () => {
+    expect(inWindow('MC.PA', '2026-06-08T07:30:00Z')).toBe(false);
+  });
+  it('EU été : 08:00 UTC (1h après open) → dans la fenêtre', () => {
+    expect(inWindow('MC.PA', '2026-06-08T08:00:00Z')).toBe(true);
+  });
+  it('EU été : 14:30 UTC (1h avant close 15:30) → dans la fenêtre (limite)', () => {
+    expect(inWindow('MC.PA', '2026-06-08T14:30:00Z')).toBe(true);
+  });
+  it('EU été : 15:00 UTC (30min avant close) → hors fenêtre', () => {
+    expect(inWindow('MC.PA', '2026-06-08T15:00:00Z')).toBe(false);
+  });
+
+  // --- EU Euronext (.PA) HIVER : séance 08:00-16:30 UTC → fenêtre [09:00, 15:30] ---
+  // Preuve du DST : 08:00 UTC est DANS la fenêtre l'été mais HORS l'hiver.
+  it('EU hiver : 08:00 UTC (= open, 0min) → hors fenêtre (≠ été)', () => {
+    expect(inWindow('MC.PA', '2026-01-12T08:00:00Z')).toBe(false);
+  });
+  it('EU hiver : 09:00 UTC (1h après open) → dans la fenêtre', () => {
+    expect(inWindow('MC.PA', '2026-01-12T09:00:00Z')).toBe(true);
+  });
+  it('EU hiver : 15:30 UTC (1h avant close 16:30) → dans la fenêtre', () => {
+    expect(inWindow('MC.PA', '2026-01-12T15:30:00Z')).toBe(true);
+  });
+  it('EU hiver : 16:00 UTC (30min avant close) → hors fenêtre', () => {
+    expect(inWindow('MC.PA', '2026-01-12T16:00:00Z')).toBe(false);
+  });
+
+  // --- US (.US) ÉTÉ : séance 13:30-20:00 UTC → fenêtre [14:30, 19:00] ---
+  it('US été : 14:00 UTC (30min après open) → hors fenêtre', () => {
+    expect(inWindow('AAPL.US', '2026-06-08T14:00:00Z')).toBe(false);
+  });
+  it('US été : 14:30 UTC (1h après open) → dans la fenêtre', () => {
+    expect(inWindow('AAPL.US', '2026-06-08T14:30:00Z')).toBe(true);
+  });
+  it('US été : 19:00 UTC (1h avant close 20:00) → dans la fenêtre', () => {
+    expect(inWindow('AAPL.US', '2026-06-08T19:00:00Z')).toBe(true);
+  });
+  it('US été : 19:30 UTC (30min avant close) → hors fenêtre', () => {
+    expect(inWindow('AAPL.US', '2026-06-08T19:30:00Z')).toBe(false);
+  });
+
+  // --- Hors séance / week-end → toujours hors fenêtre ---
+  it('week-end → hors fenêtre (EU et US)', () => {
+    expect(inWindow('MC.PA', '2026-06-06T10:00:00Z')).toBe(false);  // samedi
+    expect(inWindow('AAPL.US', '2026-06-06T17:00:00Z')).toBe(false);
+  });
+});
+
 describe('isInExchangeSession — couverture EU étendue (Milan/Madrid/Amsterdam)', () => {
   // été : CET/CEST → 09:00 local = 07:00 UTC. Mi-séance 09:06 UTC = 11:06 local → ouvert.
   it.each(['FCA.MI', 'SAN.MC', 'SAN.BME', 'INGA.AMS'])('%s ouvert mi-séance (09:06 UTC été)', (sym) => {

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -41,6 +41,7 @@ import {
   type IntradayReboundConfig,
 } from './oversold-intraday.helper';
 import { IntradayProviderRouter } from './intraday-provider-router.service';
+import { minutesSinceExchangeOpen, minutesToExchangeClose } from './exchange-sessions.helper';
 
 /** Une position oversold enrichie pour l'UI dédiée (book summary). */
 export interface OversoldBookPosition {
@@ -389,10 +390,16 @@ export class OversoldScannerService {
   }
 
   /**
-   * Cron horaire pendant session US — 15:00 à 19:00 UTC, weekdays only.
-   * Skip 14:30 (ouverture turbulente) et 20:00 (dernière heure, gamma/EOD prep).
+   * Cron horaire couvrant les séances EU + US (08:00-20:00 UTC, weekdays).
+   * Le créneau réel par portfolio est borné DST-aware à [ouverture +1h,
+   * clôture -1h] de SA bourse (cf. scanPortfolioIntraday) — MÊME logique US et
+   * EU : on saute la 1ère heure (ouverture turbulente) et la dernière heure
+   * (EOD prep). Un cron UTC fixe ne suffisait pas pour l'EU dont la séance
+   * décale d'1h été/hiver (07:00-15:30 vs 08:00-16:30 UTC). Les gardes
+   * marché-fermé skippent les fetchs hors-séance → élargir le cron ne gaspille
+   * aucun appel EODHD.
    */
-  @Cron('0 0 15,16,17,18,19 * * 1-5', { name: 'oversold-intraday-scan', timeZone: 'UTC' })
+  @Cron('0 0 8-20 * * 1-5', { name: 'oversold-intraday-scan', timeZone: 'UTC' })
   async runIntradayScan(): Promise<void> {
     try {
       if (!this.isEnabled() || !this.intradayEnabled()) {
@@ -421,6 +428,23 @@ export class OversoldScannerService {
   private async scanPortfolioIntraday(row: OversoldPortfolioRow): Promise<void> {
     const portfolioId = row.portfolio_id;
     const cfg = this.resolveConfig(row);
+
+    // Fenêtre intraday = [ouverture +1h, clôture -1h] de la bourse de l'univers,
+    // DST-aware (même logique US et EU). On saute la 1ère heure (ouverture
+    // turbulente) et la dernière heure (EOD prep). La séance EU décale d'1h
+    // été/hiver → minutesSinceExchangeOpen/ToClose lisent l'horaire réel par
+    // IANA TZ. refSym = bourse représentative (Euronext .PA pour l'EU, .US sinon).
+    const nowWindow = new Date();
+    const refSym = this.regionOfUniverse(cfg.universe) === 'EU' ? 'MC.PA' : 'AAPL.US';
+    const sinceOpen = minutesSinceExchangeOpen(refSym, nowWindow);
+    const toClose = minutesToExchangeClose(refSym, nowWindow);
+    if (sinceOpen == null || sinceOpen < 60 || toClose == null || toClose < 60) {
+      this.logger.debug(
+        `[oversold-intraday] ${portfolioId.slice(0, 8)} ${cfg.universe} hors fenêtre [open+1h,close-1h] (sinceOpen=${sinceOpen ?? 'closed'} toClose=${toClose ?? 'closed'}) → skip`,
+      );
+      return;
+    }
+
     const reboundCfg = this.intradayConfig();
     const maxOpensPerDay = this.intradayMaxOpensPerDay();
     const notionalRatio = this.intradayNotionalRatio();


### PR DESCRIPTION
## Ce que tu as flairé

Le cron oversold-intraday était figé à `15,16,17,18,19 UTC` = calé sur la séance **US**. Il boucle pourtant sur **tous** les portfolios oversold, dont l'**EU** (`stoxx600`, séance 07:00-16:30 UTC été). Résultat pour l'EU :
- seuls **15:00 et 16:00 UTC** tombaient en séance → le dernier à **30 min de la clôture** = *"ça fait juste"*, aucun temps pour le rebond ;
- **toute la matinée EU (07:00→15:00 UTC) jamais scannée** en intraday.

## Fix — ta règle exacte, DST-aware

**Même logique que le US** (sauter la 1ère heure d'ouverture turbulente + la dernière heure EOD), appliquée à l'EU : **fenêtre [ouverture +1h, clôture −1h]**.

Un cron UTC fixe ne peut pas le faire (la séance EU décale d'1h été/hiver : 07:00-15:30 vs 08:00-16:30 UTC). Donc :
1. Cron élargi à **`0 0 8-20 * * 1-5`** (couvre les deux séances).
2. Gate dans `scanPortfolioIntraday`, borné par bourse via les helpers DST-aware déjà en place :
   ```
   fenêtre = minutesSinceExchangeOpen >= 60  ET  minutesToExchangeClose >= 60
   ```
   `refSym` = bourse représentative de l'univers (`MC.PA` Euronext pour l'EU via `regionOfUniverse`, `.US` sinon). Hors fenêtre / hors séance / week-end → skip avant tout fetch.

### Créneaux résultants

| | Ouverture | Fenêtre scan | Clôture |
|---|---|---|---|
| 🇪🇺 EU été | 07:00 | **08:00 → 14:30 UTC** | 15:30 |
| 🇪🇺 EU hiver | 08:00 | **09:00 → 15:30 UTC** | 16:30 |
| 🇺🇸 US été | 13:30 | 14:30 → 19:00 UTC (≈ inchangé) | 20:00 |
| 🇺🇸 US hiver | 14:30 | 16:00 → 20:00 UTC | 21:00 |

Les gardes marché-fermé (LOT 1/2) skippent les fetchs hors-séance → élargir le cron **ne gaspille aucun appel EODHD** (le portfolio US est skippé le matin, l'EU l'après-midi).

## Tests

+13 cas documentant la fenêtre DST (EU/US été+hiver, bornes open+1h / close−1h, week-end), dont la **preuve du décalage DST** : 08:00 UTC est *dans* la fenêtre EU l'été mais *hors* l'hiver. **191 verts** (exchange-sessions + oversold-scanner). Typecheck OK.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_