### PR TITLE
fix(gainers): fenêtre de scan [ouverture +60min, clôture -60min] DST-aware avant fetch

### DIFF
--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18e-skip-summary.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p18e-skip-summary.spec.ts
@@ -45,6 +45,10 @@ beforeEach(() => {
 function makeService(): TopGainersScannerService {
   mockConfig.get.mockImplementation((key: string) => {
     if (key === 'SCAN_INTERVAL_MINUTES') return '15';
+    // PR #638 — désactive le gate fenêtre [open+buffer/close-buffer] pour rester
+    // déterministe : les tests tournent à une heure CI quelconque avec des
+    // candidats US equity → sinon le gate viderait filteredTop hors séance US.
+    if (key === 'GAINERS_OPEN_BUFFER_MIN' || key === 'GAINERS_CLOSE_BUFFER_MIN') return '0';
     return undefined;
   });
   return new TopGainersScannerService(

--- a/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p19beta-shadow.spec.ts
+++ b/apps/api/src/modules/lisa/__tests__/top-gainers-scanner.p19beta-shadow.spec.ts
@@ -77,6 +77,9 @@ function makeService(): TopGainersScannerService {
     // Sinon isInExchangeSession bloque les opens des symboles equity selon l'heure
     // du run CI → tests non-déterministes (mêmes raison que sessionFilterEnabled=false).
     if (key === 'GAINERS_OPEN_SESSION_GUARD') return 'false';
+    // PR #638 — désactive le gate fenêtre [open+buffer/close-buffer] (même
+    // raison : déterminisme hors séance US au moment du run CI).
+    if (key === 'GAINERS_OPEN_BUFFER_MIN' || key === 'GAINERS_CLOSE_BUFFER_MIN') return '0';
     return undefined;
   });
   return new TopGainersScannerService(

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -2836,7 +2836,7 @@ export class TopGainersScannerService implements OnModuleInit {
     );
 
     // P18 — LLM re-ranking (inert when SCANNER_LLM_ROUTER_ENABLED=false)
-    const filteredTop = await this.rankCandidates(top);
+    let filteredTop = await this.rankCandidates(top);
 
     // Garde-fou : count current open positions (utilise maxOpen depuis config)
     const { data: openPositions } = await this.supabase
@@ -2950,6 +2950,32 @@ export class TopGainersScannerService implements OnModuleInit {
       `[top-gainers] ${portfolioId.slice(0, 8)}: capacity check — deployed=$${deployedNotional.toFixed(2)}/${availableCapital.toFixed(2)} ` +
       `(${budgetBasedSlots} budget slots, ${slotsAvailable} pos slots, max-per-cycle=${maxPerCycle}) → up to ${effectiveMaxThisCycle} this cycle`,
     );
+
+    // PR #638 — Fenêtre de trading par place [ouverture +openBuffer, clôture
+    // -closeBuffer], DST-aware, AVANT le fetch persistence (analyzeBatch). On ne
+    // consomme AUCUN appel EODHD pendant le buffer d'ouverture ni dans la
+    // dernière heure avant la clôture, et on n'ouvre pas hors fenêtre. Crypto
+    // exempt (24/7). Même logique que l'oversold (#637). DST géré par IANA TZ
+    // (minutesSinceExchangeOpen/ToClose). Réversible : GAINERS_OPEN_BUFFER_MIN /
+    // GAINERS_CLOSE_BUFFER_MIN. ⚠️ secret prod GAINERS_OPEN_BUFFER_MIN=15 →
+    // à passer à 60 (Fly UI) pour appliquer le choix +60min.
+    const openBufMin = Number(this.config.get<string>('GAINERS_OPEN_BUFFER_MIN') ?? '60');
+    const closeBufMin = Number(this.config.get<string>('GAINERS_CLOSE_BUFFER_MIN') ?? '60');
+    if (openBufMin > 0 || closeBufMin > 0) {
+      const nowWin = new Date();
+      const beforeWin = filteredTop.length;
+      filteredTop = filteredTop.filter((c) => {
+        if (c.assetClass === 'crypto_major' || c.assetClass === 'crypto_alt') return true; // 24/7
+        const sinceOpen = minutesSinceExchangeOpen(c.symbol, nowWin);
+        const toClose = minutesToExchangeClose(c.symbol, nowWin);
+        return sinceOpen != null && sinceOpen >= openBufMin && toClose != null && toClose >= closeBufMin;
+      });
+      if (filteredTop.length < beforeWin) {
+        this.logger.log(
+          `[top-gainers] ${portfolioId.slice(0, 8)}: trading-window gate [open+${openBufMin}/close-${closeBufMin}min] ${beforeWin}→${filteredTop.length} (skip buffer ouverture + dernière heure → 0 fetch EODHD)`,
+        );
+      }
+    }
 
     // P8 — Calcule la persistance multi-TF pour les top candidats (parallèle)
     // PR #3 — utilise filteredTop (universe toggles per-portfolio)
@@ -3785,7 +3811,7 @@ export class TopGainersScannerService implements OnModuleInit {
       // open du marché concerné. Justification : volatilité/slippage gap-fill,
       // faux signaux de momentum sur premier tick. Crypto exempt (24/7, no open).
       // Configurable via env GAINERS_OPEN_BUFFER_MIN (default 0 = disabled).
-      const openBufferMin = Number(this.config.get<string>('GAINERS_OPEN_BUFFER_MIN') ?? '0');
+      const openBufferMin = Number(this.config.get<string>('GAINERS_OPEN_BUFFER_MIN') ?? '60');
       if (openBufferMin > 0 && cand.assetClass !== 'crypto_major' && cand.assetClass !== 'crypto_alt') {
         // Minutes depuis l'open RÉEL de la bourse (DST-safe, par exchange). Le bloc
         // agrégé MARKET_SESSION_HOURS est l'horaire d'hiver → en été l'EU ouvrait


### PR DESCRIPTION
## Vérifié par les chiffres (tu avais raison)

`eodhd_request_log`, séance EU de vendredi 05/06 :
- ouverture EU 07:00 UTC → **1er appel à 07:10 UTC** (10 min après, pas 30-60)
- clôture Euronext 15:30 UTC (été) → appels **jusqu'à 16:30 UTC** (1h après la clôture réelle)

**Causes racines (code + prod) :**
1. `GAINERS_OPEN_BUFFER_MIN = 15` en prod (trop court) **et appliqué après le fetch** → il bloquait l'ouverture mais pas l'appel EODHD ;
2. **aucun buffer de clôture** sur le scan (juste le force-close des positions existantes) ;
3. garde session sur **fenêtre large 07:00-16:30 UTC** (pas la vraie clôture DST 15:30 été).

## Fix — ta règle, DST-aware, avant le fetch

Gate **fenêtre [ouverture +60min, clôture −60min]** appliqué **avant `analyzeBatch`** (le fetch persistence multi-TF). Les candidats hors fenêtre sont retirés → **zéro appel EODHD** pendant le buffer d'ouverture et la dernière heure, et **pas d'ouverture hors fenêtre**. Crypto exempt (24/7). Même logique que l'oversold (#637), via `minutesSinceExchangeOpen/ToClose` (IANA TZ → DST natif).

| | Ouverture | **Scan/ouverture** | Clôture |
|---|---|---|---|
| 🇪🇺 EU été | 07:00 | **08:00 → 14:30 UTC** | 15:30 |
| 🇪🇺 EU hiver | 08:00 | **09:00 → 15:30 UTC** | 16:30 |
| 🇺🇸 US été | 13:30 | 14:30 → 19:00 UTC | 20:00 |
| 🇺🇸 US hiver | 14:30 | 15:30 → 20:00 UTC | 21:00 |

Defaults : `GAINERS_OPEN_BUFFER_MIN` 60, `GAINERS_CLOSE_BUFFER_MIN` 60 (nouveau).

## ⚠️ Action Fly requise (sinon ouverture reste à 15 min)

Le **secret Fly `GAINERS_OPEN_BUFFER_MIN=15`** override le default 60. Pour appliquer ton +60min côté ouverture : passe-le à **60** (ou supprime-le) dans Fly UI. Le **closing buffer** (nouvelle clé) est actif dès le déploiement, sans action.

## Tests

2 specs scanner (p18e, p19beta) désactivent le gate (buffer=0) pour rester déterministes hors séance US — **170 verts**. La fenêtre [open+60/close−60] DST elle-même est couverte par `exchange-sessions.spec` (#637). Typecheck OK.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_