### PR TITLE
feat(oversold): 2e axe régime — rotation sectorielle offensif/défensif par région (shadow)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/oversold-scanner.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/oversold-scanner.spec.ts
@@ -10,6 +10,7 @@ import {
   buildOversoldCandidates,
   selectOversoldOpens,
   decideRegimeBlock,
+  computeRotationRegime,
   type EodBar,
   type OversoldConfig,
   type RegimeThresholds,
@@ -203,5 +204,55 @@ describe('decideRegimeBlock', () => {
     expect(decideRegimeBlock({ vix: 17, vixChg: 0, idx5d: 0 }, US_THRESH, US_LABELS).block).toBe(false);
     // idx5d == min : -1 < -1 est faux → pas de block
     expect(decideRegimeBlock({ vix: 15, vixChg: 0, idx5d: -1 }, US_THRESH, US_LABELS).block).toBe(false);
+  });
+});
+
+describe('computeRotationRegime (rotation offensif/défensif, PR #639)', () => {
+  const mkBars = (closes: number[]): EodBar[] => {
+    const base = Date.UTC(2026, 0, 1);
+    return closes.map((c, i) => ({
+      date: new Date(base + i * 86_400_000).toISOString().slice(0, 10),
+      close: c,
+      volume: 1,
+    }));
+  };
+  const inc = Array.from({ length: 60 }, (_, i) => 100 + i); // 100→159 croissant
+  const dec = Array.from({ length: 60 }, (_, i) => 159 - i); // 159→100 décroissant
+  const flat = Array.from({ length: 60 }, () => 50);
+
+  it('offensif : numérateur monte vs dénominateur plat → ratio > MM50', () => {
+    const r = computeRotationRegime(mkBars(inc), mkBars(flat), 50);
+    expect(r.regime).toBe('offensive');
+    expect(r.ratio! > r.ma!).toBe(true);
+    expect(r.n).toBe(60);
+  });
+
+  it('défensif : numérateur baisse vs dénominateur plat → ratio < MM50', () => {
+    const r = computeRotationRegime(mkBars(dec), mkBars(flat), 50);
+    expect(r.regime).toBe('defensive');
+    expect(r.ratio! < r.ma!).toBe(true);
+  });
+
+  it('données insuffisantes (< maLen+1 points) → null (fail-open)', () => {
+    const r = computeRotationRegime(mkBars(inc.slice(0, 30)), mkBars(flat.slice(0, 30)), 50);
+    expect(r.regime).toBeNull();
+    expect(r.ma).toBeNull();
+  });
+
+  it('aligne par date : dates manquantes dans le dénominateur sont ignorées', () => {
+    const off = mkBars(inc); // 60 dates
+    const def = mkBars(flat).filter((_, i) => i % 2 === 0); // 1 date sur 2
+    const r = computeRotationRegime(off, def, 50);
+    expect(r.n).toBe(30); // seules les dates communes comptent
+    expect(r.regime).toBeNull(); // 30 < 51 → fail-open
+  });
+
+  it('ignore les closes invalides (0 / négatif) dans les deux séries', () => {
+    const off = mkBars(inc);
+    off[5].close = 0; // ignoré
+    const def = mkBars(flat);
+    def[10].close = -1; // ignoré
+    const r = computeRotationRegime(off, def, 50);
+    expect(r.n).toBe(58); // 60 − 2 dates invalides
   });
 });

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -30,9 +30,11 @@ import {
   selectOversoldOpens,
   businessDaysSince,
   decideRegimeBlock,
+  computeRotationRegime,
   type OversoldConfig,
   type EodBar,
   type OversoldCandidate,
+  type RotationRegime,
 } from './oversold.helper';
 import {
   analyzeIntradayRebound,
@@ -652,6 +654,7 @@ export class OversoldScannerService {
     idx5d: number | null;
     vixSource: 'live' | 'eod';
     thresholds: { vixMax: number; vixDeltaMax: number; idx5dMin: number };
+    rotation: (RotationRegime & { mode: string; appliedVixPenalty: number }) | null;
   }> {
     const enabled =
       (this.config.get<string>('OVERSOLD_REGIME_GATE_ENABLED') ?? 'true').toLowerCase() === 'true';
@@ -679,7 +682,7 @@ export class OversoldScannerService {
     const thresholds = { vixMax, vixDeltaMax, idx5dMin };
 
     if (!enabled) {
-      return { block: false, reason: 'gate disabled', region, vix: null, vixChg: null, idx5d: null, vixSource: 'eod', thresholds };
+      return { block: false, reason: 'gate disabled', region, vix: null, vixChg: null, idx5d: null, vixSource: 'eod', thresholds, rotation: null };
     }
 
     const labels = { vix: region === 'EU' ? 'V2TX' : 'VIX', idx: region === 'EU' ? 'SX5E' : 'SPY' };
@@ -730,8 +733,71 @@ export class OversoldScannerService {
       idx5d = fiveBack > 0 ? (last / fiveBack - 1) * 100 : null;
     }
 
-    const decision = decideRegimeBlock({ vix, vixChg, idx5d }, thresholds, labels);
-    return { ...decision, region, vix, vixChg, idx5d, vixSource, thresholds };
+    // PR #639 — Modulateur de rotation sectorielle (offensif/défensif), par région.
+    // Quand la rotation est DÉFENSIVE (data 3 ans : %positif forward 20j en baisse
+    // US 79→59% / EU 69→59%, vol future +35-90%), on DURCIT le seuil VIX/V2TX d'une
+    // pénalité. Modulateur de PRUDENCE uniquement (signal modeste + biais bull) —
+    // JAMAIS un assouplissement. Modes : off / shadow (log only) / active.
+    // Default shadow → valide en live (out-of-sample) avant d'agir, cf. discipline
+    // anti-overfit. Fail-open : rotation indispo (null) → aucune modulation.
+    const rotMode = (this.config.get<string>('OVERSOLD_ROTATION_GATE_MODE') ?? 'shadow').toLowerCase();
+    let effThresholds = thresholds;
+    let rotation: (RotationRegime & { mode: string; appliedVixPenalty: number }) | null = null;
+    if (rotMode !== 'off') {
+      const rot = await this.fetchRotationRegime(region).catch(() => null);
+      if (rot) {
+        const penalty = parseFloat(this.config.get<string>('OVERSOLD_ROTATION_VIX_PENALTY') ?? '2');
+        const wouldApply = rot.regime === 'defensive' && penalty > 0;
+        const applied = wouldApply && rotMode === 'active';
+        if (applied) {
+          effThresholds = { ...thresholds, vixMax: thresholds.vixMax - penalty };
+        }
+        rotation = { ...rot, mode: rotMode, appliedVixPenalty: applied ? penalty : 0 };
+        if (wouldApply) {
+          this.logger.log(
+            `[oversold-rotation:${rotMode}] ${region} régime=DÉFENSIF ratio=${rot.ratio?.toFixed(3)} ma50=${rot.ma?.toFixed(3)} (spread ${rot.spreadPct?.toFixed(1)}%) → ` +
+              (applied
+                ? `vixMax durci ${thresholds.vixMax}→${effThresholds.vixMax}`
+                : `aurait durci vixMax ${thresholds.vixMax}→${thresholds.vixMax - penalty} (shadow, non appliqué)`),
+          );
+        }
+      }
+    }
+
+    const decision = decideRegimeBlock({ vix, vixChg, idx5d }, effThresholds, labels);
+    return { ...decision, region, vix, vixChg, idx5d, vixSource, thresholds: effThresholds, rotation };
+  }
+
+  // ─── PR #639 — Rotation sectorielle offensif/défensif (cache + fetch par région) ───
+  private rotationCache = new Map<'US' | 'EU', { at: number; data: RotationRegime }>();
+  private readonly ROTATION_TTL_MS = 60 * 60 * 1000; // EOD change 1×/jour → 1h suffit
+
+  /** Paire offensif/défensif par région (override possible via env). */
+  private rotationSymbols(region: 'US' | 'EU'): { off: string; def: string } {
+    if (region === 'EU') {
+      return {
+        off: this.config.get<string>('OVERSOLD_ROTATION_EU_OFF') ?? 'EXV3.XETRA', // STOXX600 Tech
+        def: this.config.get<string>('OVERSOLD_ROTATION_EU_DEF') ?? 'EXH3.XETRA', // STOXX600 Food&Bev
+      };
+    }
+    return {
+      off: this.config.get<string>('OVERSOLD_ROTATION_US_OFF') ?? 'SMH.US', // Semis/IA
+      def: this.config.get<string>('OVERSOLD_ROTATION_US_DEF') ?? 'XLP.US', // Consumer staples
+    };
+  }
+
+  /** Régime de rotation offensif/défensif de la région (cache 1h, fail-open). */
+  private async fetchRotationRegime(region: 'US' | 'EU'): Promise<RotationRegime> {
+    const cached = this.rotationCache.get(region);
+    if (cached && Date.now() - cached.at < this.ROTATION_TTL_MS) return cached.data;
+    const { off, def } = this.rotationSymbols(region);
+    const [offBars, defBars] = await Promise.all([
+      this.fetchEodBars(off, 80).catch(() => [] as EodBar[]), // ~80j calendaires ⊇ 55 ouvrés (MM50)
+      this.fetchEodBars(def, 80).catch(() => [] as EodBar[]),
+    ]);
+    const data = computeRotationRegime(offBars, defBars, 50);
+    this.rotationCache.set(region, { at: Date.now(), data });
+    return data;
   }
 
   /**
@@ -1036,12 +1102,12 @@ export class OversoldScannerService {
    * Fetch direct EODHD EOD sur la fenêtre des ~5 derniers jours pour 1 symbole.
    * 1 call EOD = 1 quota. La clé n'est JAMAIS loggée.
    */
-  private async fetchEodBars(symbol: string): Promise<EodBar[]> {
+  private async fetchEodBars(symbol: string, calendarDays = 8): Promise<EodBar[]> {
     const apiKey = this.config.get<string>('EODHD_API_KEY');
     if (!apiKey) return [];
 
     const to = new Date();
-    const from = new Date(to.getTime() - 8 * 86_400_000); // 8 jours calendaires ⊇ 5 jours ouvrés
+    const from = new Date(to.getTime() - calendarDays * 86_400_000); // 8j ⊇ 5 ouvrés ; ~80j ⊇ 55 ouvrés (MM50)
     const fromStr = from.toISOString().slice(0, 10);
     const toStr = to.toISOString().slice(0, 10);
 

--- a/apps/api/src/modules/lisa/services/oversold.helper.ts
+++ b/apps/api/src/modules/lisa/services/oversold.helper.ts
@@ -203,3 +203,49 @@ export function decideRegimeBlock(
   }
   return { block: false, reason: 'pass' };
 }
+
+/** Régime de rotation sectorielle offensif/défensif (cf. computeRotationRegime). */
+export interface RotationRegime {
+  regime: 'offensive' | 'defensive' | null;
+  ratio: number | null; // dernier ratio offensif/défensif
+  ma: number | null; // MM(maLen) du ratio
+  spreadPct: number | null; // (ratio/ma - 1)*100 — distance au seuil
+  n: number; // nb de points alignés par date
+}
+
+/**
+ * Régime de rotation sectorielle offensif/défensif.
+ *
+ * ratio = close(secteur offensif) / close(secteur défensif), aligné par date.
+ * regime = 'offensive' si dernier ratio ≥ MM(maLen) du ratio, sinon 'defensive'.
+ * `null` (fail-open) si < maLen+1 points alignés — le caller ne module alors rien.
+ *
+ * Paires validées sur 3 ans (juin 2023→2026) :
+ *   US : SMH/XLP (semis vs staples)         — régime DEF → fwd20j %pos 79→59%, vol +56%
+ *   EU : EXV3/EXH3 (STOXX tech vs food&bev) — régime DEF → fwd20j %pos 69→59%, vol +36%
+ * Signal MODESTE, surtout utile combiné au VIX/V2TX (désambiguïse le régime
+ * vol-élevé : rebond vs vrai risk-off). Biais bull market (corrections rachetées
+ * sur la période) → modulateur de PRUDENCE, jamais feu vert agressif.
+ */
+export function computeRotationRegime(
+  offBars: EodBar[],
+  defBars: EodBar[],
+  maLen = 50,
+): RotationRegime {
+  const defByDate = new Map(defBars.map((b) => [b.date, b.close]));
+  const ratios: number[] = [];
+  for (const b of offBars) {
+    const d = defByDate.get(b.date);
+    if (d != null && d > 0 && b.close > 0) ratios.push(b.close / d);
+  }
+  const lastRatio = ratios.length > 0 ? ratios[ratios.length - 1] : null;
+  if (ratios.length < maLen + 1) {
+    return { regime: null, ratio: lastRatio, ma: null, spreadPct: null, n: ratios.length };
+  }
+  const last = ratios[ratios.length - 1];
+  const window = ratios.slice(ratios.length - maLen);
+  const ma = window.reduce((s, x) => s + x, 0) / maLen;
+  const regime: 'offensive' | 'defensive' = last >= ma ? 'offensive' : 'defensive';
+  const spreadPct = ma > 0 ? (last / ma - 1) * 100 : null;
+  return { regime, ratio: last, ma, spreadPct, n: ratios.length };
+}


### PR DESCRIPTION
## Contexte

Suite à notre analyse de régimes sur 3 ans de données réelles EODHD, le seul levier robuste identifié au-delà du VIX = la **rotation sectorielle offensif/défensif**. Ce PR l'ajoute comme **2e axe** au `checkRegimeGate` des **2 portfolios oversold** (US `russell1000` + EU `stoxx600`), avec un **signal natif par région** (validé légèrement meilleur que le proxy US sur le marché EU).

## Le signal (mesuré, pas supposé)

Ratio offensif/défensif vs sa MM50, par région :
- **US** : `SMH/XLP` (semis vs staples)
- **EU** : `EXV3.XETRA / EXH3.XETRA` (STOXX 600 Tech vs Food & Beverage)

Validation backtest 3 ans (forward 20j de l'indice de la région) :

| Régime | US %positif | EU %positif | Vol future |
|---|---|---|---|
| Offensif | 79% | 69% | ~10-11% |
| **Défensif** | **59%** | **59%** | **+35 à +90%** |

- Complémentaire au VIX (corrélation −0,31, pas redondant).
- **Valeur clé** : désambiguïse le régime VIX-élevé (rebond à acheter vs vrai risk-off) — défaut d'un gate VIX binaire.

## Intégration prudente

Rotation **défensive → DURCIT** le seuil VIX/V2TX d'une pénalité (default 2). **Jamais d'assouplissement** (le signal est modeste + biaisé bull market : sur la période, toutes les corrections ont été rachetées).

**Modes `OVERSOLD_ROTATION_GATE_MODE` = `off` | `shadow` | `active`, default `shadow`** : on calcule + log `[oversold-rotation:shadow]` ce que ça *aurait* changé, **sans agir**, pour valider en **live (out-of-sample)** avant d'activer — exactement la discipline anti-overfit qu'on s'est fixée. Passage à `active` = 1 secret quand les données live confirment.

**Fail-open** : rotation indisponible (data insuffisante) → `null` → aucune modulation, gate strictement inchangé.

## Implémentation

- `computeRotationRegime` (pur, testé) dans `oversold.helper.ts`.
- `fetchEodBars` paramétré (`calendarDays`, rétrocompatible 8j) pour récupérer ~55 jours (MM50).
- `fetchRotationRegime` + cache 1h par région dans le service (EOD → 1×/jour).

## Réversibilité

`OVERSOLD_ROTATION_GATE_MODE` (shadow), `OVERSOLD_ROTATION_VIX_PENALTY` (2), `OVERSOLD_ROTATION_{US,EU}_{OFF,DEF}` (defaults SMH/XLP, EXV3/EXH3).

## Tests

+5 cas `computeRotationRegime` (offensif / défensif / fail-open data insuffisante / alignement par date / closes invalides) — **39 verts** oversold. Typecheck OK.

## Suite

Démarre en **shadow**. Dans 2-4 semaines, on grep les logs `[oversold-rotation:shadow]` pour mesurer combien de fois la rotation aurait durci le gate et si ça aurait évité des pertes → si confirmé out-of-sample, on passe `active`.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_