### PR TITLE
feat(oversold): rotation gate en mode réel (active) par défaut

### DIFF
--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -738,9 +738,12 @@ export class OversoldScannerService {
     // US 79→59% / EU 69→59%, vol future +35-90%), on DURCIT le seuil VIX/V2TX d'une
     // pénalité. Modulateur de PRUDENCE uniquement (signal modeste + biais bull) —
     // JAMAIS un assouplissement. Modes : off / shadow (log only) / active.
-    // Default shadow → valide en live (out-of-sample) avant d'agir, cf. discipline
-    // anti-overfit. Fail-open : rotation indispo (null) → aucune modulation.
-    const rotMode = (this.config.get<string>('OVERSOLD_ROTATION_GATE_MODE') ?? 'shadow').toLowerCase();
+    // Default ACTIVE : modulateur qui ne fait que DURCIR le seuil → risque
+    // asymétrique (au pire trop prudent, jamais plus exposé), et mesure backtest
+    // 3 ans déjà disponible. Effet analysé en réel après ~1 semaine via les logs
+    // [oversold-rotation:active]. Repli : OVERSOLD_ROTATION_GATE_MODE=off|shadow.
+    // Fail-open : rotation indispo (null) → aucune modulation (gate inchangé).
+    const rotMode = (this.config.get<string>('OVERSOLD_ROTATION_GATE_MODE') ?? 'active').toLowerCase();
     let effThresholds = thresholds;
     let rotation: (RotationRegime & { mode: string; appliedVixPenalty: number }) | null = null;
     if (rotMode !== 'off') {


### PR DESCRIPTION
## Décision : rotation gate en RÉEL, fin du shadow

Suite à ta remarque (juste) : on empile trop de couches shadow et on ne tranche jamais. Je passe le modulateur de rotation (#639) **directement en mode `active`** par défaut.

**Pourquoi c'est sûr de l'activer sans shadow ici :**
- Le modulateur **ne fait que DURCIR** le seuil VIX/V2TX quand la rotation est défensive → **risque asymétrique** : au pire on ouvre quelques trades de moins (trop prudent), **jamais plus exposé**.
- La mesure **backtest 3 ans** existe déjà (régime défensif → %positif 79→59% US / 69→59% EU, vol future +35-90%).
- L'effet **réel** sera analysé **dans ~1 semaine** via les logs `[oversold-rotation:active]` — c'est de l'A/B en live, plus parlant que le shadow.

**Repli immédiat** si besoin : `OVERSOLD_ROTATION_GATE_MODE=off` (ou `shadow`) — 1 secret, sans redéploiement de code.

Aucun autre changement vs #639 (logique identique, juste le défaut du mode). Typecheck OK.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_