### PR TITLE
chore(shadow): hard-off feature A/B tuning + TwelveData supertrend shadow

### DIFF
--- a/apps/api/src/modules/lisa/services/feature-ab-tuning.service.ts
+++ b/apps/api/src/modules/lisa/services/feature-ab-tuning.service.ts
@@ -47,7 +47,10 @@ export class FeatureABTuningService {
   ) {}
 
   onModuleInit(): void {
-    this.enabled = (this.config.get<string>('FEATURE_AB_TUNING_ENABLED') ?? 'false').toLowerCase() === 'true';
+    // PR #641 — Feature A/B tuning TUÉ (inventaire 06/06 : 98% no-op sur 1000
+    // décisions, 1.8% d'actions à impact non démontré = bruit). Hard-off : le flag
+    // FEATURE_AB_TUNING_ENABLED est ignoré (secret Fly orphelin → à supprimer).
+    this.enabled = false;
     const wdRaw = Number.parseInt(this.config.get<string>('FEATURE_AB_WINDOW_DAYS') ?? '', 10);
     this.windowDays = Number.isFinite(wdRaw) && wdRaw >= 3 && wdRaw <= 90 ? wdRaw : 14;
     if (this.enabled) {

--- a/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/top-gainers-scanner.service.ts
@@ -4193,14 +4193,15 @@ export class TopGainersScannerService implements OnModuleInit {
             (this.config.get<string>('TWELVEDATA_FILTER_ASIA_SUPERTREND_ENABLED') ?? 'false') === 'true';
           const liveEu =
             (this.config.get<string>('TWELVEDATA_FILTER_EU_SUPERTREND_ENABLED') ?? 'false') === 'true';
-          const shadowUs =
-            (this.config.get<string>('TWELVEDATA_FILTER_US_SUPERTREND_SHADOW') ?? 'false') === 'true';
+          // PR #641 — supertrend shadow US/EU/ASIA TUÉ (inventaire 06/06 : pas de
+          // verdict d'amélioration, ne sert que si on active le filtre live). Hard-off :
+          // flags TWELVEDATA_FILTER_*_SUPERTREND_SHADOW ignorés (secrets orphelins).
+          // Le live (TWELVEDATA_FILTER_*_SUPERTREND_ENABLED) reste intact s'il est activé.
+          const shadowUs = false;
           const shadowCrypto =
             (this.config.get<string>('TWELVEDATA_FILTER_CRYPTO_RSI_SHADOW') ?? 'false') === 'true';
-          const shadowAsia =
-            (this.config.get<string>('TWELVEDATA_FILTER_ASIA_SUPERTREND_SHADOW') ?? 'false') === 'true';
-          const shadowEu =
-            (this.config.get<string>('TWELVEDATA_FILTER_EU_SUPERTREND_SHADOW') ?? 'false') === 'true';
+          const shadowAsia = false;
+          const shadowEu = false;
           const supertrendEnabled = liveUs || shadowUs;
           const cryptoRsiEnabled = liveCrypto || shadowCrypto;
           const asiaSupertrendEnabled = liveAsia || shadowAsia;


### PR DESCRIPTION
## Suite à "creuse et selon les résultats hard-off"

J'ai creusé les 2 shadows "à trancher", et les résultats justifient de les couper :

### 1. Feature A/B tuning → 🔴 hard-off
`shadow_sizing_autotune_log`, 1 000 décisions récentes : **982 no-op (`action_applied=false`) vs 18 appliquées (1,8%)**, surtout `target_progress` (suivi) et `sizing_suggestion` (suggestions, et le sizing A/B perd de toute façon). → **Bruit, impact non démontré.** Service hard-off (`this.enabled=false`).

### 2. TwelveData supertrend shadow (US/EU/ASIA) → 🔴 hard-off
`supertrendEnabled = liveUs || shadowUs` : le shadow force le calcul supertrend **sans verdict d'amélioration**, et ne servirait que si on activait le filtre **live** (pas le cas). → Les 3 flags shadow forcés `false`. **Le live (`TWELVEDATA_FILTER_*_SUPERTREND_ENABLED`) reste intact** s'il est activé.

## Hard-off propre ici (contrairement aux LLM)

**0 test cassé** : les specs concernés testent des **fonctions pures** (`computeFeatureContributions`, `buildNarrative`), pas le flag `enabled`. **179 verts.** Les secrets Fly correspondants deviennent orphelins (à supprimer quand tu veux).

> ⚠️ Les shadows **LLM** (`MISTRAL_LARGE_SHADOW`, `MISTRAL_SHADOW`, `GAINERS_V1_SHADOW`) ne sont **pas** hard-off ici : leur hard-off casse 24 tests de logique → à couper par **secret Fly = false** (la voie propre pour ceux-là). Idem `SIZING_AB_TEST` / `SHADOW_SIZING_*` (settés par secret, conclusion déjà atteinte).

## Bilan désempilage

- 🔴 Hard-off code (ce PR) : feature tuning, TD supertrend shadow.
- 🔴 Secrets Fly → `false` (toi) : `MISTRAL_LARGE_SHADOW_ENABLED`, `MISTRAL_SHADOW_ENABLED`, `GAINERS_V1_SHADOW`, `SIZING_AB_TEST_ENABLED`, `SHADOW_SIZING_GEMINI_ENABLED`, `SHADOW_SIZING_ORCHESTRATOR_ENABLED`.
- 🟢 Gardés : `SCANNER_AB_SHADOW` (funnel) + rotation oversold (réel).

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_