### PR TITLE
Fix traceur EODHD: retire la colonne générée `provider` de l'insert

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -33,8 +33,9 @@ function installEodhdTracer(): void {
   const origFetch = globalThis.fetch;
 
   const record = (caller: string, endpoint: string, ticker: string, ok: boolean, status: number): void => {
+    // NB: ne PAS insérer `provider` — colonne générée (dérivée de `source`),
+    // un insert explicite échoue ("cannot insert a non-DEFAULT value").
     void sb.from('eodhd_request_log').insert({
-      provider: 'eodhd',
       source: 'eodhd',
       called_by: `trace:${caller}`,
       endpoint,


### PR DESCRIPTION
Le traceur EODHD (#642) ne produisait **0 ligne `trace:*`** malgré un déploiement réussi (SHA `ea48119` live, app active à 604 calls/10min).

**Cause** : l'insert mettait `provider:'eodhd'`, or `provider` est une colonne **GENERATED** (dérivée de `source`) → `cannot insert a non-DEFAULT value into column "provider"` → chaque insert échouait en silence (fire-and-forget).

**Fix** : retirer `provider` de l'insert (testé depuis sandbox : sans `provider`, l'insert passe et `provider` se dérive bien en `'eodhd'`).

Diff = 1 fichier, le seul changement.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_