### PR TITLE
feat(lisa): panneau "Esprit décision OVERSOLD" mode-aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ apps/web/content/docs/
 # SHORT-SHADOW Phase 2 local outputs (rétroactif rigoureux, local only)
 phase2-retro-results.json
 .claude/credentials.local
+
+# Scripts de diagnostic jetables (sandbox local, jamais committés)
+scripts/_tmp_*.ts

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -33,8 +33,9 @@ function installEodhdTracer(): void {
   const origFetch = globalThis.fetch;
 
   const record = (caller: string, endpoint: string, ticker: string, ok: boolean, status: number): void => {
+    // NB: ne PAS insérer `provider` — colonne générée (dérivée de `source`),
+    // un insert explicite échoue ("cannot insert a non-DEFAULT value").
     void sb.from('eodhd_request_log').insert({
-      provider: 'eodhd',
       source: 'eodhd',
       called_by: `trace:${caller}`,
       endpoint,

--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -1792,6 +1792,19 @@ export class LisaController {
     return this.lisa.getTraderMind(extractUserId(headers), portfolioId, n);
   }
 
+  // 07/06/2026 — OVERSOLD mind feed pour panel UI live (poll 60s côté front).
+  // Lit lisa_decision_log filtré sur les kinds oversold (scan/exits), pas
+  // trader_agent_decisions. Pendant du panel trader pour le mode swing.
+  @Get('oversold-mind/:portfolioId')
+  getOversoldMind(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+    @Query('limit') limit?: string,
+  ) {
+    const n = Math.min(Math.max(parseInt(limit ?? '30', 10) || 30, 1), 100);
+    return this.lisa.getOversoldMind(extractUserId(headers), portfolioId, n);
+  }
+
   // LISA refonte B.2 — Lessons Impact Tracker.
   // Agrège les citations sur une fenêtre glissante (default 30j, max 365).
   @Get('lessons-impact/:portfolioId')

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -2635,6 +2635,62 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
   }
 
   /**
+   * 07/06/2026 — OVERSOLD mind feed pour panel UI live (poll 60s côté front).
+   *
+   * Le mode oversold ne passe PAS par trader_agent_decisions (pas de cycle LLM
+   * 2 min) : ses décisions sont déjà tracées dans lisa_decision_log via
+   * DecisionLogService.append (oversold_scan_completed, blocked_regime, exits…).
+   * On filtre sur les kinds pertinents pour EXCLURE le bruit `risk_advisory`
+   * par-minute + l'historique legacy gainers/trader des portfolios migrés
+   * (rebound_scan_completed, proposal_generated, skeptic_verdict, shadow_sizing…).
+   */
+  async getOversoldMind(userId: string, portfolioId: string, limit = 30) {
+    await this.assertPortfolioOwner(userId, portfolioId);
+    const OVERSOLD_MIND_KINDS = [
+      // Entrées (scan déterministe daily 21:15 + intraday horaire)
+      'oversold_scan_completed',
+      'oversold_intraday_scan_completed',
+      'oversold_scan_blocked_regime',
+      'oversold_candidate_skip_news',
+      'scanner_candidate_skip',
+      'position_opened',
+      // Sorties (mécanique + choppy-exit LLM + thèse cassée)
+      'position_closed',
+      'position_closed_manual',
+      'mechanical_close_stop',
+      'mechanical_close_target',
+      'choppy_exit_llm_approved',
+      'choppy_exit_llm_blocked',
+      'risk_manager_thesis_broken',
+    ];
+    const { data, error } = await this.supabase.getClient()
+      .from('lisa_decision_log')
+      .select('id, timestamp, kind, summary, rationale, payload')
+      .eq('portfolio_id', portfolioId)
+      .in('kind', OVERSOLD_MIND_KINDS)
+      .order('timestamp', { ascending: false })
+      .limit(limit);
+    if (error) throw new BadRequestException(error.message);
+    return (data ?? []).map((d) => {
+      const p = (d.payload ?? {}) as Record<string, unknown>;
+      const num = (v: unknown): number | null =>
+        v == null || Number.isNaN(Number(v)) ? null : Number(v);
+      return {
+        id: d.id as string,
+        timestamp: d.timestamp as string,
+        kind: d.kind as string,
+        summary: (d.summary as string) ?? '',
+        rationale: (d.rationale as string) ?? null,
+        symbol: (p.symbol ?? p.target_symbol ?? null) as string | null,
+        pnl_usd: num(p.realized_pnl_usd ?? p.pnl_usd),
+        drop_pct: num(p.drop_pct),
+        opened: num(p.opened),
+        candidates: num(p.candidates),
+      };
+    });
+  }
+
+  /**
    * LISA refonte B.2 — Lessons Impact Tracker.
    *
    * Agrège les citations de lessons par TRADER sur une fenêtre glissante.

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -32,6 +32,7 @@ import { DailyHarvestPanel } from '@/components/lisa/daily-harvest-panel';
 import { MacroModeSelector } from '@/components/lisa/macro-mode-selector';
 import { GainersStatusTile } from '@/components/lisa/gainers-status-tile';
 import { TraderMindPanel } from '@/components/lisa/trader-mind-panel';
+import { OversoldMindPanel } from '@/components/lisa/oversold-mind-panel';
 import { GainersConfigPanel } from '@/components/lisa/gainers-config-panel';
 import { LisaStickyHeader } from '@/components/lisa/lisa-sticky-header';
 import { GainsTracker } from '@/components/lisa/gains-tracker';
@@ -729,8 +730,14 @@ export default function LisaPage() {
           HIGH est passé en oversold : le comparatif A/B momentum n'a plus de sens.
           Carte supprimée de l'UI dans tous les modes (historique conservé en DB). */}
 
-      {/* 05/06/2026 — TRADER mind feed live (poll 60s) */}
-      {selectedPortfolioId && <TraderMindPanel portfolioId={selectedPortfolioId} />}
+      {/* Mind feed live (poll 60s) — mode-aware : oversold lit lisa_decision_log
+          (scan swing + exits), les autres modes lisent trader_agent_decisions. */}
+      {selectedPortfolioId && currentMode === 'oversold' && (
+        <OversoldMindPanel portfolioId={selectedPortfolioId} />
+      )}
+      {selectedPortfolioId && currentMode !== 'oversold' && (
+        <TraderMindPanel portfolioId={selectedPortfolioId} />
+      )}
 
       {/* LISA refonte C.2 — Strategy Coach proposals (Gemini hourly + review modal) */}
       {selectedPortfolioId && <CoachProposalsPanel portfolioId={selectedPortfolioId} />}

--- a/apps/web/src/components/lisa/oversold-mind-panel.tsx
+++ b/apps/web/src/components/lisa/oversold-mind-panel.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { Brain, AlertCircle } from 'lucide-react';
+import { useOversoldMind } from '@/hooks/use-lisa';
+import { SkeletonCard } from '@/components/ui/skeleton';
+
+interface Props {
+  portfolioId: string;
+}
+
+function fmtTime(iso: string): string {
+  // timestamp Supabase peut être '...T03:15:22.72+00:00' ou '...Z'
+  return iso.slice(11, 19);
+}
+
+function relativeAge(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return 'à l\'instant';
+  const min = Math.round(ms / 60_000);
+  if (min < 60) return `il y a ${min} min`;
+  const h = Math.round(min / 60);
+  if (h < 24) return `il y a ${h}h`;
+  return `il y a ${Math.round(h / 24)}j`;
+}
+
+// Mapping kind → libellé + couleur. Couvre les décisions oversold (scan
+// déterministe + sorties) tracées dans lisa_decision_log.
+const KIND_LABELS: Record<string, { label: string; color: string }> = {
+  oversold_scan_completed: { label: 'SCAN jour', color: 'bg-emerald-50 text-emerald-700 border-emerald-200' },
+  oversold_intraday_scan_completed: { label: 'SCAN intraday', color: 'bg-teal-50 text-teal-700 border-teal-200' },
+  oversold_scan_blocked_regime: { label: 'RÉGIME BLOQUÉ', color: 'bg-slate-100 text-slate-600 border-slate-300' },
+  oversold_candidate_skip_news: { label: 'SKIP news', color: 'bg-amber-50 text-amber-700 border-amber-200' },
+  scanner_candidate_skip: { label: 'SKIP', color: 'bg-slate-50 text-slate-500 border-slate-200' },
+  position_opened: { label: 'OPEN', color: 'bg-emerald-50 text-emerald-700 border-emerald-200' },
+  position_closed: { label: 'CLOSE', color: 'bg-blue-50 text-blue-700 border-blue-200' },
+  position_closed_manual: { label: 'CLOSE manuel', color: 'bg-blue-50 text-blue-700 border-blue-200' },
+  mechanical_close_stop: { label: 'STOP', color: 'bg-red-50 text-red-700 border-red-200' },
+  mechanical_close_target: { label: 'TAKE-PROFIT', color: 'bg-emerald-50 text-emerald-700 border-emerald-200' },
+  choppy_exit_llm_approved: { label: 'EXIT validé', color: 'bg-amber-50 text-amber-700 border-amber-200' },
+  choppy_exit_llm_blocked: { label: 'EXIT bloqué', color: 'bg-slate-50 text-slate-500 border-slate-200' },
+  risk_manager_thesis_broken: { label: 'THÈSE CASSÉE', color: 'bg-red-50 text-red-700 border-red-200' },
+};
+
+export function OversoldMindPanel({ portfolioId }: Props) {
+  const { data, isLoading, error } = useOversoldMind(portfolioId, 30);
+
+  return (
+    <div className="rounded-lg border p-5 space-y-3">
+      <div className="flex items-center gap-2">
+        <Brain className="h-4 w-4 text-muted-foreground" />
+        <h2 className="text-sm font-medium">Esprit décision OVERSOLD</h2>
+        <span className="text-xs text-muted-foreground">(30 dernières décisions · refresh 60s)</span>
+      </div>
+
+      {isLoading && <SkeletonCard />}
+
+      {error && (
+        <div className="text-xs text-red-600 flex items-center gap-1.5">
+          <AlertCircle className="h-3 w-3" />
+          Erreur chargement : {error instanceof Error ? error.message : String(error)}
+        </div>
+      )}
+
+      {!isLoading && !error && (data?.length ?? 0) === 0 && (
+        <div className="rounded border border-dashed p-4 text-center text-xs text-muted-foreground">
+          Aucune décision oversold pour l'instant (scan quotidien 21:15 UTC + intraday horaire).
+        </div>
+      )}
+
+      {!isLoading && data && data.length > 0 && (
+        <div className="space-y-2 max-h-[60vh] overflow-y-auto">
+          {data.map((d) => {
+            const spec = KIND_LABELS[d.kind] ?? {
+              label: d.kind.toUpperCase(),
+              color: 'bg-slate-50 text-slate-600 border-slate-200',
+            };
+            const pnl = d.pnl_usd;
+            return (
+              <div
+                key={d.id}
+                className="rounded-md border p-2.5 bg-card hover:bg-accent/30 transition-colors"
+              >
+                <div className="flex items-center gap-2 flex-wrap text-xs">
+                  <span className="font-mono text-muted-foreground">{fmtTime(d.timestamp)}Z</span>
+                  <span className={`inline-flex items-center rounded border px-1.5 py-0.5 font-medium ${spec.color}`}>
+                    {spec.label}
+                  </span>
+                  {d.symbol && <span className="font-mono font-medium">{d.symbol}</span>}
+                  {d.drop_pct != null && (
+                    <span className="text-rose-600">drop {d.drop_pct.toFixed(1)}%</span>
+                  )}
+                  {d.candidates != null && d.opened != null && (
+                    <span className="text-muted-foreground">{d.candidates} cand → {d.opened} ouverts</span>
+                  )}
+                  {pnl != null && (
+                    <span className={`ml-auto font-medium ${pnl >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                      {pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}
+                    </span>
+                  )}
+                </div>
+                {d.summary && (
+                  <div className="mt-1.5 text-xs">{d.summary}</div>
+                )}
+                {d.rationale && (
+                  <div className="mt-0.5 text-[11px] text-muted-foreground line-clamp-2">
+                    💭 {d.rationale}
+                  </div>
+                )}
+                <div className="mt-1 text-[10px] text-muted-foreground/70">{relativeAge(d.timestamp)}</div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-lisa.ts
+++ b/apps/web/src/hooks/use-lisa.ts
@@ -275,6 +275,29 @@ export function useTraderMind(portfolioId: string | null, limit = 30) {
   });
 }
 
+// 07/06/2026 — Esprit décision OVERSOLD (lit lisa_decision_log filtré, poll 60s).
+export interface OversoldMindEvent {
+  id: string;
+  timestamp: string;
+  kind: string;
+  summary: string;
+  rationale: string | null;
+  symbol: string | null;
+  pnl_usd: number | null;
+  drop_pct: number | null;
+  opened: number | null;
+  candidates: number | null;
+}
+
+export function useOversoldMind(portfolioId: string | null, limit = 30) {
+  return useQuery({
+    queryKey: ['lisa', 'oversold-mind', portfolioId, limit],
+    queryFn: () => apiFetch<OversoldMindEvent[]>(`/lisa/oversold-mind/${portfolioId}?limit=${limit}`),
+    enabled: !!portfolioId,
+    refetchInterval: 60_000,
+  });
+}
+
 export function useUpsertLisaConfig(portfolioId: string) {
   const qc = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Quoi

Réplique le panneau « Esprit décision TRADER » pour le mode **oversold**, qui ne passe pas par `trader_agent_decisions` (pas de cycle LLM 2 min). Ses décisions sont déjà tracées dans `lisa_decision_log` via `DecisionLogService` — ce PR les **surface** dans l'UI.

## Détail

- **API** `GET /lisa/oversold-mind/:portfolioId` — lit `lisa_decision_log` filtré sur les kinds oversold pertinents (scan jour 21:15 + scan intraday horaire + sorties : stop / take-profit / choppy-exit / thèse cassée). Exclut le bruit `risk_advisory` par-minute et l'historique legacy gainers/trader des portfolios migrés.
- **Web** — hook `useOversoldMind` + composant `OversoldMindPanel` (calque du panel trader, adapté au swing : badge décision, `drop%`, `N candidats → M ouverts`, PnL réalisé coloré, refresh 60s).
- **Montage mode-aware** dans `/lisa` : `oversold → OversoldMindPanel`, autres modes → `TraderMindPanel`. En mode oversold le panneau TRADER ne s'affiche plus (prépare le retrait UI complet du mode trader).

## Garanties

- Aucun changement de schéma DB (lecture seule de `lisa_decision_log`).
- `assertPortfolioOwner` appliqué (même garde que `getTraderMind`).
- `tsc -b` vert localement.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_