### PR TITLE
feat(oversold): fondation boucle apprentissage — collecte features + outcomes

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/oversold-features.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/oversold-features.spec.ts
@@ -1,0 +1,76 @@
+import {
+  computeRsi,
+  computeEntryFeatures,
+  type EodBar,
+} from '../oversold.helper';
+
+function bar(date: string, close: number, volume = 1000): EodBar {
+  return { date, close, volume };
+}
+
+describe('computeRsi', () => {
+  it('renvoie null si pas assez de barres', () => {
+    expect(computeRsi([100, 101, 102], 14)).toBeNull();
+  });
+
+  it('renvoie 100 si aucune perte sur la fenêtre (hausse pure)', () => {
+    const closes = Array.from({ length: 20 }, (_, i) => 100 + i); // monotone croissant
+    expect(computeRsi(closes, 14)).toBe(100);
+  });
+
+  it('renvoie 0 si la fenêtre est plate puis chute (oversold extrême)', () => {
+    const closes = [...Array.from({ length: 19 }, () => 100), 92]; // 19 plats + 1 chute
+    expect(computeRsi(closes, 14)).toBe(0);
+  });
+});
+
+describe('computeEntryFeatures', () => {
+  // 60 barres plates à 100, drop -8% à l'entrée (idx 59), volume ×2 à l'entrée.
+  const bars: EodBar[] = [
+    ...Array.from({ length: 59 }, (_, i) => bar(`2026-01-${String(i + 1).padStart(2, '0')}`, 100, 1000)),
+    bar('2026-03-01', 92, 2000),
+  ];
+  const idx = 59;
+
+  it('renvoie null si entryIdx hors bornes', () => {
+    expect(computeEntryFeatures(bars, 0)).toBeNull();
+    expect(computeEntryFeatures(bars, 999)).toBeNull();
+  });
+
+  it('calcule drop1d = -8% sur le drop déclencheur', () => {
+    const f = computeEntryFeatures(bars, idx)!;
+    expect(f.drop1d).toBeCloseTo(-8, 5);
+  });
+
+  it('trend20 ~ 0% sur un historique plat avant le drop (pas falling-knife)', () => {
+    const f = computeEntryFeatures(bars, idx)!;
+    expect(f.trend20).toBeCloseTo(0, 5);
+  });
+
+  it('distMa20 et distMa50 négatives (close sous la moyenne après le drop)', () => {
+    const f = computeEntryFeatures(bars, idx)!;
+    expect(f.distMa20).toBeCloseTo(-7.63, 1);
+    expect(f.distMa50).toBeCloseTo(-7.85, 1);
+  });
+
+  it('rsi14 = 0 sur plat puis chute, relVol20 = 2 (volume doublé)', () => {
+    const f = computeEntryFeatures(bars, idx)!;
+    expect(f.rsi14).toBe(0);
+    expect(f.relVol20).toBeCloseTo(2, 5);
+  });
+
+  it('vol14 > 0 et drop3d défini', () => {
+    const f = computeEntryFeatures(bars, idx)!;
+    expect(f.vol14).not.toBeNull();
+    expect(f.vol14!).toBeGreaterThan(0);
+    expect(f.drop3d).toBeCloseTo(-8, 5);
+  });
+
+  it('features de profondeur null si historique trop court', () => {
+    const short = bars.slice(50); // 10 barres seulement
+    const f = computeEntryFeatures(short, short.length - 1)!;
+    expect(f.trend20).toBeNull();
+    expect(f.distMa50).toBeNull();
+    expect(f.drop1d).toBeCloseTo(-8, 5); // le drop 1j reste calculable
+  });
+});

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -31,6 +31,7 @@ import {
   businessDaysSince,
   decideRegimeBlock,
   computeRotationRegime,
+  computeEntryFeatures,
   type OversoldConfig,
   type EodBar,
   type OversoldCandidate,
@@ -144,6 +145,11 @@ export class OversoldScannerService {
         this.logger.debug('[oversold] OVERSOLD_SCANNER_ENABLED=false → skip cycle');
         return;
       }
+
+      // PR-1 — collecte features/outcomes pour la boucle d'apprentissage (best-effort).
+      await this.reconcileOversoldFeatures().catch((e) =>
+        this.logger.warn(`[oversold-features] reconcile failed: ${String(e).slice(0, 200)}`),
+      );
 
       const portfolios = await this.loadOversoldPortfolios();
       if (portfolios.length === 0) {
@@ -408,6 +414,12 @@ export class OversoldScannerService {
         this.logger.debug('[oversold-intraday] disabled (OVERSOLD_SCANNER_ENABLED or OVERSOLD_INTRADAY_ENABLED off)');
         return;
       }
+
+      // PR-1 — collecte features/outcomes (best-effort, idempotent via scanner_position_id).
+      await this.reconcileOversoldFeatures().catch((e) =>
+        this.logger.warn(`[oversold-features] reconcile failed: ${String(e).slice(0, 200)}`),
+      );
+
       const portfolios = await this.loadOversoldPortfolios();
       if (portfolios.length === 0) {
         this.logger.debug('[oversold-intraday] aucun portfolio en mode oversold → skip');
@@ -1137,6 +1149,131 @@ export class OversoldScannerService {
       return bars;
     } finally {
       clearTimeout(timer);
+    }
+  }
+
+  /**
+   * PR-1 — Fondation boucle d'apprentissage oversold.
+   *
+   * Réconcilie les positions oversold (lisa_positions, source dans
+   * venue_fee_detail) vers `paper_trades` (strategy='oversold') avec le vecteur
+   * de features calculé AS-OF l'entrée + l'outcome quand la position est fermée.
+   *
+   * Idempotent : la clé est `scanner_position_id` = id de la lisa_position.
+   *  - position sans ligne paper_trades → fetch barres profondes + INSERT (features
+   *    as-of entrée ; outcome si déjà fermée). Backfill des positions existantes.
+   *  - ligne paper_trades 'open' dont la position est désormais fermée → UPDATE
+   *    outcome uniquement (aucun fetch).
+   *
+   * NE FILTRE RIEN, NE TRADE RIEN : pure collecte pour que l'empirical law
+   * (PR ultérieur) mesure quelles features prédisent les winners. Best-effort,
+   * jamais bloquant pour le scan.
+   */
+  private async reconcileOversoldFeatures(): Promise<void> {
+    const enabled =
+      (this.config.get<string>('OVERSOLD_FEATURE_COLLECTION_ENABLED') ?? 'true').toLowerCase() === 'true';
+    if (!enabled) return;
+    const client = this.supabase.getClient();
+
+    const sinceIso = new Date(Date.now() - 120 * 86_400_000).toISOString();
+    const { data: posRows } = await client
+      .from('lisa_positions')
+      .select(
+        'id, portfolio_id, symbol, asset_class, status, entry_price, entry_timestamp, exit_timestamp, realized_pnl_usd, realized_pnl_pct, entry_notional_usd, stop_loss_price, take_profit_price, venue_fee_detail',
+      )
+      .gte('entry_timestamp', sinceIso)
+      .limit(2000);
+
+    const oversold = (posRows ?? []).filter((p) => {
+      const vfd = p.venue_fee_detail as { source?: string } | null;
+      return vfd?.source === 'scanner_oversold';
+    });
+    if (oversold.length === 0) return;
+
+    const { data: ptRows } = await client
+      .from('paper_trades')
+      .select('id, scanner_position_id, status')
+      .eq('strategy', 'oversold')
+      .limit(5000);
+    const ptByPos = new Map<string, { id: string; status: string }>();
+    for (const r of ptRows ?? []) {
+      if (r.scanner_position_id) ptByPos.set(r.scanner_position_id as string, { id: r.id as string, status: r.status as string });
+    }
+
+    const pids = [...new Set(oversold.map((p) => p.portfolio_id as string))];
+    const { data: pf } = await client.from('portfolios').select('id, user_id').in('id', pids);
+    const userByPf = new Map((pf ?? []).map((p) => [p.id as string, p.user_id as string]));
+
+    let inserted = 0;
+    let updated = 0;
+    for (const p of oversold) {
+      const posId = p.id as string;
+      const closed = p.status !== 'open';
+      const pnl = Number(p.realized_pnl_usd ?? 0);
+      const existing = ptByPos.get(posId);
+
+      if (existing) {
+        if (closed && existing.status === 'open') {
+          await client
+            .from('paper_trades')
+            .update({
+              status: 'closed',
+              closed_at: p.exit_timestamp,
+              pnl_usd: String(pnl),
+              pnl_pct: p.realized_pnl_pct != null ? String(p.realized_pnl_pct) : null,
+              outcome_label: pnl > 0 ? 1 : 0,
+            })
+            .eq('id', existing.id);
+          updated++;
+        }
+        continue;
+      }
+
+      // Nouvelle position → features as-of entrée depuis barres profondes.
+      const entryDate = String(p.entry_timestamp ?? '').slice(0, 10);
+      if (!entryDate) continue;
+      const bars = await this.fetchEodBars(p.symbol as string, 160);
+      if (bars.length < 22) continue;
+      let idx = bars.findIndex((b) => b.date === entryDate);
+      if (idx < 0) {
+        for (let i = bars.length - 1; i >= 0; i--) {
+          if (bars[i].date <= entryDate) { idx = i; break; }
+        }
+      }
+      if (idx < 1) continue;
+      const feat = computeEntryFeatures(bars, idx);
+      if (!feat) continue;
+
+      const row: Record<string, unknown> = {
+        user_id: userByPf.get(p.portfolio_id as string) ?? null,
+        portfolio_id: p.portfolio_id,
+        symbol: p.symbol,
+        asset_class: p.asset_class ?? 'us_equity',
+        entry_price: p.entry_price != null ? String(p.entry_price) : null,
+        size_usd: p.entry_notional_usd != null ? String(p.entry_notional_usd) : null,
+        stop_loss: p.stop_loss_price != null ? String(p.stop_loss_price) : null,
+        take_profit: p.take_profit_price != null ? String(p.take_profit_price) : null,
+        status: closed ? 'closed' : 'open',
+        strategy: 'oversold',
+        scanner_position_id: posId,
+        setup_kind: 'OVERSOLD_DIP',
+        features_at_entry: feat,
+        opened_at: p.entry_timestamp,
+      };
+      if (closed) {
+        row.closed_at = p.exit_timestamp;
+        row.pnl_usd = String(pnl);
+        row.pnl_pct = p.realized_pnl_pct != null ? String(p.realized_pnl_pct) : null;
+        row.outcome_label = pnl > 0 ? 1 : 0;
+      }
+      const { error } = await client.from('paper_trades').insert(row);
+      if (!error) inserted++;
+    }
+
+    if (inserted || updated) {
+      this.logger.log(
+        `[oversold-features] reconcile: +${inserted} insérés, ${updated} outcomes maj (${oversold.length} positions oversold)`,
+      );
     }
   }
 

--- a/apps/api/src/modules/lisa/services/oversold.helper.ts
+++ b/apps/api/src/modules/lisa/services/oversold.helper.ts
@@ -249,3 +249,85 @@ export function computeRotationRegime(
   const spreadPct = ma > 0 ? (last / ma - 1) * 100 : null;
   return { regime, ratio: last, ma, spreadPct, n: ratios.length };
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// Features d'entrée pour la boucle d'apprentissage (PR-1 fondation oversold).
+// Calculées AS-OF l'entrée (uniquement barres jusqu'à entryIdx → pas de
+// look-ahead). EodBar n'a pas d'OHLC → "volatilité" = réalisée (stddev des
+// returns), PAS d'ATR vrai. Pures + testables, aucune dépendance réseau.
+// ⚠️ Aucune de ces features ne FILTRE l'entrée (cf. backtest n=6130 : un skip
+// par trend-20d détruit l'edge). Elles sont LOGGÉES pour que l'empirical law
+// (PR ultérieur) mesure lesquelles méritent un sizing différencié.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface OversoldEntryFeatures {
+  drop1d: number; // (close[t]/close[t-1]-1)*100 — le drop déclencheur
+  drop3d: number | null; // drop cumulé 3j
+  trend20: number | null; // (close[t-1]/close[t-21]-1)*100 — tendance AVANT le drop
+  distMa20: number | null; // distance au MA20 en % (close vs moyenne)
+  distMa50: number | null; // distance au MA50 en %
+  rsi14: number | null; // RSI Wilder simplifié 14
+  vol14: number | null; // volatilité réalisée 14j (stddev returns) en %
+  relVol20: number | null; // volume[t] / moyenne(volume, 20j)
+}
+
+/** RSI 14 (moyenne simple des gains/pertes sur la fenêtre). closes triés ASC. */
+export function computeRsi(closes: number[], period = 14): number | null {
+  if (closes.length < period + 1) return null;
+  let gain = 0;
+  let loss = 0;
+  for (let i = closes.length - period; i < closes.length; i++) {
+    const ch = closes[i] - closes[i - 1];
+    if (ch >= 0) gain += ch;
+    else loss -= ch;
+  }
+  const avgG = gain / period;
+  const avgL = loss / period;
+  if (avgL === 0) return 100;
+  return 100 - 100 / (1 + avgG / avgL);
+}
+
+/**
+ * Calcule le vecteur de features à l'index d'entrée `entryIdx` dans `bars`
+ * (triées par date ASC). Renvoie null si pas assez de barres pour le drop 1j.
+ * Chaque feature individuelle est null si la profondeur est insuffisante.
+ */
+export function computeEntryFeatures(bars: EodBar[], entryIdx: number): OversoldEntryFeatures | null {
+  if (entryIdx < 1 || entryIdx >= bars.length) return null;
+  const closes = bars.map((b) => b.close);
+  const vols = bars.map((b) => b.volume);
+  const c = closes[entryIdx];
+  if (!(c > 0)) return null;
+
+  const drop1d = (c / closes[entryIdx - 1] - 1) * 100;
+  const drop3d = entryIdx >= 3 ? (c / closes[entryIdx - 3] - 1) * 100 : null;
+  const trend20 = entryIdx >= 21 ? (closes[entryIdx - 1] / closes[entryIdx - 21] - 1) * 100 : null;
+
+  const ma = (n: number): number | null =>
+    entryIdx >= n - 1
+      ? closes.slice(entryIdx - n + 1, entryIdx + 1).reduce((s, x) => s + x, 0) / n
+      : null;
+  const ma20 = ma(20);
+  const ma50 = ma(50);
+  const distMa20 = ma20 ? (c / ma20 - 1) * 100 : null;
+  const distMa50 = ma50 ? (c / ma50 - 1) * 100 : null;
+
+  const rsi14 = computeRsi(closes.slice(0, entryIdx + 1), 14);
+
+  let vol14: number | null = null;
+  if (entryIdx >= 14) {
+    const rets: number[] = [];
+    for (let i = entryIdx - 13; i <= entryIdx; i++) rets.push(closes[i] / closes[i - 1] - 1);
+    const mean = rets.reduce((s, x) => s + x, 0) / rets.length;
+    const variance = rets.reduce((s, x) => s + (x - mean) ** 2, 0) / rets.length;
+    vol14 = Math.sqrt(variance) * 100;
+  }
+
+  let relVol20: number | null = null;
+  if (entryIdx >= 20) {
+    const avg = vols.slice(entryIdx - 20, entryIdx).reduce((s, x) => s + x, 0) / 20;
+    relVol20 = avg > 0 ? vols[entryIdx] / avg : null;
+  }
+
+  return { drop1d, drop3d, trend20, distMa20, distMa50, rsi14, vol14, relVol20 };
+}


### PR DESCRIPTION
## Quoi

Pose la **fondation de la boucle d'apprentissage oversold** : collecte les features d'entrée + outcomes des trades oversold dans `paper_trades` (strategy='oversold'), pour que l'empirical law (PR ultérieur) puisse mesurer quelles features prédisent les winners.

**Aucun filtre, aucun trade modifié** — pure collecte de données.

## Détail

- **`oversold.helper.ts`** : `computeRsi` + `computeEntryFeatures` (pures, testables) → `drop1d`, `drop3d`, `trend20` (tendance avant le drop), `distMa20/50`, `rsi14`, `vol14` (volatilité réalisée), `relVol20`. Close-based (EodBar sans OHLC → vol réalisée, pas d'ATR vrai). **Pas de look-ahead** (uniquement barres ≤ entrée).
- **`oversold-scanner.service.ts`** : `reconcileOversoldFeatures()` idempotent (clé = `scanner_position_id`). INSERT features as-of entrée (fetch barres profondes 160j) pour les nouvelles positions, UPDATE outcome quand fermées. Branché best-effort en tête des crons daily + intraday. Flag `OVERSOLD_FEATURE_COLLECTION_ENABLED` (défaut true).
- **Tests** : 10 cas sur `computeRsi` + `computeEntryFeatures`.

## Pourquoi pas de filtre trend-20d

Le backtest **n=6130, 2 ans, US+EU, horizon J+10** a montré que tout skip par trend-20d **détruit l'edge** (deep downtrends = meilleurs rebonds : `< -30%` → +8.2% J+10). Les features sont donc **loggées**, jamais utilisées comme gate — l'empirical law dira lesquelles méritent un sizing différencié.

## Validation

- `tsc -b` vert · 10/10 tests verts.
- Dry-run read-only contre la DB prod : **55 positions oversold** détectées (7 open EU + 48 closed US), tag `venue_fee_detail.source='scanner_oversold'` correct, fetch+features OK sur échantillon → backfill de ~55 lignes labellisées au premier cycle.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_