### PR TITLE
feat(oversold): features news as-of entrée (mesurées, pas de gate)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/oversold-features.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/oversold-features.spec.ts
@@ -1,6 +1,7 @@
 import {
   computeRsi,
   computeEntryFeatures,
+  summarizeEntryNews,
   type EodBar,
 } from '../oversold.helper';
 
@@ -72,5 +73,45 @@ describe('computeEntryFeatures', () => {
     expect(f.trend20).toBeNull();
     expect(f.distMa50).toBeNull();
     expect(f.drop1d).toBeCloseTo(-8, 5); // le drop 1j reste calculable
+  });
+});
+
+describe('summarizeEntryNews', () => {
+  const entry = '2026-06-04T20:00:00.000Z';
+
+  it('renvoie 0/null sans article', () => {
+    const f = summarizeEntryNews([], entry);
+    expect(f.newsCount).toBe(0);
+    expect(f.newsMinSentiment).toBeNull();
+    expect(f.newsAvgSentiment).toBeNull();
+    expect(f.newsAgeHours).toBeNull();
+  });
+
+  it('ignore les articles hors fenêtre [entry-72h, entry] (pas de look-ahead)', () => {
+    const f = summarizeEntryNews([
+      { publishedAt: '2026-06-04T21:00:00.000Z', sentiment: -0.9 }, // APRÈS l'entrée → exclu
+      { publishedAt: '2026-05-01T10:00:00.000Z', sentiment: -0.8 }, // > 72h avant → exclu
+    ], entry);
+    expect(f.newsCount).toBe(0);
+  });
+
+  it('agrège count/min/avg/age sur la fenêtre', () => {
+    const f = summarizeEntryNews([
+      { publishedAt: '2026-06-04T18:00:00.000Z', sentiment: -0.6 }, // 2h avant
+      { publishedAt: '2026-06-03T20:00:00.000Z', sentiment: 0.2 }, // 24h avant
+    ], entry);
+    expect(f.newsCount).toBe(2);
+    expect(f.newsMinSentiment).toBeCloseTo(-0.6, 5);
+    expect(f.newsAvgSentiment).toBeCloseTo(-0.2, 5);
+    expect(f.newsAgeHours).toBeCloseTo(2, 1); // plus récent = 2h avant l'entrée
+  });
+
+  it('gère les sentiments null sans casser count', () => {
+    const f = summarizeEntryNews([
+      { publishedAt: '2026-06-04T18:00:00.000Z', sentiment: null },
+      { publishedAt: '2026-06-04T17:00:00.000Z', sentiment: -0.4 },
+    ], entry);
+    expect(f.newsCount).toBe(2);
+    expect(f.newsMinSentiment).toBeCloseTo(-0.4, 5);
   });
 });

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -32,6 +32,7 @@ import {
   decideRegimeBlock,
   computeRotationRegime,
   computeEntryFeatures,
+  summarizeEntryNews,
   type OversoldConfig,
   type EodBar,
   type OversoldCandidate,
@@ -1221,6 +1222,33 @@ export class OversoldScannerService {
   }
 
   /**
+   * PR-3 — Résume les news persistées (eodhd_news_articles) dans [entry-72h,
+   * entry] pour un symbole. Lecture DB pure (zéro fetch EODHD, zéro LLM),
+   * fail-soft : aucune news / erreur → features news à 0/null.
+   */
+  private async summarizeNewsForEntry(symbol: string, entryIso: string) {
+    const empty = { newsCount: 0, newsMinSentiment: null, newsAvgSentiment: null, newsAgeHours: null };
+    if (!entryIso) return empty;
+    try {
+      const from = new Date(new Date(entryIso).getTime() - 72 * 3600_000).toISOString();
+      const { data } = await this.supabase.getClient()
+        .from('eodhd_news_articles')
+        .select('published_at, sentiment_polarity')
+        .eq('ticker', symbol)
+        .lte('published_at', entryIso)
+        .gte('published_at', from)
+        .order('published_at', { ascending: false })
+        .limit(50);
+      return summarizeEntryNews(
+        (data ?? []).map((a) => ({ publishedAt: a.published_at as string, sentiment: a.sentiment_polarity as number | null })),
+        entryIso,
+      );
+    } catch {
+      return empty;
+    }
+  }
+
+  /**
    * PR-1 — Fondation boucle d'apprentissage oversold.
    *
    * Réconcilie les positions oversold (lisa_positions, source dans
@@ -1316,7 +1344,9 @@ export class OversoldScannerService {
       if (!feat) continue;
       // Merge contexte régime as-of entrée (champs null si indispo).
       const reg = this.regimeAsOf(regimeByDate, bars[idx].date);
-      const featPlus = reg ? { ...feat, ...reg } : feat;
+      // PR-3 — features news persistées as-of entrée (fail-soft, lecture DB).
+      const news = await this.summarizeNewsForEntry(p.symbol as string, String(p.entry_timestamp ?? ''));
+      const featPlus = { ...feat, ...(reg ?? {}), ...news };
 
       const row: Record<string, unknown> = {
         user_id: userByPf.get(p.portfolio_id as string) ?? null,

--- a/apps/api/src/modules/lisa/services/oversold.helper.ts
+++ b/apps/api/src/modules/lisa/services/oversold.helper.ts
@@ -331,3 +331,43 @@ export function computeEntryFeatures(bars: EodBar[], entryIdx: number): Oversold
 
   return { drop1d, drop3d, trend20, distMa20, distMa50, rsi14, vol14, relVol20 };
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// Features news pour la boucle d'apprentissage (PR-3). Résumé des articles
+// persistés (eodhd_news_articles) dans la fenêtre AVANT l'entrée — sert à
+// MESURER si le sentiment news autour du drop prédit l'outcome (catalyseur
+// structurel vs bruit). Étape déterministe/cheap (lecture DB, pas de LLM) :
+// si le sentiment brut porte du signal, un classifieur LLM nuancé viendra
+// après. Aucun filtre — feature loggée uniquement.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface OversoldNewsFeatures {
+  newsCount: number; // nb d'articles dans la fenêtre [entry-72h, entry]
+  newsMinSentiment: number | null; // sentiment le PLUS négatif (catalyseur structurel ?)
+  newsAvgSentiment: number | null; // sentiment moyen
+  newsAgeHours: number | null; // ancienneté du plus récent article vs entrée (h)
+}
+
+/**
+ * Résume les articles news (déjà filtrés ≤ entrée) en features. Pur/testable.
+ * `articles` : sentiment_polarity ∈ [-1, 1] (EODHD), publishedAt ISO-8601.
+ */
+export function summarizeEntryNews(
+  articles: { publishedAt: string; sentiment: number | null }[],
+  entryIso: string,
+): OversoldNewsFeatures {
+  const entryMs = new Date(entryIso).getTime();
+  const inWindow = articles.filter((a) => {
+    const t = new Date(a.publishedAt).getTime();
+    return Number.isFinite(t) && t <= entryMs && t >= entryMs - 72 * 3600_000;
+  });
+  if (inWindow.length === 0) {
+    return { newsCount: 0, newsMinSentiment: null, newsAvgSentiment: null, newsAgeHours: null };
+  }
+  const sents = inWindow.map((a) => a.sentiment).filter((s): s is number => s != null && Number.isFinite(s));
+  const newsMinSentiment = sents.length ? Math.min(...sents) : null;
+  const newsAvgSentiment = sents.length ? sents.reduce((s, x) => s + x, 0) / sents.length : null;
+  const latestMs = Math.max(...inWindow.map((a) => new Date(a.publishedAt).getTime()));
+  const newsAgeHours = (entryMs - latestMs) / 3600_000;
+  return { newsCount: inWindow.length, newsMinSentiment, newsAvgSentiment, newsAgeHours };
+}


### PR DESCRIPTION
## Quoi

PR-3 de la boucle d'apprentissage. Ajoute des **features news** à `features_at_entry` (résumé des news persistées `eodhd_news_articles` dans `[entry-72h, entry]`) : `newsCount`, `newsMinSentiment`, `newsAvgSentiment`, `newsAgeHours`. **Aucun filtre** — on mesure d'abord.

## Pourquoi pas de LLM tout de suite

Le LLM (classifieur catalyseur structurel vs transitoire) est le seul usage LLM justifié — mais on ne l'ajoute pas à l'aveugle. **On MESURE d'abord** si le sentiment brut porte du signal (via l'empirical law). Si oui → classifieur LLM nuancé en suivi. Même discipline que trend-20d (ne pas gater sur du non-mesuré).

## Détail

- `summarizeEntryNews()` : pure/testable, fenêtre as-of entrée (pas de look-ahead).
- `summarizeNewsForEntry()` : lecture DB pure (**zéro fetch EODHD, zéro LLM**), fail-soft. Mergé dans `reconcileOversoldFeatures`.
- Tests : 4 cas (14 au total).

## Couverture (honnête)

Le collector news ne couvre **que le US** (vérifié : `MU.US` = 514 articles ; `BHP.LSE`/`ADYEN.AS` = 0). Donc features news peuplées pour oversold **US**, `null` (fail-soft) pour l'**EU**. La couverture EU news est un gap séparé (collector) → à traiter si le signal news US s'avère porteur.

## Validation
`tsc -b` vert · 14/14 tests verts · format ticker confirmé contre la DB prod.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_