### PR TITLE
feat(oversold): label horizon-fixe J+10 (qualité d'entrée, hors timing sortie)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/oversold-features.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/oversold-features.spec.ts
@@ -1,6 +1,7 @@
 import {
   computeRsi,
   computeEntryFeatures,
+  computeForwardOutcome,
   summarizeEntryNews,
   type EodBar,
 } from '../oversold.helper';
@@ -113,5 +114,32 @@ describe('summarizeEntryNews', () => {
     ], entry);
     expect(f.newsCount).toBe(2);
     expect(f.newsMinSentiment).toBeCloseTo(-0.4, 5);
+  });
+});
+
+describe('computeForwardOutcome', () => {
+  // 15 barres : entry à idx 2 (close 100), J+10 à idx 12.
+  const mk = (closes: number[]): EodBar[] =>
+    closes.map((c, i) => ({ date: `2026-01-${String(i + 1).padStart(2, '0')}`, close: c, volume: 1000 }));
+
+  it('null si entry+horizon hors série (position trop récente)', () => {
+    const bars = mk(Array.from({ length: 8 }, () => 100)); // 8 barres
+    expect(computeForwardOutcome(bars, 2, 10)).toBeNull(); // 2+10=12 >= 8
+  });
+
+  it('rendement positif → outcome 1', () => {
+    const closes = Array.from({ length: 15 }, () => 100);
+    closes[12] = 110; // J+10 (idx 2+10) à +10%
+    const f = computeForwardOutcome(mk(closes), 2, 10)!;
+    expect(f.fwdReturn).toBeCloseTo(10, 5);
+    expect(f.fwdOutcome).toBe(1);
+  });
+
+  it('rendement négatif → outcome 0', () => {
+    const closes = Array.from({ length: 15 }, () => 100);
+    closes[12] = 92; // J+10 à -8%
+    const f = computeForwardOutcome(mk(closes), 2, 10)!;
+    expect(f.fwdReturn).toBeCloseTo(-8, 5);
+    expect(f.fwdOutcome).toBe(0);
   });
 });

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -32,6 +32,7 @@ import {
   decideRegimeBlock,
   computeRotationRegime,
   computeEntryFeatures,
+  computeForwardOutcome,
   summarizeEntryNews,
   type OversoldConfig,
   type EodBar,
@@ -1249,6 +1250,29 @@ export class OversoldScannerService {
   }
 
   /**
+   * PR-4a — Calcule le label J+10 d'une position (fetch barres + index entrée).
+   * Renvoie null si entry+horizon pas encore disponible (position trop récente).
+   */
+  private async computeFwdForPosition(
+    symbol: string,
+    entryIso: string,
+    horizon = 10,
+  ): Promise<{ fwdReturn: number; fwdOutcome: number } | null> {
+    const entryDate = entryIso.slice(0, 10);
+    if (!entryDate) return null;
+    const bars = await this.fetchEodBars(symbol, 160);
+    if (bars.length < 2) return null;
+    let idx = bars.findIndex((b) => b.date === entryDate);
+    if (idx < 0) {
+      for (let i = bars.length - 1; i >= 0; i--) {
+        if (bars[i].date <= entryDate) { idx = i; break; }
+      }
+    }
+    if (idx < 0) return null;
+    return computeForwardOutcome(bars, idx, horizon);
+  }
+
+  /**
    * PR-1 — Fondation boucle d'apprentissage oversold.
    *
    * Réconcilie les positions oversold (lisa_positions, source dans
@@ -1288,12 +1312,17 @@ export class OversoldScannerService {
 
     const { data: ptRows } = await client
       .from('paper_trades')
-      .select('id, scanner_position_id, status')
+      .select('id, scanner_position_id, status, fwd_return_10d')
       .eq('strategy', 'oversold')
       .limit(5000);
-    const ptByPos = new Map<string, { id: string; status: string }>();
+    const ptByPos = new Map<string, { id: string; status: string; fwdSet: boolean }>();
     for (const r of ptRows ?? []) {
-      if (r.scanner_position_id) ptByPos.set(r.scanner_position_id as string, { id: r.id as string, status: r.status as string });
+      if (r.scanner_position_id)
+        ptByPos.set(r.scanner_position_id as string, {
+          id: r.id as string,
+          status: r.status as string,
+          fwdSet: r.fwd_return_10d != null,
+        });
     }
 
     const pids = [...new Set(oversold.map((p) => p.portfolio_id as string))];
@@ -1325,6 +1354,22 @@ export class OversoldScannerService {
             .eq('id', existing.id);
           updated++;
         }
+        // PR-4a — backfill label J+10 quand la position a vieilli au-delà de
+        // l'horizon (entry+10 jours ouvrés disponible). Idempotent : une seule
+        // fois par position (fwdSet devient true ensuite).
+        if (!existing.fwdSet) {
+          const ageDays = (Date.now() - new Date(String(p.entry_timestamp ?? '')).getTime()) / 86_400_000;
+          if (Number.isFinite(ageDays) && ageDays >= 14) {
+            const fwd = await this.computeFwdForPosition(p.symbol as string, String(p.entry_timestamp ?? ''));
+            if (fwd) {
+              await client
+                .from('paper_trades')
+                .update({ fwd_return_10d: String(fwd.fwdReturn), fwd_outcome_10d: fwd.fwdOutcome, fwd_horizon_days: 10 })
+                .eq('id', existing.id);
+              updated++;
+            }
+          }
+        }
         continue;
       }
 
@@ -1347,6 +1392,8 @@ export class OversoldScannerService {
       // PR-3 — features news persistées as-of entrée (fail-soft, lecture DB).
       const news = await this.summarizeNewsForEntry(p.symbol as string, String(p.entry_timestamp ?? ''));
       const featPlus = { ...feat, ...(reg ?? {}), ...news };
+      // PR-4a — label J+10 (null si position trop récente → backfill ultérieur).
+      const fwd = computeForwardOutcome(bars, idx, 10);
 
       const row: Record<string, unknown> = {
         user_id: userByPf.get(p.portfolio_id as string) ?? null,
@@ -1369,6 +1416,11 @@ export class OversoldScannerService {
         row.pnl_usd = String(pnl);
         row.pnl_pct = p.realized_pnl_pct != null ? String(p.realized_pnl_pct) : null;
         row.outcome_label = pnl > 0 ? 1 : 0;
+      }
+      if (fwd) {
+        row.fwd_return_10d = String(fwd.fwdReturn);
+        row.fwd_outcome_10d = fwd.fwdOutcome;
+        row.fwd_horizon_days = 10;
       }
       const { error } = await client.from('paper_trades').insert(row);
       if (!error) inserted++;

--- a/apps/api/src/modules/lisa/services/oversold.helper.ts
+++ b/apps/api/src/modules/lisa/services/oversold.helper.ts
@@ -332,6 +332,25 @@ export function computeEntryFeatures(bars: EodBar[], entryIdx: number): Oversold
   return { drop1d, drop3d, trend20, distMa20, distMa50, rsi14, vol14, relVol20 };
 }
 
+/**
+ * Label à HORIZON FIXE (PR-4a) : rendement % à entryIdx+horizon, indépendant
+ * de la sortie réelle. Neutralise la variance des sorties pour apprendre la
+ * qualité d'ENTRÉE. Renvoie null si la barre entry+horizon n'existe pas encore
+ * (position trop récente → à backfiller quand elle aura vieilli). Pur/testable.
+ */
+export function computeForwardOutcome(
+  bars: EodBar[],
+  entryIdx: number,
+  horizon = 10,
+): { fwdReturn: number; fwdOutcome: number } | null {
+  if (entryIdx < 0 || entryIdx + horizon >= bars.length) return null;
+  const entryClose = bars[entryIdx].close;
+  const fwdClose = bars[entryIdx + horizon].close;
+  if (!(entryClose > 0) || !(fwdClose > 0)) return null;
+  const fwdReturn = (fwdClose / entryClose - 1) * 100;
+  return { fwdReturn, fwdOutcome: fwdReturn > 0 ? 1 : 0 };
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // Features news pour la boucle d'apprentissage (PR-3). Résumé des articles
 // persistés (eodhd_news_articles) dans la fenêtre AVANT l'entrée — sert à

--- a/supabase/migrations/0195_paper_trades_fwd_outcome.sql
+++ b/supabase/migrations/0195_paper_trades_fwd_outcome.sql
@@ -1,0 +1,20 @@
+-- 0195_paper_trades_fwd_outcome.sql
+-- PR-4a — Label à HORIZON FIXE (J+10) pour la boucle d'apprentissage oversold.
+--
+-- Le PnL réalisé (outcome_label/pnl_pct) dépend de DEUX choses : la qualité de
+-- l'ENTRÉE *et* le timing de la SORTIE (manuelle / Mistral / stop). Pour
+-- apprendre la qualité d'ENTRÉE proprement, il faut un label qui neutralise la
+-- variance des sorties → rendement à horizon fixe (close[entry+N]/entry - 1).
+--
+-- Append-only, idempotent. Peuplé par OversoldScannerService.reconcileOversoldFeatures
+-- une fois la position vieillie au-delà de l'horizon (N jours ouvrés écoulés).
+ALTER TABLE public.paper_trades ADD COLUMN IF NOT EXISTS fwd_return_10d NUMERIC;
+ALTER TABLE public.paper_trades ADD COLUMN IF NOT EXISTS fwd_outcome_10d INTEGER;
+ALTER TABLE public.paper_trades ADD COLUMN IF NOT EXISTS fwd_horizon_days INTEGER;
+
+COMMENT ON COLUMN public.paper_trades.fwd_return_10d IS
+  'Rendement % à horizon fixe = (close[entry+fwd_horizon_days]/entry_price - 1)*100. Label propre pour apprendre la qualité d''entrée, indépendant du timing de sortie réel.';
+COMMENT ON COLUMN public.paper_trades.fwd_outcome_10d IS
+  'Label binaire dérivé de fwd_return_10d (1 si > 0, sinon 0). Cible de la régression P(bonne entrée | features).';
+COMMENT ON COLUMN public.paper_trades.fwd_horizon_days IS
+  'Horizon (jours ouvrés) utilisé pour fwd_return_10d. Défaut 10 (= hold oversold cible).';


### PR DESCRIPTION
## Quoi

PR-4a — la pièce manquante pour fermer la boucle d'auto-apprentissage **proprement**. Collecte un **label à horizon fixe J+10** sur les trades oversold.

## Pourquoi (l'insight clé)

Le PnL réalisé dépend de **2 choses** : la qualité de l'**ENTRÉE** ET le **timing de la SORTIE** (manuelle / Mistral / stop). Apprendre sur le PnL brut mélange les deux. Pour apprendre la qualité d'**entrée**, il faut un label qui neutralise la variance des sorties → `fwd_return_10d = close[entry+10]/entry - 1`.

## Détail

- **Migration 0195** : `paper_trades += fwd_return_10d, fwd_outcome_10d, fwd_horizon_days` (append-only, idempotent).
- `computeForwardOutcome()` : pur/testable, `null` si `entry+horizon` pas encore disponible.
- `reconcileOversoldFeatures` : calcule fwd à l'INSERT + **backfill idempotent** quand une position dépasse l'horizon (~14j cal.). `fwdSet` évite tout re-fetch.
- Tests : 3 cas (17 au total).

## Place dans la boucle (validée)

Collecte (✅ #645/646/647 + ce PR) → **TRAIN** `P(win | features)` [P9, à venir] → **APPLY** sizing Kelly×pWin / ranking → **CONTINUOUS** cron hebdo + garde-fous (N≥30, AUC≥0.55). Ce label J+10 est la **cible propre** du TRAIN.

⚠️ Timeline : positions actuelles à 2-3j → le label J+10 se peuplera vers ~18/06 (cohérent avec l'accumulation data).

## Validation
`tsc -b` vert · 17/17 tests verts. Migration idempotente (auto-apply au boot Fly + trigger workflow explicite post-merge).

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_