### PR TITLE
fix(oversold): collecte features en cron dédié 7j/7 (pas weekday-only)

### DIFF
--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -161,11 +161,6 @@ export class OversoldScannerService {
         return;
       }
 
-      // PR-1 — collecte features/outcomes pour la boucle d'apprentissage (best-effort).
-      await this.reconcileOversoldFeatures().catch((e) =>
-        this.logger.warn(`[oversold-features] reconcile failed: ${String(e).slice(0, 200)}`),
-      );
-
       const portfolios = await this.loadOversoldPortfolios();
       if (portfolios.length === 0) {
         this.logger.debug('[oversold] aucun portfolio en mode oversold actif → skip');
@@ -429,11 +424,6 @@ export class OversoldScannerService {
         this.logger.debug('[oversold-intraday] disabled (OVERSOLD_SCANNER_ENABLED or OVERSOLD_INTRADAY_ENABLED off)');
         return;
       }
-
-      // PR-1 — collecte features/outcomes (best-effort, idempotent via scanner_position_id).
-      await this.reconcileOversoldFeatures().catch((e) =>
-        this.logger.warn(`[oversold-features] reconcile failed: ${String(e).slice(0, 200)}`),
-      );
 
       const portfolios = await this.loadOversoldPortfolios();
       if (portfolios.length === 0) {
@@ -1270,6 +1260,22 @@ export class OversoldScannerService {
     }
     if (idx < 0) return null;
     return computeForwardOutcome(bars, idx, horizon);
+  }
+
+  /**
+   * PR-4 (fix) — Réconciliation features/outcomes en cron DÉDIÉ 7j/7.
+   *
+   * Avant : la collecte était câblée en tête des scans (runDailyScan 21:15 +
+   * runIntradayScan 08-20h), TOUS DEUX Mon-Fri → aucune collecte le week-end et
+   * backfill retardé au lundi. La collecte est du housekeeping data : elle ne
+   * doit PAS dépendre des jours de marché. Cron autonome toutes les 30 min,
+   * self-gated par OVERSOLD_FEATURE_COLLECTION_ENABLED dans reconcile. Best-effort.
+   */
+  @Cron('0 */30 * * * *', { name: 'oversold-feature-reconcile', timeZone: 'UTC' })
+  async runFeatureReconcile(): Promise<void> {
+    await this.reconcileOversoldFeatures().catch((err) =>
+      this.logger.warn(`[oversold-features] reconcile cron failed: ${String(err).slice(0, 200)}`),
+    );
   }
 
   /**


### PR DESCRIPTION
## Problème constaté (via le SQL de vérif)

`paper_trades` strategy='oversold' = **0 ligne** alors qu'il y a **55 positions oversold** à collecter. Cause : la réconciliation était câblée en tête de `runDailyScan` (21:15) + `runIntradayScan` (08-20h), **tous deux Mon-Fri**. Le code déployé un dimanche → aucun de ces crons n'a tiré → collecte jamais lancée (et backfill retardé au lundi).

## Fix

La collecte features/outcomes est du **housekeeping data**, indépendant des jours de marché :
- Retire les 2 appels inline weekday-only.
- Ajoute `@Cron('0 */30 * * * *') runFeatureReconcile` (**7j/7, toutes les 30 min**), self-gated par `OVERSOLD_FEATURE_COLLECTION_ENABLED`, best-effort.

## Effet

Backfill des **55 positions au prochain tick** (< 30 min après déploiement), puis collecte continue (outcomes au close + label J+10 quand les positions dépassent l'horizon). Le SQL de vérif montrera alors les lignes peuplées.

## Validation
`tsc -b` vert · 17/17 tests verts.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_