### PR TITLE
fix(oversold): stop_loss/take_profit NOT NULL → fallback 0 (la collecte produisait 0 ligne)

### DIFF
--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -1408,8 +1408,11 @@ export class OversoldScannerService {
         asset_class: p.asset_class ?? 'us_equity',
         entry_price: p.entry_price != null ? String(p.entry_price) : null,
         size_usd: p.entry_notional_usd != null ? String(p.entry_notional_usd) : null,
-        stop_loss: p.stop_loss_price != null ? String(p.stop_loss_price) : null,
-        take_profit: p.take_profit_price != null ? String(p.take_profit_price) : null,
+        // paper_trades.stop_loss / take_profit sont NOT NULL → fallback '0' quand
+        // la position n'a pas de stop/TP enregistré (sinon l'INSERT échoue et la
+        // collecte ne produit aucune ligne — bug constaté 07/06).
+        stop_loss: String(p.stop_loss_price ?? 0),
+        take_profit: String(p.take_profit_price ?? 0),
         status: closed ? 'closed' : 'open',
         strategy: 'oversold',
         scanner_position_id: posId,


### PR DESCRIPTION
## Bug (constaté via "Check?")

Malgré 55 positions oversold + le cron 7j/7 (#650), `paper_trades` strategy='oversold' = **0 ligne**. Cause trouvée en testant l'INSERT réel depuis le sandbox :

```
null value in column "stop_loss" of relation "paper_trades" violates not-null constraint
```

`paper_trades.stop_loss` et `take_profit` sont **NOT NULL**. `reconcileOversoldFeatures` insérait `null` quand la position n'avait pas de stop/TP enregistré → **tous les inserts échouaient** (catch silencieux) → 0 ligne.

## Fix

`stop_loss: String(p.stop_loss_price ?? 0)` + `take_profit` idem. Ces champs ne servent pas à l'apprentissage (les vraies features sont dans `features_at_entry`) — seule la non-nullité compte. **Vérifié** : insert OK avec `0`.

## Effet

Au prochain tick du cron (≤30 min après deploy), les **55 positions seront enfin collectées** avec leurs features.

## Validation
`tsc -b` vert · insert testé OK contre la DB prod.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_