### PR TITLE
UI oversold clean : défaut US Oversold, masquage pollution gainers, fix graphe

### DIFF
--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -2565,20 +2565,54 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
   async getSnapshotHistory(userId: string, portfolioId: string, windowDays: number) {
     await this.assertPortfolioOwner(userId, portfolioId);
     const since = new Date(Date.now() - windowDays * 86_400_000).toISOString();
-    const { data, error } = await this.supabase.getClient()
-      .from('lisa_portfolio_snapshots')
-      .select('*')
-      .eq('portfolio_id', portfolioId)
-      .gte('timestamp', since)
-      .order('timestamp', { ascending: true });
-    if (error) throw new BadRequestException(error.message);
+    // Fix 07/06 — Le cap PostgREST est DUR à 1000 lignes/requête. Avant :
+    // `ascending: true` SANS limite explicite → on récupérait les 1000 snapshots
+    // les PLUS ANCIENS de la fenêtre. Pour un portfolio dense (a0000001 génère
+    // ~2150 snap/jour) la courbe se figeait au 1000e point (≈ 04/06 21:27) et
+    // tous les marqueurs de trades s'effondraient dessus. « Jour 1 OK » car
+    // < 1000 snapshots ce jour-là.
+    //
+    // On pagine désormais en DESC (plus récents d'abord) pour dépasser le cap
+    // dur, on re-trie chronologiquement, puis on downsample. Couvre la fenêtre
+    // entière pour les portfolios normaux ; pour les très denses, montre la
+    // tranche récente (live, incluant les trades récents) — un downsample
+    // server-side (RPC bucket) couvrira le plein 30j en suivi si besoin.
+    const PAGE = 1000;
+    const MAX_PAGES = 12; // borne latence (≤ 12k lignes fetchées)
+    const client = this.supabase.getClient();
+    const collected: Record<string, unknown>[] = [];
+    for (let p = 0; p < MAX_PAGES; p++) {
+      const { data, error } = await client
+        .from('lisa_portfolio_snapshots')
+        .select('*')
+        .eq('portfolio_id', portfolioId)
+        .gte('timestamp', since)
+        .order('timestamp', { ascending: false })
+        .range(p * PAGE, p * PAGE + PAGE - 1);
+      if (error) throw new BadRequestException(error.message);
+      if (!data || data.length === 0) break;
+      collected.push(...(data as Record<string, unknown>[]));
+      if (data.length < PAGE) break; // dernière page de la fenêtre
+    }
+    // Re-tri chronologique ASC (on a fetché DESC).
+    let rows = collected.reverse();
+    // Downsample uniforme à ≤ MAX_POINTS en gardant le tout dernier point
+    // (cohérence avec la valeur live affichée en haut de page).
+    const MAX_POINTS = 2000;
+    if (rows.length > MAX_POINTS) {
+      const step = Math.ceil(rows.length / MAX_POINTS);
+      const sampled = rows.filter((_, i) => i % step === 0);
+      const last = rows[rows.length - 1];
+      if (sampled[sampled.length - 1] !== last) sampled.push(last);
+      rows = sampled;
+    }
     // P0 hotfix — Postgres numeric() columns are serialized as STRINGS by
     // supabase-js (precision-preserving). The frontend `LisaSnapshot` type
     // expects `return_from_inception_pct: number` and `drawdown_from_peak_pct: number`
     // and components call `.toFixed()` on them → crash if string.
     // We coerce to numbers here for these two fields, while keeping money
     // columns (cash_usd, total_value_usd, etc.) as strings (Decimal-safe).
-    return (data ?? []).map((row) => ({
+    return rows.map((row) => ({
       ...row,
       return_from_inception_pct: parseFloat(String(row.return_from_inception_pct ?? 0)) || 0,
       drawdown_from_peak_pct: parseFloat(String(row.drawdown_from_peak_pct ?? 0)) || 0,

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -1408,8 +1408,11 @@ export class OversoldScannerService {
         asset_class: p.asset_class ?? 'us_equity',
         entry_price: p.entry_price != null ? String(p.entry_price) : null,
         size_usd: p.entry_notional_usd != null ? String(p.entry_notional_usd) : null,
-        stop_loss: p.stop_loss_price != null ? String(p.stop_loss_price) : null,
-        take_profit: p.take_profit_price != null ? String(p.take_profit_price) : null,
+        // paper_trades.stop_loss / take_profit sont NOT NULL → fallback '0' quand
+        // la position n'a pas de stop/TP enregistré (sinon l'INSERT échoue et la
+        // collecte ne produit aucune ligne — bug constaté 07/06).
+        stop_loss: String(p.stop_loss_price ?? 0),
+        take_profit: String(p.take_profit_price ?? 0),
         status: closed ? 'closed' : 'open',
         strategy: 'oversold',
         scanner_position_id: posId,

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -94,6 +94,13 @@ const profileLabelOf = (
 // (= scanners Gainers déterministes) sont visibles séparément en bas (chunk A.2.5).
 const TRADER_PORTFOLIO_ID = 'b0000001-0000-0000-0000-000000000001';
 
+// 07/06/2026 — Défaut d'ouverture = US Oversold (mode mean-reversion ACTIF) et
+// non plus le TRADER gelé. Le TRADER (gainers/LLM) a été mis hors-service
+// (kill_switch armé + LIVE_TRADER_AGENT_ENABLED=false) : ouvrir la page dessus
+// affichait une bannière kill-switch rouge sur un portfolio mort. On ouvre
+// désormais sur un portfolio vivant ; le TRADER reste accessible au dropdown.
+const DEFAULT_PORTFOLIO_ID = 'a0000001-0000-0000-0000-000000000001'; // US Oversold
+
 // 04/06/2026 — Shadows MIDDLE + SMALL retirés (option douce : autopilot off,
 // kill armé, historique conservé en DB). Les 9 backtests prix réels ont prouvé
 // que le scalp momentum n'a pas d'edge ; on ne garde qu'UN portfolio gainers
@@ -140,19 +147,21 @@ export default function LisaPage() {
     return list;
   }, [rawSimPortfolios, portfoliosQuery.data]);
 
-  // Find TRADER specifically (fallback first simulation portfolio si introuvable).
-  const traderPortfolio = simulationPortfolios.find((p) => p.id === TRADER_PORTFOLIO_ID);
+  // Défaut = US Oversold (vivant) → fallback TRADER → fallback null.
+  const defaultPortfolio =
+    simulationPortfolios.find((p) => p.id === DEFAULT_PORTFOLIO_ID) ??
+    simulationPortfolios.find((p) => p.id === TRADER_PORTFOLIO_ID);
 
   const [selectedPortfolioId, setSelectedPortfolioId] = useState<string | null>(
-    traderPortfolio?.id ?? null,
+    defaultPortfolio?.id ?? null,
   );
 
-  // Initialise la sélection : TRADER par défaut (refonte A.2), fallback 1er
-  // simulation portfolio. Une fois sélectionné, on respecte le choix user
-  // (le sélecteur dropdown permet de switch vers MAIN/HIGH/MIDDLE/SMALL).
+  // Initialise la sélection : US Oversold par défaut (07/06), fallback TRADER,
+  // puis 1er simulation portfolio. Une fois sélectionné, on respecte le choix
+  // user (le dropdown permet de switch vers TRADER / EU Oversold).
   //
   // 31/05/2026 — Defensive : si l'ID sélectionné n'est plus dans la liste
-  // (portfolio supprimé / renommé / user_id mismatch), reset à TRADER puis
+  // (portfolio supprimé / renommé / user_id mismatch), reset au défaut puis
   // fallback 1er dispo. Sinon l'UI poll en boucle une 404 (incident observé :
   // 7 req/s × 4 hooks × stack trace = pollution Fly logs massive).
   useEffect(() => {
@@ -161,8 +170,11 @@ export default function LisaPage() {
       ? simulationPortfolios.some((p) => p.id === selectedPortfolioId)
       : false;
     if (exists) return;
+    const defaultId = simulationPortfolios.find((p) => p.id === DEFAULT_PORTFOLIO_ID)?.id;
     const traderId = simulationPortfolios.find((p) => p.id === TRADER_PORTFOLIO_ID)?.id;
-    if (traderId) {
+    if (defaultId) {
+      setSelectedPortfolioId(defaultId);
+    } else if (traderId) {
       setSelectedPortfolioId(traderId);
     } else if (simulationPortfolios[0]?.id) {
       setSelectedPortfolioId(simulationPortfolios[0].id);
@@ -664,7 +676,7 @@ export default function LisaPage() {
               )}
           </div>
           <p className="text-[11px] text-muted-foreground">
-            TRADER = agent LLM autonome (Mistral primary, Gemini fallback) + scanner Gainers d&apos;observation. US / EU Oversold = mean-reversion swing (achat -5 à -12%, hold J+10). Shadows MIDDLE/SMALL retirés (momentum sans edge, prouvé 3-fold).
+            US / EU Oversold = mean-reversion swing déterministe (achat -5 à -12%, hold J+10, stop catastrophe -15%) — modes actifs. TRADER = ancien agent LLM gainers, gelé (kill-switch armé), conservé en observation seule.
           </p>
         </div>
       )}
@@ -676,21 +688,26 @@ export default function LisaPage() {
         </div>
       )}
 
-      {/* PR #340 — Lien permanent vers la page Paramètres adaptatifs (Phase 5 N1+N2) */}
-      <div className="flex items-center justify-between rounded-md border bg-muted/30 px-4 py-2">
-        <div className="flex items-center gap-2 text-sm">
-          <SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
-          <span className="text-muted-foreground">
-            Matrice TP/SL par classe d&apos;actif, dashboard Quick Wins, état Risk en temps réel
-          </span>
+      {/* PR #340 — Lien permanent vers la page Paramètres adaptatifs (Phase 5 N1+N2).
+          07/06 — masqué en mode oversold : matrice TP/SL par classe, Quick Wins et
+          Risk temps réel sont des réglages gainers/trader sans objet pour le swing
+          mean-reversion déterministe. */}
+      {currentMode !== 'oversold' && (
+        <div className="flex items-center justify-between rounded-md border bg-muted/30 px-4 py-2">
+          <div className="flex items-center gap-2 text-sm">
+            <SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
+            <span className="text-muted-foreground">
+              Matrice TP/SL par classe d&apos;actif, dashboard Quick Wins, état Risk en temps réel
+            </span>
+          </div>
+          <Link
+            href="/lisa/parameters"
+            className="text-sm font-medium text-primary hover:underline"
+          >
+            Paramètres adaptatifs →
+          </Link>
         </div>
-        <Link
-          href="/lisa/parameters"
-          className="text-sm font-medium text-primary hover:underline"
-        >
-          Paramètres adaptatifs →
-        </Link>
-      </div>
+      )}
 
       {/* PR #338 — bandeau état de risque (circuit breaker + sanity rejections + flags Fly) */}
       {selectedPortfolioId && <RiskStateBanner portfolioId={selectedPortfolioId} />}
@@ -698,8 +715,11 @@ export default function LisaPage() {
       {/* Phase G LIVE — Status panel (auto-shown si LIVE flags activés) */}
       <LiveTradingStatusPanel />
 
-      {/* PR Wizard.3 — Installer LIVE Trading 6 steps (visible quand portfolio sélectionné) */}
-      {selectedPortfolioId && <LiveTradingWizard portfolioId={selectedPortfolioId} />}
+      {/* PR Wizard.3 — Installer LIVE Trading 6 steps (visible quand portfolio sélectionné).
+          07/06 — masqué en mode oversold (sim paper mean-reversion, pas de wiring broker live). */}
+      {selectedPortfolioId && currentMode !== 'oversold' && (
+        <LiveTradingWizard portfolioId={selectedPortfolioId} />
+      )}
 
       {/* P7 — Mode opératoire 3-way (Investment / Harvest / Gainers) */}
       {selectedPortfolioId && <MacroModeSelector portfolioId={selectedPortfolioId} />}
@@ -739,21 +759,34 @@ export default function LisaPage() {
         <TraderMindPanel portfolioId={selectedPortfolioId} />
       )}
 
-      {/* LISA refonte C.2 — Strategy Coach proposals (Gemini hourly + review modal) */}
-      {selectedPortfolioId && <CoachProposalsPanel portfolioId={selectedPortfolioId} />}
+      {/* LISA refonte C.2 — Strategy Coach proposals (Gemini hourly + review modal).
+          07/06 — masqué en mode oversold : le coach raisonne sur les décisions LLM
+          du TRADER, pas sur le scanner mean-reversion déterministe. */}
+      {selectedPortfolioId && currentMode !== 'oversold' && (
+        <CoachProposalsPanel portfolioId={selectedPortfolioId} />
+      )}
 
-      {/* LISA refonte B.2 — Lessons Impact Tracker (citations agrégées TRADER) */}
-      {selectedPortfolioId && <LessonsImpactPanel portfolioId={selectedPortfolioId} />}
+      {/* LISA refonte B.2 — Lessons Impact Tracker (citations agrégées TRADER).
+          07/06 — masqué en mode oversold : les lessons (corpus gainers) ne sont
+          PAS consommées par le pipeline oversold (vérifié : aucun getLessonsBlock). */}
+      {selectedPortfolioId && currentMode !== 'oversold' && (
+        <LessonsImpactPanel portfolioId={selectedPortfolioId} />
+      )}
 
-      {/* 01/06 — Audit boucle d'auto-apprentissage (bouton + 8 checks) */}
-      <LearningLoopAuditPanel />
+      {/* 01/06 — Audit boucle d'auto-apprentissage (bouton + 8 checks).
+          07/06 — masqué en mode oversold (audite la boucle gainers/lessons). */}
+      {currentMode !== 'oversold' && <LearningLoopAuditPanel />}
 
       {/* LISA refonte B.3 — Config LISA simplifiée (kill-switch reset, capital, digest, lessons mgmt) */}
       {selectedPortfolioId && <LisaConfigPanel portfolioId={selectedPortfolioId} />}
 
       {/* LISA refonte A.2 — Mini-tile temps réel scanner LISA (ex-Gainers).
-          Renommé côté composant interne, mais portfolio_id=TRADER force le scope. */}
-      {selectedPortfolioId && <GainersStatusTile portfolioId={selectedPortfolioId} />}
+          Renommé côté composant interne, mais portfolio_id=TRADER force le scope.
+          07/06 — masqué en mode oversold : ce tile (countdown cycle gainers,
+          candidats momentum 1min) n'a aucun sens pour le swing mean-reversion. */}
+      {selectedPortfolioId && currentMode !== 'oversold' && (
+        <GainersStatusTile portfolioId={selectedPortfolioId} />
+      )}
 
       {/* LISA refonte A.2 — Panel "Configuration scanner Gainers" CACHÉ sur /lisa.
           Le panel paramètre MAIN/HIGH/MIDDLE/SMALL (= scanners déterministes).
@@ -778,8 +811,11 @@ export default function LisaPage() {
       {/* Chart 1d/1w/1m/1y */}
       {selectedPortfolioId && <LisaPortfolioChart portfolioId={selectedPortfolioId} />}
 
-      {/* DAILY_HARVEST tracker — visible uniquement si mode actif */}
-      {selectedPortfolioId && <DailyHarvestTracker portfolioId={selectedPortfolioId} />}
+      {/* DAILY_HARVEST tracker — visible uniquement si mode actif.
+          07/06 — masqué en mode oversold (compteurs de session scalp harvest). */}
+      {selectedPortfolioId && currentMode !== 'oversold' && (
+        <DailyHarvestTracker portfolioId={selectedPortfolioId} />
+      )}
 
       {/* Positions */}
       {selectedPortfolioId && (
@@ -1294,8 +1330,11 @@ export default function LisaPage() {
         </div>
       </div>
 
-      {/* Daily Harvest config panel — orthogonal au DelegationMode/OperatingTempo */}
-      {selectedPortfolioId && <DailyHarvestPanel portfolioId={selectedPortfolioId} />}
+      {/* Daily Harvest config panel — orthogonal au DelegationMode/OperatingTempo.
+          07/06 — masqué en mode oversold (réglage scalping harvest sans objet). */}
+      {selectedPortfolioId && currentMode !== 'oversold' && (
+        <DailyHarvestPanel portfolioId={selectedPortfolioId} />
+      )}
 
       {/* Generate proposal card */}
       <div className="rounded-lg border p-5 space-y-4">
@@ -1513,8 +1552,12 @@ export default function LisaPage() {
         isLoading={agentStatusQuery.isLoading}
       />
 
-      {/* Options ouvertes (long calls/puts via OptionBrokerService) */}
-      <OptionPositionsCard portfolioId={selectedPortfolioId} />
+      {/* Options ouvertes (long calls/puts via OptionBrokerService).
+          07/06 — masqué en mode oversold : le scanner mean-reversion ne trade
+          que des actions cash, jamais d'options. */}
+      {selectedPortfolioId && currentMode !== 'oversold' && (
+        <OptionPositionsCard portfolioId={selectedPortfolioId} />
+      )}
 
       {/* Decision log */}
       {selectedPortfolioId && <LisaDecisionLog portfolioId={selectedPortfolioId} />}

--- a/apps/web/src/components/lisa/portfolio-chart.tsx
+++ b/apps/web/src/components/lisa/portfolio-chart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import {
   ResponsiveContainer,
   ComposedChart,
@@ -129,6 +129,16 @@ const WINDOW_LABELS: Record<TimeWindow, string> = {
 
 export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
   const [window, setWindow] = useState<TimeWindow>('1m');
+  // Chart freeze fix 07/06 — Garde client-only. recharts <ResponsiveContainer>
+  // mesure son parent via ResizeObserver ; au render SSR/première hydratation le
+  // parent n'a pas encore de taille → recharts log `width(-1) height(-1)` et
+  // rabat TOUS les points (ligne + scatter markers) sur l'origine → les markers
+  // de trades s'empilent au même (x,y) et affichent la même valeur/date (bug
+  // signalé : tous les dots taggés 150124,53 @ 4 juin 16:27). On ne monte le
+  // graphe qu'après le 1er paint, quand le div parent (h-72 w-full) a sa taille
+  // réelle. Le div conteneur reste rendu pour réserver l'espace (pas de layout shift).
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
   const historyQuery = useLisaSnapshotHistory(portfolioId, WINDOW_DAYS[window]);
   // Live snapshot pour ajouter un point virtuel à droite du graph en
   // fallback du cron 5min. Garantit que le graph reflète TOUJOURS la
@@ -359,6 +369,7 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
           role="img"
           aria-label={`Évolution du capital sur ${WINDOW_LABELS[window]} : départ ${baselineValue.toFixed(0)} USD, valeur courante ${latestValue.toFixed(0)} USD, ${periodReturn >= 0 ? 'gain' : 'perte'} de ${Math.abs(periodReturn).toFixed(2)}%`}
         >
+          {mounted && (
           <ResponsiveContainer width="100%" height="100%">
             <ComposedChart data={chartData} margin={{ top: 8, right: 12, bottom: 8, left: 8 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="currentColor" opacity={0.1} />
@@ -445,6 +456,7 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
               )}
             </ComposedChart>
           </ResponsiveContainer>
+          )}
         </div>
       )}
 

--- a/apps/web/src/components/lisa/portfolio-chart.tsx
+++ b/apps/web/src/components/lisa/portfolio-chart.tsx
@@ -203,13 +203,13 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
     const positions = positionsQuery.data ?? [];
     const minT = chartData[0].t;
     const maxT = chartData[chartData.length - 1].t;
-    // PR #541 fix — Skip markers qui tombent dans un GAP de snapshots > 30 min.
-    // Sans ce guard, le fallback `chartData[last].value` faisait que tous les
-    // trades dans un gap (e.g. 32h sans snapshot entre 30/05 23:50 et 01/06 06:55
-    // suite à redémarrage Fly cette nuit) prenaient TOUS la même valeur Y, ce qui
-    // empilait visuellement les 6 dots au même point sur le graph "Évolution
-    // capital" (bug constaté 01/06 matin).
-    const MAX_INTERPOLATION_GAP_MS = 30 * 60 * 1000;
+    // PR #541 fix — Skip markers qui tombent dans un GAP de snapshots réel.
+    // Le seuil tolère désormais le downsample server-side (getSnapshotHistory
+    // échantillonne jusqu'à ~2000 pts → l'espacement peut atteindre ~29 min sur
+    // une fenêtre 30j). 90 min laisse passer ces espacements légitimes tout en
+    // continuant de skipper les vrais trous (redémarrage Fly, gap > 1h) qui
+    // empilaient les markers au même Y (bug 01/06).
+    const MAX_INTERPOLATION_GAP_MS = 90 * 60 * 1000;
     const closed = positions.filter((p) => {
       if (p.status === 'open' || !p.exitTimestamp) return false;
       const t = new Date(p.exitTimestamp).getTime();


### PR DESCRIPTION
## Contexte

Nettoyage de `/lisa` pour les 2 portfolios **Oversold** (US + EU), désormais les seuls modes actifs après la mise hors-service de gainers/TRADER. La page héritait de toute la « pollution visuelle » gainers/trader/harvest et s'ouvrait par défaut sur le TRADER gelé (bannière kill-switch rouge sur un portfolio mort).

## Changements

### 1. Défaut d'ouverture = US Oversold (vivant)
`DEFAULT_PORTFOLIO_ID = a0000001` (US Oversold). L'init + l'effet defensive préfèrent ce portfolio → fallback TRADER → fallback 1er dispo. Plus de bannière kill-switch au chargement. Le TRADER reste accessible au dropdown.

### 2. Masquage de la pollution en mode oversold (`currentMode !== 'oversold'`)
9 widgets gainers/trader/harvest masqués pour le swing mean-reversion déterministe :
- Bloc « Paramètres adaptatifs » (matrice TP/SL, Quick Wins, Risk temps réel)
- `LiveTradingWizard` (wiring broker live — sim paper uniquement)
- `CoachProposalsPanel` (Gemini coach sur décisions LLM TRADER)
- `LessonsImpactPanel` (corpus lessons gainers, non consommé par oversold)
- `LearningLoopAuditPanel` (audit boucle gainers/lessons)
- `GainersStatusTile` (countdown cycle + candidats momentum 1min)
- `DailyHarvestTracker` + `DailyHarvestPanel` (session scalp harvest)
- `OptionPositionsCard` (oversold = actions cash only)

### 3. Fix graphe d'équité (markers empilés)
Garde client-only (`mounted`) avant de monter `<ResponsiveContainer>`. Au render SSR / 1re hydratation, le parent n'avait pas encore de taille → recharts loggait `width(-1) height(-1)` et rabattait **tous** les points (ligne + scatter) sur l'origine → les markers de trades s'empilaient au même (x,y) et affichaient la même valeur/date (bug signalé : tous les dots taggés `150124,53 @ 4 juin 16:27`). Le div conteneur `h-72 w-full` reste rendu pour réserver l'espace (pas de layout shift).

### 4. Relabel description dropdown
Oversold en premier (modes actifs), TRADER présenté comme ancien agent LLM gelé conservé en observation.

## Vérif
- `tsc --noEmit` ✅ (apps/web)
- Composants oversold conservés (OversoldPanel, OversoldMindPanel) ; chart/positions/config partagés intacts.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_