### PR TITLE
PR-2 oversold : panel régime de marché (thermomètre VIX/indice + prochain scan)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -1590,6 +1590,19 @@ export class LisaController {
   }
 
   /**
+   * PR-2 UI — Statut régime de marché LIVE (thermomètre VIX/indice + verdict du
+   * gate) + prochain scan programmé. Région-aware selon oversold_universe.
+   */
+  @Get('oversold-regime/:portfolioId')
+  async getOversoldRegime(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+  ) {
+    extractUserId(headers);
+    return this.oversoldScanner.getRegimeStatus(portfolioId);
+  }
+
+  /**
    * 04/06 — Boucles d'apprentissage SÉPARÉES (user request). Chacune lit
    * uniquement les closes labellisés de SA source pour ne pas mixer les
    * patterns scalp gainers (5-60min) avec swing oversold (J+10).

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -97,6 +97,36 @@ export interface OversoldBookSummary {
   positions: OversoldBookPosition[];
 }
 
+/**
+ * PR-2 UI — Statut de régime de marché LIVE pour le panel oversold dédié.
+ * Reflète la décision du gate régime (checkRegimeGate) à l'instant T + le
+ * prochain scan programmé. Région-aware (US : VIX+SPY ; EU : V2TX+SX5E).
+ */
+export interface OversoldRegimeStatus {
+  portfolioId: string;
+  universe: string;
+  region: 'US' | 'EU';
+  enabled: boolean; // gate régime actif (OVERSOLD_REGIME_GATE_ENABLED)
+  block: boolean; // un scan ouvert MAINTENANT serait-il bloqué ?
+  reason: string; // libellé human du verdict (ex: "VIX 21.5 > 17")
+  vixLabel: string; // 'VIX' | 'V2TX'
+  idxLabel: string; // 'SPY' | 'SX5E'
+  vix: number | null;
+  vixChgPct: number | null; // ΔVIX 1j en %
+  idx5dPct: number | null; // rendement indice 5j en %
+  vixSource: 'live' | 'eod';
+  thresholds: { vixMax: number; vixDeltaMax: number; idx5dMin: number }; // effectifs (post-pénalité rotation)
+  rotation: {
+    regime: 'offensive' | 'defensive' | null;
+    spreadPct: number | null;
+    mode: string; // off | shadow | active
+    appliedVixPenalty: number; // durcissement vixMax effectivement appliqué
+  } | null;
+  nextScanUtc: string; // ISO du prochain cron de scan
+  nextScanKind: 'intraday' | 'daily';
+  asOf: string;
+}
+
 /** Row config oversold lue depuis lisa_session_configs. */
 interface OversoldPortfolioRow {
   portfolio_id: string;
@@ -1210,6 +1240,83 @@ export class OversoldScannerService {
       if (d <= date && (best === null || d > best)) best = d;
     }
     return best ? byDate.get(best) ?? null : null;
+  }
+
+  /**
+   * PR-2 UI — Statut régime LIVE pour le panel oversold dédié.
+   *
+   * Réutilise checkRegimeGate (région-aware, VIX live intraday US) pour exposer
+   * au front la même décision que celle prise par le scan, plus le prochain
+   * créneau de scan. Lecture seule, fail-soft : toute erreur indicateur →
+   * champ null (le gate lui-même est fail-open côté scan).
+   */
+  async getRegimeStatus(portfolioId: string): Promise<OversoldRegimeStatus> {
+    const { data: cfg } = await this.supabase
+      .getClient()
+      .from('lisa_session_configs')
+      .select('oversold_universe')
+      .eq('portfolio_id', portfolioId)
+      .maybeSingle();
+    const universe = (cfg?.oversold_universe as string | null) ?? DEFAULTS.universe;
+
+    const enabled =
+      (this.config.get<string>('OVERSOLD_REGIME_GATE_ENABLED') ?? 'true').toLowerCase() === 'true';
+
+    // intraday:true → VIX live (real-time EODHD) côté US ; EU reste EOD (V2TX live = NA).
+    const gate = await this.checkRegimeGate(universe, { intraday: true });
+    const next = this.computeNextScanUtc(new Date());
+
+    return {
+      portfolioId,
+      universe,
+      region: gate.region,
+      enabled,
+      block: gate.block,
+      reason: gate.reason,
+      vixLabel: gate.region === 'EU' ? 'V2TX' : 'VIX',
+      idxLabel: gate.region === 'EU' ? 'SX5E' : 'SPY',
+      vix: gate.vix,
+      vixChgPct: gate.vixChg,
+      idx5dPct: gate.idx5d,
+      vixSource: gate.vixSource,
+      thresholds: gate.thresholds,
+      rotation: gate.rotation
+        ? {
+            regime: gate.rotation.regime,
+            spreadPct: gate.rotation.spreadPct,
+            mode: gate.rotation.mode,
+            appliedVixPenalty: gate.rotation.appliedVixPenalty,
+          }
+        : null,
+      nextScanUtc: next.iso,
+      nextScanKind: next.kind,
+      asOf: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Prochain créneau de scan oversold (UTC), aligné sur les crons :
+   *  - intraday : `0 0 8-20 * * 1-5` → 08:00..20:00 pile, lun-ven
+   *  - daily    : `0 15 21 * * 1-5` → 21:15, lun-ven
+   * On itère les créneaux d'un jour ouvré, en sautant samedi/dimanche.
+   */
+  private computeNextScanUtc(now: Date): { iso: string; kind: 'intraday' | 'daily' } {
+    const slots: Array<{ h: number; m: number; kind: 'intraday' | 'daily' }> = [];
+    for (let h = 8; h <= 20; h++) slots.push({ h, m: 0, kind: 'intraday' });
+    slots.push({ h: 21, m: 15, kind: 'daily' });
+    for (let dayOffset = 0; dayOffset <= 7; dayOffset++) {
+      const d = new Date(now);
+      d.setUTCDate(now.getUTCDate() + dayOffset);
+      const dow = d.getUTCDay(); // 0=dim, 6=sam
+      if (dow === 0 || dow === 6) continue;
+      for (const s of slots) {
+        const cand = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), s.h, s.m, 0);
+        if (cand > now.getTime()) {
+          return { iso: new Date(cand).toISOString(), kind: s.kind };
+        }
+      }
+    }
+    return { iso: now.toISOString(), kind: 'intraday' };
   }
 
   /**

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -37,6 +37,7 @@ import { GainersConfigPanel } from '@/components/lisa/gainers-config-panel';
 import { LisaStickyHeader } from '@/components/lisa/lisa-sticky-header';
 import { GainsTracker } from '@/components/lisa/gains-tracker';
 import { OversoldPanel } from '@/components/lisa/oversold-panel';
+import { OversoldRegimePanel } from '@/components/lisa/oversold-regime-panel';
 import { LessonsImpactPanel } from '@/components/lisa/lessons-impact-panel';
 import { LearningLoopAuditPanel } from '@/components/lisa/learning-loop-audit-panel';
 import { LisaConfigPanel } from '@/components/lisa/lisa-config-panel';
@@ -738,6 +739,13 @@ export default function LisaPage() {
           + l'historique gainers de HIGH) crée la confusion signalée. */}
       {selectedPortfolioId && currentMode !== 'oversold' && (
         <GainsTracker portfolioId={selectedPortfolioId} />
+      )}
+
+      {/* 07/06 PR-2 — Régime de marché LIVE (thermomètre VIX/indice + verdict gate
+          + prochain scan). Remplace la pollution gainers par du contexte utile au
+          mean-reversion : explique pourquoi le scan ouvre ou s'abstient. */}
+      {selectedPortfolioId && currentMode === 'oversold' && (
+        <OversoldRegimePanel portfolioId={selectedPortfolioId} />
       )}
 
       {/* 04/06 — Vue dédiée mode oversold (remplace les widgets gainers) :

--- a/apps/web/src/components/lisa/oversold-regime-panel.tsx
+++ b/apps/web/src/components/lisa/oversold-regime-panel.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Gauge, Clock, Activity, ShieldCheck, ShieldAlert } from 'lucide-react';
+import { useOversoldRegime, type OversoldRegimeStatus } from '@/hooks/use-oversold-regime';
+
+/**
+ * PR-2 — Panel régime de marché du mode OVERSOLD (remplace la pollution gainers).
+ *
+ * Thermomètre LIVE des indicateurs qui pilotent le gate d'entrée mean-reversion :
+ * volatilité (VIX / V2TX), son accélération 1j, et le rendement 5j de l'indice
+ * (SPY / SX5E). Chaque indicateur est coloré selon qu'il franchit ou non son
+ * seuil. Affiche le verdict global (scan ouvert / bloqué), le régime de rotation
+ * sectorielle, et un compte à rebours vers le prochain scan programmé.
+ */
+export function OversoldRegimePanel({ portfolioId }: { portfolioId: string }) {
+  const { data, isLoading, isError } = useOversoldRegime(portfolioId);
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border p-4 text-sm text-muted-foreground">
+        🌡️ Chargement du régime de marché…
+      </div>
+    );
+  }
+  if (isError || !data) {
+    return (
+      <div className="rounded-lg border p-4 text-sm text-muted-foreground">
+        🌡️ Régime de marché indisponible pour le moment.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border p-4 space-y-4">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-2">
+          <Gauge className="h-4 w-4 text-purple-600" />
+          <h2 className="text-sm font-medium">
+            🌡️ Régime de marché — {data.region} ({data.universe})
+          </h2>
+        </div>
+        <Verdict data={data} />
+      </div>
+
+      {/* Thermomètre 3 indicateurs */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <Thermo
+          label={`${data.vixLabel} (volatilité)`}
+          value={data.vix}
+          fmt={(n) => n.toFixed(2)}
+          threshold={`max ${data.thresholds.vixMax}`}
+          breach={data.vix != null && data.vix > data.thresholds.vixMax}
+          tag={data.vixSource === 'live' ? 'live' : 'EOD J-1'}
+        />
+        <Thermo
+          label={`Δ${data.vixLabel} 1j`}
+          value={data.vixChgPct}
+          fmt={(n) => `${n >= 0 ? '+' : ''}${n.toFixed(1)}%`}
+          threshold={`max +${data.thresholds.vixDeltaMax}%`}
+          breach={data.vixChgPct != null && data.vixChgPct > data.thresholds.vixDeltaMax}
+        />
+        <Thermo
+          label={`${data.idxLabel} 5j`}
+          value={data.idx5dPct}
+          fmt={(n) => `${n >= 0 ? '+' : ''}${n.toFixed(2)}%`}
+          threshold={`min ${data.thresholds.idx5dMin}%`}
+          breach={data.idx5dPct != null && data.idx5dPct < data.thresholds.idx5dMin}
+        />
+      </div>
+
+      {/* Rotation sectorielle + compte à rebours */}
+      <div className="flex items-center justify-between gap-3 flex-wrap text-xs">
+        <div className="flex items-center gap-2">
+          <Activity className="h-3.5 w-3.5 text-muted-foreground" />
+          {data.rotation && data.rotation.regime ? (
+            <span className="text-muted-foreground">
+              Rotation sectorielle :{' '}
+              <span
+                className={
+                  data.rotation.regime === 'defensive' ? 'text-amber-600 font-medium' : 'text-emerald-600 font-medium'
+                }
+              >
+                {data.rotation.regime === 'defensive' ? 'défensive' : 'offensive'}
+              </span>
+              {data.rotation.spreadPct != null && ` (${data.rotation.spreadPct >= 0 ? '+' : ''}${data.rotation.spreadPct.toFixed(1)}%)`}
+              {data.rotation.appliedVixPenalty > 0 && (
+                <span className="text-amber-600"> · seuil VIX durci −{data.rotation.appliedVixPenalty}</span>
+              )}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">Rotation sectorielle : —</span>
+          )}
+        </div>
+        <Countdown iso={data.nextScanUtc} kind={data.nextScanKind} />
+      </div>
+
+      <p className="text-[11px] text-muted-foreground italic">
+        {data.enabled
+          ? 'Le scan oversold s’abstient automatiquement quand le régime est hostile (volatilité élevée + indice en repli) — les meilleurs rebonds J+10 sortent en marché calme.'
+          : 'Gate régime désactivé (OVERSOLD_REGIME_GATE_ENABLED=false) : le scan ouvre quel que soit le régime.'}{' '}
+        MAJ : {new Date(data.asOf).toLocaleTimeString('fr-FR')}.
+      </p>
+    </div>
+  );
+}
+
+function Verdict({ data }: { data: OversoldRegimeStatus }) {
+  if (!data.enabled) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+        ⚪ Gate désactivé
+      </span>
+    );
+  }
+  if (data.block) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-red-500/40 bg-red-500/10 px-2 py-0.5 text-[11px] font-medium text-red-600">
+        <ShieldAlert className="h-3 w-3" /> Hostile — scan bloqué
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[11px] font-medium text-emerald-600">
+      <ShieldCheck className="h-3 w-3" /> Favorable — scan ouvert
+    </span>
+  );
+}
+
+function Thermo(props: {
+  label: string;
+  value: number | null;
+  fmt: (n: number) => string;
+  threshold: string;
+  breach: boolean;
+  tag?: string;
+}) {
+  const { label, value, fmt, threshold, breach, tag } = props;
+  const valueCls = value == null ? 'text-muted-foreground' : breach ? 'text-red-600' : 'text-emerald-600';
+  return (
+    <div className={`rounded-md border p-2 ${breach ? 'border-red-500/40 bg-red-500/5' : ''}`}>
+      <div className="flex items-center justify-between">
+        <div className="text-[10px] uppercase text-muted-foreground">{label}</div>
+        {tag && (
+          <span className="text-[9px] uppercase tracking-wide text-muted-foreground border rounded px-1">
+            {tag}
+          </span>
+        )}
+      </div>
+      <div className={`text-base font-semibold tabular-nums ${valueCls}`}>
+        {value == null ? '—' : fmt(value)}
+      </div>
+      <div className="text-[10px] text-muted-foreground">seuil {threshold}</div>
+    </div>
+  );
+}
+
+function Countdown({ iso, kind }: { iso: string; kind: 'intraday' | 'daily' }) {
+  const [now, setNow] = useState<number | null>(null);
+  // Client-only : démarre après montage pour éviter un mismatch SSR (Date.now
+  // diffère serveur/client) et n'afficher le timer qu'avec l'heure du client.
+  useEffect(() => {
+    setNow(Date.now());
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  const target = new Date(iso).getTime();
+  let remaining = '—';
+  if (now != null) {
+    const ms = Math.max(0, target - now);
+    const h = Math.floor(ms / 3_600_000);
+    const m = Math.floor((ms % 3_600_000) / 60_000);
+    const s = Math.floor((ms % 60_000) / 1000);
+    remaining = h > 0 ? `${h}h ${m}m ${s}s` : `${m}m ${s}s`;
+  }
+
+  return (
+    <div className="flex items-center gap-1.5 text-muted-foreground">
+      <Clock className="h-3.5 w-3.5" />
+      <span>
+        Prochain scan ({kind === 'daily' ? 'EOD' : 'intraday'}) dans{' '}
+        <span className="font-mono font-medium text-foreground tabular-nums">{remaining}</span>
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-oversold-regime.ts
+++ b/apps/web/src/hooks/use-oversold-regime.ts
@@ -1,0 +1,43 @@
+// LISA — Oversold regime status hook (panel dédié mode oversold).
+// Source : GET /lisa/oversold-regime/:portfolioId — thermomètre VIX/indice LIVE
+// + verdict du gate régime (région-aware US/EU) + prochain scan programmé.
+
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+export interface OversoldRegimeStatus {
+  portfolioId: string;
+  universe: string;
+  region: 'US' | 'EU';
+  enabled: boolean;
+  block: boolean;
+  reason: string;
+  vixLabel: string;
+  idxLabel: string;
+  vix: number | null;
+  vixChgPct: number | null;
+  idx5dPct: number | null;
+  vixSource: 'live' | 'eod';
+  thresholds: { vixMax: number; vixDeltaMax: number; idx5dMin: number };
+  rotation: {
+    regime: 'offensive' | 'defensive' | null;
+    spreadPct: number | null;
+    mode: string;
+    appliedVixPenalty: number;
+  } | null;
+  nextScanUtc: string;
+  nextScanKind: 'intraday' | 'daily';
+  asOf: string;
+}
+
+export function useOversoldRegime(portfolioId: string | null) {
+  return useQuery({
+    queryKey: ['lisa', 'oversold-regime', portfolioId],
+    queryFn: () => apiFetch<OversoldRegimeStatus>(`/lisa/oversold-regime/${portfolioId}`),
+    enabled: !!portfolioId,
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+}


### PR DESCRIPTION
## Contexte

Suite de la refonte UI oversold (#653). PR-1 a **masqué** la pollution gainers/trader/harvest sur le mode oversold ; PR-2 la **remplace** par un widget dédié et utile au mean-reversion : un thermomètre de régime de marché qui explique pourquoi le scan ouvre ou s'abstient.

## Backend

- `OversoldScannerService.getRegimeStatus(portfolioId)` — réutilise le `checkRegimeGate` existant (région-aware : **US** VIX+SPY, **EU** V2TX+SX5E, VIX **live** intraday) pour exposer au front **le même verdict** que celui pris par le scan, avec les seuils effectifs (post-pénalité rotation) et le régime de rotation sectorielle. Lecture seule, fail-soft (indicateur indispo → `null`).
- `computeNextScanUtc()` — prochain créneau de scan aligné sur les crons réels (intraday `0 0 8-20 * * 1-5` + daily `0 15 21 * * 1-5`), week-ends sautés.
- `GET /lisa/oversold-regime/:portfolioId`.

## Frontend

- `useOversoldRegime` (poll 60s) + `OversoldRegimePanel` :
  - **Thermomètre 3 indicateurs** (VIX/V2TX, ΔVIX 1j, indice 5j) colorés vert/rouge selon franchissement de seuil, avec tag `live`/`EOD J-1`.
  - **Badge verdict** : 🟢 Favorable (scan ouvert) / 🔴 Hostile (scan bloqué) / ⚪ Gate désactivé.
  - **Chip rotation sectorielle** (offensive/défensive + durcissement VIX éventuel).
  - **Compte à rebours live** vers le prochain scan (intraday/EOD), garde client-only anti-mismatch SSR.
  - Rendu uniquement si `currentMode === 'oversold'`.

## Vérif

- `tsc --noEmit` ✅ (api + web).
- `computeNextScanUtc` validé sur 5 cas limites (week-end → lundi 08:00, rollover horaire, créneau EOD 21:15, rollover lendemain).

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_