### PR TITLE
PR-2 (widget 3) oversold : veille news contraires sur positions tenues

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -1603,6 +1603,19 @@ export class LisaController {
   }
 
   /**
+   * PR-2 (widget 3) — Veille news contraires (sentiment négatif récent) sur les
+   * positions oversold ouvertes. Lecture seule (visibilité), pas un trigger d'exit.
+   */
+  @Get('oversold-news-watch/:portfolioId')
+  async getOversoldNewsWatch(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+  ) {
+    extractUserId(headers);
+    return this.oversoldScanner.getNewsWatch(portfolioId);
+  }
+
+  /**
    * 04/06 — Boucles d'apprentissage SÉPARÉES (user request). Chacune lit
    * uniquement les closes labellisés de SA source pour ne pas mixer les
    * patterns scalp gainers (5-60min) avec swing oversold (J+10).

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -127,6 +127,28 @@ export interface OversoldRegimeStatus {
   asOf: string;
 }
 
+/**
+ * PR-2 (widget 3) — Veille news contraires sur une position oversold ouverte.
+ * Lecture seule (visibilité), jamais un déclencheur d'exit.
+ */
+export interface OversoldNewsAlert {
+  symbol: string;
+  articleCount: number; // articles dans la fenêtre
+  minSentiment: number; // polarité la plus négative [-1..1]
+  latestTitle: string | null;
+  latestUrl: string | null;
+  latestAgeHours: number | null;
+  level: 'shock' | 'watch'; // ≤ -0.6 (shock, réf checkNewsShockClose) / ≤ -0.3 (veille)
+}
+
+export interface OversoldNewsWatch {
+  portfolioId: string;
+  openPositions: number; // nb positions oversold ouvertes (dénominateur)
+  windowHours: number;
+  alerts: OversoldNewsAlert[]; // uniquement les positions à sentiment contraire, plus négatif d'abord
+  asOf: string;
+}
+
 /** Row config oversold lue depuis lisa_session_configs. */
 interface OversoldPortfolioRow {
   portfolio_id: string;
@@ -1317,6 +1339,84 @@ export class OversoldScannerService {
       }
     }
     return { iso: now.toISOString(), kind: 'intraday' };
+  }
+
+  /**
+   * PR-2 (widget 3) — Veille news contraires sur les positions oversold OUVERTES.
+   *
+   * Lecture seule (zéro fetch EODHD live, zéro LLM, zéro close) : interroge les
+   * news déjà persistées (eodhd_news_articles) sur les symboles tenus, sur une
+   * fenêtre récente (48h), et remonte celles à sentiment négatif. C'est une
+   * VISIBILITÉ pour l'utilisateur — PAS un déclencheur d'exit : le mean-reversion
+   * tient délibérément à travers le bruit (la chute initiale est souvent due à
+   * une mauvaise news ; auto-fermer dessus couperait l'edge). Le seuil -0.6
+   * reprend la référence checkNewsShockClose pour la cohérence visuelle.
+   * Une seule requête DB (.in sur les tickers), agrégation en mémoire.
+   */
+  async getNewsWatch(portfolioId: string): Promise<OversoldNewsWatch> {
+    const client = this.supabase.getClient();
+    const WINDOW_HOURS = 48;
+    const nowMs = Date.now();
+    const fromIso = new Date(nowMs - WINDOW_HOURS * 3_600_000).toISOString();
+
+    const { data: openRows } = await client
+      .from('lisa_positions')
+      .select('symbol')
+      .eq('portfolio_id', portfolioId)
+      .eq('venue_fee_detail->>source', 'scanner_oversold')
+      .eq('status', 'open');
+    const symbols = Array.from(new Set((openRows ?? []).map((r) => String(r.symbol))));
+    const openPositions = symbols.length;
+
+    if (openPositions === 0) {
+      return { portfolioId, openPositions: 0, windowHours: WINDOW_HOURS, alerts: [], asOf: new Date().toISOString() };
+    }
+
+    const { data: news } = await client
+      .from('eodhd_news_articles')
+      .select('ticker, published_at, title, sentiment_polarity, source_url')
+      .in('ticker', symbols)
+      .gte('published_at', fromIso)
+      .lte('published_at', new Date(nowMs).toISOString())
+      .order('published_at', { ascending: false })
+      .limit(500);
+
+    // Agrège par symbole : min sentiment + article le plus récent (news triées DESC).
+    const bySym = new Map<
+      string,
+      { count: number; min: number; latestTitle: string | null; latestUrl: string | null; latestAt: string | null }
+    >();
+    for (const a of news ?? []) {
+      const sym = String(a.ticker);
+      const sent = typeof a.sentiment_polarity === 'number' ? a.sentiment_polarity : null;
+      const cur = bySym.get(sym) ?? { count: 0, min: 1, latestTitle: null, latestUrl: null, latestAt: null };
+      cur.count += 1;
+      if (sent != null && sent < cur.min) cur.min = sent;
+      if (cur.latestAt === null) {
+        cur.latestTitle = (a.title as string | null) ?? null;
+        cur.latestUrl = (a.source_url as string | null) ?? null;
+        cur.latestAt = (a.published_at as string | null) ?? null;
+      }
+      bySym.set(sym, cur);
+    }
+
+    const alerts: OversoldNewsAlert[] = [];
+    for (const [sym, v] of bySym.entries()) {
+      if (!(v.min <= -0.3)) continue; // garde uniquement le sentiment contraire
+      alerts.push({
+        symbol: sym,
+        articleCount: v.count,
+        minSentiment: v.min,
+        latestTitle: v.latestTitle,
+        latestUrl: v.latestUrl,
+        latestAgeHours: v.latestAt ? Math.max(0, (nowMs - new Date(v.latestAt).getTime()) / 3_600_000) : null,
+        level: v.min <= -0.6 ? 'shock' : 'watch',
+      });
+    }
+    // shock d'abord, du plus négatif au moins négatif.
+    alerts.sort((a, b) => a.minSentiment - b.minSentiment);
+
+    return { portfolioId, openPositions, windowHours: WINDOW_HOURS, alerts, asOf: new Date().toISOString() };
   }
 
   /**

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -38,6 +38,7 @@ import { LisaStickyHeader } from '@/components/lisa/lisa-sticky-header';
 import { GainsTracker } from '@/components/lisa/gains-tracker';
 import { OversoldPanel } from '@/components/lisa/oversold-panel';
 import { OversoldRegimePanel } from '@/components/lisa/oversold-regime-panel';
+import { OversoldNewsWatchPanel } from '@/components/lisa/oversold-news-watch-panel';
 import { LessonsImpactPanel } from '@/components/lisa/lessons-impact-panel';
 import { LearningLoopAuditPanel } from '@/components/lisa/learning-loop-audit-panel';
 import { LisaConfigPanel } from '@/components/lisa/lisa-config-panel';
@@ -752,6 +753,12 @@ export default function LisaPage() {
           book value, P&L réalisé vs latent, positions + drop% + compte à rebours J+10. */}
       {selectedPortfolioId && currentMode === 'oversold' && (
         <OversoldPanel portfolioId={selectedPortfolioId} />
+      )}
+
+      {/* 07/06 PR-2 (widget 3) — Veille news contraires sur les positions tenues
+          (visibilité, pas un trigger d'exit). */}
+      {selectedPortfolioId && currentMode === 'oversold' && (
+        <OversoldNewsWatchPanel portfolioId={selectedPortfolioId} />
       )}
 
       {/* Shadow Sizing — RETIRÉ 04/06. Les shadows MIDDLE/SMALL sont figés et

--- a/apps/web/src/components/lisa/oversold-news-watch-panel.tsx
+++ b/apps/web/src/components/lisa/oversold-news-watch-panel.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { Newspaper, ExternalLink } from 'lucide-react';
+import { useOversoldNewsWatch, type OversoldNewsAlert } from '@/hooks/use-oversold-news-watch';
+
+/**
+ * PR-2 (widget 3) — Veille news contraires sur les positions oversold ouvertes.
+ *
+ * Surface les news à sentiment négatif récent (48h) sur les titres tenus, du
+ * plus négatif au moins négatif. VISIBILITÉ uniquement : le mean-reversion tient
+ * délibérément à travers le bruit (la chute initiale est souvent due à une
+ * mauvaise news), donc ce panel n'auto-ferme RIEN — il aide l'utilisateur à
+ * repérer un éventuel falling-knife qui s'aggrave, à arbitrer manuellement.
+ */
+export function OversoldNewsWatchPanel({ portfolioId }: { portfolioId: string }) {
+  const { data, isLoading, isError } = useOversoldNewsWatch(portfolioId);
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border p-4 text-sm text-muted-foreground">
+        📰 Chargement de la veille news…
+      </div>
+    );
+  }
+  if (isError || !data) {
+    return (
+      <div className="rounded-lg border p-4 text-sm text-muted-foreground">
+        📰 Veille news indisponible pour le moment.
+      </div>
+    );
+  }
+
+  const shockCount = data.alerts.filter((a) => a.level === 'shock').length;
+
+  return (
+    <div className="rounded-lg border p-4 space-y-3">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-2">
+          <Newspaper className="h-4 w-4 text-purple-600" />
+          <h2 className="text-sm font-medium">📰 Veille news — positions tenues</h2>
+        </div>
+        <span className="text-[11px] text-muted-foreground">
+          {data.alerts.length === 0
+            ? `0 alerte · ${data.openPositions} position${data.openPositions > 1 ? 's' : ''}`
+            : `${data.alerts.length} alerte${data.alerts.length > 1 ? 's' : ''}${shockCount > 0 ? ` (dont ${shockCount} 🔴)` : ''} · ${data.openPositions} position${data.openPositions > 1 ? 's' : ''}`}
+        </span>
+      </div>
+
+      {data.alerts.length === 0 ? (
+        <p className="text-xs text-muted-foreground italic">
+          {data.openPositions === 0
+            ? 'Aucune position oversold ouverte.'
+            : `Aucune news à sentiment contraire (≤ -0.3) sur les ${data.openPositions} position(s) tenue(s) ces ${data.windowHours} dernières heures.`}
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {data.alerts.map((a) => (
+            <AlertRow key={a.symbol} a={a} />
+          ))}
+        </ul>
+      )}
+
+      <p className="text-[11px] text-muted-foreground italic">
+        Information seulement — le mode oversold tient ses positions à travers le bruit (hold J+10).
+        Ce panel n&apos;auto-ferme rien ; il signale un éventuel <em>falling-knife</em> à arbitrer à la main.
+        Fenêtre {data.windowHours}h · MAJ {new Date(data.asOf).toLocaleTimeString('fr-FR')}.
+      </p>
+    </div>
+  );
+}
+
+function AlertRow({ a }: { a: OversoldNewsAlert }) {
+  const shock = a.level === 'shock';
+  const age =
+    a.latestAgeHours == null
+      ? '—'
+      : a.latestAgeHours < 1
+        ? `${Math.round(a.latestAgeHours * 60)} min`
+        : `${a.latestAgeHours.toFixed(0)} h`;
+  return (
+    <li
+      className={`rounded-md border p-2 text-xs ${
+        shock ? 'border-red-500/40 bg-red-500/5' : 'border-amber-500/40 bg-amber-500/5'
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <span>{shock ? '🔴' : '🟡'}</span>
+        <span className="font-medium">{a.symbol.replace('.US', '')}</span>
+        <span
+          className={`font-mono tabular-nums ${shock ? 'text-red-600' : 'text-amber-600'}`}
+          title="Sentiment le plus négatif sur la fenêtre"
+        >
+          {a.minSentiment.toFixed(2)}
+        </span>
+        <span className="text-muted-foreground">
+          · {a.articleCount} article{a.articleCount > 1 ? 's' : ''} · il y a {age}
+        </span>
+      </div>
+      {a.latestTitle && (
+        <div className="mt-1 text-muted-foreground line-clamp-2">
+          {a.latestUrl ? (
+            <a
+              href={a.latestUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline inline-flex items-start gap-1"
+            >
+              {a.latestTitle}
+              <ExternalLink className="h-3 w-3 shrink-0 mt-0.5" />
+            </a>
+          ) : (
+            a.latestTitle
+          )}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/apps/web/src/hooks/use-oversold-news-watch.ts
+++ b/apps/web/src/hooks/use-oversold-news-watch.ts
@@ -1,0 +1,37 @@
+// LISA — Oversold news watch hook (panel dédié mode oversold).
+// Source : GET /lisa/oversold-news-watch/:portfolioId — veille des news à
+// sentiment négatif récent sur les positions tenues. VISIBILITÉ uniquement
+// (le mean-reversion tient à travers le bruit ; ce n'est pas un trigger d'exit).
+
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+export interface OversoldNewsAlert {
+  symbol: string;
+  articleCount: number;
+  minSentiment: number;
+  latestTitle: string | null;
+  latestUrl: string | null;
+  latestAgeHours: number | null;
+  level: 'shock' | 'watch';
+}
+
+export interface OversoldNewsWatch {
+  portfolioId: string;
+  openPositions: number;
+  windowHours: number;
+  alerts: OversoldNewsAlert[];
+  asOf: string;
+}
+
+export function useOversoldNewsWatch(portfolioId: string | null) {
+  return useQuery({
+    queryKey: ['lisa', 'oversold-news-watch', portfolioId],
+    queryFn: () => apiFetch<OversoldNewsWatch>(`/lisa/oversold-news-watch/${portfolioId}`),
+    enabled: !!portfolioId,
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchInterval: 120_000,
+    staleTime: 60_000,
+  });
+}


### PR DESCRIPTION
## Contexte

3ᵉ et dernier widget de la refonte UI oversold (après #653 masquage + fix, #654 thermomètre régime). Surface les **news à sentiment négatif récent** sur les positions oversold tenues.

## Design : visibilité, PAS auto-close

Choix délibéré et important : ce widget **n'auto-ferme aucune position**. Le mode oversold est un mean-reversion qui **achète la chute** (souvent causée par une mauvaise news) et **tient J+10**. Brancher un auto-close sur news négative (comme `checkNewsShockClose` le fait pour les positions Lisa) **couperait l'edge** — on fermerait au pire moment, juste avant le rebond. Le widget est donc une **veille** : il aide l'utilisateur à repérer un éventuel *falling-knife* qui s'aggrave et à arbitrer **manuellement**. Aucun nouveau chemin d'exécution introduit.

## Backend

- `OversoldScannerService.getNewsWatch(portfolioId)` — 1 requête `eodhd_news_articles` (`.in` sur les tickers tenus, fenêtre 48h), agrège par symbole le min-sentiment + l'article le plus récent, remonte **uniquement** les positions à sentiment contraire (≤ -0.3 ; `level: shock` ≤ -0.6, réf. `checkNewsShockClose`). Lecture seule, fail-soft.
- `GET /lisa/oversold-news-watch/:portfolioId`.

## Frontend

- `useOversoldNewsWatch` (poll 120s) + `OversoldNewsWatchPanel` : liste triée (plus négatif d'abord) des alertes 🔴 shock / 🟡 veille avec symbole, min-sentiment, nb d'articles, âge, titre cliquable. Compteur `N alertes · M positions`. Disclaimer explicite. Rendu si `currentMode === 'oversold'`.

## Vérif
- `tsc --noEmit` ✅ (api + web).

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_