### PR TITLE
oversold : widget loi empirique par bande de drop (réalisé + J+10)

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -1616,6 +1616,19 @@ export class LisaController {
   }
 
   /**
+   * PR-2 (widget loi empirique) — loi empirique oversold par bande de drop :
+   * realized (clôturés, dispo) + forwardJ10 (qualité d'entrée isolée, ~18/06).
+   */
+  @Get('oversold-empirical-law/:portfolioId')
+  async getOversoldEmpiricalLaw(
+    @Headers() headers: Record<string, string>,
+    @Param('portfolioId') portfolioId: string,
+  ) {
+    extractUserId(headers);
+    return this.oversoldScanner.getEmpiricalLaw(portfolioId);
+  }
+
+  /**
    * 04/06 — Boucles d'apprentissage SÉPARÉES (user request). Chacune lit
    * uniquement les closes labellisés de SA source pour ne pas mixer les
    * patterns scalp gainers (5-60min) avec swing oversold (J+10).

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -149,6 +149,34 @@ export interface OversoldNewsWatch {
   asOf: string;
 }
 
+/**
+ * PR-2 (widget loi empirique) — un bucket de la loi empirique oversold,
+ * segmenté par bande de drop 1j à l'entrée.
+ */
+export interface OversoldLawBucket {
+  label: string; // ex: "-10 à -8%"
+  n: number;
+  wins: number;
+  winRatePct: number | null;
+  avgPct: number | null; // PnL réalisé moyen, ou rendement J+10 moyen selon la loi
+  ciLowPct: number | null; // borne basse Wilson 95% (sur le winRate)
+  ciHighPct: number | null;
+}
+
+export interface OversoldLawTable {
+  sampleSize: number;
+  overallWinRatePct: number | null;
+  overallAvgPct: number | null;
+  byDropBand: OversoldLawBucket[];
+}
+
+export interface OversoldEmpiricalLaw {
+  portfolioId: string;
+  realized: OversoldLawTable; // pnl_pct des trades clôturés (entrée+sortie mêlées)
+  forwardJ10: OversoldLawTable & { horizonDays: number }; // rendement J+10 (qualité d'entrée isolée) — se peuple ~18/06
+  asOf: string;
+}
+
 /** Row config oversold lue depuis lisa_session_configs. */
 interface OversoldPortfolioRow {
   portfolio_id: string;
@@ -1417,6 +1445,143 @@ export class OversoldScannerService {
     alerts.sort((a, b) => a.minSentiment - b.minSentiment);
 
     return { portfolioId, openPositions, windowHours: WINDOW_HOURS, alerts, asOf: new Date().toISOString() };
+  }
+
+  /**
+   * PR-2 (widget loi empirique) — loi empirique oversold segmentée par bande de
+   * drop 1j à l'entrée, calculée sur paper_trades (strategy=oversold) du portfolio.
+   *
+   * Deux lois :
+   *  - realized : winRate / PnL moyen des trades CLÔTURÉS (pnl_pct). Disponible
+   *    tout de suite. ⚠ mêle qualité d'entrée ET timing de sortie.
+   *  - forwardJ10 : winRate / rendement J+10 (fwd_outcome_10d / fwd_return_10d) =
+   *    qualité d'entrée ISOLÉE (horizon fixe). Se peuple à mesure que chaque
+   *    entrée atteint J+10 ouvré (≈ 18/06).
+   *
+   * Wilson 95% sur le winRate par bucket pour signaler les bandes à petit n.
+   * Lecture seule.
+   */
+  async getEmpiricalLaw(portfolioId: string): Promise<OversoldEmpiricalLaw> {
+    const { data } = await this.supabase
+      .getClient()
+      .from('paper_trades')
+      .select('pnl_pct, fwd_return_10d, fwd_outcome_10d, features_at_entry')
+      .eq('strategy', 'oversold')
+      .eq('portfolio_id', portfolioId)
+      .limit(2000);
+    const rows = (data ?? []) as Array<{
+      pnl_pct: number | string | null;
+      fwd_return_10d: number | string | null;
+      fwd_outcome_10d: number | string | null;
+      features_at_entry: { drop1d?: number | null } | null;
+    }>;
+
+    const realizedSamples: Array<{ drop: number; win: boolean; value: number }> = [];
+    const fwdSamples: Array<{ drop: number; win: boolean; value: number }> = [];
+    for (const r of rows) {
+      const drop = r.features_at_entry?.drop1d;
+      if (drop == null || !Number.isFinite(drop)) continue;
+      const pnl = r.pnl_pct == null ? null : Number(r.pnl_pct);
+      if (pnl != null && Number.isFinite(pnl)) {
+        realizedSamples.push({ drop, win: pnl > 0, value: pnl });
+      }
+      const fwdRet = r.fwd_return_10d == null ? null : Number(r.fwd_return_10d);
+      const fwdOut = r.fwd_outcome_10d == null ? null : Number(r.fwd_outcome_10d);
+      if (fwdRet != null && Number.isFinite(fwdRet)) {
+        fwdSamples.push({ drop, win: fwdOut != null ? fwdOut === 1 : fwdRet > 0, value: fwdRet });
+      }
+    }
+
+    return {
+      portfolioId,
+      realized: this.buildLawTable(realizedSamples),
+      forwardJ10: { ...this.buildLawTable(fwdSamples), horizonDays: 10 },
+      asOf: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Bande de drop 1j d'un échantillon (null si non fini). Bandes fines dans la
+   * zone 0..-5% car c'est là que se concentrent les entrées (la veine intraday-
+   * rebound entre souvent sur un jour déjà vert) — un découpage grossier
+   * masquerait le gradient (jour vert ≫ jour encore rouge pour le mean-reversion).
+   */
+  private static dropBandLabel(drop: number): string | null {
+    if (!Number.isFinite(drop)) return null;
+    if (drop <= -12) return '≤ -12% (knife)';
+    if (drop <= -10) return '-12 à -10%';
+    if (drop <= -8) return '-10 à -8%';
+    if (drop <= -6) return '-8 à -6%';
+    if (drop <= -5) return '-6 à -5%';
+    if (drop <= -3) return '-5 à -3%';
+    if (drop <= -1) return '-3 à -1%';
+    if (drop < 0) return '-1 à 0%';
+    return '≥ 0% (vert)';
+  }
+
+  private static readonly DROP_BAND_ORDER = [
+    '≤ -12% (knife)',
+    '-12 à -10%',
+    '-10 à -8%',
+    '-8 à -6%',
+    '-6 à -5%',
+    '-5 à -3%',
+    '-3 à -1%',
+    '-1 à 0%',
+    '≥ 0% (vert)',
+  ];
+
+  /** Intervalle de Wilson 95% pour une proportion wins/n (null si n=0). */
+  private static wilson(wins: number, n: number): { low: number; high: number } | null {
+    if (n <= 0) return null;
+    const z = 1.96;
+    const p = wins / n;
+    const z2 = z * z;
+    const denom = 1 + z2 / n;
+    const centre = (p + z2 / (2 * n)) / denom;
+    const margin = (z * Math.sqrt((p * (1 - p)) / n + z2 / (4 * n * n))) / denom;
+    return { low: Math.max(0, centre - margin), high: Math.min(1, centre + margin) };
+  }
+
+  /** Construit une table de loi (overall + buckets par bande de drop). */
+  private buildLawTable(samples: Array<{ drop: number; win: boolean; value: number }>): OversoldLawTable {
+    const byBand = new Map<string, { n: number; wins: number; sum: number }>();
+    let totN = 0;
+    let totWins = 0;
+    let totSum = 0;
+    for (const s of samples) {
+      const band = OversoldScannerService.dropBandLabel(s.drop);
+      if (!band) continue;
+      const cur = byBand.get(band) ?? { n: 0, wins: 0, sum: 0 };
+      cur.n += 1;
+      if (s.win) cur.wins += 1;
+      cur.sum += s.value;
+      byBand.set(band, cur);
+      totN += 1;
+      if (s.win) totWins += 1;
+      totSum += s.value;
+    }
+    const byDropBand: OversoldLawBucket[] = OversoldScannerService.DROP_BAND_ORDER.filter((b) =>
+      byBand.has(b),
+    ).map((b) => {
+      const v = byBand.get(b)!;
+      const ci = OversoldScannerService.wilson(v.wins, v.n);
+      return {
+        label: b,
+        n: v.n,
+        wins: v.wins,
+        winRatePct: v.n > 0 ? (v.wins / v.n) * 100 : null,
+        avgPct: v.n > 0 ? v.sum / v.n : null,
+        ciLowPct: ci ? ci.low * 100 : null,
+        ciHighPct: ci ? ci.high * 100 : null,
+      };
+    });
+    return {
+      sampleSize: totN,
+      overallWinRatePct: totN > 0 ? (totWins / totN) * 100 : null,
+      overallAvgPct: totN > 0 ? totSum / totN : null,
+      byDropBand,
+    };
   }
 
   /**

--- a/apps/web/src/app/lisa/page.tsx
+++ b/apps/web/src/app/lisa/page.tsx
@@ -39,6 +39,7 @@ import { GainsTracker } from '@/components/lisa/gains-tracker';
 import { OversoldPanel } from '@/components/lisa/oversold-panel';
 import { OversoldRegimePanel } from '@/components/lisa/oversold-regime-panel';
 import { OversoldNewsWatchPanel } from '@/components/lisa/oversold-news-watch-panel';
+import { OversoldEmpiricalLawPanel } from '@/components/lisa/oversold-empirical-law-panel';
 import { LessonsImpactPanel } from '@/components/lisa/lessons-impact-panel';
 import { LearningLoopAuditPanel } from '@/components/lisa/learning-loop-audit-panel';
 import { LisaConfigPanel } from '@/components/lisa/lisa-config-panel';
@@ -759,6 +760,11 @@ export default function LisaPage() {
           (visibilité, pas un trigger d'exit). */}
       {selectedPortfolioId && currentMode === 'oversold' && (
         <OversoldNewsWatchPanel portfolioId={selectedPortfolioId} />
+      )}
+
+      {/* 07/06 — Loi empirique par bande de drop : réalisé (dispo) + J+10 (~18/06). */}
+      {selectedPortfolioId && currentMode === 'oversold' && (
+        <OversoldEmpiricalLawPanel portfolioId={selectedPortfolioId} />
       )}
 
       {/* Shadow Sizing — RETIRÉ 04/06. Les shadows MIDDLE/SMALL sont figés et

--- a/apps/web/src/components/lisa/oversold-empirical-law-panel.tsx
+++ b/apps/web/src/components/lisa/oversold-empirical-law-panel.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState } from 'react';
+import { BarChart3 } from 'lucide-react';
+import {
+  useOversoldEmpiricalLaw,
+  type OversoldLawTable,
+  type OversoldLawBucket,
+} from '@/hooks/use-oversold-empirical-law';
+
+/**
+ * PR-2 (widget loi empirique) — loi empirique oversold par bande de drop 1j.
+ *
+ * Deux lentilles, sélectionnables :
+ *  - « Réalisé » : winRate / PnL moyen des trades CLÔTURÉS (dispo tout de suite).
+ *    ⚠ mêle qualité d'entrée ET timing de sortie.
+ *  - « J+10 » : winRate / rendement à horizon fixe J+10 = qualité d'ENTRÉE isolée.
+ *    Se peuple à mesure que chaque entrée atteint J+10 ouvré (~18/06).
+ *
+ * Intervalle de Wilson 95% sur le winRate par bande → signale les bandes à petit n.
+ */
+export function OversoldEmpiricalLawPanel({ portfolioId }: { portfolioId: string }) {
+  const { data, isLoading, isError } = useOversoldEmpiricalLaw(portfolioId);
+  const [lens, setLens] = useState<'realized' | 'j10'>('realized');
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border p-4 text-sm text-muted-foreground">
+        📊 Chargement de la loi empirique…
+      </div>
+    );
+  }
+  if (isError || !data) {
+    return (
+      <div className="rounded-lg border p-4 text-sm text-muted-foreground">
+        📊 Loi empirique indisponible pour le moment.
+      </div>
+    );
+  }
+
+  const table: OversoldLawTable = lens === 'realized' ? data.realized : data.forwardJ10;
+  const valueLabel = lens === 'realized' ? 'PnL moyen' : 'Ret. J+10 moyen';
+
+  return (
+    <div className="rounded-lg border p-4 space-y-3">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-2">
+          <BarChart3 className="h-4 w-4 text-purple-600" />
+          <h2 className="text-sm font-medium">📊 Loi empirique — par bande de drop</h2>
+        </div>
+        <div className="flex gap-1 rounded-md border p-0.5">
+          <LensButton active={lens === 'realized'} onClick={() => setLens('realized')}>
+            Réalisé ({data.realized.sampleSize})
+          </LensButton>
+          <LensButton active={lens === 'j10'} onClick={() => setLens('j10')}>
+            J+10 ({data.forwardJ10.sampleSize})
+          </LensButton>
+        </div>
+      </div>
+
+      {/* Bandeau résumé global */}
+      {table.sampleSize > 0 ? (
+        <div className="grid grid-cols-3 gap-2 text-xs">
+          <Summary label="Échantillon" value={`${table.sampleSize} trades`} />
+          <Summary
+            label="Win rate global"
+            value={table.overallWinRatePct != null ? `${table.overallWinRatePct.toFixed(0)}%` : '—'}
+          />
+          <Summary
+            label={valueLabel}
+            value={table.overallAvgPct != null ? `${table.overallAvgPct >= 0 ? '+' : ''}${table.overallAvgPct.toFixed(2)}%` : '—'}
+            valueCls={table.overallAvgPct != null ? (table.overallAvgPct >= 0 ? 'text-emerald-600' : 'text-red-600') : ''}
+          />
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground italic">
+          {lens === 'j10'
+            ? `Aucun label J+${data.forwardJ10.horizonDays} disponible pour l’instant — la loi de qualité d’entrée se peuplera à mesure que les entrées atteignent J+${data.forwardJ10.horizonDays} ouvré (≈ mi-juin). Bascule sur « Réalisé » en attendant.`
+            : 'Aucun trade clôturé pour l’instant sur ce portefeuille.'}
+        </p>
+      )}
+
+      {/* Table par bande */}
+      {table.byDropBand.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-left text-muted-foreground border-b">
+                <th className="py-1.5 pr-2">Bande de drop 1j</th>
+                <th className="py-1.5 px-2 text-right">n</th>
+                <th className="py-1.5 px-2 text-right">Win rate</th>
+                <th className="py-1.5 px-2 text-right">IC 95% (Wilson)</th>
+                <th className="py-1.5 pl-2 text-right">{valueLabel}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {table.byDropBand.map((b) => (
+                <LawRow key={b.label} b={b} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <p className="text-[11px] text-muted-foreground italic">
+        {lens === 'realized'
+          ? 'Réalisé = PnL des trades clôturés : mêle la qualité d’entrée ET le timing de sortie. Pour isoler la qualité d’entrée, voir l’onglet J+10.'
+          : `J+${data.forwardJ10.horizonDays} = rendement à horizon fixe depuis l’entrée : isole la qualité d’ENTRÉE (indépendant du timing de sortie).`}{' '}
+        L’IC de Wilson large = échantillon encore petit, prudence. MAJ {new Date(data.asOf).toLocaleTimeString('fr-FR')}.
+      </p>
+    </div>
+  );
+}
+
+function LensButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+        active ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Summary(props: { label: string; value: string; valueCls?: string }) {
+  return (
+    <div className="rounded-md border p-2">
+      <div className="text-[10px] uppercase text-muted-foreground">{props.label}</div>
+      <div className={`text-sm font-semibold tabular-nums ${props.valueCls ?? ''}`}>{props.value}</div>
+    </div>
+  );
+}
+
+function LawRow({ b }: { b: OversoldLawBucket }) {
+  const wr = b.winRatePct;
+  const wrCls = wr == null ? 'text-muted-foreground' : wr >= 50 ? 'text-emerald-600' : 'text-red-600';
+  const avgCls =
+    b.avgPct == null ? 'text-muted-foreground' : b.avgPct >= 0 ? 'text-emerald-600' : 'text-red-600';
+  return (
+    <tr className="border-b last:border-0">
+      <td className="py-1.5 pr-2 font-medium">{b.label}</td>
+      <td className="py-1.5 px-2 text-right tabular-nums">{b.n}</td>
+      <td className={`py-1.5 px-2 text-right tabular-nums ${wrCls}`}>
+        {wr != null ? `${wr.toFixed(0)}%` : '—'}
+      </td>
+      <td className="py-1.5 px-2 text-right tabular-nums text-muted-foreground">
+        {b.ciLowPct != null && b.ciHighPct != null
+          ? `${b.ciLowPct.toFixed(0)}–${b.ciHighPct.toFixed(0)}%`
+          : '—'}
+      </td>
+      <td className={`py-1.5 pl-2 text-right tabular-nums ${avgCls}`}>
+        {b.avgPct != null ? `${b.avgPct >= 0 ? '+' : ''}${b.avgPct.toFixed(2)}%` : '—'}
+      </td>
+    </tr>
+  );
+}

--- a/apps/web/src/hooks/use-oversold-empirical-law.ts
+++ b/apps/web/src/hooks/use-oversold-empirical-law.ts
@@ -1,0 +1,43 @@
+// LISA — Oversold empirical law hook (panel dédié mode oversold).
+// Source : GET /lisa/oversold-empirical-law/:portfolioId — winRate / PnL moyen
+// par bande de drop 1j à l'entrée. Deux lois : realized (clôturés, dispo) et
+// forwardJ10 (qualité d'entrée isolée, se peuple ~18/06).
+
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api-client';
+
+export interface OversoldLawBucket {
+  label: string;
+  n: number;
+  wins: number;
+  winRatePct: number | null;
+  avgPct: number | null;
+  ciLowPct: number | null;
+  ciHighPct: number | null;
+}
+
+export interface OversoldLawTable {
+  sampleSize: number;
+  overallWinRatePct: number | null;
+  overallAvgPct: number | null;
+  byDropBand: OversoldLawBucket[];
+}
+
+export interface OversoldEmpiricalLaw {
+  portfolioId: string;
+  realized: OversoldLawTable;
+  forwardJ10: OversoldLawTable & { horizonDays: number };
+  asOf: string;
+}
+
+export function useOversoldEmpiricalLaw(portfolioId: string | null) {
+  return useQuery({
+    queryKey: ['lisa', 'oversold-empirical-law', portfolioId],
+    queryFn: () => apiFetch<OversoldEmpiricalLaw>(`/lisa/oversold-empirical-law/${portfolioId}`),
+    enabled: !!portfolioId,
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchInterval: 300_000,
+    staleTime: 120_000,
+  });
+}


### PR DESCRIPTION
## Contexte

Réponse à « j'ai un widget sur la loi empirique ? » → non, il n'y en avait aucun sur l'oversold (seul `/lisa/gainers/insights`, retiré, existait). Construit maintenant sur les **46 trades réalisés** (choix validé), avec bascule auto vers la vue J+10 dès que les labels mûrissent (~18/06).

## Backend

- `OversoldScannerService.getEmpiricalLaw(portfolioId)` — loi empirique sur `paper_trades` (strategy=oversold) du portefeuille, segmentée par **bande de drop 1j à l'entrée** (`features_at_entry.drop1d`). Deux tables :
  - **realized** : winRate / PnL moyen des clôturés. Dispo tout de suite. ⚠ mêle qualité d'entrée + timing de sortie.
  - **forwardJ10** : winRate / rendement J+10 = **qualité d'entrée isolée** (horizon fixe). Se peuple ~18/06.
  - Intervalle de **Wilson 95 %** par bucket pour signaler les bandes à petit n.
  - Bandes fines dans la zone 0→-5 % (la veine intraday-rebound entre souvent sur un jour déjà vert ; un découpage grossier masquerait le gradient).
- `GET /lisa/oversold-empirical-law/:portfolioId`.

## Frontend

- `useOversoldEmpiricalLaw` + `OversoldEmpiricalLawPanel` : toggle **Réalisé / J+10** (avec compteur d'échantillon), bandeau résumé global (n, winRate, valeur moyenne), table par bande (n, winRate, IC Wilson, PnL/rendement moyen). État vide explicite pour J+10 tant que les labels ne sont pas mûrs. Rendu si `currentMode === 'oversold'`.

## Donnée live observée (US, n=46 réalisés)

Gradient net et exploitable : entrée sur **jour déjà vert (drop1d ≥ 0)** → **100 % WR / +2,56 %** (n=28) ; jours encore rouges en forte dégradation (-1→0 : 56 % ; -3→-1 : 17 % ; ≤ -6 : 0 %). Lecture mean-reversion : mieux vaut entrer quand le rebond a commencé que rattraper le couteau. À confirmer sur la vue J+10 (le réalisé reste pollué par le timing de sortie).

## Vérif
- `tsc --noEmit` ✅ (api + web). Loi recoupée sur données réelles via sandbox.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_