### PR TITLE
feat(oversold): logging per-candidat du scan intraday (mission "gate qui rate les pépites")

### DIFF
--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -630,16 +630,37 @@ export class OversoldScannerService {
       positionNotionalUsd: Math.round(cfg.positionNotionalUsd * notionalRatio),
     };
 
+    // Logging per-candidat (mission "gate qui rate les pépites") — capture POUR
+    // CHAQUE candidat le verdict gate + les métriques, au lieu du seul compteur
+    // agrégé `rejected_rebound`. Shadow append-only, jamais bloquant.
+    const scanLog: Record<string, unknown>[] = [];
+    const baseRecOf = (c: OversoldCandidate): Record<string, unknown> => ({
+      portfolio_id: portfolioId,
+      scan_phase: 'intraday',
+      universe: cfg.universe,
+      region: regime.region,
+      symbol: c.symbol,
+      drop_pct: Number.isFinite(c.dropPct) ? Number(c.dropPct.toFixed(3)) : null,
+      close_j: Number.isFinite(c.closeJ) ? c.closeJ : null,
+    });
+
     for (const cand of toScan) {
       if (remaining <= 0) break;
       evaluated++;
+      const base = baseRecOf(cand);
       try {
         const series = await this.intraday
           .getCandles(cand.symbol, '5m', 18, { calledBy: 'oversold_intraday' })
           .catch(() => null);
         const raw = series?.candles ?? [];
+        if (raw.length === 0) {
+          rejectedRebound++;
+          scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'no_candles' });
+          continue;
+        }
         if (raw.length < reboundCfg.minBarsRequired) {
           rejectedRebound++;
+          scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'insufficient_bars', bars_count: raw.length });
           continue;
         }
         const analysis = analyzeIntradayRebound(
@@ -648,11 +669,21 @@ export class OversoldScannerService {
         );
         if (!analysis) {
           rejectedRebound++;
+          scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'analysis_null', bars_count: raw.length });
           continue;
         }
+        const metricCols = {
+          current_price: analysis.currentPrice,
+          rebound_pct: Number(analysis.reboundPct.toFixed(3)),
+          trend_15m_pct: Number(analysis.trend15mPct.toFixed(3)),
+          volume_ratio: Number(analysis.volumeRatio.toFixed(3)),
+          bottom_bar_idx: analysis.lowAtBarIdx,
+          bars_count: analysis.barsCount,
+        };
         const gate = passesIntradayReboundFilter(analysis, reboundCfg);
         if (!gate.pass) {
           rejectedRebound++;
+          scanLog.push({ ...base, ...metricCols, outcome: 'rejected', reject_stage: 'rebound_filter', reject_reasons: gate.reasons });
           continue;
         }
 
@@ -660,12 +691,16 @@ export class OversoldScannerService {
         await this.openIntradayPosition(portfolioId, cand, reboundCfgForOpens, analysis.currentPrice, regime.vix);
         opened++;
         remaining--;
+        scanLog.push({ ...base, ...metricCols, outcome: 'opened' });
       } catch (err) {
         this.logger.warn(
           `[oversold-intraday] ${cand.symbol} évaluation échouée: ${String(err).slice(0, 160)}`,
         );
       }
     }
+
+    // Persiste le log per-candidat (un seul INSERT batch, fire-and-forget).
+    await this.persistScanLog(scanLog);
 
     await this.decisionLog
       .append({
@@ -696,6 +731,31 @@ export class OversoldScannerService {
       `[oversold-intraday] portfolio=${portfolioId.slice(0, 8)} bande=${candidates.length} ` +
         `évalués=${evaluated} ouverts=${opened} (cap ${maxOpensPerDay}, used ${intradayOpenedToday + opened})`,
     );
+  }
+
+  /** Gate du logging per-candidat (désactivable via secret, default on). */
+  private scanRejectLogEnabled(): boolean {
+    return (this.config.get<string>('OVERSOLD_SCAN_REJECT_LOG_ENABLED') ?? 'true').toLowerCase() === 'true';
+  }
+
+  /**
+   * Persiste le log per-candidat du scan (table shadow oversold_scan_rejections).
+   * Un seul INSERT batch par scan. Jamais bloquant : toute erreur est avalée en
+   * debug (le scan ne doit jamais crasher pour un échec de logging d'audit).
+   */
+  private async persistScanLog(rows: Record<string, unknown>[]): Promise<void> {
+    if (!this.scanRejectLogEnabled() || rows.length === 0) return;
+    try {
+      const { error } = await this.supabase
+        .getClient()
+        .from('oversold_scan_rejections')
+        .insert(rows);
+      if (error) {
+        this.logger.debug(`[oversold-intraday] scan-reject log insert failed: ${error.message.slice(0, 160)}`);
+      }
+    } catch (e) {
+      this.logger.debug(`[oversold-intraday] scan-reject log exception: ${String(e).slice(0, 120)}`);
+    }
   }
 
   /** Compte les positions ouvertes par le scanner intraday aujourd'hui UTC. */

--- a/scripts/analyze-oversold-scan-rejections.ts
+++ b/scripts/analyze-oversold-scan-rejections.ts
@@ -1,0 +1,186 @@
+/**
+ * Analyse de la table `oversold_scan_rejections` (mission "gate qui rate les pépites").
+ *
+ * Le scan intraday loggue désormais CHAQUE candidat avec le gate exact qui l'a
+ * rejeté + les métriques. Ce script exploite ce corpus pour répondre à LA
+ * question : quel gate étrangle le pipeline, et le fait-il à raison ?
+ *
+ *   1. Répartition des rejets par stage (no_candles / insufficient_bars /
+ *      analysis_null / rebound_filter) + ouvertures.
+ *   2. Pour rebound_filter : QUEL sous-gate bloque (rebound% / trend15m /
+ *      bottom-timing / volRatio), en distinguant "apparaît" (≥1 fois dans les
+ *      raisons) vs "SEUL bloqueur" (la raison unique = le vrai goulot).
+ *   3. Near-miss : combien de candidats étaient JUSTE sous le seuil (≥70% du
+ *      seuil) → récupérables en relâchant légèrement.
+ *   4. Regret forward : combien de rejets ont rebondi ≥1,5% depuis le creux
+ *      (close_j) jusqu'au prix live actuel (proxy EODHD real-time).
+ *
+ * Usage : npx tsx scripts/analyze-oversold-scan-rejections.ts [--days 7]
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+const EODHD = process.env.EODHD_API_KEY!;
+
+// Seuils par défaut (cf. DEFAULT_INTRADAY_REBOUND_CONFIG). Override si tu changes la config Fly.
+const TH = { rebound: 1.5, trend15m: 0.3, volRatio: 0.8, bottomBars: 2 };
+
+interface Row {
+  symbol: string;
+  scanned_at: string;
+  scan_phase: string;
+  region: string | null;
+  drop_pct: number | null;
+  close_j: number | null;
+  outcome: string;
+  reject_stage: string | null;
+  reject_reasons: string[] | null;
+  rebound_pct: number | null;
+  trend_15m_pct: number | null;
+  volume_ratio: number | null;
+  bottom_bar_idx: number | null;
+  bars_count: number | null;
+}
+
+/** Classe une chaîne de raison en label de gate. */
+function gateOf(reason: string): 'rebound' | 'trend15m' | 'bottom_timing' | 'volume_ratio' | 'autre' {
+  if (reason.startsWith('rebound=')) return 'rebound';
+  if (reason.startsWith('trend15m=')) return 'trend15m';
+  if (reason.startsWith('bottom ')) return 'bottom_timing';
+  if (reason.startsWith('volRatio=')) return 'volume_ratio';
+  return 'autre';
+}
+
+async function realtimeBulk(symbols: string[]): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  for (let k = 0; k < symbols.length; k += 20) {
+    const chunk = symbols.slice(k, k + 20);
+    const [first, ...rest] = chunk;
+    const s = rest.length ? `&s=${rest.join(',')}` : '';
+    const url = `https://eodhd.com/api/real-time/${encodeURIComponent(first)}?api_token=${EODHD}&fmt=json${s}`;
+    try {
+      const r = await fetch(url, { signal: AbortSignal.timeout(8000) });
+      if (!r.ok) continue;
+      let j = await r.json();
+      if (!Array.isArray(j)) j = [j];
+      for (const q of j as Array<{ code?: string; close?: number }>) {
+        if (q.code && Number.isFinite(Number(q.close))) out.set(q.code, Number(q.close));
+      }
+    } catch { /* skip */ }
+  }
+  return out;
+}
+
+function bar(n: number, max: number, width = 30): string {
+  const f = max > 0 ? Math.round((n / max) * width) : 0;
+  return '█'.repeat(f) + '·'.repeat(width - f);
+}
+
+async function main() {
+  const daysArg = process.argv.indexOf('--days');
+  const days = daysArg >= 0 ? Number(process.argv[daysArg + 1]) : 7;
+  const since = new Date(Date.now() - days * 86400_000).toISOString();
+
+  const { data, error } = await sb
+    .from('oversold_scan_rejections')
+    .select('symbol, scanned_at, scan_phase, region, drop_pct, close_j, outcome, reject_stage, reject_reasons, rebound_pct, trend_15m_pct, volume_ratio, bottom_bar_idx, bars_count')
+    .gte('scanned_at', since)
+    .order('scanned_at', { ascending: false });
+  if (error) { console.error('ERR', error.message); process.exit(1); }
+  const rows = (data ?? []) as Row[];
+
+  console.log(`\n🔬 ANALYSE oversold_scan_rejections — ${days}j (depuis ${since.slice(0, 10)})`);
+  console.log(`   ${rows.length} candidat-scans loggés\n`);
+  if (rows.length === 0) {
+    console.log('⚠️ Table vide. Elle se peuple au prochain scan intraday sur Fly (post-deploy).');
+    console.log('   Cron intraday : 0 0 8-20 * * 1-5 UTC (horaire, séances EU+US).');
+    return;
+  }
+
+  // 1. Répartition par stage
+  const byStage = new Map<string, number>();
+  for (const r of rows) {
+    const k = r.outcome === 'opened' ? '✅ opened' : (r.reject_stage ?? 'rejected(?)');
+    byStage.set(k, (byStage.get(k) ?? 0) + 1);
+  }
+  console.log('─'.repeat(64));
+  console.log('1) RÉPARTITION PAR STAGE');
+  console.log('─'.repeat(64));
+  const maxStage = Math.max(...byStage.values());
+  for (const [k, n] of [...byStage.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${k.padEnd(20)} ${bar(n, maxStage)} ${n}`);
+  }
+
+  // 2. Sous-gate pour rebound_filter : apparaît vs SEUL bloqueur
+  const rf = rows.filter((r) => r.reject_stage === 'rebound_filter' && Array.isArray(r.reject_reasons));
+  const appears = new Map<string, number>();
+  const sole = new Map<string, number>();
+  for (const r of rf) {
+    const gates = (r.reject_reasons ?? []).map(gateOf);
+    const uniq = [...new Set(gates)];
+    for (const g of uniq) appears.set(g, (appears.get(g) ?? 0) + 1);
+    if (uniq.length === 1) sole.set(uniq[0], (sole.get(uniq[0]) ?? 0) + 1);
+  }
+  console.log('\n' + '─'.repeat(64));
+  console.log(`2) SOUS-GATE rebound_filter (${rf.length} rejets) — apparaît vs SEUL bloqueur`);
+  console.log('─'.repeat(64));
+  console.log(`  ${'gate'.padEnd(16)} ${'apparaît'.padEnd(10)} ${'SEUL'.padEnd(8)} (seul = vrai goulot)`);
+  const allGates = new Set([...appears.keys(), ...sole.keys()]);
+  for (const g of [...allGates].sort((a, b) => (appears.get(b) ?? 0) - (appears.get(a) ?? 0))) {
+    const a = appears.get(g) ?? 0;
+    const s = sole.get(g) ?? 0;
+    const flag = s / Math.max(1, rf.length) > 0.3 ? '  🔴 SUSPECT' : '';
+    console.log(`  ${g.padEnd(16)} ${String(a).padEnd(10)} ${String(s).padEnd(8)}${flag}`);
+  }
+
+  // 3. Near-miss : juste sous le seuil (≥70% du seuil) sur le gate dominant
+  console.log('\n' + '─'.repeat(64));
+  console.log('3) NEAR-MISS (juste sous le seuil → récupérables)');
+  console.log('─'.repeat(64));
+  const nmRebound = rf.filter((r) => r.rebound_pct != null && r.rebound_pct >= TH.rebound * 0.7 && r.rebound_pct < TH.rebound).length;
+  const nmTrend = rf.filter((r) => r.trend_15m_pct != null && r.trend_15m_pct >= TH.trend15m * 0.5 && r.trend_15m_pct < TH.trend15m).length;
+  const nmVol = rf.filter((r) => r.volume_ratio != null && r.volume_ratio >= TH.volRatio * 0.85 && r.volume_ratio < TH.volRatio).length;
+  console.log(`  rebound ∈ [${(TH.rebound * 0.7).toFixed(2)}%, ${TH.rebound}%)  : ${nmRebound} candidats (seuil rebound=${TH.rebound}%)`);
+  console.log(`  trend15m ∈ [${(TH.trend15m * 0.5).toFixed(2)}%, ${TH.trend15m}%) : ${nmTrend} candidats (seuil trend15m=${TH.trend15m}%)`);
+  console.log(`  volRatio ∈ [${(TH.volRatio * 0.85).toFixed(2)}, ${TH.volRatio})   : ${nmVol} candidats (seuil volRatio=${TH.volRatio})`);
+
+  // 4. Regret forward : rejets qui ont rebondi ≥1,5% depuis close_j
+  console.log('\n' + '─'.repeat(64));
+  console.log('4) REGRET FORWARD (rejet → rebond ≥1,5% depuis le creux close_j ?)');
+  console.log('─'.repeat(64));
+  // Dernier rejet par symbole (close_j de référence le plus récent)
+  const lastRej = new Map<string, Row>();
+  for (const r of rows) {
+    if (r.outcome !== 'rejected' || r.close_j == null) continue;
+    if (!lastRej.has(r.symbol)) lastRej.set(r.symbol, r); // rows sont déjà desc → 1er = plus récent
+  }
+  const syms = [...lastRej.keys()];
+  if (syms.length === 0) {
+    console.log('  (aucun rejet avec close_j → rien à mesurer)');
+  } else {
+    const live = await realtimeBulk(syms);
+    let measured = 0, regret = 0;
+    const lines: string[] = [];
+    for (const [sym, r] of lastRej) {
+      const cur = live.get(sym);
+      if (cur == null || r.close_j == null) continue;
+      measured++;
+      const reb = ((cur - r.close_j) / r.close_j) * 100;
+      const isRegret = reb >= 1.5;
+      if (isRegret) regret++;
+      const gate = (r.reject_reasons ?? []).map(gateOf).join(',') || r.reject_stage;
+      lines.push(`  ${sym.padEnd(13)} close_j=${String(r.close_j).padEnd(9)} live=${String(cur).padEnd(9)} reb=${reb >= 0 ? '+' : ''}${reb.toFixed(2)}%  ${isRegret ? '🔴' : reb >= 0.5 ? '🟡' : '🟢'} [${gate}]`);
+    }
+    lines.sort();
+    for (const l of lines) console.log(l);
+    const pct = measured ? (regret / measured) * 100 : 0;
+    console.log(`\n  VERDICT : ${regret}/${measured} rejets ont rebondi ≥1,5% (${pct.toFixed(0)}% de regret).`);
+    console.log(pct > 30
+      ? '  ⚠️ > 30% → le filtre intraday rate de vrais rebonds → relâcher le gate SEUL-bloqueur dominant (cf. §2).'
+      : '  ✅ < 30% → le filtre rejette majoritairement à raison.');
+  }
+  console.log('');
+}
+
+main().catch((e) => { console.error('failed:', e); process.exit(1); });

--- a/supabase/migrations/0200_oversold_scan_rejections.sql
+++ b/supabase/migrations/0200_oversold_scan_rejections.sql
@@ -1,0 +1,55 @@
+-- 0200 — Logging per-candidat du scanner oversold (mission "gate qui rate les pépites").
+--
+-- PROBLÈME : le scan intraday bucketise tous les rejets en un seul compteur
+-- `rejected_rebound` dans le decision_log — sans dire QUEL des 4 sous-gates
+-- (rebound% / trend15m / bottom-timing / volRatio) a rejeté chaque candidat,
+-- ni les valeurs réelles des métriques. Impossible de savoir si un gate est
+-- trop strict (= rate des pépites) ou rejette à raison (= du bruit).
+--
+-- SOLUTION : table shadow append-only qui enregistre, pour CHAQUE candidat de
+-- CHAQUE scan, le verdict gate + les métriques. Permet ensuite de calculer le
+-- "regret par gate" (% de rejets qui ont rebondi APRÈS) en joignant les prix
+-- forward EODHD. C'est l'outil fondateur de la mission de calibration.
+--
+-- Append-only, jamais d'UPDATE. Rétention : purge > 30j via cron à venir (faible
+-- volume : ~quelques dizaines de rows / scan / portfolio / heure).
+
+CREATE TABLE IF NOT EXISTS oversold_scan_rejections (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  portfolio_id    UUID NOT NULL,
+  scanned_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  scan_phase      TEXT NOT NULL DEFAULT 'intraday',   -- 'intraday' | 'daily'
+  universe        TEXT,
+  region          TEXT,                                -- 'US' | 'EU'
+  symbol          TEXT NOT NULL,
+
+  -- Contexte bande (drop EOD qui a qualifié le candidat)
+  drop_pct        NUMERIC(8,3),                        -- (closeJ/closeJ-1 - 1)×100
+  close_j         NUMERIC(14,4),                       -- close de référence (creux d'entrée)
+
+  -- Verdict
+  outcome         TEXT NOT NULL,                       -- 'opened' | 'rejected'
+  reject_stage    TEXT,                                -- 'no_candles' | 'insufficient_bars'
+                                                       -- | 'analysis_null' | 'rebound_filter' (NULL si opened)
+  reject_reasons  JSONB,                               -- array de strings (gates échoués, ex: ["rebound=0.42% < 1.5%"])
+
+  -- Métriques intraday au moment du scan (NULL si pas de candles)
+  current_price   NUMERIC(14,4),
+  rebound_pct     NUMERIC(8,3),                        -- (current - low_60min) / low × 100
+  trend_15m_pct   NUMERIC(8,3),                        -- slope 3 dernières bars 5m
+  volume_ratio    NUMERIC(8,3),                        -- vol_last_30m / vol_first_30m
+  bottom_bar_idx  INT,                                 -- idx du low (0=plus ancien, n-1=courant)
+  bars_count      INT
+);
+
+CREATE INDEX IF NOT EXISTS idx_oversold_scan_rejections_scanned_at
+  ON oversold_scan_rejections (scanned_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_oversold_scan_rejections_portfolio
+  ON oversold_scan_rejections (portfolio_id, scanned_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_oversold_scan_rejections_symbol
+  ON oversold_scan_rejections (symbol, scanned_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_oversold_scan_rejections_stage
+  ON oversold_scan_rejections (reject_stage);


### PR DESCRIPTION
## Pourquoi

Le scan intraday oversold bucketisait tous les rejets en un seul compteur `rejected_rebound` dans le decision_log — sans dire **quel** des 4 sous-gates (`rebound%` / `trend15m` / `bottom-timing` / `volRatio`) a rejeté chaque candidat, ni les valeurs réelles. Impossible de savoir si un gate est trop strict (= rate des pépites) ou rejette à raison (= bruit).

Constat live 08/06 (EU / stoxx600, `c0000001`) : 3 scans intraday → **0 ouverture** (4, 4, 8 rejets rebond) — sans visibilité sur la cause par gate.

## Ce que fait ce PR

- **Migration `0200`** → table shadow append-only `oversold_scan_rejections`.
- **Scanner câblé** → enregistre, pour **chaque candidat de chaque scan** : verdict (`opened`/`rejected`), stage (`no_candles` / `insufficient_bars` / `analysis_null` / `rebound_filter`), **raisons exactes du gate** (`reject_reasons`) + **métriques** (rebound%, trend15m%, volRatio, bottom_bar_idx, bars_count). 1 INSERT batch/scan, fire-and-forget, désactivable via `OVERSOLD_SCAN_REJECT_LOG_ENABLED=false`.
- **Script** `scripts/analyze-oversold-scan-rejections.ts` → répartition par stage, sous-gate dominant (apparaît vs SEUL bloqueur = vrai goulot), near-miss (juste sous le seuil), regret forward (rejets ayant rebondi ≥1,5%).

## Tests

- `tsc -b apps/api` ✅
- 65/65 tests oversold ✅ (aucune régression : la logique de scan est inchangée, seul le logging est ajouté)

## Activation

Au merge sur `main` → Fly redéploie → migration 0200 auto-appliquée au boot + logging live → la table se peuple au prochain scan intraday.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_