### PR TITLE
feat(oversold): cadence scan intraday configurable 15 min (rattrape les rebonds intra-heure)

### DIFF
--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -510,22 +510,60 @@ export class OversoldScannerService {
   }
 
   /**
-   * Cron horaire couvrant les séances EU + US (08:00-20:00 UTC, weekdays).
-   * Le créneau réel par portfolio est borné DST-aware à [ouverture +1h,
-   * clôture -1h] de SA bourse (cf. scanPortfolioIntraday) — MÊME logique US et
-   * EU : on saute la 1ère heure (ouverture turbulente) et la dernière heure
-   * (EOD prep). Un cron UTC fixe ne suffisait pas pour l'EU dont la séance
-   * décale d'1h été/hiver (07:00-15:30 vs 08:00-16:30 UTC). Les gardes
-   * marché-fermé skippent les fetchs hors-séance → élargir le cron ne gaspille
-   * aucun appel EODHD.
+   * Cadence effective du scan intraday en minutes (default 15, clamp 5..60).
+   * Le cron tire toutes les 5 min (base) ; ce gate throttle à la cadence
+   * configurée pour que l'utilisateur la règle sans redeploy via
+   * OVERSOLD_INTRADAY_CADENCE_MIN.
+   *
+   * Diagnostic 08/06 (logging per-candidat) : les pépites (SOI +5.9%, ADYEN
+   * +2.4%, IFX +1.9%) confirmaient leur rebond ENTRE deux scans horaires —
+   * elles ressemblaient à des falling-knives au scan de 11:00 (trend15m négatif,
+   * rebond < 1%), correctement rejetées à cet instant, puis rebondies avant le
+   * scan de 12:00. 15 min les rattrape quand le rebond se confirme, SANS toucher
+   * au seuil rebond (les 2 near-miss NEL/ETL à ~1.4% ont fadé → baisser le seuil
+   * aurait ouvert des losers).
    */
-  @Cron('0 0 8-20 * * 1-5', { name: 'oversold-intraday-scan', timeZone: 'UTC' })
+  private intradayCadenceMin(): number {
+    const v = Number(this.config.get<string>('OVERSOLD_INTRADAY_CADENCE_MIN'));
+    if (!Number.isFinite(v) || v <= 0) return 15;
+    return Math.min(60, Math.max(5, v));
+  }
+
+  /** Horodatage du dernier cycle intraday réellement exécuté (gate cadence). */
+  private lastIntradayCycleAt = 0;
+
+  /**
+   * Cron base 5 min couvrant les séances EU + US (08:00-20:00 UTC, weekdays).
+   * La cadence EFFECTIVE est throttlée par intradayCadenceMin() (default 15 min,
+   * réglable via OVERSOLD_INTRADAY_CADENCE_MIN sans redeploy). Le créneau réel
+   * par portfolio est borné DST-aware à [ouverture +1h, clôture -1h] de SA
+   * bourse (cf. scanPortfolioIntraday) — MÊME logique US et EU : on saute la
+   * 1ère heure (ouverture turbulente) et la dernière heure (EOD prep). Un cron
+   * UTC fixe ne suffisait pas pour l'EU dont la séance décale d'1h été/hiver
+   * (07:00-15:30 vs 08:00-16:30 UTC). Les gardes marché-fermé skippent les
+   * fetchs hors-séance, et le gate cadence skippe AVANT tout fetch → élargir le
+   * cron ne gaspille aucun appel EODHD.
+   */
+  @Cron('0 */5 8-20 * * 1-5', { name: 'oversold-intraday-scan', timeZone: 'UTC' })
   async runIntradayScan(): Promise<void> {
     try {
       if (!this.isEnabled() || !this.intradayEnabled()) {
         this.logger.debug('[oversold-intraday] disabled (OVERSOLD_SCANNER_ENABLED or OVERSOLD_INTRADAY_ENABLED off)');
         return;
       }
+
+      // Gate cadence : throttle la base 5 min à la cadence configurée (default
+      // 15 min). Le -30s absorbe la dérive de tick du cron (évite de sauter une
+      // fenêtre quand l'écart retombe à 14min59 au lieu de 15min pile).
+      const cadenceMin = this.intradayCadenceMin();
+      const elapsedMs = Date.now() - this.lastIntradayCycleAt;
+      if (elapsedMs < (cadenceMin * 60 - 30) * 1000) {
+        this.logger.debug(
+          `[oversold-intraday] cadence gate: ${Math.round(elapsedMs / 1000)}s < ${cadenceMin}min → skip`,
+        );
+        return;
+      }
+      this.lastIntradayCycleAt = Date.now();
 
       const portfolios = await this.loadOversoldPortfolios();
       if (portfolios.length === 0) {


### PR DESCRIPTION
## Pourquoi

Diagnostic 08/06 via le logging per-candidat (#657) sur le scan EU de 11:00 UTC (8 candidats, tous rejetés) croisé avec leur prix forward :

| Candidat | reb@scan | trend15@scan | fwd depuis 11:00 |
|---|---|---|---|
| SOI.PA | 0.93% | +0.21% | **+5.90%** 🔴 |
| ADYEN.AS | 0.17% | **-0.73%** | **+2.42%** 🔴 |
| IFX.XETRA | 0.48% | **-0.27%** | **+1.91%** 🔴 |
| NEL.OL | **1.36%** | +0.51% | -1.18% 🟢 (near-miss qui fade) |
| ETL.PA | **1.45%** | -0.46% | -0.17% ⚪ (near-miss qui fade) |

**Ce n'est PAS un seuil trop strict** : les 2 candidats les plus proches du seuil rebond (NEL/ETL ~1.4%) ont **fadé** → baisser le seuil ouvrirait des losers. Les vraies pépites (SOI/ADYEN/IFX) ressemblaient à des falling-knives au scan (trend15m négatif, rebond < 1%), **correctement rejetées à cet instant**, puis confirmées ENTRE 11:00 et 11:35. Le scan suivant n'étant qu'à 12:00, SOI avait déjà fait +5.9% (on achèterait le sommet).

**La cause = cadence horaire trop lente**, pas la discipline du gate.

## Ce que fait ce PR

- Cron intraday : horaire → **base 5 min** + gate qui throttle à la cadence configurée `OVERSOLD_INTRADAY_CADENCE_MIN` (**default 15**, clamp 5..60, réglable sans redeploy).
- Même pattern que le gain-picker (`lastIntradayCycleAt` + fenêtre -30s pour la dérive de tick). Le gate skippe **avant tout fetch EODHD** → aucun appel gaspillé hors cadence.
- **Seuil rebond (1.5%) INCHANGÉ.**

## Mesure

Le logging #657 mesurera l'effet sur 24-48h (boucle fermée).

## Tests

- `tsc -b` workspace ✅
- 65/65 tests oversold ✅

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_