### PR TITLE
feat(oversold): chemin intraday real-time OHLC pour l'EU (bougies 5m gelées)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/oversold-intraday.helper.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/oversold-intraday.helper.spec.ts
@@ -1,0 +1,65 @@
+import {
+  analyzeRealtimeRebound,
+  passesRealtimeReboundFilter,
+  DEFAULT_REALTIME_REBOUND_CONFIG,
+} from '../oversold-intraday.helper';
+
+describe('analyzeRealtimeRebound', () => {
+  it('calcule reboundFromLow, rangePos et dayChg depuis l’OHLC du jour', () => {
+    // SOI.PA 08/06/2026 (données EODHD real-time réelles)
+    const a = analyzeRealtimeRebound({ open: 138.15, high: 157.6, low: 137.3, close: 152.85, prevClose: 146.65 });
+    expect(a).not.toBeNull();
+    expect(a!.reboundFromLowPct).toBeCloseTo(11.32, 1); // (152.85-137.3)/137.3
+    expect(a!.rangePosPct).toBeCloseTo(76.6, 0); // (152.85-137.3)/(157.6-137.3)
+    expect(a!.dayChgPct).toBeCloseTo(4.23, 1); // (152.85-146.65)/146.65
+  });
+
+  it('retourne null si close ou low invalides', () => {
+    expect(analyzeRealtimeRebound({ open: 1, high: 1, low: 0, close: 1, prevClose: 1 })).toBeNull();
+    expect(analyzeRealtimeRebound({ open: 1, high: 1, low: 1, close: 0, prevClose: 1 })).toBeNull();
+  });
+
+  it('rangePos=0 quand high==low (range nul, pas de division par zéro)', () => {
+    const a = analyzeRealtimeRebound({ open: 10, high: 10, low: 10, close: 10, prevClose: 9 });
+    expect(a!.rangePosPct).toBe(0);
+    expect(a!.reboundFromLowPct).toBe(0);
+  });
+});
+
+describe('passesRealtimeReboundFilter (seuils par défaut: reboundFromLow≥1.5%, rangePos≥50%)', () => {
+  const pass = (ohlc: { open: number; high: number; low: number; close: number; prevClose: number }) =>
+    passesRealtimeReboundFilter(analyzeRealtimeRebound(ohlc)!, DEFAULT_REALTIME_REBOUND_CONFIG);
+
+  // Régression sur données réelles 08/06/2026 : le gate doit OUVRIR les 3 vrais
+  // winners (qui ont continué à monter) et REJETER les 2 faders (qui ont refadé).
+  it('OUVRE les winners SOI / IFX / ADYEN', () => {
+    expect(pass({ open: 138.15, high: 157.6, low: 137.3, close: 152.85, prevClose: 146.65 }).pass).toBe(true); // SOI
+    expect(pass({ open: 74.7, high: 79.58, low: 74.02, close: 78.78, prevClose: 77.3 }).pass).toBe(true); // IFX
+    expect(pass({ open: 821, high: 841, low: 815.8, close: 833.7, prevClose: 817.4 }).pass).toBe(true); // ADYEN
+  });
+
+  it('REJETTE NEL (rebond du creux mais scotché en bas de range, rangePos 41%)', () => {
+    const r = pass({ open: 2.895, high: 3.095, low: 2.85, close: 2.95, prevClose: 2.975 }); // NEL
+    expect(r.pass).toBe(false);
+    expect(r.reasons.some((x) => x.startsWith('rangePos='))).toBe(true);
+    // reboundFromLow (3.5%) passe seul → c'est bien rangePos qui sauve le filtre
+    expect(r.reasons.some((x) => x.startsWith('reboundFromLow='))).toBe(false);
+  });
+
+  it('REJETTE ETL (rebond insuffisant 1.1% ET bas de range 15%)', () => {
+    const r = pass({ open: 3.029, high: 3.158, low: 2.934, close: 2.967, prevClose: 3.013 }); // ETL
+    expect(r.pass).toBe(false);
+    expect(r.reasons.some((x) => x.startsWith('reboundFromLow='))).toBe(true);
+    expect(r.reasons.some((x) => x.startsWith('rangePos='))).toBe(true);
+  });
+
+  it('requirePositiveDay ajoute un gate sur dayChg < 0', () => {
+    // ADYEN est vert (+2%), donc passe même avec requirePositiveDay
+    const adyen = analyzeRealtimeRebound({ open: 821, high: 841, low: 815.8, close: 833.7, prevClose: 817.4 })!;
+    expect(passesRealtimeReboundFilter(adyen, { ...DEFAULT_REALTIME_REBOUND_CONFIG, requirePositiveDay: true }).pass).toBe(true);
+    // Un titre rouge sur la journée mais haut de range serait rejeté par ce gate
+    const redButHigh = analyzeRealtimeRebound({ open: 100, high: 100, low: 95, close: 98, prevClose: 102 })!;
+    const r = passesRealtimeReboundFilter(redButHigh, { ...DEFAULT_REALTIME_REBOUND_CONFIG, requirePositiveDay: true });
+    expect(r.reasons.some((x) => x.startsWith('dayChg='))).toBe(true);
+  });
+});

--- a/apps/api/src/modules/lisa/services/oversold-intraday.helper.ts
+++ b/apps/api/src/modules/lisa/services/oversold-intraday.helper.ts
@@ -144,3 +144,94 @@ export function passesIntradayReboundFilter(
 
   return { pass: reasons.length === 0, reasons };
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// CHEMIN REAL-TIME OHLC (EU) — fallback quand les bougies intraday 5m sont
+// GELÉES.
+//
+// Découverte 08/06/2026 (logging per-candidat #657) : pour l'EU, les deux
+// sources de bougies intraday (TwelveData time_series ET EODHD intraday) sont
+// gelées sur la séance de vendredi → le scanner ré-analyse du vieux et ne voit
+// jamais le rebond du jour (cf. P19-staleness dans intraday-provider-router).
+// Seul EODHD `/api/real-time` est frais pour l'EU et expose l'OHLC du jour
+// (open/high/low/close/prevClose).
+//
+// On reconstruit donc le "rebond confirmé" à partir de l'OHLC du jour, sans
+// série :
+//   reboundFromLow = (close - low) / low                  → ampleur du rebond
+//   rangePos       = (close - low) / (high - low)          → où on est dans le
+//                                                            range du jour
+//                                                            (100% = au plus haut)
+//   dayChg         = (close - prevClose) / prevClose       → variation du jour
+//
+// rangePos est LE discriminant que les bougies gelées ne donnaient pas : un
+// titre qui rebondit du creux mais reste scotché en bas de range (rangePos bas)
+// est un faux rebond qui refade (validé 08/06 : NEL rangePos 41% → −1.7% ;
+// ETL 15% → −1.6% ; vs SOI 77%/IFX 86%/ADYEN 71% qui ont continué à monter).
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface RealtimeOhlc {
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  prevClose: number;
+}
+
+export interface RealtimeReboundAnalysis {
+  currentPrice: number; // = close du jour
+  reboundFromLowPct: number; // (close - low) / low × 100
+  rangePosPct: number; // (close - low) / (high - low) × 100 ∈ [0, 100]
+  dayChgPct: number; // (close - prevClose) / prevClose × 100
+}
+
+export interface RealtimeReboundConfig {
+  /** % min de rebond depuis le low du jour. Ex 1.5 = +1.5%. */
+  minReboundFromLowPct: number;
+  /** Position min dans le range du jour [0..100]. Ex 50 = moitié haute. */
+  minRangePosPct: number;
+  /** Exiger close ≥ prevClose (vert sur la journée). Default false. */
+  requirePositiveDay: boolean;
+}
+
+export const DEFAULT_REALTIME_REBOUND_CONFIG: RealtimeReboundConfig = {
+  minReboundFromLowPct: 1.5,
+  minRangePosPct: 50,
+  requirePositiveDay: false,
+};
+
+/**
+ * Analyse "rebond confirmé" à partir de l'OHLC real-time du jour (pas de série).
+ * Retourne null si close/low invalides (données incohérentes ou indispo).
+ */
+export function analyzeRealtimeRebound(ohlc: RealtimeOhlc): RealtimeReboundAnalysis | null {
+  const { high, low, close, prevClose } = ohlc;
+  if (!Number.isFinite(close) || close <= 0) return null;
+  if (!Number.isFinite(low) || low <= 0) return null;
+  const reboundFromLowPct = ((close - low) / low) * 100;
+  const range = high - low;
+  const rangePosPct = range > 0 ? ((close - low) / range) * 100 : 0;
+  const dayChgPct = prevClose > 0 ? ((close - prevClose) / prevClose) * 100 : 0;
+  return { currentPrice: close, reboundFromLowPct, rangePosPct, dayChgPct };
+}
+
+/**
+ * Applique les gates "rebond confirmé real-time" sur une analyse OHLC.
+ * Retourne { pass, reasons[] } — reasons liste les gates failed (vide si pass).
+ */
+export function passesRealtimeReboundFilter(
+  a: RealtimeReboundAnalysis,
+  cfg: RealtimeReboundConfig = DEFAULT_REALTIME_REBOUND_CONFIG,
+): { pass: boolean; reasons: string[] } {
+  const reasons: string[] = [];
+  if (a.reboundFromLowPct < cfg.minReboundFromLowPct) {
+    reasons.push(`reboundFromLow=${a.reboundFromLowPct.toFixed(2)}% < ${cfg.minReboundFromLowPct}%`);
+  }
+  if (a.rangePosPct < cfg.minRangePosPct) {
+    reasons.push(`rangePos=${a.rangePosPct.toFixed(0)}% < ${cfg.minRangePosPct}%`);
+  }
+  if (cfg.requirePositiveDay && a.dayChgPct < 0) {
+    reasons.push(`dayChg=${a.dayChgPct.toFixed(2)}% < 0`);
+  }
+  return { pass: reasons.length === 0, reasons };
+}

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -43,7 +43,12 @@ import {
   analyzeIntradayRebound,
   passesIntradayReboundFilter,
   DEFAULT_INTRADAY_REBOUND_CONFIG,
+  analyzeRealtimeRebound,
+  passesRealtimeReboundFilter,
+  DEFAULT_REALTIME_REBOUND_CONFIG,
   type IntradayReboundConfig,
+  type RealtimeReboundConfig,
+  type RealtimeOhlc,
 } from './oversold-intraday.helper';
 import { IntradayProviderRouter } from './intraday-provider-router.service';
 import { minutesSinceExchangeOpen, minutesToExchangeClose } from './exchange-sessions.helper';
@@ -499,6 +504,62 @@ export class OversoldScannerService {
     };
   }
 
+  /** Config du chemin real-time OHLC (EU). Seuils réglables sans redeploy. */
+  private realtimeReboundConfig(): RealtimeReboundConfig {
+    const num = (key: string, dflt: number) => {
+      const v = Number(this.config.get<string>(key));
+      return Number.isFinite(v) ? v : dflt;
+    };
+    return {
+      minReboundFromLowPct: num('OVERSOLD_INTRADAY_MIN_REBOUND_FROM_LOW_PCT', DEFAULT_REALTIME_REBOUND_CONFIG.minReboundFromLowPct),
+      minRangePosPct: num('OVERSOLD_INTRADAY_MIN_RANGE_POS_PCT', DEFAULT_REALTIME_REBOUND_CONFIG.minRangePosPct),
+      requirePositiveDay:
+        (this.config.get<string>('OVERSOLD_INTRADAY_REQUIRE_POSITIVE_DAY') ?? 'false').toLowerCase() === 'true',
+    };
+  }
+
+  /**
+   * Régions utilisant le chemin real-time OHLC au lieu des bougies 5m.
+   * Default 'EU' (bougies intraday EU gelées — cf. analyzeRealtimeRebound).
+   * 'US' garde les bougies TD (real-time OK). Réglable via
+   * OVERSOLD_INTRADAY_RT_OHLC_REGIONS (CSV, ex 'EU,US' ou '' pour désactiver).
+   */
+  private useRealtimeOhlcPath(region: 'US' | 'EU'): boolean {
+    const raw = this.config.get<string>('OVERSOLD_INTRADAY_RT_OHLC_REGIONS') ?? 'EU';
+    return raw
+      .split(',')
+      .map((s) => s.trim().toUpperCase())
+      .includes(region);
+  }
+
+  /**
+   * OHLC du jour via EODHD real-time (frais pour l'EU, contrairement à
+   * l'intraday 5m gelé). Retourne null si indispo / incohérent.
+   */
+  private async fetchRealtimeOhlc(symbol: string): Promise<RealtimeOhlc | null> {
+    const apiKey = this.config.get<string>('EODHD_API_KEY');
+    if (!apiKey) return null;
+    const url = `https://eodhd.com/api/real-time/${encodeURIComponent(symbol)}?api_token=${apiKey}&fmt=json`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) return null;
+      const j = (await res.json()) as Record<string, unknown>;
+      const open = Number(j.open);
+      const high = Number(j.high);
+      const low = Number(j.low);
+      const close = Number(j.close);
+      const prevClose = Number(j.previousClose);
+      if (![open, high, low, close].every((v) => Number.isFinite(v) && v > 0)) return null;
+      return { open, high, low, close, prevClose: Number.isFinite(prevClose) ? prevClose : close };
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   private intradayMaxOpensPerDay(): number {
     const v = Number(this.config.get<string>('OVERSOLD_INTRADAY_MAX_OPENS_PER_DAY'));
     return Number.isFinite(v) && v > 0 ? v : 8;
@@ -682,23 +743,64 @@ export class OversoldScannerService {
       close_j: Number.isFinite(c.closeJ) ? c.closeJ : null,
     });
 
+    // Sélection du chemin d'analyse par région : EU → real-time OHLC (bougies
+    // 5m intraday gelées sur vendredi, P19-staleness), US → bougies 5m TD
+    // (real-time OK). Cf. useRealtimeOhlcPath / analyzeRealtimeRebound.
+    const useRt = this.useRealtimeOhlcPath(regime.region);
+    const rtCfg = this.realtimeReboundConfig();
+
     for (const cand of toScan) {
       if (remaining <= 0) break;
       evaluated++;
       const base = baseRecOf(cand);
       try {
+        if (useRt) {
+          // ── Chemin REAL-TIME OHLC (EU) ──
+          const ohlc = await this.fetchRealtimeOhlc(cand.symbol);
+          if (!ohlc) {
+            rejectedRebound++;
+            scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'no_realtime', analysis_mode: 'realtime_ohlc' });
+            continue;
+          }
+          const a = analyzeRealtimeRebound(ohlc);
+          if (!a) {
+            rejectedRebound++;
+            scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'analysis_null', analysis_mode: 'realtime_ohlc' });
+            continue;
+          }
+          const rtCols = {
+            analysis_mode: 'realtime_ohlc',
+            current_price: a.currentPrice,
+            rebound_from_low_pct: Number(a.reboundFromLowPct.toFixed(3)),
+            range_pos_pct: Number(a.rangePosPct.toFixed(3)),
+            day_chg_pct: Number(a.dayChgPct.toFixed(3)),
+          };
+          const gate = passesRealtimeReboundFilter(a, rtCfg);
+          if (!gate.pass) {
+            rejectedRebound++;
+            scanLog.push({ ...base, ...rtCols, outcome: 'rejected', reject_stage: 'rebound_filter', reject_reasons: gate.reasons });
+            continue;
+          }
+          await this.openIntradayPosition(portfolioId, cand, reboundCfgForOpens, a.currentPrice, regime.vix);
+          opened++;
+          remaining--;
+          scanLog.push({ ...base, ...rtCols, outcome: 'opened' });
+          continue;
+        }
+
+        // ── Chemin BOUGIES 5m (US) ──
         const series = await this.intraday
           .getCandles(cand.symbol, '5m', 18, { calledBy: 'oversold_intraday' })
           .catch(() => null);
         const raw = series?.candles ?? [];
         if (raw.length === 0) {
           rejectedRebound++;
-          scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'no_candles' });
+          scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'no_candles', analysis_mode: 'candles' });
           continue;
         }
         if (raw.length < reboundCfg.minBarsRequired) {
           rejectedRebound++;
-          scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'insufficient_bars', bars_count: raw.length });
+          scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'insufficient_bars', bars_count: raw.length, analysis_mode: 'candles' });
           continue;
         }
         const analysis = analyzeIntradayRebound(
@@ -707,10 +809,11 @@ export class OversoldScannerService {
         );
         if (!analysis) {
           rejectedRebound++;
-          scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'analysis_null', bars_count: raw.length });
+          scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'analysis_null', bars_count: raw.length, analysis_mode: 'candles' });
           continue;
         }
         const metricCols = {
+          analysis_mode: 'candles',
           current_price: analysis.currentPrice,
           rebound_pct: Number(analysis.reboundPct.toFixed(3)),
           trend_15m_pct: Number(analysis.trend15mPct.toFixed(3)),
@@ -745,10 +848,13 @@ export class OversoldScannerService {
         portfolioId,
         kind: 'oversold_intraday_scan_completed',
         summary: `Intraday scan: ${tickers.length} univers → ${candidates.length} bande → ${evaluated} évalués → ${opened} ouverts`,
-        rationale:
-          `Drop band [${cfg.dropMinPct}%, ${cfg.dropMaxPct}%], rebound ≥${reboundCfg.minReboundPct}%, ` +
-          `trend15m ≥${reboundCfg.minTrend15mPct}%, bottom-before-${reboundCfg.bottomMustBeBeforeLastNBars}bars, ` +
-          `volRatio ≥${reboundCfg.minVolumeRatio}, cap ${maxOpensPerDay}/j (used ${intradayOpenedToday + opened}).`,
+        rationale: useRt
+          ? `[real-time OHLC] Drop band [${cfg.dropMinPct}%, ${cfg.dropMaxPct}%], reboundFromLow ≥${rtCfg.minReboundFromLowPct}%, ` +
+            `rangePos ≥${rtCfg.minRangePosPct}%${rtCfg.requirePositiveDay ? ', dayChg ≥0' : ''}, ` +
+            `cap ${maxOpensPerDay}/j (used ${intradayOpenedToday + opened}).`
+          : `[candles 5m] Drop band [${cfg.dropMinPct}%, ${cfg.dropMaxPct}%], rebound ≥${reboundCfg.minReboundPct}%, ` +
+            `trend15m ≥${reboundCfg.minTrend15mPct}%, bottom-before-${reboundCfg.bottomMustBeBeforeLastNBars}bars, ` +
+            `volRatio ≥${reboundCfg.minVolumeRatio}, cap ${maxOpensPerDay}/j (used ${intradayOpenedToday + opened}).`,
         payload: {
           universe: cfg.universe,
           universe_size: tickers.length,
@@ -758,10 +864,11 @@ export class OversoldScannerService {
           rejected_rebound: rejectedRebound,
           intraday_opened_today: intradayOpenedToday + opened,
           notional_ratio: notionalRatio,
+          analysis_mode: useRt ? 'realtime_ohlc' : 'candles',
         },
         triggeredBy: 'autopilot_cron',
         watchlistSource: 'mechanical',
-        market: 'us_equity',
+        market: regime.region === 'EU' ? 'eu_equity' : 'us_equity',
       })
       .catch((e) => this.logger.warn(`[oversold-intraday] decision_log append failed: ${String(e).slice(0, 160)}`));
 

--- a/supabase/migrations/0201_oversold_scan_rejections_realtime.sql
+++ b/supabase/migrations/0201_oversold_scan_rejections_realtime.sql
@@ -1,0 +1,19 @@
+-- 0201 — Colonnes métriques du chemin REAL-TIME OHLC pour oversold_scan_rejections.
+--
+-- Pour l'EU, les bougies intraday 5m (TD + EODHD) sont gelées sur vendredi
+-- (P19-staleness) → le scanner bascule sur un chemin real-time OHLC (EODHD
+-- /api/real-time, frais) qui reconstruit le rebond sans série :
+--   reboundFromLow = (close - low) / low
+--   rangePos       = (close - low) / (high - low)
+--   dayChg         = (close - prevClose) / prevClose
+--
+-- Ces métriques n'ont pas d'équivalent dans les colonnes "candles"
+-- (rebound_pct / trend_15m_pct / volume_ratio / bottom_bar_idx). On les ajoute
+-- pour que l'analyse de gate (mission "gate qui rate les pépites") reste
+-- exploitable sur le chemin real-time. `analysis_mode` distingue les 2 chemins.
+
+ALTER TABLE oversold_scan_rejections
+  ADD COLUMN IF NOT EXISTS analysis_mode       TEXT,           -- 'candles' | 'realtime_ohlc'
+  ADD COLUMN IF NOT EXISTS rebound_from_low_pct NUMERIC(8,3),  -- (close-low)/low ×100
+  ADD COLUMN IF NOT EXISTS range_pos_pct        NUMERIC(8,3),  -- (close-low)/(high-low) ×100 ∈ [0,100]
+  ADD COLUMN IF NOT EXISTS day_chg_pct          NUMERIC(8,3);  -- (close-prevClose)/prevClose ×100


### PR DESCRIPTION
## Pourquoi

Diagnostic 08/06 (logging #657 + vérif directe EODHD/TD) : les bougies intraday 5m **EU** (TwelveData time_series **ET** EODHD intraday) sont **gelées sur vendredi 15:29 UTC** (limitation P19-staleness, documentée dans `intraday-provider-router`). Le scanner ré-analysait la séance de vendredi à chaque cycle → `currentPrice = close vendredi`, métriques figées d'un scan à l'autre → **0 ouverture**, alors qu'en réel SOI **+4.5%**, IFX **+2.1%**, ADYEN **+2.0%** rebondissaient aujourd'hui.

Ce n'était donc ni le gate ni la cadence : **la source de bougies intraday EU est morte.** Seul EODHD `/api/real-time` est frais pour l'EU et expose l'OHLC du jour.

## Ce que fait ce PR

Forke le chemin intraday **par région** :
- **EU** → analyse real-time OHLC (sans série) :
  - `reboundFromLow = (close-low)/low` ≥ **1.5%**
  - `rangePos = (close-low)/(high-low)` ≥ **50%** (close dans la moitié haute du range)
  - `dayChg` (gate optionnel)
- **US** → bougies 5m TD inchangées (real-time OK là-bas).

`rangePos` est **le discriminant** que les bougies gelées ne pouvaient pas fournir.

## Validation sur données réelles 08/06 (test de régression)

| Sym | reboundFromLow | rangePos | gate | fwd réel |
|---|---|---|---|---|
| SOI | 11.3% | 77% | ✅ OUVRE | +4.5% |
| IFX | 6.4% | 86% | ✅ OUVRE | +2.1% |
| ADYEN | 2.2% | 71% | ✅ OUVRE | +2.0% |
| NEL | 3.5% | **41%** | 🟢 rejette | -1.7% |
| ETL | 1.1% | 15% | 🟢 rejette | -1.6% |

Séparation parfaite winners / faders, encodée en test.

## Réglable sans redeploy

`OVERSOLD_INTRADAY_RT_OHLC_REGIONS` (default `EU`), `OVERSOLD_INTRADAY_MIN_REBOUND_FROM_LOW_PCT` (1.5), `OVERSOLD_INTRADAY_MIN_RANGE_POS_PCT` (50), `OVERSOLD_INTRADAY_REQUIRE_POSITIVE_DAY` (false). Migration 0201 ajoute les colonnes métriques RT (+ `analysis_mode`).

## Tests
- `tsc -b` workspace ✅
- 72/72 tests oversold ✅ (dont 7 nouveaux sur les helpers RT)

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_