### PR TITLE
fix(oversold): positions intraday first-class (UI + exits) + bouton "forcer le scan"

### DIFF
--- a/apps/api/src/modules/lisa/lisa.controller.ts
+++ b/apps/api/src/modules/lisa/lisa.controller.ts
@@ -1626,10 +1626,23 @@ export class LisaController {
    * portfolios strategy_mode='oversold' + autopilot. Idempotent (anti-doublon).
    */
   @Post('oversold/scan-now')
-  async triggerOversoldScan(@Headers() headers: Record<string, string>) {
+  async triggerOversoldScan(
+    @Headers() headers: Record<string, string>,
+    @Query('phase') phase?: string,
+  ) {
     extractUserId(headers);
-    await this.oversoldScanner.runDailyScan();
-    return { ok: true, triggeredAt: new Date().toISOString() };
+    // phase: 'daily' (EOD, défaut, back-compat) | 'intraday' (rebond confirmé,
+    // force le scan intraday en bypassant la cadence) | 'both'.
+    const ph = (phase ?? 'daily').toLowerCase();
+    if (ph === 'intraday') {
+      await this.oversoldScanner.runIntradayScan({ force: true });
+    } else if (ph === 'both') {
+      await this.oversoldScanner.runDailyScan();
+      await this.oversoldScanner.runIntradayScan({ force: true });
+    } else {
+      await this.oversoldScanner.runDailyScan();
+    }
+    return { ok: true, phase: ph, triggeredAt: new Date().toISOString() };
   }
 
   /**

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -3436,7 +3436,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       const ageMin = (Date.now() - new Date(String((result as { entryTimestamp?: string }).entryTimestamp ?? Date.now())).getTime()) / 60_000;
       // 07/06 — contexte + échéance pour l'imitation learning étendu (J+10 oversold).
       const ovSource = (row as { venue_fee_detail?: { source?: string } | null }).venue_fee_detail?.source;
-      const isOversold = ovSource === 'scanner_oversold';
+      const isOversold = (ovSource ?? '').startsWith('scanner_oversold');
       const wasManualControl = (row as { manual_control?: boolean | null }).manual_control === true;
       const closeContext: 'danger_zone' | 'oversold_early' | 'manual_other' =
         isOversold ? 'oversold_early' : wasManualControl ? 'danger_zone' : 'manual_other';

--- a/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
+++ b/apps/api/src/modules/lisa/services/open-position-risk-monitor.service.ts
@@ -166,7 +166,7 @@ export class OpenPositionRiskMonitorService {
       // avant le rebond → destruction de l'edge. Le risk-monitor ne pilote QUE
       // les positions LLM (gainers/trader). Source via venue_fee_detail.source.
       const source = (p.venue_fee_detail as { source?: string } | null)?.source;
-      if (source === 'scanner_oversold') return false;
+      if ((source ?? '').startsWith('scanner_oversold')) return false;
       return this.isClassEnabled(p.asset_class);
     });
   }

--- a/apps/api/src/modules/lisa/services/oversold-exit.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-exit.service.ts
@@ -279,13 +279,15 @@ export class OversoldExitService {
 
   /** Charge les positions oversold ouvertes (toutes portfolios). */
   private async loadOpenOversoldPositions(): Promise<OpenOversoldPosition[]> {
-    // Filtre sur le JSONB venue_fee_detail->>source (= 'scanner_oversold'),
-    // car le broker n'écrit pas la colonne `source` (CHECK lisa/mechanical).
+    // Filtre sur le JSONB venue_fee_detail->>source, car le broker n'écrit pas
+    // la colonne `source` (CHECK lisa/mechanical). Inclut le scanner intraday
+    // (`scanner_oversold_intraday`) : ces positions ont aussi besoin du J+10 +
+    // stop catastrophe, sinon elles seraient orphelines de toute gestion d'exit.
     const { data, error } = await this.supabase
       .getClient()
       .from('lisa_positions')
       .select('id, portfolio_id, symbol, entry_price, entry_timestamp, manual_control, manual_control_since')
-      .eq('venue_fee_detail->>source', 'scanner_oversold')
+      .in('venue_fee_detail->>source', ['scanner_oversold', 'scanner_oversold_intraday'])
       .eq('status', 'open');
     if (error) {
       this.logger.warn(`[oversold-exit] load positions failed: ${error.message}`);

--- a/apps/api/src/modules/lisa/services/oversold-mistral-exit.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-mistral-exit.service.ts
@@ -521,7 +521,7 @@ export class OversoldMistralExitService {
     const { data, error } = await this.supabase.getClient()
       .from('lisa_positions')
       .select('id, portfolio_id, symbol, direction, asset_class, entry_price, entry_timestamp, take_profit_price, stop_loss_price')
-      .eq('venue_fee_detail->>source', 'scanner_oversold')
+      .in('venue_fee_detail->>source', ['scanner_oversold', 'scanner_oversold_intraday'])
       .eq('status', 'open');
     if (error) {
       this.logger.warn(`[oversold-mistral-exit] load positions failed: ${error.message}`);

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -606,7 +606,7 @@ export class OversoldScannerService {
    * cron ne gaspille aucun appel EODHD.
    */
   @Cron('0 */5 8-20 * * 1-5', { name: 'oversold-intraday-scan', timeZone: 'UTC' })
-  async runIntradayScan(): Promise<void> {
+  async runIntradayScan(opts?: { force?: boolean }): Promise<void> {
     try {
       if (!this.isEnabled() || !this.intradayEnabled()) {
         this.logger.debug('[oversold-intraday] disabled (OVERSOLD_SCANNER_ENABLED or OVERSOLD_INTRADAY_ENABLED off)');
@@ -616,13 +616,18 @@ export class OversoldScannerService {
       // Gate cadence : throttle la base 5 min à la cadence configurée (default
       // 15 min). Le -30s absorbe la dérive de tick du cron (évite de sauter une
       // fenêtre quand l'écart retombe à 14min59 au lieu de 15min pile).
+      // opts.force (bouton UI "forcer le scan") bypass la cadence — déclenchement
+      // manuel délibéré.
       const cadenceMin = this.intradayCadenceMin();
       const elapsedMs = Date.now() - this.lastIntradayCycleAt;
-      if (elapsedMs < (cadenceMin * 60 - 30) * 1000) {
+      if (!opts?.force && elapsedMs < (cadenceMin * 60 - 30) * 1000) {
         this.logger.debug(
           `[oversold-intraday] cadence gate: ${Math.round(elapsedMs / 1000)}s < ${cadenceMin}min → skip`,
         );
         return;
+      }
+      if (opts?.force) {
+        this.logger.log('[oversold-intraday] FORCE scan (bypass cadence) — déclenchement manuel');
       }
       this.lastIntradayCycleAt = Date.now();
 
@@ -1269,12 +1274,12 @@ export class OversoldScannerService {
       max: Number(cfg?.oversold_drop_max_pct ?? DEFAULTS.dropMaxPct),
     };
 
-    // 2. Positions oversold OUVERTES de ce portfolio.
+    // 2. Positions oversold OUVERTES de ce portfolio (daily + intraday).
     const { data: openRows } = await client
       .from('lisa_positions')
       .select('symbol, entry_price, entry_notional_usd, quantity, entry_timestamp, stop_loss_price')
       .eq('portfolio_id', portfolioId)
-      .eq('venue_fee_detail->>source', 'scanner_oversold')
+      .in('venue_fee_detail->>source', ['scanner_oversold', 'scanner_oversold_intraday'])
       .eq('status', 'open');
     const open = (openRows ?? []) as Array<Record<string, unknown>>;
 
@@ -1283,7 +1288,7 @@ export class OversoldScannerService {
       .from('lisa_positions')
       .select('realized_pnl_usd')
       .eq('portfolio_id', portfolioId)
-      .eq('venue_fee_detail->>source', 'scanner_oversold')
+      .in('venue_fee_detail->>source', ['scanner_oversold', 'scanner_oversold_intraday'])
       .neq('status', 'open');
     const closed = (closedRows ?? []) as Array<{ realized_pnl_usd?: unknown }>;
     let realizedPnlUsd = 0;
@@ -1625,7 +1630,7 @@ export class OversoldScannerService {
       .from('lisa_positions')
       .select('symbol')
       .eq('portfolio_id', portfolioId)
-      .eq('venue_fee_detail->>source', 'scanner_oversold')
+      .in('venue_fee_detail->>source', ['scanner_oversold', 'scanner_oversold_intraday'])
       .eq('status', 'open');
     const symbols = Array.from(new Set((openRows ?? []).map((r) => String(r.symbol))));
     const openPositions = symbols.length;
@@ -1918,7 +1923,7 @@ export class OversoldScannerService {
 
     const oversold = (posRows ?? []).filter((p) => {
       const vfd = p.venue_fee_detail as { source?: string } | null;
-      return vfd?.source === 'scanner_oversold';
+      return (vfd?.source ?? '').startsWith('scanner_oversold');
     });
     if (oversold.length === 0) return;
 

--- a/apps/web/src/components/lisa/oversold-regime-panel.tsx
+++ b/apps/web/src/components/lisa/oversold-regime-panel.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Gauge, Clock, Activity, ShieldCheck, ShieldAlert } from 'lucide-react';
+import { Gauge, Clock, Activity, ShieldCheck, ShieldAlert, RefreshCw } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useOversoldRegime, type OversoldRegimeStatus } from '@/hooks/use-oversold-regime';
+import { apiFetch } from '@/lib/api-client';
 
 /**
  * PR-2 — Panel régime de marché du mode OVERSOLD (remplace la pollution gainers).
@@ -92,7 +94,10 @@ export function OversoldRegimePanel({ portfolioId }: { portfolioId: string }) {
             <span className="text-muted-foreground">Rotation sectorielle : —</span>
           )}
         </div>
-        <Countdown iso={data.nextScanUtc} kind={data.nextScanKind} />
+        <div className="flex items-center gap-2">
+          <ForceScanButton portfolioId={portfolioId} />
+          <Countdown iso={data.nextScanUtc} kind={data.nextScanKind} />
+        </div>
       </div>
 
       <p className="text-[11px] text-muted-foreground italic">
@@ -152,6 +157,54 @@ function Thermo(props: {
       </div>
       <div className="text-[10px] text-muted-foreground">seuil {threshold}</div>
     </div>
+  );
+}
+
+/**
+ * Bouton "Forcer le scan" — déclenche un scan intraday immédiat (bypass de la
+ * cadence 15 min) via POST /lisa/oversold/scan-now?phase=intraday. Ouvre les
+ * positions sur les rebonds confirmés sans attendre le prochain cron. Rafraîchit
+ * positions + book + régime après coup.
+ */
+function ForceScanButton({ portfolioId }: { portfolioId: string }) {
+  const qc = useQueryClient();
+  const [state, setState] = useState<'idle' | 'running' | 'done' | 'error'>('idle');
+
+  const run = async () => {
+    if (state === 'running') return;
+    setState('running');
+    try {
+      await apiFetch('/lisa/oversold/scan-now?phase=intraday', { method: 'POST' });
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['lisa', 'positions', portfolioId] }),
+        qc.invalidateQueries({ queryKey: ['lisa', 'open-positions-live', portfolioId] }),
+        qc.invalidateQueries({ queryKey: ['lisa', 'oversold-summary', portfolioId] }),
+        qc.invalidateQueries({ queryKey: ['lisa', 'oversold-regime', portfolioId] }),
+      ]);
+      setState('done');
+      setTimeout(() => setState('idle'), 4000);
+    } catch {
+      setState('error');
+      setTimeout(() => setState('idle'), 4000);
+    }
+  };
+
+  return (
+    <button
+      onClick={run}
+      disabled={state === 'running'}
+      title="Force un scan intraday immédiat (bypass la cadence). Ouvre les positions sur rebonds confirmés."
+      className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-60 transition-colors"
+    >
+      <RefreshCw className={`h-3.5 w-3.5 ${state === 'running' ? 'animate-spin' : ''}`} />
+      {state === 'running'
+        ? 'Scan en cours…'
+        : state === 'done'
+          ? '✅ Scan lancé'
+          : state === 'error'
+            ? '❌ Échec'
+            : 'Forcer le scan'}
+    </button>
   );
 }
 

--- a/apps/web/src/components/lisa/positions-table.tsx
+++ b/apps/web/src/components/lisa/positions-table.tsx
@@ -71,9 +71,10 @@ export function LisaPositionsTable({
   sourceFilter,
 }: {
   portfolioId: string;
-  /** 04/06 — Filtre l'historique sur une source précise (ex: 'scanner_oversold').
-   *  Évite que la vue oversold de HIGH expose les vieux trades shadow-gainers du
-   *  même portfolio_id (HIGH a 28 vieux gainers + 25 oversold). null = pas de filtre. */
+  /** 04/06 — Filtre l'historique sur un PRÉFIXE de source (ex: 'scanner_oversold').
+   *  Match par préfixe → 'scanner_oversold' couvre aussi 'scanner_oversold_intraday'
+   *  (les positions du scanner intraday EU). Évite que la vue oversold de HIGH
+   *  expose les vieux trades shadow-gainers du même portfolio_id. null = pas de filtre. */
   sourceFilter?: string | null;
 }) {
   // PR E — invalidation immédiate de la cache positions sur INSERT/UPDATE/DELETE
@@ -90,11 +91,12 @@ export function LisaPositionsTable({
   const openRawAll = openQuery.data ?? [];
   const allRaw = allQuery.data ?? [];
   // Filtre source si demandé (mode oversold sur HIGH : on cache les vieux gainers).
+  // Match par PRÉFIXE : 'scanner_oversold' inclut 'scanner_oversold_intraday'.
   const openRaw = sourceFilter
-    ? openRawAll.filter((p) => p.source === sourceFilter)
+    ? openRawAll.filter((p) => (p.source ?? '').startsWith(sourceFilter))
     : openRawAll;
   const all = sourceFilter
-    ? allRaw.filter((p) => p.source === sourceFilter)
+    ? allRaw.filter((p) => (p.source ?? '').startsWith(sourceFilter))
     : allRaw;
   // Tri par entry_timestamp desc (plus récente en haut) pour voir l'activité Lisa
   const open = [...openRaw].sort(


### PR DESCRIPTION
## Bug visibilité (signalé : "aucune position visible sur l'UI ??")

Les 7 positions ouvertes par le scanner intraday (source `scanner_oversold_intraday`) étaient **exclues partout où on filtrait `scanner_oversold` exact** → invisibles dans l'UI **et orphelines de gestion d'exit** (ni J+10, ni gain-picker TP_LOCK gérés par les services dédiés ; seul le SL -15% mécanique broker s'appliquait).

### `scanner_oversold_intraday` rendu first-class
- **UI** : `getBookSummary` (open + realized), news-watch, mind feed → `.in(['scanner_oversold','scanner_oversold_intraday'])` ; `LisaPositionsTable` (front) → filtre par **préfixe** `scanner_oversold*`.
- **Exits** : `OversoldExitService` (J+10 + catastrophe) et `OversoldMistralExitService` (gain-picker TP_LOCK) chargent désormais l'intraday.
- **Risk-monitor** : exclut aussi l'intraday du scoring momentum gainers (même rationale déterministe).
- **Capture close** : `context=oversold_early` + deadline J+10 pour l'intraday.

## Bouton "Forcer le scan" (demandé : oui)
- `runIntradayScan({ force: true })` → bypass la gate cadence (déclenchement manuel délibéré).
- `POST /lisa/oversold/scan-now?phase=intraday|daily|both` (default `daily`, back-compat).
- Bouton dans `OversoldRegimePanel` (à côté du countdown) → POST puis invalide positions / book / régime.

## Tests
- `tsc -b` workspace ✅
- 72/72 tests oversold ✅

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_