### PR TITLE
fix(ui): démarre le graphe au 1er mouvement (trim plateau weekend) — EU au 08/06

### DIFF
--- a/apps/web/src/components/lisa/portfolio-chart.tsx
+++ b/apps/web/src/components/lisa/portfolio-chart.tsx
@@ -202,6 +202,19 @@ export function LisaPortfolioChart({ portfolioId }: { portfolioId: string }) {
       }
     }
 
+    // Trim du PLATEAU DE TÊTE : un portefeuille récent affiche souvent un long
+    // plat au capital initial (weekend / avant la 1ère activité de marché) qui
+    // écrase la partie utile de la courbe à droite. On démarre la courbe au 1er
+    // mouvement de valeur, en gardant 1 point d'ancrage juste avant pour montrer
+    // le niveau de départ. Ex EU Oversold : créé vendredi 05/06 à $10k, figé tout
+    // le weekend (marchés fermés) → la courbe démarre au 08/06 quand la valeur
+    // bouge, au lieu d'afficher 3 jours de plat inutiles.
+    if (points.length >= 3 && points[0].value > 0) {
+      const v0 = points[0].value;
+      const firstMove = points.findIndex((p) => Math.abs(p.value - v0) / v0 > 0.0002);
+      if (firstMove > 1) return points.slice(firstMove - 1);
+    }
+
     return points;
   }, [data, liveQuery.data]);
 


### PR DESCRIPTION
## Demande
Faire démarrer la courbe "Évolution du capital" au 08/06 pour EU Oversold (au lieu d'afficher le plat de weekend 05→08).

## Contexte
EU Oversold créé **vendredi 05/06** à $10k, figé tout le weekend (marchés fermés, 7 positions du vendredi valorisées au close), puis saut à $20k le 08/06 (augmentation capital + intraday). Le graphe affichait donc **3 jours de plat à $10k** suivis d'un trait vertical — la partie utile (08/06) écrasée dans un sliver à droite.

## Fix
Le graphe **trimme le plateau de tête** : il démarre au 1er mouvement de valeur (en gardant 1 point d'ancrage juste avant pour montrer le niveau de départ). Pour EU → démarre au 08/06. Logique **générale** : tout portefeuille avec un démarrage dormant (weekend, avant 1ère activité) en bénéficie. Seuil 0.02% pour ignorer le bruit sous-cent. `baseline`/`periodReturn` inchangés (calculés sur le capital initial config).

## Tests
- `tsc -b` workspace ✅

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_