### PR TITLE
feat(oversold): sizing base en % du capital (auto-scale, défaut 5%)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/oversold-sizing.helper.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/oversold-sizing.helper.spec.ts
@@ -63,3 +63,39 @@ describe('computeOversoldNotional — sizing dynamique oversold', () => {
     }
   });
 });
+
+describe('computeOversoldNotional — base en % du capital (auto-scale)', () => {
+  it('basePctCapital=5% prioritaire sur le notionnel fixe → base = capital × 5%', () => {
+    // US $150k × 5% = $7500 base, × deep 2.0 = $15000 (sous plafond 12% = $18000)
+    const r = computeOversoldNotional({
+      baseNotionalUsd: 1000, // ignoré car % > 0
+      dropPct: -9,
+      vix: 15,
+      capitalUsd: 150_000,
+      config: { basePctCapital: 5 },
+    });
+    expect(r.dynamic).toBe(true);
+    expect(r.notionalUsd).toBe(15_000); // 7500 × 2.0
+  });
+
+  it('auto-scale : même 5% donne un ticket différent selon le capital', () => {
+    const us = computeOversoldNotional({ baseNotionalUsd: 1000, dropPct: -6, vix: 15, capitalUsd: 150_000, config: { basePctCapital: 5 } });
+    const eu = computeOversoldNotional({ baseNotionalUsd: 1000, dropPct: -6, vix: 15, capitalUsd: 20_000, config: { basePctCapital: 5 } });
+    expect(us.notionalUsd).toBe(7_500); // 150k × 5% × shallow 1.0
+    expect(eu.notionalUsd).toBe(1_000); // 20k × 5% × shallow 1.0 (= ancien base fixe préservé)
+  });
+
+  it('basePctCapital=0 ou null → retombe sur le notionnel fixe (back-compat)', () => {
+    const zero = computeOversoldNotional({ baseNotionalUsd: 1000, dropPct: -6, vix: 15, capitalUsd: 150_000, config: { basePctCapital: 0 } });
+    const nul = computeOversoldNotional({ baseNotionalUsd: 1000, dropPct: -6, vix: 15, capitalUsd: 150_000, config: { basePctCapital: null } });
+    expect(zero.notionalUsd).toBe(1_000);
+    expect(nul.notionalUsd).toBe(1_000);
+  });
+
+  it('le plafond 12% s\'applique toujours à la base en %', () => {
+    // 10% base × deep 2.0 = 20% du capital > plafond 12% → clamp ceiling
+    const r = computeOversoldNotional({ baseNotionalUsd: 1000, dropPct: -9, vix: 15, capitalUsd: 100_000, config: { basePctCapital: 10 } });
+    expect(r.clamp).toBe('ceiling');
+    expect(r.notionalUsd).toBe(12_000); // 12% de 100k
+  });
+});

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -3540,7 +3540,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     const { data } = await this.supabase.getClient()
       .from('lisa_session_configs')
       .select(
-        'capital_usd, oversold_position_notional_usd, oversold_size_dynamic_enabled, ' +
+        'capital_usd, oversold_position_notional_usd, oversold_size_dynamic_enabled, oversold_size_base_pct_capital, ' +
           'oversold_size_band_mult_deep, oversold_size_band_mult_shallow, oversold_size_vix_damp_elevated, ' +
           'oversold_size_vix_damp_stress, oversold_size_floor_usd, oversold_size_ceiling_pct_capital',
       )
@@ -3551,6 +3551,7 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     return {
       enabled: r.oversold_size_dynamic_enabled == null ? true : r.oversold_size_dynamic_enabled === true,
       baseNotionalUsd: num(r.oversold_position_notional_usd, 1000),
+      basePctCapital: num(r.oversold_size_base_pct_capital, 0),
       capitalUsd: num(r.capital_usd, 10000),
       bandMultDeep: num(r.oversold_size_band_mult_deep, 2.0),
       bandMultShallow: num(r.oversold_size_band_mult_shallow, 1.0),
@@ -3579,6 +3580,8 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
     };
     if (patch.enabled != null) upd.oversold_size_dynamic_enabled = patch.enabled === true;
     setNum('baseNotionalUsd', 'oversold_position_notional_usd', 50, 100_000);
+    // Base en % du capital (0 = désactivé → retombe sur le notionnel fixe ci-dessus).
+    setNum('basePctCapital', 'oversold_size_base_pct_capital', 0, 100);
     // Cohérence capital : le sizing lit capital_usd, le bandeau/targets lisent
     // lisa_initial_capital_usd → on synchronise les DEUX à chaque édition (sinon
     // divergence comme constaté 08/06 : capital_usd=20k mais bandeau affichait 10k).

--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -196,6 +196,7 @@ interface OversoldPortfolioRow {
   oversold_max_open_positions: number | null;
   oversold_universe: string | null;
   oversold_size_dynamic_enabled: boolean | null;
+  oversold_size_base_pct_capital: number | string | null;
   oversold_size_band_mult_deep: number | string | null;
   oversold_size_band_mult_shallow: number | string | null;
   oversold_size_vix_damp_elevated: number | string | null;
@@ -286,7 +287,7 @@ export class OversoldScannerService {
         'portfolio_id, capital_usd, oversold_drop_min_pct, oversold_drop_max_pct, oversold_hold_days, ' +
           'oversold_stop_catastrophe_pct, oversold_tp_pct, oversold_position_notional_usd, ' +
           'oversold_max_open_positions, oversold_universe, ' +
-          'oversold_size_dynamic_enabled, oversold_size_band_mult_deep, oversold_size_band_mult_shallow, ' +
+          'oversold_size_dynamic_enabled, oversold_size_base_pct_capital, oversold_size_band_mult_deep, oversold_size_band_mult_shallow, ' +
           'oversold_size_vix_damp_elevated, oversold_size_vix_damp_stress, oversold_size_floor_usd, ' +
           'oversold_size_ceiling_pct_capital',
       )
@@ -324,6 +325,7 @@ export class OversoldScannerService {
       capitalUsd: num(row.capital_usd, 10000),
       sizing: {
         enabled: row.oversold_size_dynamic_enabled, // null → helper retombe sur env/défaut
+        basePctCapital: numOrNull(row.oversold_size_base_pct_capital), // base = capital × % (auto-scale)
         bandMultDeep: numOrNull(row.oversold_size_band_mult_deep),
         bandMultShallow: numOrNull(row.oversold_size_band_mult_shallow),
         vixDampElevated: numOrNull(row.oversold_size_vix_damp_elevated),
@@ -729,9 +731,16 @@ export class OversoldScannerService {
     let evaluated = 0;
     let opened = 0;
     let rejectedRebound = 0;
+    // Intraday = plus petit que daily (ratio 0.7). On réduit la base : le
+    // notionnel fixe ET le % du capital (sinon le sizing en % ignorerait le ratio).
     const reboundCfgForOpens: OversoldConfig = {
       ...cfg,
       positionNotionalUsd: Math.round(cfg.positionNotionalUsd * notionalRatio),
+      sizing: {
+        ...cfg.sizing,
+        basePctCapital:
+          cfg.sizing.basePctCapital != null ? cfg.sizing.basePctCapital * notionalRatio : null,
+      },
     };
 
     // Logging per-candidat (mission "gate qui rate les pépites") — capture POUR

--- a/apps/api/src/modules/lisa/services/oversold-sizing.helper.ts
+++ b/apps/api/src/modules/lisa/services/oversold-sizing.helper.ts
@@ -7,6 +7,10 @@
  * Logique (demande user 08/06/2026) :
  *   notional = base × multiplicateur(bande) × amortisseur(VIX), clampé [plancher, plafond]
  *
+ *   - base : soit un % du capital (basePctCapital, prioritaire → auto-scale avec
+ *     le capital, recommandé) soit un notionnel fixe en $ (baseNotionalUsd,
+ *     back-compat). Le % évite de re-régler le ticket à chaque changement de
+ *     capital et garde un risque cohérent entre portefeuilles (US $150k / EU $20k).
  *   - bande -8/-12% (alpha J+10 +2,45%, meilleur edge) → ×2,0 par défaut
  *   - bande -5/-8%  (alpha +1%)                         → ×1,0
  *   - VIX ≥30 (stress) → ×0,5 · VIX 20-30 (élevé) → ×0,8 · <20 → ×1,0
@@ -28,6 +32,8 @@ export interface OversoldSizingResult {
 /** Paramètres réglables (depuis l'UI/DB). Chaque champ optionnel tombe sur env puis défaut. */
 export interface OversoldSizingConfig {
   enabled?: boolean | null;
+  /** Base = capital × ce % (prioritaire sur baseNotionalUsd, auto-scale). null = base fixe. */
+  basePctCapital?: number | null;
   bandMultDeep?: number | null;
   bandMultShallow?: number | null;
   vixDampElevated?: number | null;
@@ -58,7 +64,12 @@ export function computeOversoldNotional(p: {
   const enabled = c.enabled != null
     ? c.enabled === true
     : (process.env.OVERSOLD_DYNAMIC_SIZING_ENABLED ?? 'true').toLowerCase() === 'true';
-  const base = Math.max(0, p.baseNotionalUsd);
+  // Base = % du capital si configuré (auto-scale, prioritaire), sinon notionnel
+  // fixe (back-compat). OVERSOLD_SIZE_BASE_PCT_CAPITAL en fallback env.
+  const basePct = resolveNum(c.basePctCapital, 'OVERSOLD_SIZE_BASE_PCT_CAPITAL', 0);
+  const base = basePct > 0 && p.capitalUsd > 0
+    ? Math.max(0, (p.capitalUsd * basePct) / 100)
+    : Math.max(0, p.baseNotionalUsd);
   if (!enabled || p.dropPct == null || !Number.isFinite(p.dropPct)) {
     return { notionalUsd: Math.round(base), band: 'flat', bandMult: 1, vixDamp: 1, clamp: null, dynamic: false };
   }

--- a/apps/web/src/components/lisa/oversold-sizing-card.tsx
+++ b/apps/web/src/components/lisa/oversold-sizing-card.tsx
@@ -28,14 +28,16 @@ export function OversoldSizingCard({ portfolioId }: { portfolioId: string }) {
   const set = (k: keyof OversoldSizing, v: number | boolean) => setForm({ ...f, [k]: v });
 
   // Aperçu live (miroir client de la logique serveur).
+  // Base effective : % du capital si > 0 (prioritaire, auto-scale), sinon notionnel fixe.
+  const effectiveBase = f.basePctCapital > 0 && f.capitalUsd > 0 ? (f.capitalUsd * f.basePctCapital) / 100 : f.baseNotionalUsd;
   const ceiling = f.capitalUsd > 0 ? (f.capitalUsd * f.ceilingPctCapital) / 100 : Infinity;
   const clampPv = (n: number) => Math.round(Math.max(f.floorUsd, Math.min(ceiling, n)));
   const previews = f.enabled
     ? [
-        { label: 'Drop −9% · VIX calme', usd: clampPv(f.baseNotionalUsd * f.bandMultDeep) },
-        { label: 'Drop −6% · VIX calme', usd: clampPv(f.baseNotionalUsd * f.bandMultShallow) },
-        { label: 'Drop −9% · VIX 20-30', usd: clampPv(f.baseNotionalUsd * f.bandMultDeep * f.vixDampElevated) },
-        { label: 'Drop −9% · VIX ≥30', usd: clampPv(f.baseNotionalUsd * f.bandMultDeep * f.vixDampStress) },
+        { label: 'Drop −9% · VIX calme', usd: clampPv(effectiveBase * f.bandMultDeep) },
+        { label: 'Drop −6% · VIX calme', usd: clampPv(effectiveBase * f.bandMultShallow) },
+        { label: 'Drop −9% · VIX 20-30', usd: clampPv(effectiveBase * f.bandMultDeep * f.vixDampElevated) },
+        { label: 'Drop −9% · VIX ≥30', usd: clampPv(effectiveBase * f.bandMultDeep * f.vixDampStress) },
       ]
     : [];
 
@@ -62,10 +64,12 @@ export function OversoldSizingCard({ portfolioId }: { portfolioId: string }) {
 
       <p className="text-[11px] text-muted-foreground">
         À chaque ouverture : <strong>notional = base × multiplicateur(bande) × amortisseur(VIX)</strong>, borné plancher/plafond.
+        Base = <strong>{f.basePctCapital > 0 ? `${f.basePctCapital}% du capital ($${Math.round(effectiveBase).toLocaleString()})` : `notionnel fixe ($${Math.round(f.baseNotionalUsd).toLocaleString()})`}</strong>.
       </p>
 
       <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-        <Field label="Base ($)" value={f.baseNotionalUsd} step={100} onChange={(v) => set('baseNotionalUsd', v)} />
+        <Field label="Base (% capital) ★" value={f.basePctCapital} step={0.5} onChange={(v) => set('basePctCapital', v)} />
+        <Field label="Base fixe ($, si %=0)" value={f.baseNotionalUsd} step={100} onChange={(v) => set('baseNotionalUsd', v)} />
         <Field label="Capital ($)" value={f.capitalUsd} step={1000} onChange={(v) => set('capitalUsd', v)} />
         <Field label="Mult. −8/−12% (deep)" value={f.bandMultDeep} step={0.1} onChange={(v) => set('bandMultDeep', v)} />
         <Field label="Mult. −5/−8% (shallow)" value={f.bandMultShallow} step={0.1} onChange={(v) => set('bandMultShallow', v)} />

--- a/apps/web/src/hooks/use-oversold-sizing.ts
+++ b/apps/web/src/hooks/use-oversold-sizing.ts
@@ -7,6 +7,7 @@ import { apiFetch } from '@/lib/api-client';
 export interface OversoldSizing {
   enabled: boolean;
   baseNotionalUsd: number;
+  basePctCapital: number; // base = capital × ce % (prioritaire si > 0, auto-scale)
   capitalUsd: number;
   bandMultDeep: number;
   bandMultShallow: number;

--- a/supabase/migrations/0202_oversold_base_pct_capital.sql
+++ b/supabase/migrations/0202_oversold_base_pct_capital.sql
@@ -1,0 +1,17 @@
+-- 0202 — Sizing oversold en % du capital (auto-scale), par portfolio.
+--
+-- Avant : la base du sizing était un notionnel fixe en $ (oversold_position_notional_usd),
+-- identique pour US ($150k) et EU ($20k) → le US sous-déployait massivement
+-- ($1000 base = 0,67% de son capital) et tout changement de capital exigeait un
+-- re-réglage manuel du ticket (cf. bug capital 08/06).
+--
+-- On ajoute une base en % du capital (prioritaire quand > 0) : base = capital × %.
+-- Auto-scale avec le capital, risque cohérent entre portefeuilles. Le notionnel
+-- fixe reste comme fallback (% = 0). Le multiplicateur de bande, l'amortisseur
+-- VIX et le plancher/plafond 12% s'appliquent ensuite, inchangés.
+--
+-- Default 5% (choix user 08/06) : préserve l'EU à l'identique ($20k × 5% = $1000,
+-- = l'ancien base fixe) et fait scaler le US ($150k × 5% = $7500).
+ALTER TABLE lisa_session_configs
+  ADD COLUMN IF NOT EXISTS oversold_size_base_pct_capital NUMERIC(5,2) DEFAULT 5
+    CHECK (oversold_size_base_pct_capital IS NULL OR (oversold_size_base_pct_capital >= 0 AND oversold_size_base_pct_capital <= 100));


### PR DESCRIPTION
## Choix user : sizing en % du capital (option B), défaut 5%

Avant, la base du sizing était un notionnel fixe en $ — le même $1000 servait US ($150k) et EU ($20k) → le **US sous-déployait** (0,67% de son capital, ~$1400/position) et **chaque changement de capital exigeait un re-réglage manuel** du ticket (cf. bug capital 08/06).

## Fix
`base = capital × basePctCapital` (prioritaire quand > 0), sinon notionnel fixe (back-compat, `basePct=0`). Le multiplicateur de bande, l'amortisseur VIX et le plancher/plafond 12% s'appliquent ensuite, inchangés. Pour l'intraday, le ratio 0.7 s'applique aussi au %.

**Migration 0202** : `oversold_size_base_pct_capital NUMERIC DEFAULT 5` (peuple les rows existantes US+EU). À 5% :
- **EU préservé à l'identique** : $20k × 5% = $1000 (= l'ancien base fixe)
- **US scale** : $150k × 5% = $7500 (×2 deep = $15k, sous le plafond $18k)

Réglable depuis la carte sizing (champ **Base (% capital) ★** + base fixe en fallback + aperçu basé sur la base effective). **Auto-scale** → plus de re-réglage à chaque changement de capital, risque cohérent entre portefeuilles.

## Tests
- `tsc -b` workspace ✅
- 76/76 oversold ✅ (dont 4 nouveaux sur la base %)

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_