### PR TITLE
fix(oversold): garde anti-bougies périmées sur le scan intraday US (cas KXIAY)

### DIFF
--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -817,6 +817,21 @@ export class OversoldScannerService {
           scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'insufficient_bars', bars_count: raw.length, analysis_mode: 'candles' });
           continue;
         }
+        // Garde anti-bougies PÉRIMÉES : sur les titres thin / ADR mal couverts
+        // par TD, la dernière bougie peut dater de la veille → entrée sur signal
+        // périmé à un prix figé (bug KXIAY 08/06 : entré à 44.75 = close veille
+        // alors que le titre était réellement +5.8%). On skippe si la dernière
+        // bougie est trop vieille (default 30 min, réglable).
+        const lastTsRaw = Number(raw[raw.length - 1]?.timestamp ?? 0);
+        const lastTsSec = lastTsRaw > 1e11 ? lastTsRaw / 1000 : lastTsRaw;
+        const candleAgeMin = lastTsSec > 0 ? (Date.now() / 1000 - lastTsSec) / 60 : Number.POSITIVE_INFINITY;
+        const staleMaxMin = Number(this.config.get<string>('OVERSOLD_INTRADAY_STALE_CANDLE_MAX_MIN') ?? '30');
+        if (candleAgeMin > staleMaxMin) {
+          rejectedRebound++;
+          scanLog.push({ ...base, outcome: 'rejected', reject_stage: 'stale_candles', bars_count: raw.length, analysis_mode: 'candles' });
+          this.logger.debug(`[oversold-intraday] ${cand.symbol} bougies périmées (dernière ${candleAgeMin.toFixed(0)}min) → skip`);
+          continue;
+        }
         const analysis = analyzeIntradayRebound(
           raw.map((c) => ({ high: c.high, low: c.low, close: c.close, volume: c.volume })),
           reboundCfg,


### PR DESCRIPTION
## Le « loup » signalé par l'utilisateur
Diagnostic complet du 08/06 :
- **Le US fonctionne** : 6 positions ouvertes, le sizing 5% est live ($10,500 deep / $5,250 shallow vs $1,400 avant).
- **1 seul cas problématique** : `KXIAY.US` (ADR coréen mal couvert par TD) est entré à **44.75 = close de la veille** alors que le titre était réellement à **47.35 (+5.8%)**. Bougies TD périmées → entrée sur signal de la veille + prix live figé à +0.00% → position ingérable par le gain-picker.

## Fix
Avant d'analyser le rebond (chemin bougies US), on vérifie l'âge de la **dernière bougie**. Si > 30 min (réglable `OVERSOLD_INTRADAY_STALE_CANDLE_MAX_MIN`), on skippe (`reject_stage='stale_candles'`). Titres liquides (bougies < 5-10 min) → passent ; ADR périmés → écartés. Plus d'entrée KXIAY-style.

Le chemin **EU** (real-time OHLC) n'est pas concerné (frais par construction).

## Reste à décider (hors scope ce PR)
- La position **KXIAY existante** a un prix live figé (TD US `/quote` périmé). Fix possible (Fix B) : appliquer le « freshness-wins » EODHD vs TD au live US (comme déjà fait pour l'EU) — mais ça touche le chemin live partagé (stops/TP US), donc à valider avec l'utilisateur.

## Tests
- `tsc -b` ✅ · 76/76 oversold ✅

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_