### PR TITLE
fix(oversold): Fix B — freshness-wins sur le live US (anti-quote TD périmé, cas KXIAY)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/intraday-provider-router.spec.ts
@@ -858,11 +858,28 @@ describe('IntradayProviderRouter — PR #352/353 dual-call', () => {
       expect(r).toEqual({ price: 1500, source: 'twelvedata', quoteTsMs: 1 });
     });
 
-    it('suffixe .US (default whitelist depuis PR #468) → TD US prioritaire (true real-time)', async () => {
-      const { router, td } = makeRouter({}, { price: 180, changePct: 1, timestamp: 1 });
+    it('suffixe .US (default whitelist depuis PR #468) → TD US prioritaire quand FRAIS (true real-time)', async () => {
+      const ts = Date.now(); // TD timestamp en ms, frais → utilisé tel quel sans appel EODHD
+      const { router, td } = makeRouter({}, { price: 180, changePct: 1, timestamp: ts });
       const r = await router.getLiveQuote('AAPL.US');
-      expect(r).toEqual({ price: 180, source: 'twelvedata', quoteTsMs: 1 });
+      expect(r).toEqual({ price: 180, source: 'twelvedata', quoteTsMs: ts });
       expect(td.quoteCalls).toBeGreaterThan(0);
+    });
+
+    it('suffixe .US — TD US PÉRIMÉ (titre thin/ADR, ex KXIAY figé au close veille) → bascule EODHD real-time (freshness-wins)', async () => {
+      // TD vieux de 4h (périmé) vs EODHD frais → on garde EODHD (le plus récent).
+      const eodhd = makeEodhdMock({ quote: { price: 47.35, changePct: 5.8, timestamp: Math.floor(Date.now() / 1000) } });
+      const td = makeTdMock({ quote: { price: 44.75, changePct: 0, timestamp: Date.now() - 4 * 3600 * 1000 } });
+      const router = new IntradayProviderRouter(
+        makeConfig({}),
+        eodhd.service,
+        td.service,
+        makeBlacklistMock(),
+        makeSupabaseMock(),
+      );
+      const r = await router.getLiveQuote('KXIAY.US');
+      expect(r?.source).toBe('eodhd');
+      expect(r?.price).toBe(47.35);
     });
 
     it('suffixe vraiment hors périmètre (.XYZ inexistant) → null sans appeler TD', async () => {

--- a/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
+++ b/apps/api/src/modules/lisa/services/intraday-provider-router.service.ts
@@ -539,8 +539,31 @@ export class IntradayProviderRouter implements OnModuleInit {
       const tdSymUs = this.convertToTdSymbol(eodhdTicker);
       if (tdSymUs) {
         const tdUs = await this.td.getQuote(tdSymUs, 'live_price_us').catch(() => null);
+        const toMs = (ts: number): number => (ts > 1e12 ? ts : ts * 1000); // sec→ms si besoin
         if (tdUs && Number.isFinite(tdUs.price) && tdUs.price > 0 && tdUs.timestamp > 0) {
-          return { price: tdUs.price, source: 'twelvedata', quoteTsMs: tdUs.timestamp };
+          const tdTsMs = toMs(tdUs.timestamp);
+          const tdAgeMin = (Date.now() - tdTsMs) / 60_000;
+          const staleMaxMin = Number(this.config.get<string>('LIVE_PRICE_TD_STALE_MAX_MIN') ?? '15');
+          // Cas commun : TD est true real-time (< qq min) → on l'utilise tel quel,
+          // SANS appel EODHD supplémentaire (zéro impact budget sur les liquides).
+          if (tdAgeMin <= staleMaxMin) {
+            return { price: tdUs.price, source: 'twelvedata', quoteTsMs: tdTsMs };
+          }
+          // TD PÉRIMÉ (titres thin / ADR mal couverts, ex KXIAY figé au close de la
+          // veille pendant des heures) → freshness-wins : on tente EODHD real-time
+          // (délayé ~15min mais BIEN plus frais qu'un TD vieux de plusieurs heures)
+          // et on garde le plus récent. Évite qu'un quote TD figé écrase le prix
+          // réel → stops/TP/gain-picker sur prix correct.
+          const eodhdQ = await this.eodhd.getQuote(eodhdTicker).catch(() => null);
+          if (eodhdQ && Number.isFinite(eodhdQ.price) && eodhdQ.price > 0 && eodhdQ.timestamp > 0) {
+            const eodhdTsMs = toMs(eodhdQ.timestamp);
+            if (eodhdTsMs >= tdTsMs) {
+              return { price: eodhdQ.price, source: 'eodhd', quoteTsMs: eodhdTsMs };
+            }
+          }
+          // EODHD indispo ou plus vieux → on rend le TD (périmé mais seule source ;
+          // le caller tagStaleness marquera si nécessaire).
+          return { price: tdUs.price, source: 'twelvedata', quoteTsMs: tdTsMs };
         }
       }
     }


### PR DESCRIPTION
## Fix B (go user) — freshness-wins sur le live US

Le live US (`getLiveQuote`) renvoyait le quote TD `/quote` dès qu'il avait un `timestamp > 0`, **sans vérifier sa fraîcheur**. Sur les titres thin / ADR mal couverts (ex **KXIAY**), TD sert un quote **figé au close de la veille** (vieux de plusieurs heures) → prix live bloqué → stops/TP/gain-picker sur un prix faux (KXIAY affiché +0.00% alors que réel +5.8%).

## Fix (chirurgical, zéro surcoût sur le cas normal)
- **TD frais** (< 15 min, réglable `LIVE_PRICE_TD_STALE_MAX_MIN`) → utilisé tel quel (cas commun des liquides, **aucun appel EODHD supplémentaire**).
- **TD périmé** → on tente EODHD real-time (délayé ~15min mais bien plus frais qu'un TD de plusieurs heures) et on garde le **plus récent** (freshness-wins, comme déjà fait pour l'EU).

→ Débloque la position KXIAY existante (le gain-picker verra le +5.8% réel) **et** protège toutes les positions US d'un quote TD figé sur les titres thin.

## Tests
- `tsc -b` ✅
- 68/68 intraday-router ✅ (dont 1 nouveau : TD périmé → bascule EODHD ; + test « TD frais → TD » mis à jour avec timestamp réaliste)

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_