### PR TITLE
fix(oversold): exclut les portfolios oversold du rebound-scanner (anti-contamination)

### DIFF
--- a/apps/api/src/modules/lisa/services/__tests__/rebound-scanner.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/rebound-scanner.spec.ts
@@ -59,6 +59,7 @@ function makeSupabaseMock(state: MockState) {
     const chain: Record<string, unknown> = {};
     chain.select = () => chain;
     chain.eq = () => chain;
+    chain.neq = () => chain;
     chain.like = () => chain;
     chain.gte = () => chain;
     chain.lt = () => chain;

--- a/apps/api/src/modules/lisa/services/rebound-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/rebound-scanner.service.ts
@@ -91,13 +91,20 @@ export class ReboundScannerService {
   }
 
   private async runScannerInner(): Promise<void> {
-    // Charge tous les portfolios autopilot actifs (mêmes que lisa-autopilot).
+    // Charge les portfolios autopilot actifs — SAUF ceux en mode oversold.
+    // Le rebound-scanner est le pipeline gainers/momentum (ouvre des
+    // rebound_positions) ; il ne doit PAS tourner sur les portfolios oversold
+    // (mean-reversion swing J+10), sinon : (1) contamination de stratégie si un
+    // signal rebound déclenche un open gainers sur un portfolio oversold, (2)
+    // application d'un objectif jour $100 (concept scalp) à du swing J+10 →
+    // skips daily_target_hit parasites dans le decision_log oversold.
     const { data: configs, error } = await this.supabase
       .getClient()
       .from('lisa_session_configs')
       .select('user_id, portfolio_id')
       .eq('autopilot_enabled', true)
-      .eq('kill_switch_active', false);
+      .eq('kill_switch_active', false)
+      .neq('strategy_mode', 'oversold');
 
     if (error) {
       this.logger.error(`[rebound-scanner] fetch configs failed: ${error.message}`);


### PR DESCRIPTION
## Vérification demandée : « pas de blocage silencieux non justifié pour ouverture de positions »

### Résultat de l'enquête
1. **Les ouvertures OVERSOLD ne sont PAS bloquées.** Le `daily_target_hit` vient du **rebound-scanner** (pipeline gainers, ouvre des `rebound_positions`), pas de l'`OversoldScannerService` (cron séparé, **aucun** gate daily_target). Preuve : 6 US + 8 EU oversold ouverts aujourd'hui.
2. **Le skip était justifié** : US `a0000001` réalisé jour **$116.51 ≥ $100** (= le gain KXIAY) ; EU `c0000001` réalisé $88 + latent ≥ $100.

### Loup latent trouvé
Le rebound-scanner chargeait **tous** les portfolios autopilot-on **sans filtre `strategy_mode`** → il tournait sur les portfolios **oversold** (les 2 seuls actifs). Bénin aujourd'hui (signals=0 + skip target), mais :
- risque de **contamination** (ouverture de `rebound_positions` gainers sur un portfolio oversold),
- objectif jour $100 (concept scalp) appliqué à du swing J+10 → skips `daily_target_hit` parasites dans le decision_log oversold.

### Fix
`.neq('strategy_mode', 'oversold')` au chargement des portfolios du rebound-scanner.

## Tests
- `tsc -b` ✅ · 9/9 rebound-scanner ✅ (mock `.neq` ajouté)

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_