### PR TITLE
feat(ui): indicateur "marché fermé" sur la tendance 5min (au lieu de "—" ambigu)

### DIFF
--- a/apps/web/src/components/lisa/positions-table.tsx
+++ b/apps/web/src/components/lisa/positions-table.tsx
@@ -378,6 +378,13 @@ function PositionLiveValue({ live }: { live?: OpenPositionLive }) {
       ? ((live.livePrice - oldest.price) / oldest.price) * 100
       : null;
 
+  // Marché fermé : prix figé (timestamp trop vieux) → le ring buffer 5min reste
+  // vide (aucun mouvement à mesurer). On l'explicite plutôt que d'afficher « — »
+  // ambigu. Seuil 30 min : EODHD US real-time est délayé ~15min EN SÉANCE, donc
+  // on ne déclenche pas « marché fermé » sur un prix simplement différé.
+  const priceAgeMin = live.asOf ? (Date.now() - new Date(live.asOf).getTime()) / 60_000 : null;
+  const marketClosed = priceAgeMin != null && Number.isFinite(priceAgeMin) && priceAgeMin > 30;
+
   const pnlColor =
     live.pnlPct === null ? '' : live.pnlPct >= 0 ? 'text-emerald-600' : 'text-red-500';
 
@@ -403,9 +410,18 @@ function PositionLiveValue({ live }: { live?: OpenPositionLive }) {
       <div className="flex items-center gap-0.5 justify-end text-[10px]">
         <span className="text-muted-foreground">5min</span>
         {trend5mPct === null ? (
-          <span className="text-muted-foreground" title="warm-up (besoin de 2 polls)">
-            <Minus className="h-3 w-3 inline" />
-          </span>
+          marketClosed ? (
+            <span
+              className="text-amber-600/80"
+              title={`Prix figé au close — marché fermé (dernier prix il y a ${Math.round(priceAgeMin!)} min)`}
+            >
+              marché fermé
+            </span>
+          ) : (
+            <span className="text-muted-foreground" title="warm-up (besoin de 2 polls)">
+              <Minus className="h-3 w-3 inline" />
+            </span>
+          )
         ) : trend5mPct > 0.02 ? (
           <span className="text-emerald-600 font-medium">
             <ArrowUp className="h-3 w-3 inline" />


### PR DESCRIPTION
## Demande user
Sur les positions dont le marché est fermé (EU/LSE le soir, prix figé au close), la tendance 5min affichait « — » ambigu (on dirait un bug). C'est normal — la tendance ne peut pas se calculer (ring buffer 5min vide car le prix ne bouge plus), mais le « — » prête à confusion.

## Fix
Quand la tendance 5min est nulle **ET** le prix est figé (`asOf` > 30 min — seuil au-dessus du délai ~15min d'EODHD US **en séance**, pour ne pas faussement déclencher sur un prix simplement différé), on affiche **« marché fermé »** (ambre) + tooltip avec l'ancienneté du dernier prix.

Le « — » warm-up reste pour le cas marché ouvert (besoin de 2 polls pour amorcer la tendance).

## Tests
- `tsc -b` ✅

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_