### PR TITLE
feat(oversold): plafond anti-chase intraday (dayChg vs close de drop, default 10%, conservateur)

### DIFF
--- a/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-scanner.service.ts
@@ -573,6 +573,19 @@ export class OversoldScannerService {
   }
 
   /**
+   * Plafond anti-chase : % MAX de hausse vs le close de drop (closeJ) à l'entrée.
+   * Un candidat déjà trop au-dessus de son close de drop a « rebondi trop loin »
+   * — il a plus que récupéré sa chute → ce n'est plus un dip mean-reversion mais
+   * du chasing du sommet. Default 10% (conservateur : ne coupe que les cas
+   * extrêmes type INTC +12.7% du 08/06, garde les rebonds modérés +3-7%). 0 ou
+   * négatif = désactivé. Unifié EU (real-time OHLC) + US (bougies).
+   */
+  private intradayMaxDayChangePct(): number {
+    const v = Number(this.config.get<string>('OVERSOLD_INTRADAY_MAX_DAY_CHANGE_PCT'));
+    return Number.isFinite(v) ? v : 10;
+  }
+
+  /**
    * Cadence effective du scan intraday en minutes (default 15, clamp 5..60).
    * Le cron tire toutes les 5 min (base) ; ce gate throttle à la cadence
    * configurée pour que l'utilisateur la règle sans redeploy via
@@ -762,6 +775,7 @@ export class OversoldScannerService {
     // (real-time OK). Cf. useRealtimeOhlcPath / analyzeRealtimeRebound.
     const useRt = this.useRealtimeOhlcPath(regime.region);
     const rtCfg = this.realtimeReboundConfig();
+    const maxDayChg = this.intradayMaxDayChangePct(); // plafond anti-chase (vs closeJ)
 
     for (const cand of toScan) {
       if (remaining <= 0) break;
@@ -793,6 +807,13 @@ export class OversoldScannerService {
           if (!gate.pass) {
             rejectedRebound++;
             scanLog.push({ ...base, ...rtCols, outcome: 'rejected', reject_stage: 'rebound_filter', reject_reasons: gate.reasons });
+            continue;
+          }
+          // Plafond anti-chase : déjà trop au-dessus du close de drop = sommet déjà joué.
+          const dayChgEu = cand.closeJ > 0 ? ((a.currentPrice - cand.closeJ) / cand.closeJ) * 100 : 0;
+          if (maxDayChg > 0 && dayChgEu > maxDayChg) {
+            rejectedRebound++;
+            scanLog.push({ ...base, ...rtCols, outcome: 'rejected', reject_stage: 'overextended', reject_reasons: [`dayChg=${dayChgEu.toFixed(2)}% > ${maxDayChg}% (rebond déjà consommé)`] });
             continue;
           }
           await this.openIntradayPosition(portfolioId, cand, reboundCfgForOpens, a.currentPrice, regime.vix);
@@ -854,6 +875,13 @@ export class OversoldScannerService {
         if (!gate.pass) {
           rejectedRebound++;
           scanLog.push({ ...base, ...metricCols, outcome: 'rejected', reject_stage: 'rebound_filter', reject_reasons: gate.reasons });
+          continue;
+        }
+        // Plafond anti-chase : déjà trop au-dessus du close de drop = sommet déjà joué.
+        const dayChgUs = cand.closeJ > 0 ? ((analysis.currentPrice - cand.closeJ) / cand.closeJ) * 100 : 0;
+        if (maxDayChg > 0 && dayChgUs > maxDayChg) {
+          rejectedRebound++;
+          scanLog.push({ ...base, ...metricCols, outcome: 'rejected', reject_stage: 'overextended', reject_reasons: [`dayChg=${dayChgUs.toFixed(2)}% > ${maxDayChg}% (rebond déjà consommé)`] });
           continue;
         }
 


### PR DESCRIPTION
## Demande user (go, active, pas shadow)
Constat « US gros pumping » : le scan intraday entrait des semis **après** leur pump (+5-13% sur la journée), près du sommet → positions flat/négatives vs entrée. INTC +12.7% sur le jour, entré au top. Ni le chemin EU ni le US n'avaient de plafond d'extension.

## Honnêteté assumée
Je **ne suis pas certain** qu'un gate agressif soit bon (l'oversold se joue sur **J+10**, pas intraday ; le « flat vs entrée » n'est pas une preuve ; risque de répéter le piège « gate qui étrangle l'edge » de la mission du jour). Donc version **conservatrice** : je ne coupe que le cas **extrême** (déjà > 10% au-dessus du close de drop = plus un dip, du chasing pur).

## Fix
Rejette si `dayChg` (vs `closeJ`, le close de drop) > `OVERSOLD_INTRADAY_MAX_DAY_CHANGE_PCT` (**default 10%**). Unifié EU (real-time OHLC) + US (bougies), `reject_stage='overextended'`, réglable, `0`=off.

**Sur les données 08/06** : aurait coupé **uniquement INTC (+12.7%)**, gardé les 6 rebonds modérés (+3 à +6.7%). Le logging #657 mesure exactement ce qu'il coupe → validation/resserrage sur **preuve** sous 48h.

## Tests
- `tsc -b` ✅ · 76/76 oversold ✅

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_