### PR TITLE
fix(oversold): exclut les positions oversold du GeminiRiskManager (stoppe la conso Gemini + antithèse)

### DIFF
--- a/apps/api/src/modules/lisa/services/research/gemini-risk-manager.service.ts
+++ b/apps/api/src/modules/lisa/services/research/gemini-risk-manager.service.ts
@@ -258,11 +258,20 @@ export class GeminiRiskManagerService {
     const { data, error } = await this.supabase
       .getClient()
       .from('lisa_positions')
-      .select('id, symbol, asset_class, entry_timestamp, entry_price, direction, stop_loss_price, take_profit_price, peak_pre_exit')
+      .select('id, symbol, asset_class, entry_timestamp, entry_price, direction, stop_loss_price, take_profit_price, peak_pre_exit, venue_fee_detail')
       .eq('status', 'open')
-      .limit(20);
+      .limit(60);
     if (error || !data) return [];
-    return data as Array<OpenPos>;
+    // Exclut les positions OVERSOLD (source scanner_oversold*) : stratégie
+    // déterministe mean-reversion, hold J+10. Le risk-manager momentum (Gemini)
+    // est ANTITHÉTIQUE — il les fermerait pendant le creux normal, juste avant le
+    // rebond — ET consomme du Gemini inutilement (constaté 09/06 : INTC.US
+    // oversold évalué à 02:42). Même exclusion que open-position-risk-monitor.
+    // Filtre JS (gère source NULL des positions non-oversold). Cap 20 conservé.
+    const filtered = (data as Array<OpenPos & { venue_fee_detail?: { source?: string } | null }>).filter(
+      (p) => !(p.venue_fee_detail?.source ?? '').startsWith('scanner_oversold'),
+    );
+    return filtered.slice(0, 20) as Array<OpenPos>;
   }
 
   /** Calcule pnl/distances/peak depuis le live price + position. Pure-ish. */


### PR DESCRIPTION
## Constat user (09/06) : conso Gemini inattendue
Les portfolios sont en **oversold pur** (qui n'utilise pas Gemini), pourtant Gemini consomme. Cause trouvée : `GeminiRiskManagerService` (risk-manager-v2, cron */5min, `GEMINI_RISK_MANAGER_ENABLED=true`) chargeait **toutes** les positions open **sans filtre de source** → il évaluait les positions **oversold** via Gemini (constaté : `INTC.US "thèse cassée" à 02:42`).

Doublement faux pour de l'oversold :
- **Coût Gemini inutile** (et non tracké dans `api_costs_daily` → panel à $0 alors que la console Google voit les appels) ;
- **Antithétique** : un risk-manager momentum fermerait une position mean-reversion pendant son creux normal, juste avant le rebond J+10 → destruction de l'edge.

## Fix
`fetchOpenPositions` exclut les sources `scanner_oversold*` (filtre JS, gère le `source` NULL des positions non-oversold ; cap 20 conservé via fetch 60 → filter → slice 20). Même exclusion que `open-position-risk-monitor`. Les 2 portfolios actifs étant oversold → le risk-manager devient **idle → 0 appel Gemini**.

## Tests
- `tsc -b` ✅ · 6/6 gemini-risk-manager ✅

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_