### PR TITLE
fix(llm): KILL Gemini global (défaut OFF) + Mistral primaire — Gemini ne s'exécute plus

### DIFF
--- a/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
+++ b/apps/api/src/modules/lisa/services/scanner-llm-router.service.ts
@@ -62,11 +62,14 @@ export class ScannerLlmRouterService {
     @Optional() private readonly mistralSmall?: MistralSmallService,
   ) {
     this.enabled = (this.config.get<string>('SCANNER_LLM_ROUTER_ENABLED') ?? 'false').toLowerCase() === 'true';
-    this.primaryProvider = (this.config.get<string>('LLM_PRIMARY_PROVIDER') ?? 'gemini-pro').toLowerCase();
+    // Défaut MISTRAL (demande user 09/06 : « Mistral uniquement »). Primaire =
+    // Mistral Medium, tier rapide = Mistral Small. Gemini n'est plus jamais en
+    // tête, et son exécution est de toute façon bloquée (GeminiProvider kill).
+    this.primaryProvider = (this.config.get<string>('LLM_PRIMARY_PROVIDER') ?? 'mistral-medium').toLowerCase();
     if (this.primaryProvider === 'mistral-medium') {
-      this.logger.log('[scanner-llm] LLM_PRIMARY_PROVIDER=mistral-medium → Mistral Medium 3.5 décideur principal, Gemini Pro en fallback automatique');
+      this.logger.log('[scanner-llm] LLM_PRIMARY_PROVIDER=mistral-medium → Mistral Medium 3.5 décideur principal');
     }
-    this.fastProvider = (this.config.get<string>('LLM_FAST_PROVIDER') ?? '').toLowerCase();
+    this.fastProvider = (this.config.get<string>('LLM_FAST_PROVIDER') ?? 'mistral-small').toLowerCase();
     if (this.fastProvider === 'mistral-small') {
       this.logger.log('[scanner-llm] LLM_FAST_PROVIDER=mistral-small → tier rapide (call) sur Mistral Small, fallback Medium/Gemini');
     }

--- a/packages/ai-analyst/src/llm/providers/gemini-provider.ts
+++ b/packages/ai-analyst/src/llm/providers/gemini-provider.ts
@@ -37,11 +37,29 @@ export class GeminiProvider implements LlmProvider {
     else this.id = `gemini-${this.model}`;
   }
 
+  /**
+   * KILL-SWITCH GLOBAL — Gemini DÉSACTIVÉ par défaut (demande user 09/06/2026 :
+   * « Gemini OFF, Mistral uniquement »). Aucun appel Gemini ne passe, peu importe
+   * le service appelant (risk-manager, scout, daily-brief, router…). Le router LLM
+   * a Mistral en primaire → bascule transparente. Réversible UNIQUEMENT en posant
+   * explicitement GEMINI_DISABLED=false.
+   */
+  private static isKilled(): boolean {
+    return (process.env.GEMINI_DISABLED ?? 'true').toLowerCase() !== 'false';
+  }
+
+  // isConfigured reste basé sur la clé : le routeur LLM doit rester "enabled" pour
+  // que le chemin Mistral (gain-picker) fonctionne. Le kill agit sur l'EXÉCUTION
+  // (call() throw) : Gemini ne s'exécute jamais, mais le routeur ne se désactive
+  // pas (sinon il couperait aussi Mistral).
   isConfigured(): boolean {
     return !!this.apiKey;
   }
 
   async call(params: LlmCallParams): Promise<LlmCallResult> {
+    if (GeminiProvider.isKilled()) {
+      throw new Error('GeminiProvider: Gemini désactivé globalement (GEMINI_DISABLED, défaut ON) — Mistral uniquement.');
+    }
     if (!this.apiKey) throw new Error('GeminiProvider: GEMINI_API_KEY missing');
 
     const { GoogleGenAI } = await import('@google/genai');


### PR DESCRIPTION
## Demande user (explicite, répétée) : Gemini OFF, Mistral UNIQUEMENT

### 1. Kill Gemini à la source
`GeminiProvider.call()` **throw** quand `GEMINI_DISABLED != 'false'` (**défaut = killed**). Gemini ne s'exécute **jamais**, peu importe le service appelant — les 3 services « Gemini » (risk-manager, scout, daily-brief) passent **tous par le routeur LLM**, qui ne sélectionne plus Gemini en tête et dont l'exécution Gemini est bloquée. `isConfigured()` reste basé sur la clé pour que le **routeur reste "enabled"** → le chemin Mistral n'est jamais coupé. Réversible via `GEMINI_DISABLED=false`.

### 2. Routeur → Mistral par défaut
`LLM_PRIMARY_PROVIDER` défaut `mistral-medium`, `LLM_FAST_PROVIDER` défaut `mistral-small`. Mistral toujours essayé en premier.

## Préservé (NON touché)
- **danger-zone oversold** : 100% déterministe (`manual_control`), zéro LLM.
- **gain-picker** (`OversoldMistralExitService`) : `router.call()` → Mistral Small/Medium.

## Tests
- `tsc -b` ✅ · ai-analyst **767/767** ✅ · Mistral 35/35 ✅ · routeur 6/6 ✅ · risk-mgr 6/6 ✅

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_