### PR TITLE
fix(ui): répartition LLM du jour par famille — « Gemini: $0 ✓ off »

### DIFF
--- a/apps/web/src/components/lisa/llm-cost-live-panel.tsx
+++ b/apps/web/src/components/lisa/llm-cost-live-panel.tsx
@@ -109,6 +109,24 @@ export function LlmCostLivePanel() {
           <span className="text-2xl font-bold text-gray-900">${data.ledger.today_cost_usd.toFixed(2)}</span>
           <span className="text-xs text-gray-500">coût réel aujourd&apos;hui</span>
         </div>
+        {/* Répartition du JOUR par famille — montre explicitement Gemini $0, pour
+            lever la confusion récurrente avec le cumul annuel (qui inclut un
+            historique Gemini gelé pré-05/06 qui ne baissera jamais). */}
+        <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px]">
+          {(['mistral', 'gemini', 'claude'] as const).map((fam) => {
+            const famCost = Object.entries(data.ledger.today_by_model)
+              .filter(([m]) => m.toLowerCase().includes(fam))
+              .reduce((s, [, c]) => s + Number(c), 0);
+            const label = fam === 'mistral' ? 'Mistral' : fam === 'gemini' ? 'Gemini' : 'Claude';
+            const zero = famCost === 0;
+            return (
+              <span key={fam} className={zero ? 'text-gray-400' : 'font-medium text-gray-700'}>
+                {label}: ${famCost.toFixed(2)}
+                {fam === 'gemini' && zero && <span className="text-green-600"> ✓ off</span>}
+              </span>
+            );
+          })}
+        </div>
         {/* 08/06 — Agrégats mensuel + annuel (demande user). */}
         <div className="mt-2 grid grid-cols-3 gap-2 text-center">
           <div className="rounded bg-gray-50 py-1">


### PR DESCRIPTION
## Problème

Le panneau « Coût LLM réel » affichait le cumul **annuel** ($21 — historique Gemini gelé pré-05/06) à côté du coût du jour. Sans répartition explicite, ça donnait l'impression d'une conso Gemini **en cours**, alors que Gemini = **$0 aujourd'hui ET hier** depuis le kill global (#673).

C'est la 3e fois que cette confusion remonte → je corrige le panneau pour de bon.

## Fix

Ajoute, juste sous le headline « coût réel aujourd'hui », une ligne de **répartition du JOUR par famille** (Mistral / Gemini / Claude) calculée depuis `ledger.today_by_model` :

- `Mistral: $X.XX`
- `Gemini: $0.00 ✓ off` (marqueur vert explicite quand $0)
- `Claude: $X.XX`

Ainsi l'utilisateur voit d'un coup d'œil que **le jour** ne contient aucune conso Gemini, indépendamment du cumul annuel figé (qui ne baissera jamais après le kill).

## Vérif

- `npx tsc --noEmit` sur `apps/web` → exit 0
- Pur frontend, aucune logique backend touchée.

⚠️ Vercel rate-limit (>100 deploys/24h) — le déploiement front peut être différé jusqu'au reset, mais le merge sur main est propre.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_