### PR TITLE
feat(oversold): trajectoire progressive J+3/J+6 + badge meilleur jour + générateur de lessons oversold

### DIFF
--- a/apps/api/src/modules/lisa/lisa.module.ts
+++ b/apps/api/src/modules/lisa/lisa.module.ts
@@ -148,6 +148,8 @@ import { IntradayProviderRouter } from './services/intraday-provider-router.serv
 import { PositionIndicatorsTrackerService } from './services/position-indicators-tracker.service';
 // Apprentissage décisions de fermeture (capture user+mécanique + cron counterfactuel)
 import { CloseDecisionCaptureService } from './services/close-decision-capture.service';
+// Générateur déterministe de lessons oversold (cron nuit, scope oversold_*_equity)
+import { OversoldRetrospectiveService } from './services/oversold-retrospective.service';
 // Distille les close decisions en politique de sortie apprise (prompt TRADER)
 import { ExitPolicyContextService } from './services/exit-policy-context.service';
 import { GainersExitPolicyService } from './services/research/gainers-exit-policy.service';
@@ -381,6 +383,8 @@ import { SizingABTestService } from './services/research/sizing-ab-test.service'
     PositionIndicatorsTrackerService,
     // Apprentissage décisions fermeture (capture + cron counterfactuel labeler)
     CloseDecisionCaptureService,
+    // Générateur déterministe de lessons oversold (cron nuit 22:45 UTC)
+    OversoldRetrospectiveService,
     // Politique de sortie apprise injectée dans le prompt TRADER
     ExitPolicyContextService,
     GainersExitPolicyService,

--- a/apps/api/src/modules/lisa/services/__tests__/oversold-retrospective.helper.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/oversold-retrospective.helper.spec.ts
@@ -1,0 +1,72 @@
+import { buildOversoldLessons, type OversoldCloseRow } from '../oversold-retrospective.helper';
+
+function row(p: Partial<OversoldCloseRow>): OversoldCloseRow {
+  return {
+    pnlPct: p.pnlPct ?? 1.5,
+    pnlUsd: p.pnlUsd ?? 100,
+    deadlineVerdict: p.deadlineVerdict ?? 'NEUTRAL',
+    pnlIfHeldToDeadlinePct: p.pnlIfHeldToDeadlinePct ?? 1.5,
+    bestDayLabel: p.bestDayLabel ?? 'J+10',
+    bestDayPnlPct: p.bestDayPnlPct ?? 1.5,
+  };
+}
+
+const OPTS = { region: 'US', scope: 'oversold_us_equity', minSample: 5 };
+
+describe('buildOversoldLessons — générateur déterministe', () => {
+  it('renvoie [] sous le sample minimum (anti-bruit)', () => {
+    const rows = [row({}), row({}), row({})]; // n=3 < 5
+    expect(buildOversoldLessons(rows, OPTS)).toEqual([]);
+  });
+
+  it('held_better dominant + give-up positif → EXIT_TIMING_HOLD_LONGER', () => {
+    // 6 closes : sortis à +1.5%, mais tenir à J+10 aurait fait +4% → held_better.
+    const rows = Array.from({ length: 6 }, () =>
+      row({ pnlPct: 1.5, pnlIfHeldToDeadlinePct: 4, deadlineVerdict: 'HELD_BETTER', bestDayLabel: 'J+6', bestDayPnlPct: 4.2 }),
+    );
+    const out = buildOversoldLessons(rows, OPTS);
+    const kinds = out.map((l) => l.lessonKind);
+    expect(kinds).toContain('EXIT_TIMING_HOLD_LONGER');
+    expect(kinds).toContain('HEALTH_SUMMARY');
+    const exit = out.find((l) => l.lessonKind === 'EXIT_TIMING_HOLD_LONGER')!;
+    expect(exit.scope).toBe('oversold_us_equity');
+    expect(exit.sampleSize).toBe(6);
+    expect(exit.lessonText).toContain('J+6'); // meilleur jour le plus fréquent
+    expect(exit.confidence).toBeGreaterThanOrEqual(0.5);
+    expect(exit.confidence).toBeLessThan(0.95); // jamais auto-appliquable
+  });
+
+  it('close_better dominant + give-up négatif → EXIT_TIMING_LOCK_OK', () => {
+    // Tenir aurait dégradé (held = -1% vs close +1.5%).
+    const rows = Array.from({ length: 8 }, () =>
+      row({ pnlPct: 1.5, pnlIfHeldToDeadlinePct: -1, deadlineVerdict: 'CLOSE_BETTER', bestDayLabel: 'J+1', bestDayPnlPct: 1.8 }),
+    );
+    const out = buildOversoldLessons(rows, OPTS);
+    expect(out.map((l) => l.lessonKind)).toContain('EXIT_TIMING_LOCK_OK');
+  });
+
+  it('aucune majorité de verdict → EXIT_TIMING_MIXED (confiance plafonnée)', () => {
+    // 2 held / 1 close / 3 neutral : ni held ni close ≥ 50% → mitigé.
+    const rows = [
+      ...Array.from({ length: 2 }, () => row({ deadlineVerdict: 'HELD_BETTER', pnlIfHeldToDeadlinePct: 3, pnlPct: 1.5 })),
+      row({ deadlineVerdict: 'CLOSE_BETTER', pnlIfHeldToDeadlinePct: 0, pnlPct: 1.5 }),
+      ...Array.from({ length: 3 }, () => row({ deadlineVerdict: 'NEUTRAL', pnlIfHeldToDeadlinePct: 1.6, pnlPct: 1.5 })),
+    ];
+    const out = buildOversoldLessons(rows, OPTS);
+    const mixed = out.find((l) => l.lessonKind === 'EXIT_TIMING_MIXED');
+    expect(mixed).toBeDefined();
+    expect(mixed!.confidence).toBeLessThanOrEqual(0.6);
+  });
+
+  it('HEALTH_SUMMARY remonte win rate + scope correct', () => {
+    const rows = [
+      ...Array.from({ length: 4 }, () => row({ pnlPct: 2, pnlUsd: 150 })), // wins
+      ...Array.from({ length: 2 }, () => row({ pnlPct: -3, pnlUsd: -200 })), // losses
+    ];
+    const out = buildOversoldLessons(rows, { region: 'EU', scope: 'oversold_eu_equity', minSample: 5 });
+    const health = out.find((l) => l.lessonKind === 'HEALTH_SUMMARY')!;
+    expect(health.scope).toBe('oversold_eu_equity');
+    expect(health.winRateObserved).toBeCloseTo((4 / 6) * 100, 1);
+    expect(health.lessonText).toContain('Oversold EU');
+  });
+});

--- a/apps/api/src/modules/lisa/services/close-decision-capture.service.ts
+++ b/apps/api/src/modules/lisa/services/close-decision-capture.service.ts
@@ -364,66 +364,121 @@ export class CloseDecisionCaptureService {
   }
 
   /**
-   * Cron quotidien — contrefactuel à l'échéance (J+10 oversold). Pour les closes
-   * avec deadline_at atteinte et pas encore labellisés : compare "tenir jusqu'à
-   * l'échéance" vs "le close réel". Verdict CLOSE_BETTER / HELD_BETTER / NEUTRAL.
+   * Cron quotidien — labeler PROGRESSIF de la trajectoire J+1/J+3/J+6/J+10.
+   *
+   * Demande user 10/06 : voir des verdicts INTERMÉDIAIRES (J+3, J+6) qui se
+   * peuplent au fil de l'eau (pas seulement à l'échéance J+10), + un indicateur
+   * « meilleur jour » (le checkpoint où tenir aurait le mieux payé).
+   *
+   * À chaque run, pour les closes avec échéance pas encore FINALISÉE
+   * (deadline_verdict null) : on remplit la trajectoire des checkpoints déjà
+   * écoulés (P&L-si-tenu à J+1/3/6/10) + best_day. À J+10 atteint, on pose le
+   * verdict final CLOSE_BETTER / HELD_BETTER / NEUTRAL (ce qui fige la ligne).
    */
-  @Cron('0 30 22 * * *', { name: 'close-decision-deadline-labeler', timeZone: 'UTC' })
+  @Cron('0 30 22 * * *', { name: 'close-decision-trajectory-labeler', timeZone: 'UTC' })
   async labelDeadlineCounterfactuals(): Promise<void> {
     if (!this.labelerEnabled || !this.supabase.isReady()) return;
     try {
+      // Tous les closes avec échéance, pas encore finalisés, dont ~J+1 est écoulé.
+      // On re-traite la même ligne chaque jour (checkpoints qui s'ajoutent) jusqu'à
+      // ce que deadline_verdict soit posé à J+10. Coût ~1 call EOD/ligne/jour.
+      const cutoff = new Date(Date.now() - 20 * 3600_000).toISOString();
       const { data: rows } = await this.supabase.getClient()
         .from('position_close_decisions')
         .select('id, symbol, direction, entry_price, exit_price, pnl_pct, closed_at, deadline_at')
         .not('deadline_at', 'is', null)
         .is('deadline_verdict', null)
-        .lte('deadline_at', new Date().toISOString())
+        .lte('closed_at', cutoff)
+        .order('closed_at', { ascending: true })
         .limit(50);
       if (!rows || rows.length === 0) return;
       let labeled = 0;
+      let finalized = 0;
       for (const r of rows) {
-        if (await this.labelDeadlineOne(r as Record<string, unknown>).catch(() => false)) labeled++;
+        const res = await this.labelTrajectoryOne(r as Record<string, unknown>).catch(() => null);
+        if (res) {
+          labeled++;
+          if (res.finalized) finalized++;
+        }
       }
-      if (labeled > 0) this.logger.log(`[close-deadline-labeler] ${labeled}/${rows.length} closes labellisés à l'échéance`);
+      if (labeled > 0) {
+        this.logger.log(`[close-trajectory-labeler] ${labeled}/${rows.length} closes mis à jour (${finalized} finalisés J+10)`);
+      }
     } catch (e) {
-      this.logger.warn(`[close-deadline-labeler] ${String(e).slice(0, 150)}`);
+      this.logger.warn(`[close-trajectory-labeler] ${String(e).slice(0, 150)}`);
     }
   }
 
-  private async labelDeadlineOne(r: Record<string, unknown>): Promise<boolean> {
+  private async labelTrajectoryOne(r: Record<string, unknown>): Promise<{ finalized: boolean } | null> {
     const symbol = String(r.symbol);
     const entry = Number(r.entry_price);
     const pnlAtClose = r.pnl_pct != null ? Number(r.pnl_pct) : null;
     const sign = String(r.direction) === 'short' ? -1 : 1;
     const closedAt = new Date(String(r.closed_at));
+    const deadlineAt = r.deadline_at ? new Date(String(r.deadline_at)) : null;
+    const j10Reached = deadlineAt != null && deadlineAt.getTime() <= Date.now();
+
     if (!(entry > 0)) {
       await this.markDeadlineNoData(String(r.id));
-      return true;
+      return { finalized: true };
     }
     const closes = await this.fetchDailyCloses(symbol, closedAt).catch(() => [] as Array<{ date: string; close: number }>);
     if (closes.length === 0) {
-      await this.markDeadlineNoData(String(r.id));
-      return true;
+      // Pas encore de barre EOD post-close. Si J+10 dépassé → finalise neutre
+      // (no-data) ; sinon on retentera demain (rien à écrire pour l'instant).
+      if (j10Reached) {
+        await this.markDeadlineNoData(String(r.id));
+        return { finalized: true };
+      }
+      return null;
     }
-    // closes ascendant à partir de J+1 ouvré ; J+N = N-ème close.
+
+    // closes ascendant depuis J+1 ouvré ; J+N = N-ème close.
     const pick = (n: number): number | null => (closes[n - 1] ? closes[n - 1].close : null);
-    const pJ10 = pick(10) ?? closes[closes.length - 1].close;
-    const pnlIfHeld = pJ10 != null && entry > 0 ? ((pJ10 - entry) / entry) * 100 * sign : null;
-    let verdict: 'CLOSE_BETTER' | 'HELD_BETTER' | 'NEUTRAL' = 'NEUTRAL';
-    if (pnlIfHeld != null && pnlAtClose != null) {
-      if (pnlIfHeld > pnlAtClose + 0.5) verdict = 'HELD_BETTER'; // tenir aurait mieux valu → close prématuré
-      else if (pnlIfHeld < pnlAtClose - 0.5) verdict = 'CLOSE_BETTER'; // bien fermé
+    const pnlIfHeldAt = (p: number | null): number | null =>
+      p != null && entry > 0 ? ((p - entry) / entry) * 100 * sign : null;
+
+    // Trajectoire : 60min est déjà couvert par `verdict` ; ici J+1 → J+3 → J+6 → J+10.
+    // On ne pousse que les checkpoints DÉJÀ écoulés (closes.length ≥ d).
+    const checkpoints = [1, 3, 6, 10];
+    const trajectory: Array<{ d: number; pnl: number }> = [];
+    for (const d of checkpoints) {
+      const v = pnlIfHeldAt(pick(d));
+      if (v != null) trajectory.push({ d, pnl: round2(v) });
     }
-    await this.supabase.getClient().from('position_close_decisions').update({
+    // Meilleur jour observé jusqu'ici (où tenir aurait le mieux payé).
+    let best: { d: number; pnl: number } | null = null;
+    for (const t of trajectory) if (best == null || t.pnl > best.pnl) best = t;
+
+    const update: Record<string, unknown> = {
       price_j1: pick(1),
       price_j3: pick(3),
-      price_j5: pick(5),
-      price_j10: pJ10,
-      pnl_if_held_to_deadline_pct: pnlIfHeld != null ? round2(pnlIfHeld) : null,
-      deadline_verdict: verdict,
-      deadline_labeled_at: new Date().toISOString(),
-    }).eq('id', String(r.id));
-    return true;
+      price_j6: pick(6),
+      price_j10: pick(10),
+      trajectory,
+      best_day_label: best ? `J+${best.d}` : null,
+      best_day_pnl_pct: best ? best.pnl : null,
+      trajectory_labeled_at: new Date().toISOString(),
+    };
+
+    // Finalisation à J+10 : verdict close vs tenir (fige la ligne).
+    let finalized = false;
+    if (j10Reached) {
+      const pJ10 = pick(10) ?? closes[closes.length - 1].close;
+      const pnlIfHeld = pnlIfHeldAt(pJ10);
+      let verdict: 'CLOSE_BETTER' | 'HELD_BETTER' | 'NEUTRAL' = 'NEUTRAL';
+      if (pnlIfHeld != null && pnlAtClose != null) {
+        if (pnlIfHeld > pnlAtClose + 0.5) verdict = 'HELD_BETTER'; // tenir aurait mieux valu → close prématuré
+        else if (pnlIfHeld < pnlAtClose - 0.5) verdict = 'CLOSE_BETTER'; // bien fermé
+      }
+      update.pnl_if_held_to_deadline_pct = pnlIfHeld != null ? round2(pnlIfHeld) : null;
+      update.deadline_verdict = verdict;
+      update.deadline_labeled_at = new Date().toISOString();
+      finalized = true;
+    }
+
+    await this.supabase.getClient().from('position_close_decisions').update(update).eq('id', String(r.id));
+    return { finalized };
   }
 
   private async markDeadlineNoData(id: string): Promise<void> {

--- a/apps/api/src/modules/lisa/services/lisa.service.ts
+++ b/apps/api/src/modules/lisa/services/lisa.service.ts
@@ -3494,7 +3494,8 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       .select(
         'id, symbol, context, closer_type, closed_at, pnl_pct, pnl_usd, age_minutes, ' +
           'mfe_pct, give_back_from_mfe, verdict, deadline_verdict, ' +
-          'pnl_if_held_to_deadline_pct, hours_to_deadline, deadline_at, news_count, news_min_sentiment',
+          'pnl_if_held_to_deadline_pct, hours_to_deadline, deadline_at, news_count, news_min_sentiment, ' +
+          'trajectory, best_day_label, best_day_pnl_pct',
       )
       .eq('portfolio_id', portfolioId)
       .order('closed_at', { ascending: false })
@@ -3519,6 +3520,14 @@ tu n'ouvres rien de neuf. Les contraintes "Risk constraints" sont absolues.
       hasDeadline: r.deadline_at != null,
       newsCount: num(r.news_count),
       newsMinSentiment: num(r.news_min_sentiment),
+      // 10/06 — Trajectoire progressive J+1/3/6/10 + meilleur jour (badge UI).
+      trajectory: Array.isArray(r.trajectory)
+        ? (r.trajectory as Array<{ d?: unknown; pnl?: unknown }>)
+            .map((t) => ({ d: Number(t.d), pnl: num(t.pnl) }))
+            .filter((t) => Number.isFinite(t.d))
+        : [],
+      bestDayLabel: (r.best_day_label as string | null) ?? null,
+      bestDayPnlPct: num(r.best_day_pnl_pct),
     }));
     return {
       rows: mapped,

--- a/apps/api/src/modules/lisa/services/oversold-retrospective.helper.ts
+++ b/apps/api/src/modules/lisa/services/oversold-retrospective.helper.ts
@@ -1,0 +1,161 @@
+/**
+ * Générateur DÉTERMINISTE de lessons oversold (pas de LLM).
+ *
+ * Le mode oversold est une stratégie mean-reversion déterministe → ses lessons
+ * doivent l'être aussi (zéro coût LLM, zéro Gemini, reproductible). On agrège les
+ * décisions de close ARRIVÉES à J+10 (contrefactuel finalisé) et on en tire 1-2
+ * leçons actionnables par région :
+ *   - EXIT_TIMING_* : le verrou +1,5% sort-il trop tôt ? (held_better vs close_better)
+ *   - HEALTH_SUMMARY : win rate + P&L moyen de la fenêtre.
+ *
+ * Pure function → testable sans DB. La persistance/dédup vit dans le service.
+ */
+
+export interface OversoldCloseRow {
+  pnlPct: number | null;
+  pnlUsd: number | null;
+  deadlineVerdict: string | null; // 'HELD_BETTER' | 'CLOSE_BETTER' | 'NEUTRAL'
+  pnlIfHeldToDeadlinePct: number | null;
+  bestDayLabel: string | null; // 'J+1' | 'J+3' | 'J+6' | 'J+10'
+  bestDayPnlPct: number | null;
+}
+
+export interface OversoldLessonCandidate {
+  lessonKind: string;
+  lessonText: string;
+  scope: string;
+  confidence: number;
+  sampleSize: number;
+  winRateObserved: number | null;
+  avgPnlUsd: number | null;
+  payload: Record<string, unknown>;
+}
+
+function mean(xs: number[]): number {
+  return xs.length ? xs.reduce((s, v) => s + v, 0) / xs.length : 0;
+}
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+function toNum(v: unknown): number | null {
+  return v == null || !Number.isFinite(Number(v)) ? null : Number(v);
+}
+
+/**
+ * Construit les lessons oversold à partir d'un lot de closes finalisés (J+10).
+ * Renvoie [] tant que le sample est sous le minimum (anti-bruit statistique).
+ */
+export function buildOversoldLessons(
+  rows: OversoldCloseRow[],
+  opts: { region: string; scope: string; minSample?: number },
+): OversoldLessonCandidate[] {
+  const minSample = opts.minSample ?? 5;
+  const n = rows.length;
+  if (n < minSample) return [];
+
+  const reg = opts.region;
+  const pnls = rows.map((r) => toNum(r.pnlPct)).filter((v): v is number => v != null);
+  const pnlsUsd = rows.map((r) => toNum(r.pnlUsd)).filter((v): v is number => v != null);
+  const wins = pnls.filter((v) => v > 0).length;
+  const winRate = pnls.length ? (wins / pnls.length) * 100 : null;
+  const avgPnlPct = pnls.length ? mean(pnls) : null;
+  const avgPnlUsd = pnlsUsd.length ? mean(pnlsUsd) : null;
+
+  const heldBetter = rows.filter((r) => r.deadlineVerdict === 'HELD_BETTER').length;
+  const closeBetter = rows.filter((r) => r.deadlineVerdict === 'CLOSE_BETTER').length;
+  const neutral = n - heldBetter - closeBetter;
+  const heldPct = (heldBetter / n) * 100;
+  const closePct = (closeBetter / n) * 100;
+
+  // Give-up = combien tenir jusqu'à J+10 aurait ajouté vs la sortie réelle.
+  const giveUps = rows
+    .map((r) => {
+      const h = toNum(r.pnlIfHeldToDeadlinePct);
+      const c = toNum(r.pnlPct);
+      return h != null && c != null ? h - c : null;
+    })
+    .filter((v): v is number => v != null);
+  const avgGiveUp = giveUps.length ? mean(giveUps) : 0;
+
+  // Distribution du meilleur jour (mode = plus fréquent).
+  const bestDist: Record<string, number> = {};
+  for (const r of rows) if (r.bestDayLabel) bestDist[r.bestDayLabel] = (bestDist[r.bestDayLabel] ?? 0) + 1;
+  const modeBestDay = Object.entries(bestDist).sort((a, b) => b[1] - a[1])[0]?.[0] ?? 'J+10';
+
+  const confidence = round2(clamp(0.5 + 0.08 * Math.log2(n / minSample + 1), 0.5, 0.9));
+  const fmtPct = (v: number | null): string => (v == null ? 'n/a' : `${v >= 0 ? '+' : ''}${v.toFixed(1)}%`);
+  const fmtUsd = (v: number | null): string => (v == null ? 'n/a' : `${v >= 0 ? '+' : ''}$${v.toFixed(0)}`);
+
+  const basePayload: Record<string, unknown> = {
+    region: reg,
+    n,
+    win_rate: winRate != null ? round2(winRate) : null,
+    avg_pnl_pct: avgPnlPct != null ? round2(avgPnlPct) : null,
+    avg_pnl_usd: avgPnlUsd != null ? round2(avgPnlUsd) : null,
+    held_better: heldBetter,
+    close_better: closeBetter,
+    neutral,
+    avg_give_up_pct: round2(avgGiveUp),
+    mode_best_day: modeBestDay,
+    best_day_distribution: bestDist,
+  };
+
+  const out: OversoldLessonCandidate[] = [];
+
+  // 1. EXIT TIMING — le verrou +1,5% sort-il trop tôt ?
+  if (heldPct >= 50 && avgGiveUp >= 0.5) {
+    out.push({
+      lessonKind: 'EXIT_TIMING_HOLD_LONGER',
+      lessonText: `Oversold ${reg} : sur ${n} sorties arrivées à J+10, ${heldBetter} (${heldPct.toFixed(0)}%) auraient gagné davantage en tenant — en moyenne ${fmtPct(avgGiveUp)} laissés sur la table par trade, meilleur jour le plus fréquent ${modeBestDay}. Le verrou +1,5% sort trop tôt → envisager d'étendre le hold vers ${modeBestDay}.`,
+      scope: opts.scope,
+      confidence,
+      sampleSize: n,
+      winRateObserved: winRate,
+      avgPnlUsd,
+      payload: { ...basePayload, signal: 'hold_longer' },
+    });
+  } else if (closePct >= 50 && avgGiveUp <= 0) {
+    out.push({
+      lessonKind: 'EXIT_TIMING_LOCK_OK',
+      lessonText: `Oversold ${reg} : sur ${n} sorties, tenir jusqu'à J+10 aurait dégradé le résultat (${closeBetter} close_better, give-up moyen ${fmtPct(avgGiveUp)}). Le verrou +1,5% capture bien le rebond → conserver une sortie courte.`,
+      scope: opts.scope,
+      confidence,
+      sampleSize: n,
+      winRateObserved: winRate,
+      avgPnlUsd,
+      payload: { ...basePayload, signal: 'lock_ok' },
+    });
+  } else {
+    out.push({
+      lessonKind: 'EXIT_TIMING_MIXED',
+      lessonText: `Oversold ${reg} : ${n} sorties, signal mitigé (held_better ${heldPct.toFixed(0)}% / close_better ${closePct.toFixed(0)}%, give-up moyen ${fmtPct(avgGiveUp)}). Pas d'edge clair pour étendre ou raccourcir le hold — garder le verrou actuel et ré-évaluer avec plus de données.`,
+      scope: opts.scope,
+      confidence: Math.min(confidence, 0.6),
+      sampleSize: n,
+      winRateObserved: winRate,
+      avgPnlUsd,
+      payload: { ...basePayload, signal: 'mixed' },
+    });
+  }
+
+  // 2. HEALTH — synthèse win rate / P&L de la fenêtre.
+  const healthNote =
+    winRate != null && winRate < 40
+      ? 'Sous la cible mean-reversion — surveiller la bande de drop et le régime VIX.'
+      : "Conforme à l'edge mean-reversion attendu.";
+  out.push({
+    lessonKind: 'HEALTH_SUMMARY',
+    lessonText: `Oversold ${reg} : ${n} trades clos sur la fenêtre, win rate ${winRate != null ? winRate.toFixed(0) : 'n/a'}%, P&L moyen ${fmtUsd(avgPnlUsd)}/trade (${fmtPct(avgPnlPct)}). ${healthNote}`,
+    scope: opts.scope,
+    confidence,
+    sampleSize: n,
+    winRateObserved: winRate,
+    avgPnlUsd,
+    payload: { ...basePayload, signal: 'health' },
+  });
+
+  return out;
+}

--- a/apps/api/src/modules/lisa/services/oversold-retrospective.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-retrospective.service.ts
@@ -1,0 +1,143 @@
+/**
+ * OversoldRetrospectiveService — alimente le corpus de lessons OVERSOLD.
+ *
+ * Contexte (demande user 10/06/2026) : l'UI a une section Lessons filtrée sur le
+ * préfixe de scope `oversold`, mais AUCUN générateur n'écrivait ce scope → la
+ * section restait vide. Ce service comble le trou.
+ *
+ * 100% DÉTERMINISTE (zéro LLM, zéro Gemini — cohérent avec la stratégie oversold) :
+ * chaque nuit, pour chaque portefeuille oversold (US/EU), on agrège les décisions
+ * de close arrivées à J+10 (contrefactuel finalisé par CloseDecisionCaptureService)
+ * et on en dérive 1-2 leçons (timing de sortie + santé), écrites en `scanner_lessons`
+ * avec scope `oversold_us_equity` / `oversold_eu_equity` → la section UI se peuple.
+ *
+ * Matière première : elle n'existe qu'une fois les premières positions oversold
+ * arrivées à J+10 (~mi/fin juin pour la 1re cohorte). Avant ça : 0 leçon, sans erreur.
+ *
+ * Dédup : on n'insère pas la même (scope, lesson_kind) si une leçon active a déjà
+ * été créée dans les `dedupDays` derniers jours → refresh hebdomadaire, pas de spam.
+ *
+ * Gating : OVERSOLD_RETROSPECTIVE_ENABLED (default true — append-only, sans effet
+ * sur le trading). Le pipeline oversold ne LIT pas ces lessons ; elles servent à
+ * l'inspection humaine (et à un futur tuning manuel du hold/lock).
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../../supabase/supabase.service';
+import { buildOversoldLessons, type OversoldCloseRow } from './oversold-retrospective.helper';
+
+interface OversoldPortfolioTarget {
+  portfolioId: string;
+  region: string; // libellé humain pour le texte ('US' / 'EU')
+  scope: string; // 'oversold_us_equity' | 'oversold_eu_equity'
+}
+
+// Portefeuilles oversold connus (cf. CLAUDE.md — US a0000001, EU a0000003).
+const OVERSOLD_TARGETS: OversoldPortfolioTarget[] = [
+  { portfolioId: 'a0000001-0000-0000-0000-000000000001', region: 'US', scope: 'oversold_us_equity' },
+  { portfolioId: 'a0000003-0000-0000-0000-000000000003', region: 'EU', scope: 'oversold_eu_equity' },
+];
+
+@Injectable()
+export class OversoldRetrospectiveService {
+  private readonly logger = new Logger(OversoldRetrospectiveService.name);
+  private enabled = true;
+  private minSample = 5;
+  private lookbackDays = 60;
+  private readonly dedupDays = 6;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly supabase: SupabaseService,
+  ) {}
+
+  onModuleInit(): void {
+    this.enabled = (this.config.get<string>('OVERSOLD_RETROSPECTIVE_ENABLED') ?? 'true').toLowerCase() === 'true';
+    const ms = Number(this.config.get<string>('OVERSOLD_RETRO_MIN_SAMPLE'));
+    if (Number.isFinite(ms) && ms >= 1) this.minSample = Math.floor(ms);
+    const lb = Number(this.config.get<string>('OVERSOLD_RETRO_LOOKBACK_DAYS'));
+    if (Number.isFinite(lb) && lb >= 7) this.lookbackDays = Math.floor(lb);
+  }
+
+  /** Cron quotidien 22:45 UTC — juste après le trajectory-labeler (22:30). */
+  @Cron('0 45 22 * * *', { name: 'oversold-retrospective', timeZone: 'UTC' })
+  async runRetrospective(): Promise<void> {
+    if (!this.enabled || !this.supabase.isReady()) return;
+    let inserted = 0;
+    for (const t of OVERSOLD_TARGETS) {
+      try {
+        inserted += await this.runForTarget(t);
+      } catch (e) {
+        this.logger.warn(`[oversold-retro] ${t.region}: ${String(e).slice(0, 150)}`);
+      }
+    }
+    if (inserted > 0) this.logger.log(`[oversold-retro] ${inserted} leçon(s) oversold écrite(s)`);
+  }
+
+  private async runForTarget(t: OversoldPortfolioTarget): Promise<number> {
+    const client = this.supabase.getClient();
+    const since = new Date(Date.now() - this.lookbackDays * 24 * 3600_000).toISOString();
+    // Closes FINALISÉS (J+10 atteint → deadline_verdict posé) sur la fenêtre.
+    const { data, error } = await client
+      .from('position_close_decisions')
+      .select('pnl_pct, pnl_usd, deadline_verdict, pnl_if_held_to_deadline_pct, best_day_label, best_day_pnl_pct')
+      .eq('portfolio_id', t.portfolioId)
+      .not('deadline_verdict', 'is', null)
+      .gte('closed_at', since)
+      .limit(1000);
+    if (error) {
+      this.logger.warn(`[oversold-retro] ${t.region} read: ${error.message}`);
+      return 0;
+    }
+    const rows: OversoldCloseRow[] = (data ?? []).map((r: Record<string, unknown>) => ({
+      pnlPct: r.pnl_pct == null ? null : Number(r.pnl_pct),
+      pnlUsd: r.pnl_usd == null ? null : Number(r.pnl_usd),
+      deadlineVerdict: (r.deadline_verdict as string | null) ?? null,
+      pnlIfHeldToDeadlinePct: r.pnl_if_held_to_deadline_pct == null ? null : Number(r.pnl_if_held_to_deadline_pct),
+      bestDayLabel: (r.best_day_label as string | null) ?? null,
+      bestDayPnlPct: r.best_day_pnl_pct == null ? null : Number(r.best_day_pnl_pct),
+    }));
+
+    const candidates = buildOversoldLessons(rows, { region: t.region, scope: t.scope, minSample: this.minSample });
+    if (candidates.length === 0) return 0;
+
+    const today = new Date().toISOString().slice(0, 10);
+    let inserted = 0;
+    for (const c of candidates) {
+      // Dédup : skip si une leçon active de même (scope, lesson_kind) existe déjà
+      // dans les `dedupDays` derniers jours (refresh hebdo, pas quotidien).
+      const dedupSince = new Date(Date.now() - this.dedupDays * 24 * 3600_000).toISOString();
+      const { data: existing } = await client
+        .from('scanner_lessons')
+        .select('id')
+        .eq('scope', c.scope)
+        .eq('lesson_kind', c.lessonKind)
+        .eq('is_active', true)
+        .gte('created_at', dedupSince)
+        .limit(1);
+      if (existing && existing.length > 0) continue;
+
+      const { error: insErr } = await client.from('scanner_lessons').insert({
+        derived_from_date: today,
+        lesson_kind: c.lessonKind,
+        lesson_text: c.lessonText,
+        macro_condition: null,
+        scope: c.scope,
+        confidence: c.confidence,
+        sample_size: c.sampleSize,
+        win_rate_observed: c.winRateObserved != null ? Math.round(c.winRateObserved * 100) / 100 : null,
+        avg_pnl_usd: c.avgPnlUsd != null ? Math.round(c.avgPnlUsd * 100) / 100 : null,
+        is_active: true,
+        applied: false,
+        payload: c.payload,
+      });
+      if (insErr) {
+        this.logger.warn(`[oversold-retro] ${t.region} insert ${c.lessonKind}: ${insErr.message}`);
+        continue;
+      }
+      inserted++;
+    }
+    return inserted;
+  }
+}

--- a/apps/web/src/components/lisa/close-decisions-panel.tsx
+++ b/apps/web/src/components/lisa/close-decisions-panel.tsx
@@ -60,6 +60,7 @@ export function CloseDecisionsPanel({ portfolioId }: { portfolioId: string }) {
                 <th className="py-1.5 px-2">Sortie</th>
                 <th className="py-1.5 px-2 text-right">P&amp;L close</th>
                 <th className="py-1.5 px-2">Verdict 60m</th>
+                <th className="py-1.5 px-2" title="Le checkpoint J+N où tenir aurait le mieux payé. Survolez pour la trajectoire J+1/J+3/J+6/J+10.">Meilleur jour</th>
                 <th className="py-1.5 px-2">Verdict J+10</th>
                 <th className="py-1.5 pl-2 text-right">News</th>
               </tr>
@@ -75,8 +76,10 @@ export function CloseDecisionsPanel({ portfolioId }: { portfolioId: string }) {
 
       <p className="text-[11px] text-muted-foreground italic">
         « Trop tôt » = le prix a continué favorablement +60min après ta sortie. « Tenir mieux » = tenir
-        jusqu&apos;à J+10 aurait battu ta sortie. C&apos;est la matière brute de l&apos;imitation learning :
-        le LLM apprendra à reproduire tes <strong>bonnes</strong> sorties, pas toutes.
+        jusqu&apos;à J+10 aurait battu ta sortie. <strong>Meilleur jour</strong> = le checkpoint J+N (J+1/J+3/J+6/J+10,
+        survol pour le détail) où tenir aurait le mieux payé — il se peuple au fil des jours, sans attendre J+10.
+        C&apos;est la matière brute de l&apos;imitation learning : le LLM apprendra à reproduire tes
+        <strong> bonnes</strong> sorties, pas toutes.
       </p>
     </div>
   );
@@ -112,6 +115,32 @@ function BadgeDeadline({ v, pnlIfHeld }: { v: string | null; pnlIfHeld: number |
   return <span className="text-muted-foreground" title="Se peuplera à l'échéance J+10">⏳</span>;
 }
 
+/**
+ * Meilleur jour = le checkpoint J+N de la trajectoire où tenir aurait le mieux
+ * payé (P&L-si-tenu max). Se peuple progressivement (J+1 → J+3 → J+6 → J+10).
+ * Le survol montre la trajectoire complète des checkpoints écoulés.
+ */
+function BestDayCell({ r }: { r: CloseDecisionRow }) {
+  const traj = r.trajectory ?? [];
+  if (traj.length === 0 || r.bestDayLabel == null) {
+    return (
+      <span className="text-muted-foreground" title="Se peuple à J+1, J+3, J+6 puis J+10 (le prix EOD doit d'abord publier)">
+        ⏳ en cours
+      </span>
+    );
+  }
+  const pnl = r.bestDayPnlPct;
+  const cls = pnl == null ? 'text-muted-foreground' : pnl > 0 ? 'text-emerald-600' : pnl < 0 ? 'text-rose-500' : 'text-muted-foreground';
+  const tip = traj
+    .map((t) => `J+${t.d} ${t.pnl != null ? `${t.pnl >= 0 ? '+' : ''}${t.pnl.toFixed(1)}%` : '—'}`)
+    .join('  ·  ');
+  return (
+    <span className={`tabular-nums ${cls}`} title={`Trajectoire (P&L si tenu) : ${tip}`}>
+      🏆 {r.bestDayLabel} {pnl != null ? `${pnl >= 0 ? '+' : ''}${pnl.toFixed(1)}%` : ''}
+    </span>
+  );
+}
+
 function Row({ r }: { r: CloseDecisionRow }) {
   const pnlCls = r.pnlPct == null ? 'text-muted-foreground' : r.pnlPct >= 0 ? 'text-emerald-600' : 'text-rose-500';
   return (
@@ -125,6 +154,7 @@ function Row({ r }: { r: CloseDecisionRow }) {
         {r.pnlPct != null ? `${r.pnlPct >= 0 ? '+' : ''}${r.pnlPct.toFixed(2)}%` : '—'}
       </td>
       <td className="py-1.5 px-2 whitespace-nowrap"><Badge60m v={r.verdict60m} /></td>
+      <td className="py-1.5 px-2 whitespace-nowrap"><BestDayCell r={r} /></td>
       <td className="py-1.5 px-2 whitespace-nowrap"><BadgeDeadline v={r.deadlineVerdict} pnlIfHeld={r.pnlIfHeldToDeadlinePct} /></td>
       <td className="py-1.5 pl-2 text-right tabular-nums text-muted-foreground">
         {r.newsCount != null && r.newsCount > 0

--- a/apps/web/src/hooks/use-close-decisions.ts
+++ b/apps/web/src/hooks/use-close-decisions.ts
@@ -24,6 +24,10 @@ export interface CloseDecisionRow {
   hasDeadline: boolean;
   newsCount: number | null;
   newsMinSentiment: number | null;
+  // 10/06 — Trajectoire progressive (checkpoints écoulés) + meilleur jour.
+  trajectory: Array<{ d: number; pnl: number | null }>;
+  bestDayLabel: string | null;
+  bestDayPnlPct: number | null;
 }
 
 export interface CloseDecisionsResponse {

--- a/supabase/migrations/0203_oversold_close_trajectory.sql
+++ b/supabase/migrations/0203_oversold_close_trajectory.sql
@@ -1,0 +1,23 @@
+-- 0203 — Trajectoire progressive J+1/J+3/J+6/J+10 des décisions de close (oversold).
+--
+-- 0197 a posé le contrefactuel J+10 (price_j1/3/5/10 + deadline_verdict), rempli
+-- d'un seul coup à l'échéance J+10. Demande user 10/06 : voir des verdicts
+-- INTERMÉDIAIRES (J+3, J+6) qui se peuplent au fil de l'eau, + un indicateur
+-- « meilleur jour » (le J+N où tenir aurait le mieux payé).
+--
+-- On ajoute donc :
+--   - price_j6 (le checkpoint J+6 manquant ; J+1/3/10 existent déjà, J+5 conservé)
+--   - trajectory JSONB : [{ "d": 1, "pnl": 0.8 }, { "d": 3, "pnl": 2.1 }, …] —
+--     P&L-si-tenu à chaque checkpoint ÉCOULÉ (rempli progressivement, pas à J+10)
+--   - best_day_label / best_day_pnl_pct : le meilleur checkpoint observé (badge UI)
+--   - trajectory_labeled_at : marqueur du dernier passage du labeler progressif
+--     (distinct de deadline_labeled_at qui ne se pose qu'à la finalisation J+10)
+ALTER TABLE position_close_decisions
+  ADD COLUMN IF NOT EXISTS price_j6 NUMERIC,
+  ADD COLUMN IF NOT EXISTS trajectory JSONB,            -- [{ d:int, pnl:number }] checkpoints écoulés
+  ADD COLUMN IF NOT EXISTS best_day_label TEXT,         -- 'J+6'
+  ADD COLUMN IF NOT EXISTS best_day_pnl_pct NUMERIC,    -- P&L-si-tenu au meilleur jour
+  ADD COLUMN IF NOT EXISTS trajectory_labeled_at TIMESTAMPTZ;
+
+-- Reload PostgREST schema cache (sinon l'API ne voit pas les colonnes immédiatement)
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Deux features apprentissage oversold (demande user 10/06)

### #1 — Trajectoire progressive J+3/J+6 + badge « Meilleur jour »
Le labeler de contrefactuel ne tournait qu'à l'échéance **J+10** et remplissait J+1/3/5/10 d'un coup → aucun verdict intermédiaire visible avant 10 jours.

Désormais **labeler progressif** (`close-decision-capture.service.ts`) : chaque nuit il remplit les checkpoints déjà écoulés (P&L-si-tenu à **J+1 / J+3 / J+6 / J+10**) + calcule le **meilleur jour** (le checkpoint où tenir aurait le mieux payé), et ne fige le verdict final qu'à J+10.

UI (`close-decisions-panel.tsx`) : nouvelle colonne **« Meilleur jour »** → badge `🏆 J+6 +3,4 %` + trajectoire complète au survol.

### #2 — Générateur de lessons oversold (déterministe, zéro LLM)
La section Lessons UI filtre sur le préfixe de scope `oversold` mais **aucun générateur** n'écrivait ce scope → elle restait vide.

Nouveau **`OversoldRetrospectiveService`** (cron 22:45 UTC, 100 % déterministe — pas de LLM, pas de Gemini) : agrège les closes arrivés à J+10 par région (US/EU) et écrit 1-2 leçons dans `scanner_lessons` avec scope `oversold_us_equity` / `oversold_eu_equity` :
- **EXIT_TIMING_*** — le verrou +1,5 % sort-il trop tôt ? (held_better vs close_better + give-up moyen + meilleur jour modal)
- **HEALTH_SUMMARY** — win rate + P&L moyen de la fenêtre

Helper pur (`oversold-retrospective.helper.ts`) testé : **5 cas**. Dédup hebdo (scope, lesson_kind). Confiance < 0.95 (jamais auto-appliqué). Matière première dispo quand la 1re cohorte oversold atteint J+10 (~mi/fin juin) ; avant ça : 0 leçon, sans erreur.

### Migration
`0203_oversold_close_trajectory.sql` : `price_j6` + `trajectory` JSONB + `best_day_label` / `best_day_pnl_pct` + `trajectory_labeled_at` (idempotent, `ADD COLUMN IF NOT EXISTS`).

## Vérif
- `npx tsc -b` (monorepo) → exit 0
- `apps/web` `tsc --noEmit` → exit 0
- `jest` oversold/close-decision → **81/81** (dont 5 nouveaux cas helper)

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_