### PR TITLE
fix(ui): « Meilleur jour » = — pour les closes sans horizon J+10

### DIFF
--- a/apps/web/src/components/lisa/close-decisions-panel.tsx
+++ b/apps/web/src/components/lisa/close-decisions-panel.tsx
@@ -121,6 +121,10 @@ function BadgeDeadline({ v, pnlIfHeld }: { v: string | null; pnlIfHeld: number |
  * Le survol montre la trajectoire complète des checkpoints écoulés.
  */
 function BestDayCell({ r }: { r: CloseDecisionRow }) {
+  // Pas d'échéance J+10 (closes gainers/manuels) → la trajectoire ne s'applique pas.
+  if (!r.hasDeadline) {
+    return <span className="text-muted-foreground" title="Pas d'horizon J+10 (close hors oversold)">—</span>;
+  }
   const traj = r.trajectory ?? [];
   if (traj.length === 0 || r.bestDayLabel == null) {
     return (


### PR DESCRIPTION
## Contexte
En backfillant la trajectoire des closes oversold existants (via EODHD EOD), j'ai constaté que sur les 61 décisions de close US, **56 sont des closes gainers-era / manuels sans horizon J+10** (`deadline_at` null). La nouvelle colonne « Meilleur jour » leur affichait un ⏳ « en cours » perpétuel — trompeur, puisqu'ils ne se peupleront jamais.

## Fix
`BestDayCell` affiche **« — »** quand `hasDeadline` est faux (close hors oversold). Le ⏳ reste réservé aux closes oversold dont la trajectoire J+1/J+3/J+6/J+10 mûrit encore.

## Vérif
- `apps/web` `tsc --noEmit` → exit 0
- Pur frontend.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_