### PR TITLE
fix(oversold): générateur de lessons vise le bon portefeuille EU (c0000001)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,8 +192,12 @@ Cf. `docs/adr/ADR-002-grand-public-ready.md` pour le plan 8 sprints complet.
 
 ## RÈGLE OPÉRATIONNELLE — UI MODE OVERSOLD (PR #653-#656, 07/06/2026)
 
-La page `/lisa` a été nettoyée pour les 2 portfolios **Oversold** (US `a0000001`,
-EU `a0000003`). Le mode oversold est un scanner **mean-reversion déterministe**
+La page `/lisa` a été nettoyée pour les 2 portfolios **Oversold** (US `a0000001`
+« US Oversold / Russell 1000 », EU `c0000001` « EU Oversold / stoxx600 »).
+⚠️ **L'EU oversold est `c0000001`, PAS `a0000003`** (a0000003 est un ancien
+portefeuille gainers). Source de vérité = `lisa_session_configs.strategy_mode='oversold'`
+(découverte dynamique) — ne jamais hardcoder ces IDs, ils ont déjà dérivé.
+Le mode oversold est un scanner **mean-reversion déterministe**
 (cron 21:15 UTC + intraday horaire) — il **n'utilise NI le LLM Lisa, NI les
 gates gainers, NI les lessons, NI le cycle autopilot**. Tout l'historique UI
 gainers/trader/harvest est donc de la **pollution** sur cette vue.

--- a/apps/api/src/modules/lisa/services/__tests__/oversold-retrospective.helper.spec.ts
+++ b/apps/api/src/modules/lisa/services/__tests__/oversold-retrospective.helper.spec.ts
@@ -1,4 +1,4 @@
-import { buildOversoldLessons, type OversoldCloseRow } from '../oversold-retrospective.helper';
+import { buildOversoldLessons, deriveRegionScope, type OversoldCloseRow } from '../oversold-retrospective.helper';
 
 function row(p: Partial<OversoldCloseRow>): OversoldCloseRow {
   return {
@@ -68,5 +68,27 @@ describe('buildOversoldLessons — générateur déterministe', () => {
     expect(health.scope).toBe('oversold_eu_equity');
     expect(health.winRateObserved).toBeCloseTo((4 / 6) * 100, 1);
     expect(health.lessonText).toContain('Oversold EU');
+  });
+});
+
+describe('deriveRegionScope — mapping portefeuille → région (anti ID-en-dur)', () => {
+  it('reconnaît US via nom + univers réels', () => {
+    expect(deriveRegionScope('US Oversold (Russell 1000 mean-rev)', 'russell1000')).toEqual({
+      region: 'US',
+      scope: 'oversold_us_equity',
+    });
+  });
+  it('reconnaît EU via nom + univers réels (c0000001)', () => {
+    expect(deriveRegionScope('EU Oversold (stoxx600 mean-rev)', 'stoxx600')).toEqual({
+      region: 'EU',
+      scope: 'oversold_eu_equity',
+    });
+  });
+  it('reconnaît la région même si seul l’univers est dispo', () => {
+    expect(deriveRegionScope('', 'sp500')?.region).toBe('US');
+    expect(deriveRegionScope(null, 'ftse100')?.region).toBe('EU');
+  });
+  it('renvoie null si rien de reconnaissable (skip plutôt que mal scoper)', () => {
+    expect(deriveRegionScope('Mon portefeuille', 'crypto_majors')).toBeNull();
   });
 });

--- a/apps/api/src/modules/lisa/services/oversold-retrospective.helper.ts
+++ b/apps/api/src/modules/lisa/services/oversold-retrospective.helper.ts
@@ -20,6 +20,22 @@ export interface OversoldCloseRow {
   bestDayPnlPct: number | null;
 }
 
+/**
+ * Région + scope dérivés du NOM/UNIVERS du portefeuille (jamais d'ID en dur — un
+ * ID hardcodé périmé a causé un bug : le générateur visait a0000003 alors que
+ * l'EU oversold réel est c0000001). Renvoie null si la région n'est pas
+ * reconnue (→ le caller skip plutôt que de mal scoper une leçon).
+ */
+export function deriveRegionScope(
+  name: string | null | undefined,
+  universe: string | null | undefined,
+): { region: string; scope: string } | null {
+  const hay = `${name ?? ''} ${universe ?? ''}`.toUpperCase();
+  if (/\bUS\b|RUSSELL|S&P|SP500|NASDAQ|US_EQUITY/.test(hay)) return { region: 'US', scope: 'oversold_us_equity' };
+  if (/\bEU\b|STOXX|FTSE|DAX|CAC|EURO|EU_EQUITY/.test(hay)) return { region: 'EU', scope: 'oversold_eu_equity' };
+  return null;
+}
+
 export interface OversoldLessonCandidate {
   lessonKind: string;
   lessonText: string;

--- a/apps/api/src/modules/lisa/services/oversold-retrospective.service.ts
+++ b/apps/api/src/modules/lisa/services/oversold-retrospective.service.ts
@@ -25,19 +25,13 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../../supabase/supabase.service';
-import { buildOversoldLessons, type OversoldCloseRow } from './oversold-retrospective.helper';
+import { buildOversoldLessons, deriveRegionScope, type OversoldCloseRow } from './oversold-retrospective.helper';
 
 interface OversoldPortfolioTarget {
   portfolioId: string;
   region: string; // libellé humain pour le texte ('US' / 'EU')
   scope: string; // 'oversold_us_equity' | 'oversold_eu_equity'
 }
-
-// Portefeuilles oversold connus (cf. CLAUDE.md — US a0000001, EU a0000003).
-const OVERSOLD_TARGETS: OversoldPortfolioTarget[] = [
-  { portfolioId: 'a0000001-0000-0000-0000-000000000001', region: 'US', scope: 'oversold_us_equity' },
-  { portfolioId: 'a0000003-0000-0000-0000-000000000003', region: 'EU', scope: 'oversold_eu_equity' },
-];
 
 @Injectable()
 export class OversoldRetrospectiveService {
@@ -64,8 +58,10 @@ export class OversoldRetrospectiveService {
   @Cron('0 45 22 * * *', { name: 'oversold-retrospective', timeZone: 'UTC' })
   async runRetrospective(): Promise<void> {
     if (!this.enabled || !this.supabase.isReady()) return;
+    const targets = await this.resolveTargets();
+    if (targets.length === 0) return;
     let inserted = 0;
-    for (const t of OVERSOLD_TARGETS) {
+    for (const t of targets) {
       try {
         inserted += await this.runForTarget(t);
       } catch (e) {
@@ -73,6 +69,24 @@ export class OversoldRetrospectiveService {
       }
     }
     if (inserted > 0) this.logger.log(`[oversold-retro] ${inserted} leçon(s) oversold écrite(s)`);
+  }
+
+  /** Découvre dynamiquement les portefeuilles oversold + leur région (pas d'ID en dur). */
+  private async resolveTargets(): Promise<OversoldPortfolioTarget[]> {
+    const client = this.supabase.getClient();
+    const { data: cfgs, error } = await client
+      .from('lisa_session_configs')
+      .select('portfolio_id, oversold_universe')
+      .eq('strategy_mode', 'oversold');
+    if (error || !cfgs || cfgs.length === 0) return [];
+    const targets: OversoldPortfolioTarget[] = [];
+    for (const c of cfgs as Array<{ portfolio_id: string; oversold_universe: string | null }>) {
+      const { data: pf } = await client.from('portfolios').select('name').eq('id', c.portfolio_id).maybeSingle();
+      const rs = deriveRegionScope((pf?.name as string) ?? '', c.oversold_universe);
+      if (rs) targets.push({ portfolioId: c.portfolio_id, region: rs.region, scope: rs.scope });
+      else this.logger.warn(`[oversold-retro] ${c.portfolio_id.slice(0, 8)} oversold sans région reconnue (name/univ) — skip`);
+    }
+    return targets;
   }
 
   private async runForTarget(t: OversoldPortfolioTarget): Promise<number> {


### PR DESCRIPTION
## Bug (corrige #676)
Le `OversoldRetrospectiveService` shippé en #676 **hardcodait l'EU oversold sur `a0000003`** — qui est en réalité un **ancien portefeuille gainers**. L'EU oversold réel est **`c0000001`** (« EU Oversold / stoxx600 », 13 positions ouvertes, 18 closes capturés dans la learning table). Conséquence : le générateur n'aurait **jamais** produit de lessons EU (il lisait un portefeuille sans aucun close oversold).

Découvert en investiguant « pourquoi EU ne trade pas » — c'était moi qui regardais le mauvais portefeuille (l'utilisateur avait raison : l'EU oversold trade tous les jours).

## Fix
- **Découverte dynamique** des portefeuilles oversold via `lisa_session_configs.strategy_mode='oversold'` (plus aucun ID en dur → plus de dérive silencieuse possible).
- Région/scope dérivés du **nom/univers** (`Russell/SP500→US`, `stoxx600/FTSE→EU`) par `deriveRegionScope`, extrait en **helper pur testé**.
- `CLAUDE.md` corrigé (EU oversold = `c0000001`, pas `a0000003`).

## État réel constaté (pour mémoire)
| Portefeuille | Closes oversold | Capturés learning table |
|---|---|---|
| US `a0000001` | 54 | 5/54 (49 manquants = historique pré-wiring + reset 08/06, pas un bug courant) |
| EU `c0000001` | 19 | 19/19 ✅ |

Trajectoire backfillée pour les 18 closes EU `c0000001` (7 ont déjà J+1 ; ex SOI.PA J+1 −9,02% → le lock +1,5% a bien protégé).

## Vérif
- `tsc -b` → 0 · `apps/api` `tsc` → 0
- `jest oversold` → **85/85** (dont 9 cas helper retrospective : agrégation + `deriveRegionScope`)

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_