### PR TITLE
chore(web): re-trigger déploiement prod Vercel (colonne « Meilleur jour »)

### DIFF
--- a/apps/web/src/components/lisa/close-decisions-panel.tsx
+++ b/apps/web/src/components/lisa/close-decisions-panel.tsx
@@ -11,6 +11,9 @@ import { useCloseDecisions, type CloseDecisionRow } from '@/hooks/use-close-deci
  * à l'échéance J+10 (CLOSE_BETTER / HELD_BETTER / NEUTRAL = aurais-tu mieux fait
  * de tenir ?), avec contexte (danger-zone / oversold-early) + news. Observation
  * pure — base du futur LLM qui apprendra QUAND fermer.
+ *
+ * 10/06 — Colonne « Meilleur jour » (trajectoire progressive J+1/J+3/J+6/J+10 +
+ * badge du checkpoint où tenir aurait le mieux payé).
  */
 export function CloseDecisionsPanel({ portfolioId }: { portfolioId: string }) {
   const { data, isLoading, isError } = useCloseDecisions(portfolioId);


### PR DESCRIPTION
## But
Re-déclencher un **déploiement prod Vercel propre**. Les déploiements prod déclenchés par #676/#677 ont échoué sur le rate-limit free tier (>100 deploys/24h) → la prod servait encore l'ancien bundle **sans** la colonne « Meilleur jour » (vérifié : grep des chunks JS de `smartvest.vercel.app` → absent).

Le quota semble levé (un build a réussi en fin d'après-midi). Ce commit (note de doc dans `close-decisions-panel.tsx`) force un build prod frais qui inclura la colonne.

## Vérif
- Aucune logique modifiée (1 ligne de commentaire).
- Le code de la colonne est déjà sur `main` depuis #676.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_