### PR TITLE
chore(web): redéploiement prod (Vercel Pro actif)

### DIFF
--- a/apps/web/src/components/lisa/close-decisions-panel.tsx
+++ b/apps/web/src/components/lisa/close-decisions-panel.tsx
@@ -13,7 +13,7 @@ import { useCloseDecisions, type CloseDecisionRow } from '@/hooks/use-close-deci
  * pure — base du futur LLM qui apprendra QUAND fermer.
  *
  * 10/06 — Colonne « Meilleur jour » (trajectoire progressive J+1/J+3/J+6/J+10 +
- * badge du checkpoint où tenir aurait le mieux payé).
+ * badge du checkpoint où tenir aurait le mieux payé). Déploiement prod via Vercel Pro.
  */
 export function CloseDecisionsPanel({ portfolioId }: { portfolioId: string }) {
   const { data, isLoading, isError } = useCloseDecisions(portfolioId);


### PR DESCRIPTION
## But
Relancer un **déploiement production Vercel** maintenant que le compte est passé en **Pro** (cap des 100 builds/jour levé).

La prod Vercel était figée sur **#671 (il y a 2 jours)** : tous les merges depuis (#672→#679) ont échoué sur le rate-limit free tier et ne sont jamais arrivés en production. Ce déploiement embarque tout le retard, notamment :
- **#676** — colonne « Meilleur jour » (trajectoire progressive J+1/J+3/J+6/J+10)
- **#677** — « — » pour les closes sans horizon J+10
- **#675/#678** — répartition coût LLM, fix générateur lessons EU

## Vérif
- 1 ligne de commentaire, aucune logique modifiée.
- Tout le code applicatif est déjà sur `main` depuis ces PR.

https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrqDqNZPLudUttqnUdJHHy)_